### PR TITLE
feat(linux): fix overlay window visibility on KDE Plasma Wayland

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
 - **parakeetServer.js**: sherpa-onnx CLI wrapper for transcription
 - **windowConfig.js**: Centralized window configuration
 - **windowManager.js**: Window creation and lifecycle management
+- **kdeIntegration.js**: KDE Plasma Wayland integration
+  - Configures overlay window via KWin scripting D-Bus API
+  - Sets `onAllDesktops`, `skipSwitcher`, `skipTaskbar`, `skipPager`
+  - Required because Electron's `setVisibleOnAllWorkspaces()` doesn't work on KDE Wayland
+  - Auto-detects KDE environment and applies configuration after window creation
 
 ### React Components (src/components/)
 
@@ -499,6 +504,12 @@ On GNOME Wayland, Electron's `globalShortcut` API doesn't work due to Wayland's 
   - Push-to-talk unavailable (GNOME shortcuts only fire single toggle event)
   - Falls back to X11/globalShortcut if GNOME integration fails
   - `dbus-next` npm package used for D-Bus communication
+- **KDE Plasma Wayland overlay window**:
+  - Electron's `setVisibleOnAllWorkspaces()` doesn't work on KDE Wayland
+  - Uses KWin scripting via D-Bus to configure the overlay window at runtime
+  - Sets `onAllDesktops`, `skipSwitcher`, `skipTaskbar`, `skipPager` via KWin script
+  - Window type set to `toolbar` to hide from Alt+Tab on most Linux compositors
+  - Auto-detects KDE environment; no user action required
 
 ## Code Style and Conventions
 

