### PR TITLE
feat: Add Windows taskbar visibility settings for dictation panel

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -26,27 +26,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
   pasteText: (text) => ipcRenderer.invoke("paste-text", text),
   hideWindow: () => ipcRenderer.invoke("hide-window"),
   showDictationPanel: () => ipcRenderer.invoke("show-dictation-panel"),
-  onToggleDictation: registerListener(
-    "toggle-dictation",
-    (callback) => () => callback()
-  ),
-  onStartDictation: registerListener(
-    "start-dictation",
-    (callback) => () => callback()
-  ),
-  onStopDictation: registerListener(
-    "stop-dictation",
-    (callback) => () => callback()
-  ),
+  onToggleDictation: registerListener("toggle-dictation", (callback) => () => callback()),
+  onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
+  onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
 
   // Database functions
-  saveTranscription: (text) =>
-    ipcRenderer.invoke("db-save-transcription", text),
-  getTranscriptions: (limit) =>
-    ipcRenderer.invoke("db-get-transcriptions", limit),
+  saveTranscription: (text) => ipcRenderer.invoke("db-save-transcription", text),
+  getTranscriptions: (limit) => ipcRenderer.invoke("db-get-transcriptions", limit),
   clearTranscriptions: () => ipcRenderer.invoke("db-clear-transcriptions"),
