### PR TITLE
fix: disable Push to Talk on Windows/Linux

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -152,12 +152,15 @@ export function useSettings() {
     deserialize: String,
   });
 
+  // Push-to-talk only works on macOS (requires key-up detection via Globe key listener)
+  const isMacOS = window.electronAPI?.getPlatform?.() === "darwin";
   const [activationMode, setActivationMode] = useLocalStorage<"tap" | "push">(
     "activationMode",
     "tap",
     {
       serialize: String,
-      deserialize: (value) => (value === "push" ? "push" : "tap"),
+      // Force tap mode on non-macOS platforms since push-to-talk isn't supported
+      deserialize: (value) => (value === "push" && isMacOS ? "push" : "tap"),
     }
   );
 


### PR DESCRIPTION
Push to Talk mode requires detecting key-up events, which is only supported on macOS via the Globe key listener. On Windows/Linux, globalShortcut only fires on key-down, making Push to Talk non-functional.

Changes:
- Disable and gray out Push to Talk option on non-macOS platforms
- Show "macOS only" label instead of "Hold to record"
- Add tooltip explaining the limitation
- Force tap mode in useSettings if push was previously saved on non-macOS