### PR TITLE
Add update button to control panel (as well as in settings)

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -84,8 +84,10 @@ export default function ControlPanel() {
     };
 
     const handleDownloadProgress = (_event: any, progressObj: any) => {
-      if (progressObj?.percent) {
-        setDownloadProgress(Math.round(progressObj.percent));
+      if (progressObj?.percent != null) {
+        const newProgress = Math.round(progressObj.percent);
+        setDownloadProgress((prev) => (newProgress > prev ? newProgress : prev));
+        setIsDownloading(true);
       }
     };
 
@@ -304,7 +306,7 @@ export default function ControlPanel() {
                   variant={updateStatus.updateDownloaded ? "default" : "outline"}
                   size="sm"
                   onClick={handleUpdateClick}
-                  disabled={isInstalling}
+                  disabled={isInstalling || isDownloading}
                   className={`gap-1.5 text-xs ${
                     updateStatus.updateDownloaded
                       ? "bg-blue-600 hover:bg-blue-700 text-white"

--- a/src/updater.js
+++ b/src/updater.js
@@ -181,14 +181,14 @@ class UpdateManager {
 
             if (this.isDownloading) {
               return {
-                success: false,
+                success: true,
                 message: "Download already in progress",
               };
             }
 
             if (this.updateDownloaded) {
               return {
-                success: false,
+                success: true,
                 message: "Update already downloaded. Ready to install.",
               };
             }


### PR DESCRIPTION
- Add update button to ControlPanel TitleBar that shows 4 states:
  - "Update Available" - starts download on click
  - "X%" with spinner - shows download progress
  - "Install Update" - prompts for confirmation
  - "Installing..." - shows while restart is pending
- Add download progress tracking via onUpdateDownloadProgress event
- Show toast notification when update is ready to install
- Add confirmation dialog before installing to warn about restart
- Add 10-second fallback alert if app doesn't restart automatically
- Add error handling with toast notifications for download/install failures