### PR TITLE
Fully support terminal focus detection and pasting on (KDE) Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ sudo pacman -S wtype
 
 # Alternative: ydotool (requires uinput permissions)
 sudo apt install ydotool  # or equivalent for your distro
+
+# On KDE Wayland you will additionally need `kdotool` to detect if a terminal is focused for automatically pasting with Ctrl+Shift+V instead of Ctrl+V. Automatic terminal detection on non-KDE Wayland is not yet supported.
+sudo apt install kdotool # or equivalent for your distro
 ```
 
 > ℹ️ **Note**: OpenWhispr automatically detects your display server (X11 vs Wayland) and uses the appropriate paste tool. If no paste tool is installed, text will still be copied to the clipboard - you'll just need to paste manually with Ctrl+V.


### PR DESCRIPTION
Oops, my previous PR had support for ctrl+shift+v pasting on X11 and Wayland, but only actually supported detecting terminal focus on X11. This PR adds support for KDE Wayland terminal focus detection via `kdotool`.

Non-KDE Wayland support for this feature would require compositor-specific tools like `hyperctl` or `swaymsg` and I don't use these so can't test properly.