### PR TITLE
fix(macos): hide control panel to menu bar instead of dock

### DIFF
--- a/main.js
+++ b/main.js
@@ -218,16 +218,8 @@ app.on("activate", () => {
       windowManager.createControlPanelWindow();
     }
   } else {
-    // Show control panel when dock icon is clicked (most common user action)
-    if (windowManager && windowManager.controlPanelWindow && !windowManager.controlPanelWindow.isDestroyed()) {
-      windowManager.controlPanelWindow.show();
-      windowManager.controlPanelWindow.focus();
-    } else if (windowManager) {
-      // If control panel doesn't exist, create it
-      windowManager.createControlPanelWindow();
-    }
-    
-    // Ensure dictation panel maintains its always-on-top status
+    // Don't auto-show control panel - user opens via menu bar tray icon
+    // Just ensure dictation panel maintains its always-on-top status
     if (windowManager && windowManager.mainWindow && !windowManager.mainWindow.isDestroyed()) {
       windowManager.enforceMainWindowOnTop();
     }

--- a/src/helpers/tray.js
+++ b/src/helpers/tray.js
@@ -77,6 +77,10 @@ class TrayManager {
         if (process.platform === "win32") {
           this.controlPanelWindow.setSkipTaskbar(false);
         }
+        // On macOS, show Dock icon when opening control panel
+        if (process.platform === "darwin") {
+          app.dock.show();
+        }
         if (!this.controlPanelWindow.isVisible()) {
           this.controlPanelWindow.show();
         }
@@ -98,6 +102,10 @@ class TrayManager {
         ) {
           if (process.platform === "win32") {
             this.controlPanelWindow.setSkipTaskbar(false);
+          }
+          // On macOS, show Dock icon when opening control panel
+          if (process.platform === "darwin") {
+            app.dock.show();
           }
           this.controlPanelWindow.show();
           this.controlPanelWindow.focus();

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -166,11 +166,7 @@ class WindowManager {
     this.controlPanelWindow.on("close", (event) => {
       if (!this.isQuitting) {
         event.preventDefault();
-        if (process.platform === "darwin") {
-          this.controlPanelWindow.minimize();
-        } else {
-          this.hideControlPanelToTray();
-        }
+        this.hideControlPanelToTray();
       }
     });
 
@@ -224,6 +220,11 @@ class WindowManager {
     }
 
     this.controlPanelWindow.hide();
+
+    // On macOS, hide from Dock when control panel is hidden
+    if (process.platform === "darwin") {
+      app.dock.hide();
+    }
   }
 
   hideDictationPanel() {


### PR DESCRIPTION
## Summary
- On macOS, closing the control panel now hides it completely instead of minimizing to Dock
- App icon is removed from Dock when control panel is hidden
- Users can reopen via the menu bar tray icon → "Open Control Panel"
- Quit option remains available in menu bar tray

## Test plan
- [ ] Run the app on macOS
- [ ] Close the control panel using the red traffic light button
- [ ] Verify the window hides and the app disappears from the Dock
- [ ] Click menu bar tray icon → "Open Control Panel"
- [ ] Verify control panel appears and Dock icon returns
- [ ] Test "Quit OpenWhispr" from tray menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)