### PR TITLE
Fix README instructions - tried running locally for the first time and ran into these issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
    
    **Method A - Environment file**:
    ```bash
-   cp env.example .env
+   cp .env.example .env
    # Edit .env and add your API keys:
    # OPENAI_API_KEY=your_openai_key
    # ANTHROPIC_API_KEY=your_anthropic_key
@@ -81,14 +81,19 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
    - Run the app and configure API keys through the Control Panel
    - Keys are automatically saved and persist across app restarts
 
-4. **Run the application**:
+4. **Build the application**:
+   ```bash
+   npm run build
+   ```
+
+5. **Run the application**:
    ```bash
    npm run dev  # Development mode with hot reload
    # OR
    npm start    # Production mode
    ```
 
-5. **Optional: Local Whisper from source** (only needed if you want local processing):
+6. **Optional: Local Whisper from source** (only needed if you want local processing):
    ```bash
    npm run download:whisper-cpp
    ```


### PR DESCRIPTION
1. wrong path of example env file. 
2. missing build command, leading to start error (Failed to start app: Error: HTML file not found: /Users/shaynehmad/Desktop/code/openwhispr/src/dist/index.html). Works when running dev without building, but not when running `npm start`. Since both do both anyway, better to add the build command first.

Before:

<img width="1259" height="287" alt="image" src="https://github.com/user-attachments/assets/7379a759-d551-46ab-a980-a29e0503490a" />

After:

works

<img width="1312" height="912" alt="image" src="https://github.com/user-attachments/assets/1e519098-d25f-4111-9406-9eed89eeabfa" />
