### PR TITLE
fix: use cross-env for Windows compatibility in pack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:linux": "npm run build:renderer && electron-builder --linux",
     "setup": "node setup.js",
     "prepack": "npm run compile:globe && npm run download:whisper-cpp",
-    "pack": "npm run build:renderer && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir",
+    "pack": "npm run build:renderer && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir",
     "predist": "npm run compile:globe && npm run download:whisper-cpp",
     "dist": "npm run build:renderer && electron-builder",
     "download:whisper-cpp": "node scripts/download-whisper-cpp.js --current",


### PR DESCRIPTION
A minor update to the `pack` script in the `package.json` file to improve cross-platform compatibility.

* Scripts:
  * Updated the `pack` script to use `cross-env` when setting the `CSC_IDENTITY_AUTO_DISCOVERY` environment variable, ensuring compatibility across different operating systems. Just allows it to pack on Windows.