--- a/src/helpers/kdeIntegration.js
+++ b/src/helpers/kdeIntegration.js
@@ -1,0 +1,214 @@
+/**
+ * KDE Plasma Integration for OpenWhispr
+ *
+ * Handles KDE-specific window management on Wayland, where Electron's
+ * setVisibleOnAllWorkspaces() doesn't work properly.
+ *
+ * Known issue documented by other Electron applications:
+ * - CherryHQ/cherry-studio: "setVisibleOnAllWorkspaces in Linux environments
+ *   (especially KDE Wayland) can cause windows to go into a 'false popup' state"
+ *   https://github.com/CherryHQ/cherry-studio/blob/main/src/main/services/WindowService.ts
+ * - Hiram-Wong/ZyPlayer: Same workaround, explicitly skips the call on Linux
+ *   https://github.com/Hiram-Wong/ZyPlayer/blob/main/src/main/services/WindowService.ts
+ *
+ * Uses KWin's D-Bus scripting interface to:
+ * - Make the overlay window visible on all virtual desktops
+ * - Hide the overlay from the window switcher (Alt+Tab)
+ * - Hide from pager and taskbar
+ */
+
+const { exec } = require("child_process");
+const debugLogger = require("./debugLogger");
+
+class KDEIntegration {
+  constructor() {
+    this.isKDE = false;
+    this.isWayland = false;
+    this.initialized = false;
+  }
+
+  /**
+   * Detect if running on KDE Plasma
+   */
+  detectKDE() {
+    const desktop = process.env.XDG_CURRENT_DESKTOP || "";
+    const session = process.env.DESKTOP_SESSION || "";
+    const kdeSession = process.env.KDE_FULL_SESSION || "";
+
+    this.isKDE =
+      desktop.toLowerCase().includes("kde") ||
+      session.toLowerCase().includes("plasma") ||
+      session.toLowerCase().includes("kde") ||
+      kdeSession === "true";
+
+    this.isWayland = process.env.XDG_SESSION_TYPE === "wayland";
+
+    debugLogger.debug("[KDEIntegration] Environment detection", {
+      isKDE: this.isKDE,
+      isWayland: this.isWayland,
+      desktop,
+      session,
+    });
+
+    return this.isKDE;
+  }
+
+  /**
+   * Check if KWin scripting is available via D-Bus
+   */
+  async isKWinAvailable() {
+    return new Promise((resolve) => {
+      // Try qdbus6 first (Plasma 6), then qdbus (Plasma 5)
+      exec(
+        "qdbus6 org.kde.KWin /KWin 2>/dev/null || qdbus org.kde.KWin /KWin 2>/dev/null",
+        (error) => {
+          resolve(!error);
+        }
+      );
+    });
+  }
+
+  /**
+   * Execute a KWin script via D-Bus to configure the overlay window
+   *
+   * The script finds windows matching the app's title/class and sets:
+   * - onAllDesktops = true (visible on all virtual desktops)
+   * - skipSwitcher = true (hidden from Alt+Tab)
+   * - skipTaskbar = true (hidden from taskbar)
+   * - skipPager = true (hidden from pager)
+   */
+  async configureOverlayWindow() {
+    if (process.platform !== "linux") {
+      return { success: false, reason: "not_linux" };
+    }
+
+    if (!this.initialized) {
+      this.detectKDE();
+      this.initialized = true;
+    }
+
+    if (!this.isKDE) {
+      debugLogger.debug("[KDEIntegration] Not running on KDE, skipping");
+      return { success: false, reason: "not_kde" };
+    }
+
+    const kwinAvailable = await this.isKWinAvailable();
+    if (!kwinAvailable) {
+      debugLogger.debug("[KDEIntegration] KWin D-Bus not available");
+      return { success: false, reason: "kwin_unavailable" };
+    }
+
+    // KWin script to configure the overlay window
+    // Matches by window title "Voice Recorder" or resource class containing "openwhispr"
+    const kwinScript = `
+      (function() {
+        function configureWindow(window) {
+          if (!window) return;
+          var caption = window.caption || "";
+          var resourceClass = (window.resourceClass || "").toLowerCase();
+          var resourceName = (window.resourceName || "").toLowerCase();
+          
+          // Match the dictation overlay window
+          if (caption === "Voice Recorder" || 
+              resourceClass.indexOf("openwhispr") !== -1 ||
+              resourceName.indexOf("openwhispr") !== -1) {
+            window.onAllDesktops = true;
+            window.skipSwitcher = true;
+            window.skipTaskbar = true;
+            window.skipPager = true;
+          }
+        }
+        
+        // Configure existing windows
+        var windows = workspace.windowList();
+        for (var i = 0; i < windows.length; i++) {
+          configureWindow(windows[i]);
+        }
+        
+        // Also configure any new windows that match (for hot-reload during development)
+        workspace.windowAdded.connect(configureWindow);
+      })();
+    `;
+
+    return new Promise((resolve) => {
+      // Write script to a temp file and load it via qdbus
+      const fs = require("fs");
+      const path = require("path");
+      const os = require("os");
+
+      const scriptPath = path.join(os.tmpdir(), `openwhispr-kwin-${Date.now()}.js`);
+
+      fs.writeFile(scriptPath, kwinScript, (writeErr) => {
+        if (writeErr) {
+          debugLogger.warn("[KDEIntegration] Failed to write KWin script", {
+            error: writeErr.message,
+          });
+          resolve({ success: false, reason: "write_error", error: writeErr.message });
+          return;
+        }
+
+        // Try qdbus6 first (Plasma 6), then qdbus (Plasma 5)
+        const loadCmd = `(qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "${scriptPath}" 2>/dev/null || qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "${scriptPath}" 2>/dev/null)`;
+
+        exec(loadCmd, (loadErr, stdout) => {
+          if (loadErr) {
+            debugLogger.warn("[KDEIntegration] Failed to load KWin script", {
+              error: loadErr.message,
+            });
+            // Clean up temp file
+            fs.unlink(scriptPath, () => {});
+            resolve({ success: false, reason: "load_error", error: loadErr.message });
+            return;
+          }
+
+          const scriptId = stdout.trim();
+          debugLogger.debug("[KDEIntegration] KWin script loaded", { scriptId });
+
+          // Run the script
+          const runCmd = `(qdbus6 org.kde.KWin /Scripting/Script${scriptId} org.kde.kwin.Script.run 2>/dev/null || qdbus org.kde.KWin /Scripting/Script${scriptId} org.kde.kwin.Script.run 2>/dev/null)`;
+
+          exec(runCmd, (runErr) => {
+            // Clean up temp file regardless of result
+            fs.unlink(scriptPath, () => {});
+
+            if (runErr) {
+              debugLogger.warn("[KDEIntegration] Failed to run KWin script", {
+                error: runErr.message,
+              });
+              resolve({ success: false, reason: "run_error", error: runErr.message });
+              return;
+            }
+
+            debugLogger.log(
+              "[KDEIntegration] Successfully configured overlay window via KWin script"
+            );
+            resolve({ success: true });
+          });
+        });
+      });
+    });
+  }
+
+  /**
+   * Apply window configuration with retry logic
+   * Waits a bit after window creation for KWin to register the window
+   */
+  async configureOverlayWindowWithRetry(retries = 3, delayMs = 500) {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      debugLogger.debug("[KDEIntegration] Configuration attempt", { attempt, retries });
+
+      const result = await this.configureOverlayWindow();
+      if (result.success) {
+        return result;
+      }
+
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+
+    return { success: false, reason: "max_retries_exceeded" };
+  }
+}
+
+module.exports = KDEIntegration;

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -22,7 +22,10 @@ const MAIN_WINDOW_CONFIG = {
   fullScreenable: false,
   hasShadow: false, // Remove shadow for cleaner look
   acceptsFirstMouse: true, // Accept clicks even when not focused
-  type: process.platform === "darwin" ? "panel" : "normal", // Panel on macOS preserves floating behavior
+  // Panel on macOS preserves floating behavior
+  // Toolbar on Linux hides from Alt+Tab on most compositors (GNOME, KDE, etc.)
+  type:
+    process.platform === "darwin" ? "panel" : process.platform === "linux" ? "toolbar" : "normal",
 };
 
 // Control panel window configuration
