### PR TITLE
Fix file logging initialization timing in Electron app lifecycle

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,6 +85,10 @@ function initializeManagers() {
 
   // Now it's safe to call app.getPath() and initialize managers
   debugLogger = require("./src/helpers/debugLogger");
+  // IMPORTANT: Ensure file logging is initialized now that app is ready
+  // This is necessary because debugLogger may have been loaded before app.whenReady()
+  // via transitive imports (e.g., windowManager -> hotkeyManager -> debugLogger)
+  debugLogger.ensureFileLogging();
   environmentManager = new EnvironmentManager();
   debugLogger.refreshLogLevel();
   windowManager = new WindowManager();

--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -39,14 +39,22 @@ class DebugLogger {
     this.logFile = null;
     this.logStream = null;
     this.fileLoggingEnabled = false;
+    this.fileLoggingPending = this.debugMode; // Track if we need to initialize file logging later
 
-    if (this.debugMode) {
-      this.initializeFileLogging();
-    }
+    // IMPORTANT: Do NOT call initializeFileLogging() here!
+    // It uses app.getPath() which is unsafe before app.whenReady().
+    // File logging will be initialized on first log write or via ensureFileLogging().
   }
 
   initializeFileLogging() {
     if (this.fileLoggingEnabled) return;
+
+    // Check if app is ready before accessing app.getPath()
+    // This is critical because app.getPath() can hang or fail before app.whenReady()
+    if (!app.isReady()) {
+      // App not ready yet, will try again later via ensureFileLogging() or write()
+      return;
+    }
 
     try {
       const logsDir = path.join(app.getPath("userData"), "logs");
@@ -59,6 +67,7 @@ class DebugLogger {
 
       this.logStream = fs.createWriteStream(this.logFile, { flags: "a" });
       this.fileLoggingEnabled = true;
+      this.fileLoggingPending = false;
 
       this.debug("Debug logging enabled", { logFile: this.logFile });
       this.info("System Info", {
@@ -72,7 +81,18 @@ class DebugLogger {
       });
     } catch (error) {
       this.fileLoggingEnabled = false;
+      this.fileLoggingPending = false;
       console.error("Failed to initialize debug logging:", error);
+    }
+  }
+
+  /**
+   * Ensures file logging is initialized if debug mode is enabled.
+   * This should be called after app.whenReady() to safely initialize file logging.
+   */
+  ensureFileLogging() {
+    if (this.fileLoggingPending && !this.fileLoggingEnabled) {
+      this.initializeFileLogging();
     }
   }
 
@@ -144,6 +164,11 @@ class DebugLogger {
   write(level, message, meta, scope, source) {
     const normalized = normalizeLevel(level) || "info";
     if (!this.shouldLog(normalized)) return;
+
+    // Try to initialize file logging if pending and app is ready
+    if (this.fileLoggingPending && !this.fileLoggingEnabled) {
+      this.initializeFileLogging();
+    }
 
     const timestamp = new Date().toISOString();
     const scopeTag = scope ? `[${scope}]` : "";


### PR DESCRIPTION
## Summary
This PR fixes a critical timing issue where file logging was being initialized before the Electron app was ready, causing `app.getPath()` to be called unsafely. The solution defers file logging initialization until after `app.whenReady()` completes.

## Problem
The `debugLogger` module was being loaded transitively through other managers (e.g., `windowManager` → `hotkeyManager` → `debugLogger`) before `app.whenReady()` was called. This caused the constructor to immediately call `initializeFileLogging()`, which uses `app.getPath("userData")` - an unsafe operation before the app is ready.

## Key Changes
- **debugLogger.js**: 
  - Removed immediate `initializeFileLogging()` call from constructor
  - Added `fileLoggingPending` flag to track deferred initialization
  - Added safety check in `initializeFileLogging()` to verify `app.isReady()` before accessing `app.getPath()`
  - Added new `ensureFileLogging()` method to explicitly initialize file logging when safe
  - Added lazy initialization attempt in the `write()` method as a fallback

- **main.js**:
  - Added explicit call to `debugLogger.ensureFileLogging()` in `initializeManagers()` after `app.whenReady()` has completed

## Implementation Details
- File logging initialization is now deferred and happens at the earliest safe moment
- Multiple initialization paths ensure file logging is set up: explicit call via `ensureFileLogging()`, lazy initialization on first log write, or when app becomes ready
- The `fileLoggingPending` flag prevents repeated initialization attempts
- All error states properly reset the pending flag to avoid infinite retry loops