### PR TITLE
feat: add button to fully quit openwhispr processes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-whispr",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-whispr",
-      "version": "1.0.12",
+      "version": "1.0.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/preload.js
+++ b/preload.js
@@ -100,6 +100,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   windowClose: () => ipcRenderer.invoke("window-close"),
   windowIsMaximized: () => ipcRenderer.invoke("window-is-maximized"),
   getPlatform: () => process.platform,
+  appQuit: () => ipcRenderer.invoke("app-quit"),
 
   // Cleanup function
   cleanupApp: () => ipcRenderer.invoke("cleanup-app"),

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
-import { Trash2, Settings, FileText, Mic, X } from "lucide-react";
+import { Trash2, Settings, FileText, Mic } from "lucide-react";
 import SettingsModal from "./SettingsModal";
 import TitleBar from "./TitleBar";
 import SupportDropdown from "./ui/SupportDropdown";
@@ -28,7 +28,6 @@ export default function ControlPanel() {
     updateDownloaded: false,
     isDevelopment: false,
   });
-  const isWindows = typeof window !== "undefined" && window.electronAPI?.getPlatform?.() === "win32";
 
   const {
     confirmDialog,
@@ -38,10 +37,6 @@ export default function ControlPanel() {
     hideConfirmDialog,
     hideAlertDialog,
   } = useDialogs();
-
-  const handleClose = () => {
-    void window.electronAPI.windowClose();
-  };
 
   useEffect(() => {
     loadTranscriptions();
@@ -205,19 +200,6 @@ export default function ControlPanel() {
             >
               <Settings size={16} />
             </Button>
-            {isWindows && (
-              <div className="flex items-center gap-1 ml-2">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                  onClick={handleClose}
-                  aria-label="Close window"
-                >
-                  <X size={14} />
-                </Button>
-              </div>
-            )}
           </>
         }
       />

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,5 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import WindowControls from "./WindowControls";
+import { Button } from "./ui/button";
+import { Power } from "lucide-react";
+import { ConfirmDialog } from "./ui/dialog";
 
 interface TitleBarProps {
   title?: string;
@@ -16,11 +19,21 @@ export default function TitleBar({
   className = "",
   actions,
 }: TitleBarProps) {
+  const [showQuitConfirm, setShowQuitConfirm] = useState(false);
+
   // Get platform info
   const platform =
     typeof window !== "undefined" && window.electronAPI?.getPlatform
       ? window.electronAPI.getPlatform()
       : "darwin";
+
+  const handleQuit = async () => {
+    try {
+      await window.electronAPI?.appQuit?.();
+    } catch {
+      // Silently handle if API not available
+    }
+  };
 
   return (
     <div
@@ -44,10 +57,30 @@ export default function TitleBar({
           style={{ WebkitAppRegion: "no-drag" }}
         >
           {actions}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setShowQuitConfirm(true)}
+            className="h-8 w-8 text-red-600 hover:text-red-700 hover:bg-red-50"
+            title="Quit OpenWhispr"
+            aria-label="Quit OpenWhispr"
+          >
+            <Power size={16} />
+          </Button>
           {/* Show window controls on Linux and Windows (macOS uses native controls) */}
           {platform !== "darwin" && <WindowControls />}
         </div>
       </div>
+      <ConfirmDialog
+        open={showQuitConfirm}
+        onOpenChange={setShowQuitConfirm}
+        title="Quit OpenWhispr?"
+        description="This will close OpenWhispr and stop background processes."
+        confirmText="Quit"
+        cancelText="Cancel"
+        onConfirm={handleQuit}
+        variant="destructive"
+      />
     </div>
   );
 }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -44,6 +44,10 @@ class IPCHandlers {
       return false;
     });
 
+    ipcMain.handle("app-quit", () => {
+      app.quit();
+    });
+
     ipcMain.handle("hide-window", () => {
       if (process.platform === "darwin") {
         this.windowManager.hideDictationPanel();

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -231,6 +231,7 @@ declare global {
       setMainWindowInteractivity: (interactive: boolean) => Promise<void>;
 
       // App management
+      appQuit: () => Promise<void>;
       cleanupApp: () => Promise<{ success: boolean; message: string }>;
       getTranscriptionHistory: () => Promise<any[]>;
       clearTranscriptionHistory: () => Promise<void>;


### PR DESCRIPTION
- Added a dedicated Quit control in the TitleBar that works across platforms.
- Wired a new app-quit IPC endpoint through preload/types to call app.quit().
- Removed the redundant Windows-only close button in the Control Panel.
- Added a confirmation dialog before quitting to prevent accidental exits.