### PR TITLE
docs: fix env example filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
    
    **Method A - Environment file**:
    ```bash
-   cp env.example .env
+   cp .env.example .env
    # Edit .env and add your API keys:
    # OPENAI_API_KEY=your_openai_key
    # ANTHROPIC_API_KEY=your_anthropic_key


### PR DESCRIPTION
## Summary
- fix README setup command from `cp env.example .env` to `cp .env.example .env`
- aligns docs with the actual example env filename used in the repo

Closes #215