-  deleteTranscription: (id) =>
-    ipcRenderer.invoke("db-delete-transcription", id),
+  deleteTranscription: (id) => ipcRenderer.invoke("db-delete-transcription", id),
   onTranscriptionAdded: (callback) => {
     const listener = (_event, transcription) => callback?.(transcription);
     ipcRenderer.on("transcription-added", listener);
@@ -60,15 +48,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onTranscriptionsCleared: (callback) => {
     const listener = (_event, data) => callback?.(data);
     ipcRenderer.on("transcriptions-cleared", listener);
-    return () =>
-      ipcRenderer.removeListener("transcriptions-cleared", listener);
+    return () => ipcRenderer.removeListener("transcriptions-cleared", listener);
   },
 
   // Environment variables
   getOpenAIKey: () => ipcRenderer.invoke("get-openai-key"),
   saveOpenAIKey: (key) => ipcRenderer.invoke("save-openai-key", key),
-  createProductionEnvFile: (key) =>
-    ipcRenderer.invoke("create-production-env-file", key),
+  createProductionEnvFile: (key) => ipcRenderer.invoke("create-production-env-file", key),
 
   // Settings management
   saveSettings: (settings) => ipcRenderer.invoke("save-settings", settings),
@@ -81,25 +67,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Local Whisper functions (whisper.cpp)
   transcribeLocalWhisper: (audioBlob, options) =>
     ipcRenderer.invoke("transcribe-local-whisper", audioBlob, options),
-  checkWhisperInstallation: () =>
-    ipcRenderer.invoke("check-whisper-installation"),
-  downloadWhisperModel: (modelName) =>
-    ipcRenderer.invoke("download-whisper-model", modelName),
+  checkWhisperInstallation: () => ipcRenderer.invoke("check-whisper-installation"),
+  downloadWhisperModel: (modelName) => ipcRenderer.invoke("download-whisper-model", modelName),
   onWhisperDownloadProgress: registerListener("whisper-download-progress"),
-  checkModelStatus: (modelName) =>
-    ipcRenderer.invoke("check-model-status", modelName),
+  checkModelStatus: (modelName) => ipcRenderer.invoke("check-model-status", modelName),
   listWhisperModels: () => ipcRenderer.invoke("list-whisper-models"),
-  deleteWhisperModel: (modelName) =>
-    ipcRenderer.invoke("delete-whisper-model", modelName),
+  deleteWhisperModel: (modelName) => ipcRenderer.invoke("delete-whisper-model", modelName),
   deleteAllWhisperModels: () => ipcRenderer.invoke("delete-all-whisper-models"),
   cancelWhisperDownload: () => ipcRenderer.invoke("cancel-whisper-download"),
-  checkFFmpegAvailability: () =>
-    ipcRenderer.invoke("check-ffmpeg-availability"),
+  checkFFmpegAvailability: () => ipcRenderer.invoke("check-ffmpeg-availability"),
   getAudioDiagnostics: () => ipcRenderer.invoke("get-audio-diagnostics"),
 
   // Whisper server functions (faster repeated transcriptions)
-  whisperServerStart: (modelName) =>
-    ipcRenderer.invoke("whisper-server-start", modelName),
+  whisperServerStart: (modelName) => ipcRenderer.invoke("whisper-server-start", modelName),
   whisperServerStop: () => ipcRenderer.invoke("whisper-server-stop"),
   whisperServerStatus: () => ipcRenderer.invoke("whisper-server-status"),
 
@@ -119,6 +99,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   stopWindowDrag: () => ipcRenderer.invoke("stop-window-drag"),
   setMainWindowInteractivity: (interactive) =>
     ipcRenderer.invoke("set-main-window-interactivity", interactive),
+  setMinimizeToTray: (enabled) => ipcRenderer.invoke("set-minimize-to-tray", enabled),
 
   // Update functions
   checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
@@ -140,7 +121,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // External link opener
   openExternal: (url) => ipcRenderer.invoke("open-external", url),
-  
+
   // Model management functions
   modelGetAll: () => ipcRenderer.invoke("model-get-all"),
   modelCheck: (modelId) => ipcRenderer.invoke("model-check", modelId),
@@ -150,7 +131,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   modelCheckRuntime: () => ipcRenderer.invoke("model-check-runtime"),
   modelCancelDownload: (modelId) => ipcRenderer.invoke("model-cancel-download", modelId),
   onModelDownloadProgress: registerListener("model-download-progress"),
-  
+
   // Anthropic API
   getAnthropicKey: () => ipcRenderer.invoke("get-anthropic-key"),
   saveAnthropicKey: (key) => ipcRenderer.invoke("save-anthropic-key", key),
@@ -164,20 +145,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveGroqKey: (key) => ipcRenderer.invoke("save-groq-key", key),
 
   // Local reasoning
-  processLocalReasoning: (text, modelId, agentName, config) => 
+  processLocalReasoning: (text, modelId, agentName, config) =>
     ipcRenderer.invoke("process-local-reasoning", text, modelId, agentName, config),
-  checkLocalReasoningAvailable: () => 
-    ipcRenderer.invoke("check-local-reasoning-available"),
-  
+  checkLocalReasoningAvailable: () => ipcRenderer.invoke("check-local-reasoning-available"),
+
   // Anthropic reasoning
   processAnthropicReasoning: (text, modelId, agentName, config) =>
     ipcRenderer.invoke("process-anthropic-reasoning", text, modelId, agentName, config),
-  
+
   // llama.cpp
   llamaCppCheck: () => ipcRenderer.invoke("llama-cpp-check"),
   llamaCppInstall: () => ipcRenderer.invoke("llama-cpp-install"),
   llamaCppUninstall: () => ipcRenderer.invoke("llama-cpp-uninstall"),
-  
+
   getLogLevel: () => ipcRenderer.invoke("get-log-level"),
   log: (entry) => ipcRenderer.invoke("app-log", entry),
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { RefreshCw, Download, Command, Mic, Shield, FolderOpen } from "lucide-re
 import MarkdownRenderer from "./ui/MarkdownRenderer";
 import MicPermissionWarning from "./ui/MicPermissionWarning";
 import MicrophoneSettings from "./ui/MicrophoneSettings";
+import { Toggle } from "./ui/toggle";
 import TranscriptionModelPicker from "./TranscriptionModelPicker";
 import { ConfirmDialog, AlertDialog } from "./ui/dialog";
 import { useSettings } from "../hooks/useSettings";
@@ -65,6 +66,8 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     selectedMicDeviceId,
     setPreferBuiltInMic,
     setSelectedMicDeviceId,
+    minimizeToTray,
+    setMinimizeToTray,
     setUseLocalWhisper,
     setWhisperModel,
     setAllowOpenAIFallback,
@@ -148,6 +151,13 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
       clearTimeout(timer);
     };
   }, [whisperHook, getAppVersion]);
