### PR TITLE
Fix custom provider selection not persisting (#148)

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -139,9 +139,15 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     showAlert: showAlertDialog,
   });
 
-  const [localReasoningProvider, setLocalReasoningProvider] = useState(() => {
+  const [localReasoningProvider, setLocalReasoningProviderState] = useState(() => {
     return localStorage.getItem("reasoningProvider") || reasoningProvider;
   });
+
+  // Wrap setter to persist to localStorage
+  const setLocalReasoningProvider = useCallback((provider: string) => {
+    setLocalReasoningProviderState(provider);
+    localStorage.setItem("reasoningProvider", provider);
+  }, []);
   const [isUsingGnomeHotkeys, setIsUsingGnomeHotkeys] = useState(false);
 
   // Platform detection for conditional features


### PR DESCRIPTION
When selecting a custom AI provider, the selection wasn't persisted to localStorage. Upon reopening settings, the provider tab would revert to the computed provider based on the model ID instead of the user's explicit selection.

Wrap the localReasoningProvider state setter to persist the provider choice to localStorage, ensuring the Custom tab remains selected after settings are closed and reopened.

Fixes #148