@@ -88,6 +91,9 @@ class WindowPositionUtil {
     } else {
       // Linux and other platforms
       window.setAlwaysOnTop(true, "screen-saver");
+      // Attempt to set visible on all workspaces (works on X11, may not work on Wayland)
+      // For KDE Wayland, a separate KWin script integration is used (see kdeIntegration.js)
+      window.setVisibleOnAllWorkspaces(true);
     }
 
     // Bring window to front if visible


### PR DESCRIPTION
Note: Written by Opus. Tested to work on KDE. Not tested for regressions in other environments.

## Summary

- Fix overlay window appearing in Alt+Tab on Linux by using `toolbar` window type
- Fix overlay window not showing on all virtual desktops on KDE Wayland via KWin scripting
- Add runtime KWin D-Bus integration to configure overlay window properties

## Problem

On KDE Plasma Wayland, the dictation overlay window had two issues:

1. **Appeared in Alt+Tab switcher** - The overlay window would show up when users pressed Alt+Tab, which is undesirable for a small utility overlay
2. **Only visible on one workspace** - Electron's `setVisibleOnAllWorkspaces()` API doesn't work properly on KDE Wayland, causing the overlay to disappear when switching virtual desktops

These are known issues documented by other Electron applications:

- [CherryHQ/cherry-studio](https://github.com/CherryHQ/cherry-studio/blob/main/src/main/services/WindowService.ts) - Documents that `setVisibleOnAllWorkspaces` on Linux (especially KDE Wayland) causes windows to go into a "false popup" state
- [Hiram-Wong/ZyPlayer](https://github.com/Hiram-Wong/ZyPlayer/blob/main/src/main/services/WindowService.ts) - Uses the same workaround, explicitly skipping the call on Linux

## Solution

### 1. Window Type Change

Changed the window type from `normal` to `toolbar` for Linux. Toolbar-type windows are excluded from Alt+Tab on most Linux compositors (GNOME, KDE, Sway, etc.).

```javascript
// Before
type: process.platform === "darwin" ? "panel" : "normal";

// After
type: process.platform === "darwin" ? "panel" : process.platform === "linux" ? "toolbar" : "normal";
```

### 2. KWin Scripting Integration

Created a new `kdeIntegration.js` helper that uses KWin's D-Bus scripting API to configure the overlay window at runtime:

- Auto-detects KDE Plasma environment via `XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`, and `KDE_FULL_SESSION`
- Writes a temporary KWin script that finds windows matching "Voice Recorder" or "openwhispr"
- Sets the following properties via KWin API:
  - `onAllDesktops = true` - Visible on all virtual desktops
  - `skipSwitcher = true` - Hidden from Alt+Tab
  - `skipTaskbar = true` - Hidden from taskbar
  - `skipPager = true` - Hidden from desktop pager
- Supports both Plasma 5 (`qdbus`) and Plasma 6 (`qdbus6`)
- Includes retry logic (3 attempts with 500ms delay) to handle window registration timing

### 3. Standard Linux Fallback

Also added `window.setVisibleOnAllWorkspaces(true)` in the Linux branch of `setupAlwaysOnTop()` for X11 and other Wayland compositors where the Electron API does work.

## Files Changed

| File                            | Change                                                                             |
| ------------------------------- | ---------------------------------------------------------------------------------- |
| `src/helpers/windowConfig.js`   | Changed window type to `toolbar` for Linux; added `setVisibleOnAllWorkspaces` call |
| `src/helpers/kdeIntegration.js` | New file - KDE Plasma Wayland integration via KWin D-Bus scripting                 |
| `main.js`                       | Import and initialize KDE integration after window creation                        |
| `CLAUDE.md`                     | Added documentation for KDE integration                                            |

## Testing

To test on KDE Plasma Wayland:

1. Run the app
2. Verify the overlay window:
   - Does NOT appear in Alt+Tab or taskbar ✅
   - Appears on all virtual desktops when switching ✅
   - Stays always-on-top ✅

To verify KWin script execution, run with debug logging:

```bash
OPENWHISPR_LOG_LEVEL=debug ./openwhispr
```

Look for `[KDEIntegration]` log entries showing successful script execution.

## Notes

- The KDE integration is non-blocking and fails gracefully - if KWin is unavailable or the script fails, the app continues to work normally
- On non-KDE Linux environments (GNOME, Sway, etc.), the `toolbar` window type alone should handle Alt+Tab hiding
- No user action required - KDE detection and configuration is automatic