+
+  // Sync minimizeToTray setting to main process on mount (Windows only)
+  useEffect(() => {
+    if (typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent)) {
+      window.electronAPI?.setMinimizeToTray?.(minimizeToTray);
+    }
+  }, []); // Only run on mount
 
   // Show alert dialog on update errors
   useEffect(() => {
@@ -506,6 +516,35 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
                 onDeviceSelect={setSelectedMicDeviceId}
               />
             </div>
+
+            {/* Windows-only: Dictation Panel Behavior */}
+            {typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent) && (
+              <div className="border-t pt-8">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                    Dictation Panel Behavior
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-6">
+                    Control how the dictation panel appears in your taskbar.
+                  </p>
+                </div>
+                <div className="flex items-center justify-between p-4 bg-neutral-50 rounded-lg">
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-neutral-800">Hide from Taskbar</p>
+                    <p className="text-xs text-neutral-600 mt-1">
+                      Only show dictation panel in system tray
+                    </p>
+                  </div>
+                  <Toggle
+                    checked={minimizeToTray}
+                    onChange={(enabled) => {
+                      setMinimizeToTray(enabled);
+                      window.electronAPI?.setMinimizeToTray?.(enabled);
+                    }}
+                  />
+                </div>
+              </div>
+            )}
 
             <div className="border-t pt-8">
               <div>

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -66,6 +66,11 @@ class IPCHandlers {
       return { success: true };
     });
 
+    ipcMain.handle("set-minimize-to-tray", (event, enabled) => {
+      this.windowManager.setDictationPanelSkipTaskbar(Boolean(enabled));
+      return { success: true };
+    });
+
     // Environment handlers
     ipcMain.handle("get-openai-key", async (event) => {
       return this.environmentManager.getOpenAIKey();

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -172,6 +172,12 @@ export function useSettings() {
     deserialize: String,
   });
 
+  // Window behavior settings (Windows only)
+  const [minimizeToTray, setMinimizeToTray] = useLocalStorage("minimizeToTray", false, {
+    serialize: String,
+    deserialize: (value) => value === "true",
+  });
+
   // Computed values
   const reasoningProvider = getModelProvider(reasoningModel);
 
@@ -277,6 +283,8 @@ export function useSettings() {
     selectedMicDeviceId,
     setPreferBuiltInMic,
     setSelectedMicDeviceId,
+    minimizeToTray,
+    setMinimizeToTray,
     updateTranscriptionSettings,
     updateReasoningSettings,
     updateApiKeys,

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -223,6 +223,7 @@ declare global {
       startWindowDrag: () => Promise<void>;
       stopWindowDrag: () => Promise<void>;
       setMainWindowInteractivity: (interactive: boolean) => Promise<void>;
+      setMinimizeToTray?: (enabled: boolean) => Promise<{ success: boolean }>;
 
       // App management
       appQuit: () => Promise<void>;


### PR DESCRIPTION
Adds a new Windows-only setting that allows users to **control whether the dictation panel appears in the Windows taskbar** or only in the system tray ("minimize to tray"). The setting is exposed in the control panel UI, persisted in local storage, and synchronized with the main Electron process. The implementation includes changes to the settings UI, hooks, IPC handlers, and window management logic to ensure the dictation panel respects user preferences and behaves consistently.

Tested on Windows 11, should work on Windows 10 too (same Electron APIs). Does not affect Mac/Linux.

Essentially lets you remove this:
<img width="202" height="334" alt="image" src="https://github.com/user-attachments/assets/01e57f47-3258-4c41-a1c9-2e5442c0f9b5" />
and this (Alt+Tab):
<img width="241" height="275" alt="image" src="https://github.com/user-attachments/assets/4085d268-ffd7-442e-beb3-3360ce8b1035" />

Control panel:
<img width="781" height="556" alt="Screenshot 2026-01-19 153149" src="https://github.com/user-attachments/assets/94b6f900-0f72-4e4b-a2cc-f426f9e9c10e" />