### PR TITLE
fix(hotkey): distinguish Control from Command key on macOS

### DIFF
--- a/src/components/ui/HotkeyInput.tsx
+++ b/src/components/ui/HotkeyInput.tsx
@@ -157,8 +157,18 @@ export function mapKeyboardEventToHotkey(e: KeyboardEvent): string | null {
 
   const modifiers: string[] = [];
 
-  if (e.ctrlKey || e.metaKey) {
-    modifiers.push("CommandOrControl");
+  // Distinguish between Control and Command (Meta) keys
+  // On macOS: Control = physical Ctrl key, Meta = Command key
+  // On Windows/Linux: Control = Ctrl key, Meta = Windows/Super key
+  const isMac = /Mac|Darwin/.test(navigator.platform);
+
+  if (e.metaKey) {
+    // Command key on macOS, Windows key on Windows/Linux
+    modifiers.push(isMac ? "Command" : "Super");
+  }
+  if (e.ctrlKey) {
+    // Control key - use explicit "Control" to avoid CommandOrControl mapping
+    modifiers.push("Control");
   }
   if (e.altKey) {
     modifiers.push("Alt");


### PR DESCRIPTION
## Summary

- Fix Control key being incorrectly mapped to `CommandOrControl` on macOS
- Now `Control+Space` registers as `Control+Space` instead of `Command+Space`
- Allows macOS users to use Control-based shortcuts (like`Control+Space`)

## Problem

In `HotkeyInput.tsx`, both `e.ctrlKey` and `e.metaKey` were merged into `CommandOrControl`:

```typescript
if (e.ctrlKey || e.metaKey) {
  modifiers.push("CommandOrControl");
}
```

On macOS, Electron interprets `CommandOrControl` as `Command`, so pressing `Control+Space` actually registered `Command+Space`.

## Solution

Distinguish the two keys:

```typescript
if (e.metaKey) {
  modifiers.push(isMac ? "Command" : "Super");
}
if (e.ctrlKey) {
  modifiers.push("Control");
}
```

## Test plan

- [x] Build with `npm run pack` on macOS
- [x] Open Settings → Hotkey
- [x] Press `Control+Space` → should display `Ctrl+Space`
- [x] Verify the hotkey triggers dictation correctly

Partially addresses #167

🤖 Generated with [Claude Code](https://claude.ai/code)