### PR TITLE
refactor: clean up debug logging and extract common window loading code

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,54 +80,25 @@ function setupProductionPath() {
 
 // Initialize all managers - called after app.whenReady()
 function initializeManagers() {
-  console.log("[initializeManagers] Starting...");
-
   // Set up PATH before initializing managers
   setupProductionPath();
-  console.log("[initializeManagers] PATH setup complete");
 
   // Now it's safe to call app.getPath() and initialize managers
-  console.log("[initializeManagers] Loading debugLogger...");
   debugLogger = require("./src/helpers/debugLogger");
-  // IMPORTANT: Ensure file logging is initialized now that app is ready
-  // This is necessary because debugLogger may have been loaded before app.whenReady()
-  // via transitive imports (e.g., windowManager -> hotkeyManager -> debugLogger)
+  // Ensure file logging is initialized now that app is ready
   debugLogger.ensureFileLogging();
-  console.log("[initializeManagers] debugLogger initialized");
 
-  console.log("[initializeManagers] Creating EnvironmentManager...");
   environmentManager = new EnvironmentManager();
   debugLogger.refreshLogLevel();
-  console.log("[initializeManagers] EnvironmentManager created");
 
-  console.log("[initializeManagers] Creating WindowManager...");
   windowManager = new WindowManager();
   hotkeyManager = windowManager.hotkeyManager;
-  console.log("[initializeManagers] WindowManager created");
-
-  console.log("[initializeManagers] Creating DatabaseManager...");
   databaseManager = new DatabaseManager();
-  console.log("[initializeManagers] DatabaseManager created");
-
-  console.log("[initializeManagers] Creating ClipboardManager...");
   clipboardManager = new ClipboardManager();
-  console.log("[initializeManagers] ClipboardManager created");
-
-  console.log("[initializeManagers] Creating WhisperManager...");
   whisperManager = new WhisperManager();
-  console.log("[initializeManagers] WhisperManager created");
-
-  console.log("[initializeManagers] Creating TrayManager...");
   trayManager = new TrayManager();
-  console.log("[initializeManagers] TrayManager created");
-
-  console.log("[initializeManagers] Creating UpdateManager...");
   updateManager = new UpdateManager();
-  console.log("[initializeManagers] UpdateManager created");
-
-  console.log("[initializeManagers] Creating GlobeKeyManager...");
   globeKeyManager = new GlobeKeyManager();
-  console.log("[initializeManagers] GlobeKeyManager created");
 
   // Set up Globe key error handler on macOS
   if (process.platform === "darwin") {
@@ -172,18 +143,8 @@ function initializeManagers() {
 
 // Main application startup
 async function startApp() {
-  console.log("[Main] startApp() called - app is ready");
-  console.log("[Main] Platform:", process.platform, "Arch:", process.arch);
-  console.log("[Main] NODE_ENV:", process.env.NODE_ENV);
-  console.log("[Main] App path:", app.getAppPath());
-  console.log("[Main] Resources path:", process.resourcesPath);
-  console.log("[Main] User data path:", app.getPath("userData"));
-
   // Initialize all managers now that app is ready
-  // This must happen first as other code depends on these managers
-  console.log("[Main] Initializing managers...");
   initializeManagers();
-  console.log("[Main] Managers initialized");
 
   // In development, add a small delay to let Vite start properly
   if (process.env.NODE_ENV === "development") {
@@ -228,26 +189,10 @@ async function startApp() {
   }
 
   // Create main window
-  console.log("[Main] Creating main window...");
-  try {
-    await windowManager.createMainWindow();
-    console.log("[Main] Main window created successfully");
-  } catch (error) {
-    console.error("[Main] Error creating main window:", error);
-    // Re-throw to trigger the error dialog in the catch handler
-    throw error;
-  }
+  await windowManager.createMainWindow();
 
   // Create control panel window
-  console.log("[Main] Creating control panel window...");
-  try {
-    await windowManager.createControlPanelWindow();
-    console.log("[Main] Control panel window created successfully");
-  } catch (error) {
-    console.error("[Main] Error creating control panel window:", error);
-    // Re-throw to trigger the error dialog in the catch handler
-    throw error;
-  }
+  await windowManager.createControlPanelWindow();
 
   // Set up tray
   trayManager.setWindows(windowManager.mainWindow, windowManager.controlPanelWindow);
@@ -315,8 +260,6 @@ async function startApp() {
 }
 
 // App event handlers
-console.log("[Main] Setting up app event handlers, gotSingleInstanceLock:", gotSingleInstanceLock);
-
 if (gotSingleInstanceLock) {
   app.on("second-instance", async () => {
     await app.whenReady();
@@ -341,16 +284,12 @@ if (gotSingleInstanceLock) {
     }
   });
 
-  console.log("[Main] Waiting for app.whenReady()...");
   app.whenReady().then(() => {
-    console.log("[Main] app.whenReady() resolved - app is now ready");
     startApp().catch((error) => {
-      console.error("CRITICAL: Failed to start app:", error);
-      console.error("Stack trace:", error.stack);
-      // Show an error dialog before crashing
+      console.error("Failed to start app:", error);
       dialog.showErrorBox(
         "OpenWhispr Startup Error",
-        `Failed to start the application:\n\n${error.message}\n\nStack: ${error.stack}\n\nPlease report this issue.`
+        `Failed to start the application:\n\n${error.message}\n\nPlease report this issue.`
       );
       app.exit(1);
     });

--- a/src/helpers/devServerManager.js
+++ b/src/helpers/devServerManager.js
@@ -26,15 +26,13 @@ class DevServerManager {
         });
 
         if (result) {
-          console.log(`Dev server ready after ${i + 1} attempts`);
           return true;
         }
-      } catch (error) {
-        console.log(`Waiting for dev server... attempt ${i + 1}/${maxAttempts}`);
+      } catch {
+        // Dev server not ready yet, continue waiting
       }
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
-    console.error("Dev server failed to start within timeout");
     return false;
   }
 
@@ -54,55 +52,16 @@ class DevServerManager {
    * @returns {{ path: string, query: object } | null} - Path info for loadFile() or null for dev
    */
   static getAppFilePath(isControlPanel = false) {
-    const isDev = process.env.NODE_ENV === "development";
-    console.log("[DevServerManager] getAppFilePath called:", {
-      isControlPanel,
-      NODE_ENV: process.env.NODE_ENV,
-      isDev,
-    });
-
-    if (isDev) {
-      console.log("[DevServerManager] Development mode - returning null for dev server");
+    if (process.env.NODE_ENV === "development") {
       return null; // Use getAppUrl() for dev server
     }
 
     const path = require("path");
     const { app } = require("electron");
-    const fs = require("fs");
 
     // In packaged app, files are relative to app.getAppPath()
-    // which points to the app.asar or app directory
     const appPath = app.getAppPath();
     const htmlPath = path.join(appPath, "src", "dist", "index.html");
-
-    console.log("[DevServerManager] Production mode paths:", {
-      appPath,
-      htmlPath,
-      htmlExists: fs.existsSync(htmlPath),
-      resourcesPath: process.resourcesPath,
-    });
-
-    // Log additional diagnostic info
-    try {
-      const distDir = path.join(appPath, "src", "dist");
-      if (fs.existsSync(distDir)) {
-        console.log("[DevServerManager] dist directory contents:", fs.readdirSync(distDir).slice(0, 10));
-      } else {
-        console.error("[DevServerManager] dist directory does not exist:", distDir);
-        // Try alternative paths
-        const altPaths = [
-          path.join(appPath, "dist", "index.html"),
-          path.join(process.resourcesPath || "", "app", "src", "dist", "index.html"),
-          path.join(process.resourcesPath || "", "src", "dist", "index.html"),
-        ];
-        console.log("[DevServerManager] Checking alternative paths:");
-        for (const altPath of altPaths) {
-          console.log(`  ${altPath}: ${fs.existsSync(altPath)}`);
-        }
-      }
-    } catch (err) {
-      console.error("[DevServerManager] Error checking paths:", err.message);
-    }
 
     return {
       path: htmlPath,

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -25,17 +25,10 @@ class WindowManager {
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getMainWindowPosition(display);
 
-    console.log("[WindowManager] Creating main window with position:", position);
-    console.log("[WindowManager] Display bounds:", display.bounds);
-    console.log("[WindowManager] Display workArea:", display.workArea);
-    console.log("[WindowManager] Platform:", process.platform);
-
     this.mainWindow = new BrowserWindow({
       ...MAIN_WINDOW_CONFIG,
       ...position,
     });
-
-    console.log("[WindowManager] Main window created, id:", this.mainWindow.id);
 
     if (process.platform === "darwin") {
       this.mainWindow.setSkipTaskbar(false);
@@ -46,20 +39,18 @@ class WindowManager {
     this.setMainWindowInteractivity(false);
     this.registerMainWindowEvents();
 
-    // IMPORTANT: Register load event handlers BEFORE loading to catch all events
+    // Register load event handlers BEFORE loading to catch all events
     this.mainWindow.webContents.on(
       "did-fail-load",
       async (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
         if (!isMainFrame) {
           return;
         }
-        console.error("[WindowManager] did-fail-load:", errorCode, errorDescription, validatedURL);
         if (process.env.NODE_ENV === "development" && validatedURL && validatedURL.includes("localhost:5174")) {
           // Retry connection to dev server
           setTimeout(async () => {
             const isReady = await DevServerManager.waitForDevServer();
             if (isReady) {
-              console.log("[WindowManager] Dev server ready, reloading...");
               this.mainWindow.reload();
             }
           }, 2000);
@@ -70,7 +61,6 @@ class WindowManager {
     );
 
     this.mainWindow.webContents.on("did-finish-load", () => {
-      console.log("[WindowManager] Main window did-finish-load");
       this.mainWindow.setTitle("Voice Recorder");
       this.enforceMainWindowOnTop();
     });
@@ -95,49 +85,34 @@ class WindowManager {
     this.isMainWindowInteractive = shouldCapture;
   }
 
-  async loadMainWindow() {
+  /**
+   * Load content into a BrowserWindow, handling both dev server and production file loading.
+   * @param {BrowserWindow} window - The window to load content into
+   * @param {boolean} isControlPanel - Whether this is the control panel
+   */
+  async loadWindowContent(window, isControlPanel = false) {
     if (process.env.NODE_ENV === "development") {
-      const appUrl = DevServerManager.getAppUrl(false);
-      console.log("[WindowManager] Loading main window (dev):", appUrl);
-      const isReady = await DevServerManager.waitForDevServer();
-      if (!isReady) {
-        console.warn("[WindowManager] Dev server not ready, attempting to load anyway...");
-      }
-      try {
-        await this.mainWindow.loadURL(appUrl);
-        console.log("[WindowManager] Main window loaded successfully (dev)");
-      } catch (error) {
-        console.error("[WindowManager] Failed to load main window (dev):", error);
-        throw error;
-      }
+      const appUrl = DevServerManager.getAppUrl(isControlPanel);
+      await DevServerManager.waitForDevServer();
+      await window.loadURL(appUrl);
     } else {
       // Production: use loadFile() for better compatibility with Electron 36+
-      const fileInfo = DevServerManager.getAppFilePath(false);
-      console.log("[WindowManager] Loading main window (prod), fileInfo:", fileInfo);
-
+      const fileInfo = DevServerManager.getAppFilePath(isControlPanel);
       if (!fileInfo) {
-        const error = new Error("Failed to get app file path for main window");
-        console.error("[WindowManager]", error.message);
-        throw error;
+        throw new Error("Failed to get app file path");
       }
 
-      // Verify the file exists before attempting to load
       const fs = require("fs");
       if (!fs.existsSync(fileInfo.path)) {
-        const error = new Error(`Main window HTML file not found: ${fileInfo.path}`);
-        console.error("[WindowManager]", error.message);
-        throw error;
+        throw new Error(`HTML file not found: ${fileInfo.path}`);
       }
 
-      try {
-        console.log("[WindowManager] Calling loadFile:", fileInfo.path);
-        await this.mainWindow.loadFile(fileInfo.path, { query: fileInfo.query });
-        console.log("[WindowManager] Main window loaded successfully (prod)");
-      } catch (error) {
-        console.error("[WindowManager] Failed to load main window (prod):", error);
-        throw error;
-      }
+      await window.loadFile(fileInfo.path, { query: fileInfo.query });
     }
+  }
+
+  async loadMainWindow() {
+    await this.loadWindowContent(this.mainWindow, false);
   }
 
   createHotkeyCallback() {
@@ -299,53 +274,11 @@ class WindowManager {
       }
     );
 
-    console.log("📱 Loading control panel content...");
     await this.loadControlPanel();
   }
 
   async loadControlPanel() {
-    if (process.env.NODE_ENV === "development") {
-      const appUrl = DevServerManager.getAppUrl(true);
-      console.log("[WindowManager] Loading control panel (dev):", appUrl);
-      const isReady = await DevServerManager.waitForDevServer();
-      if (!isReady) {
-        console.warn("[WindowManager] Dev server not ready for control panel, attempting to load anyway...");
-      }
-      try {
-        await this.controlPanelWindow.loadURL(appUrl);
-        console.log("[WindowManager] Control panel loaded successfully (dev)");
-      } catch (error) {
-        console.error("[WindowManager] Failed to load control panel (dev):", error);
-        throw error;
-      }
-    } else {
-      // Production: use loadFile() for better compatibility with Electron 36+
-      const fileInfo = DevServerManager.getAppFilePath(true);
-      console.log("[WindowManager] Loading control panel (prod), fileInfo:", fileInfo);
-
-      if (!fileInfo) {
-        const error = new Error("Failed to get app file path for control panel");
-        console.error("[WindowManager]", error.message);
-        throw error;
-      }
-
-      // Verify the file exists before attempting to load
-      const fs = require("fs");
-      if (!fs.existsSync(fileInfo.path)) {
-        const error = new Error(`Control panel HTML file not found: ${fileInfo.path}`);
-        console.error("[WindowManager]", error.message);
-        throw error;
-      }
-
-      try {
-        console.log("[WindowManager] Calling loadFile:", fileInfo.path);
-        await this.controlPanelWindow.loadFile(fileInfo.path, { query: fileInfo.query });
-        console.log("[WindowManager] Control panel loaded successfully (prod)");
-      } catch (error) {
-        console.error("[WindowManager] Failed to load control panel (prod):", error);
-        throw error;
-      }
-    }
+    await this.loadWindowContent(this.controlPanelWindow, true);
   }
 
   showDictationPanel(options = {}) {
@@ -404,19 +337,14 @@ class WindowManager {
     }
 
     // Safety timeout: force show the window if ready-to-show doesn't fire within 10 seconds
-    // This helps diagnose issues where the renderer fails to load
     const showTimeout = setTimeout(() => {
-      console.warn("[WindowManager] ready-to-show timeout - forcing window to show");
       if (this.mainWindow && !this.mainWindow.isDestroyed() && !this.mainWindow.isVisible()) {
-        console.log("[WindowManager] Main window was not visible after 10s, forcing show");
         this.mainWindow.show();
-        this.mainWindow.webContents.openDevTools();
       }
     }, 10000);
 
     this.mainWindow.once("ready-to-show", () => {
       clearTimeout(showTimeout);
-      console.log("[WindowManager] Main window ready-to-show event fired");
       this.enforceMainWindowOnTop();
       if (!this.mainWindow.isVisible()) {
         if (typeof this.mainWindow.showInactive === "function") {


### PR DESCRIPTION
- Remove excessive console.log statements added for debugging
- Extract duplicated window loading logic into shared loadWindowContent() method
- Remove debug code that opens DevTools in production timeout handler
- Simplify devServerManager.js path checking logic
- Keep proper debugLogger-based logging in audioManager and ReasoningService