### PR TITLE
Support pasting into Linux terminal apps + fix clipboard restore race condition

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -268,7 +268,8 @@ class ClipboardManager {
 
           if (code === 0) {
             // Restore original clipboard after successful paste
-            setTimeout(() => clipboard.writeText(originalClipboard), 100);
+            // Delay allows time for X11 to process paste event before clipboard is overwritten
+            setTimeout(() => clipboard.writeText(originalClipboard), 200);
             resolve();
           } else {
             reject(new Error(`${tool.cmd} exited with code ${code}`));


### PR DESCRIPTION
1. ctrl+v to paste transcription doesn't work if you're in a terminal app - this update detects if a common terminal app has focus and, if so, does ctrl+shift+v. Only added support for Linux since that's what I use and what I'm able to test.
2. I've been encountering a race condition where the xdotool paste doesn't complete before the old clipboard content is restored, so old clipboard content is pasted instead. This increases the delay to avoid this.

Apologies if you don't prefer two unrelated things in one PR or if you don't want either of these for any reason, happy to update!