### PR TITLE
feat: add real-time streaming transcription with live overlay

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -268,6 +268,31 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onAssemblyAiError: registerListener("assemblyai-error", (callback) => (_event, error) => callback(error)),
   onAssemblyAiSessionEnd: registerListener("assemblyai-session-end", (callback) => (_event, data) => callback(data)),
 
+  // Deepgram Streaming
+  getDeepgramKey: () => ipcRenderer.invoke("get-deepgram-key"),
+  saveDeepgramKey: (key) => ipcRenderer.invoke("save-deepgram-key", key),
+  deepgramStreamingStart: (options) => ipcRenderer.invoke("deepgram-streaming-start", options),
+  deepgramStreamingSend: (audioBuffer) => ipcRenderer.send("deepgram-streaming-send", audioBuffer),
+  deepgramStreamingStop: () => ipcRenderer.invoke("deepgram-streaming-stop"),
+  onDeepgramPartialTranscript: registerListener("deepgram-partial-transcript", (callback) => (_event, text) => callback(text)),
+  onDeepgramFinalTranscript: registerListener("deepgram-final-transcript", (callback) => (_event, text) => callback(text)),
+  onDeepgramError: registerListener("deepgram-error", (callback) => (_event, error) => callback(error)),
+
+  // Parakeet Chunked Streaming
+  parakeetStreamingStart: () => ipcRenderer.invoke("parakeet-streaming-start"),
+  parakeetStreamingSend: (audioBuffer) => ipcRenderer.send("parakeet-streaming-send", audioBuffer),
+  parakeetStreamingStop: () => ipcRenderer.invoke("parakeet-streaming-stop"),
+  onParakeetPartialTranscript: registerListener("parakeet-partial-transcript", (callback) => (_event, text) => callback(text)),
+  onParakeetError: registerListener("parakeet-error", (callback) => (_event, error) => callback(error)),
+
+  // OpenAI Realtime Streaming
+  openaiRealtimeStreamingStart: (options) => ipcRenderer.invoke("openai-realtime-streaming-start", options),
+  openaiRealtimeStreamingSend: (audioBuffer) => ipcRenderer.send("openai-realtime-streaming-send", audioBuffer),
+  openaiRealtimeStreamingStop: () => ipcRenderer.invoke("openai-realtime-streaming-stop"),
+  onOpenaiRealtimePartialTranscript: registerListener("openai-realtime-partial-transcript", (callback) => (_event, text) => callback(text)),
+  onOpenaiRealtimeFinalTranscript: registerListener("openai-realtime-final-transcript", (callback) => (_event, text) => callback(text)),
+  onOpenaiRealtimeError: registerListener("openai-realtime-error", (callback) => (_event, error) => callback(error)),
+
   // Usage limit events (for showing UpgradePrompt in ControlPanel)
   notifyLimitReached: (data) => ipcRenderer.send("limit-reached", data),
   onLimitReached: registerListener("limit-reached", (callback) => (_event, data) => callback(data)),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -128,6 +128,24 @@ export default function App() {
     }
   }, [isCommandMenuOpen, isHovered, toastCount, setWindowInteractivity]);
 
+  const handleDictationToggle = React.useCallback(() => {
+    setIsCommandMenuOpen(false);
+    setWindowInteractivity(false);
+  }, [setWindowInteractivity]);
+
+  const {
+    isRecording,
+    isProcessing,
+    isStreaming,
+    partialTranscript,
+    toggleListening,
+    cancelRecording,
+    cancelProcessing,
+    warmupStreaming,
+  } = useAudioRecording(toast, {
+    onToggle: handleDictationToggle,
+  });
+
   const showTranscript = isStreaming && !!partialTranscript;
 
   useEffect(() => {
@@ -146,24 +164,6 @@ export default function App() {
     };
     resizeWindow();
   }, [showTranscript, isCommandMenuOpen, toastCount]);
-
-  const handleDictationToggle = React.useCallback(() => {
-    setIsCommandMenuOpen(false);
-    setWindowInteractivity(false);
-  }, [setWindowInteractivity]);
-
-  const {
-    isRecording,
-    isProcessing,
-    isStreaming,
-    partialTranscript,
-    toggleListening,
-    cancelRecording,
-    cancelProcessing,
-    warmupStreaming,
-  } = useAudioRecording(toast, {
-    onToggle: handleDictationToggle,
-  });
 
   // Trigger streaming warmup when user signs in (covers first-time account creation)
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { useHotkey } from "./hooks/useHotkey";
 import { useWindowDrag } from "./hooks/useWindowDrag";
 import { useAudioRecording } from "./hooks/useAudioRecording";
 import { useAuth } from "./hooks/useAuth";
+import { LiveTranscriptOverlay } from "./components/ui/LiveTranscriptOverlay";
 
 // Sound Wave Icon Component (for idle/hover states)
 const SoundWaveIcon = ({ size = 16 }) => {
@@ -127,9 +128,13 @@ export default function App() {
     }
   }, [isCommandMenuOpen, isHovered, toastCount, setWindowInteractivity]);
 
+  const showTranscript = isStreaming && !!partialTranscript;
+
   useEffect(() => {
     const resizeWindow = () => {
-      if (isCommandMenuOpen && toastCount > 0) {
+      if (showTranscript) {
+        window.electronAPI?.resizeMainWindow?.("WITH_TRANSCRIPT");
+      } else if (isCommandMenuOpen && toastCount > 0) {
         window.electronAPI?.resizeMainWindow?.("EXPANDED");
       } else if (isCommandMenuOpen) {
         window.electronAPI?.resizeMainWindow?.("WITH_MENU");
@@ -140,7 +145,7 @@ export default function App() {
       }
     };
     resizeWindow();
-  }, [isCommandMenuOpen, toastCount]);
+  }, [showTranscript, isCommandMenuOpen, toastCount]);
 
   const handleDictationToggle = React.useCallback(() => {
     setIsCommandMenuOpen(false);
@@ -150,6 +155,8 @@ export default function App() {
   const {
     isRecording,
     isProcessing,
+    isStreaming,
+    partialTranscript,
     toggleListening,
     cancelRecording,
     cancelProcessing,
@@ -288,6 +295,10 @@ export default function App() {
             }
           }}
         >
+          <LiveTranscriptOverlay
+            text={partialTranscript}
+            isVisible={showTranscript}
+          />
           {(isRecording || isProcessing) && isHovered && (
             <button
               aria-label={isRecording ? "Cancel recording" : "Cancel processing"}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -652,6 +652,10 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setCloudBackupEnabled,
     telemetryEnabled,
     setTelemetryEnabled,
+    streamingProvider,
+    setStreamingProvider,
+    deepgramApiKey,
+    setDeepgramApiKey,
   } = useSettings();
 
   const { toast } = useToast();
@@ -1557,35 +1561,102 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
 
       case "transcription":
         return (
-          <TranscriptionSection
-            isSignedIn={isSignedIn ?? false}
-            cloudTranscriptionMode={cloudTranscriptionMode}
-            setCloudTranscriptionMode={setCloudTranscriptionMode}
-            useLocalWhisper={useLocalWhisper}
-            setUseLocalWhisper={setUseLocalWhisper}
-            updateTranscriptionSettings={updateTranscriptionSettings}
-            cloudTranscriptionProvider={cloudTranscriptionProvider}
-            setCloudTranscriptionProvider={setCloudTranscriptionProvider}
-            cloudTranscriptionModel={cloudTranscriptionModel}
-            setCloudTranscriptionModel={setCloudTranscriptionModel}
-            localTranscriptionProvider={localTranscriptionProvider}
-            setLocalTranscriptionProvider={setLocalTranscriptionProvider}
-            whisperModel={whisperModel}
-            setWhisperModel={setWhisperModel}
-            parakeetModel={parakeetModel}
-            setParakeetModel={setParakeetModel}
-            openaiApiKey={openaiApiKey}
-            setOpenaiApiKey={setOpenaiApiKey}
-            groqApiKey={groqApiKey}
-            setGroqApiKey={setGroqApiKey}
-            mistralApiKey={mistralApiKey}
-            setMistralApiKey={setMistralApiKey}
-            customTranscriptionApiKey={customTranscriptionApiKey}
-            setCustomTranscriptionApiKey={setCustomTranscriptionApiKey}
-            cloudTranscriptionBaseUrl={cloudTranscriptionBaseUrl}
-            setCloudTranscriptionBaseUrl={setCloudTranscriptionBaseUrl}
-            toast={toast}
-          />
+          <>
+            <TranscriptionSection
+              isSignedIn={isSignedIn ?? false}
+              cloudTranscriptionMode={cloudTranscriptionMode}
+              setCloudTranscriptionMode={setCloudTranscriptionMode}
+              useLocalWhisper={useLocalWhisper}
+              setUseLocalWhisper={setUseLocalWhisper}
+              updateTranscriptionSettings={updateTranscriptionSettings}
+              cloudTranscriptionProvider={cloudTranscriptionProvider}
+              setCloudTranscriptionProvider={setCloudTranscriptionProvider}
+              cloudTranscriptionModel={cloudTranscriptionModel}
+              setCloudTranscriptionModel={setCloudTranscriptionModel}
+              localTranscriptionProvider={localTranscriptionProvider}
+              setLocalTranscriptionProvider={setLocalTranscriptionProvider}
+              whisperModel={whisperModel}
+              setWhisperModel={setWhisperModel}
+              parakeetModel={parakeetModel}
+              setParakeetModel={setParakeetModel}
+              openaiApiKey={openaiApiKey}
+              setOpenaiApiKey={setOpenaiApiKey}
+              groqApiKey={groqApiKey}
+              setGroqApiKey={setGroqApiKey}
+              mistralApiKey={mistralApiKey}
+              setMistralApiKey={setMistralApiKey}
+              customTranscriptionApiKey={customTranscriptionApiKey}
+              setCustomTranscriptionApiKey={setCustomTranscriptionApiKey}
+              cloudTranscriptionBaseUrl={cloudTranscriptionBaseUrl}
+              setCloudTranscriptionBaseUrl={setCloudTranscriptionBaseUrl}
+              toast={toast}
+            />
+
+            {/* Live Transcription */}
+            <div className="mt-6 space-y-4">
+              <SectionHeader
+                title="Live Transcription"
+                description="Show real-time transcription text while recording. Text appears beside the microphone icon."
+              />
+              <SettingsPanel>
+                <SettingsPanelRow>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-[12px] font-medium text-foreground">Streaming Provider</div>
+                      <div className="text-[11px] text-muted-foreground mt-0.5">
+                        Choose which service provides live transcription
+                      </div>
+                    </div>
+                    <select
+                      value={streamingProvider}
+                      onChange={(e) => setStreamingProvider(e.target.value)}
+                      className="text-[12px] bg-background border border-border rounded-md px-2 py-1.5 text-foreground"
+                    >
+                      <option value="auto">Auto (OpenWhispr Cloud)</option>
+                      <option value="deepgram">Deepgram Nova-3</option>
+                      <option value="parakeet">Local (Parakeet)</option>
+                      <option value="openai-realtime">OpenAI Realtime</option>
+                      <option value="off">Disabled</option>
+                    </select>
+                  </div>
+                </SettingsPanelRow>
+
+                {streamingProvider === "deepgram" && (
+                  <SettingsPanelRow>
+                    <div className="space-y-2">
+                      <div className="text-[12px] font-medium text-foreground">Deepgram API Key</div>
+                      <Input
+                        type="password"
+                        placeholder="Enter your Deepgram API key"
+                        value={deepgramApiKey}
+                        onChange={(e) => setDeepgramApiKey(e.target.value)}
+                        className="text-[12px] h-8"
+                      />
+                      <p className="text-[10px] text-muted-foreground">
+                        Get your key at deepgram.com/dashboard. Nova-3 costs ~$0.0043/min.
+                      </p>
+                    </div>
+                  </SettingsPanelRow>
+                )}
+
+                {streamingProvider === "parakeet" && !useLocalWhisper && (
+                  <SettingsPanelRow>
+                    <p className="text-[11px] text-amber-500">
+                      Parakeet streaming requires local transcription mode to be enabled.
+                    </p>
+                  </SettingsPanelRow>
+                )}
+
+                {streamingProvider === "openai-realtime" && !openaiApiKey && (
+                  <SettingsPanelRow>
+                    <p className="text-[11px] text-amber-500">
+                      OpenAI Realtime requires an OpenAI API key (set above in Custom Setup).
+                    </p>
+                  </SettingsPanelRow>
+                )}
+              </SettingsPanel>
+            </div>
+          </>
         );
 
       case "dictionary":

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -412,6 +412,13 @@ function AiModelsSection({
   const isCustomMode = cloudReasoningMode === "byok";
   const isCloudMode = isSignedIn && cloudReasoningMode === "openwhispr";
 
+  // Auto-switch to BYOK when not signed in but mode is set to cloud
+  useEffect(() => {
+    if (!isSignedIn && cloudReasoningMode === "openwhispr") {
+      setCloudReasoningMode("byok");
+    }
+  }, [isSignedIn, cloudReasoningMode, setCloudReasoningMode]);
+
   return (
     <div className="space-y-4">
       <SectionHeader

--- a/src/components/ui/LiveTranscriptOverlay.tsx
+++ b/src/components/ui/LiveTranscriptOverlay.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+
+interface LiveTranscriptOverlayProps {
+  text: string;
+  isVisible: boolean;
+}
+
+export function LiveTranscriptOverlay({ text, isVisible }: LiveTranscriptOverlayProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [text]);
+
+  if (!isVisible || !text) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="max-w-[400px] max-h-[120px] overflow-y-auto px-3 py-2 text-sm text-white/90 bg-black/60 backdrop-blur-sm rounded-lg pointer-events-none select-none"
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1716,96 +1716,126 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     };
   }
 
-  shouldUseStreaming() {
+  /**
+   * Determine which streaming provider to use, or null if streaming is disabled.
+   * @returns {string|null} Provider name ("assemblyai", "deepgram", "parakeet", "openai-realtime") or null
+   */
+  getStreamingProvider() {
+    const streamingDisabled = localStorage.getItem("assemblyAiStreaming") === "false";
+    if (streamingDisabled) return null;
+
+    const provider = localStorage.getItem("streamingProvider") || "auto";
+    if (provider === "off") return null;
+
     const cloudTranscriptionMode = localStorage.getItem("cloudTranscriptionMode") || "openwhispr";
     const isSignedIn = localStorage.getItem("isSignedIn") === "true";
     const useLocalWhisper = localStorage.getItem("useLocalWhisper") === "true";
-    const streamingDisabled = localStorage.getItem("assemblyAiStreaming") === "false";
 
-    return (
-      !useLocalWhisper &&
-      cloudTranscriptionMode === "openwhispr" &&
-      isSignedIn &&
-      !streamingDisabled
-    );
+    if (provider === "deepgram") {
+      // Deepgram works regardless of cloud/local mode — just needs an API key
+      return "deepgram";
+    }
+
+    if (provider === "openai-realtime") {
+      return "openai-realtime";
+    }
+
+    if (provider === "parakeet") {
+      return useLocalWhisper ? "parakeet" : null;
+    }
+
+    // "auto" or "assemblyai" — use AssemblyAI if conditions are met
+    if (!useLocalWhisper && cloudTranscriptionMode === "openwhispr" && isSignedIn) {
+      return "assemblyai";
+    }
+
+    return null;
+  }
+
+  shouldUseStreaming() {
+    return this.getStreamingProvider() !== null;
   }
 
   async warmupStreamingConnection() {
-    if (!this.shouldUseStreaming()) {
+    const provider = this.getStreamingProvider();
+    if (!provider) {
       logger.debug("Streaming warmup skipped - not in streaming mode", {}, "streaming");
       return false;
     }
 
     try {
-      const [, wsResult] = await Promise.all([
-        this.cacheMicrophoneDeviceId(),
-        withSessionRefresh(async () => {
+      // Cache mic device ID for all providers
+      await this.cacheMicrophoneDeviceId();
+
+      // AssemblyAI-specific WebSocket warmup
+      let wsResult = { success: true };
+      if (provider === "assemblyai") {
+        wsResult = await withSessionRefresh(async () => {
           const res = await window.electronAPI.assemblyAiStreamingWarmup({
             sampleRate: 16000,
             language: getBaseLanguageCode(localStorage.getItem("preferredLanguage")),
             keyterms: this.getKeyterms(),
           });
-          // Throw error to trigger retry if AUTH_EXPIRED
           if (!res.success && res.code) {
             const err = new Error(res.error || "Warmup failed");
             err.code = res.code;
             throw err;
           }
           return res;
-        }),
-      ]);
+        });
 
-      if (wsResult.success) {
-        // Pre-load AudioWorklet module so first recording is faster
-        try {
-          const audioContext = await this.getOrCreateAudioContext();
-          if (!this.workletModuleLoaded) {
-            await audioContext.audioWorklet.addModule(this.getWorkletBlobUrl());
-            this.workletModuleLoaded = true;
-            logger.debug("AudioWorklet module pre-loaded during warmup", {}, "streaming");
+        if (!wsResult.success) {
+          if (wsResult.code === "NO_API") {
+            logger.debug("Streaming warmup skipped - API not configured", {}, "streaming");
+            return false;
           }
+          logger.warn("AssemblyAI warmup failed", { error: wsResult.error }, "streaming");
+          return false;
+        }
+      }
+
+      // Pre-load AudioWorklet module so first recording is faster (all providers)
+      try {
+        const audioContext = await this.getOrCreateAudioContext();
+        if (!this.workletModuleLoaded) {
+          const workletUrl = new URL("./pcm-streaming-processor.js", document.baseURI).href;
+          await audioContext.audioWorklet.addModule(workletUrl);
+          this.workletModuleLoaded = true;
+          logger.debug("AudioWorklet module pre-loaded during warmup", {}, "streaming");
+        }
+      } catch (e) {
+        logger.debug(
+          "AudioWorklet pre-load failed (will retry on recording)",
+          { error: e.message },
+          "streaming"
+        );
+      }
+
+      // Warm up the OS audio driver by briefly acquiring the mic, then releasing.
+      if (!this.micDriverWarmedUp) {
+        try {
+          const constraints = await this.getAudioConstraints();
+          const tempStream = await navigator.mediaDevices.getUserMedia(constraints);
+          tempStream.getTracks().forEach((track) => track.stop());
+          this.micDriverWarmedUp = true;
+          logger.debug("Microphone driver pre-warmed", {}, "streaming");
         } catch (e) {
           logger.debug(
-            "AudioWorklet pre-load failed (will retry on recording)",
+            "Mic driver warmup failed (non-critical)",
             { error: e.message },
             "streaming"
           );
         }
-
-        // Warm up the OS audio driver by briefly acquiring the mic, then releasing.
-        // This forces macOS to initialize the audio subsystem so subsequent
-        // getUserMedia calls resolve in ~100-200ms instead of ~500-1000ms.
-        if (!this.micDriverWarmedUp) {
-          try {
-            const constraints = await this.getAudioConstraints();
-            const tempStream = await navigator.mediaDevices.getUserMedia(constraints);
-            tempStream.getTracks().forEach((track) => track.stop());
-            this.micDriverWarmedUp = true;
-            logger.debug("Microphone driver pre-warmed", {}, "streaming");
-          } catch (e) {
-            logger.debug(
-              "Mic driver warmup failed (non-critical)",
-              { error: e.message },
-              "streaming"
-            );
-          }
-        }
-
-        logger.info(
-          "AssemblyAI streaming connection warmed up",
-          { alreadyWarm: wsResult.alreadyWarm, micCached: !!this.cachedMicDeviceId },
-          "streaming"
-        );
-        return true;
-      } else if (wsResult.code === "NO_API") {
-        logger.debug("Streaming warmup skipped - API not configured", {}, "streaming");
-        return false;
-      } else {
-        logger.warn("AssemblyAI warmup failed", { error: wsResult.error }, "streaming");
-        return false;
       }
+
+      logger.info(
+        "Streaming connection warmed up",
+        { provider, alreadyWarm: wsResult.alreadyWarm, micCached: !!this.cachedMicDeviceId },
+        "streaming"
+      );
+      return true;
     } catch (error) {
-      logger.error("AssemblyAI warmup error", { error: error.message }, "streaming");
+      logger.error("Streaming warmup error", { provider, error: error.message }, "streaming");
       return false;
     }
   }
@@ -1828,6 +1858,49 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         return false;
       }
 
+      const provider = this.getStreamingProvider();
+
+      // Dispatch to provider-specific start methods
+      if (provider === "deepgram") {
+        return await this._startDeepgramStreaming();
+      }
+      if (provider === "openai-realtime") {
+        return await this._startOpenAIRealtimeStreaming();
+      }
+      if (provider === "parakeet") {
+        return await this._startParakeetStreaming();
+      }
+
+      // Default: AssemblyAI
+      return await this._startAssemblyAiStreaming();
+    } catch (error) {
+      logger.error("Failed to start streaming recording", { error: error.message }, "streaming");
+
+      let errorTitle = "Streaming Error";
+      let errorDescription = `Failed to start streaming: ${error.message}`;
+
+      if (error.name === "NotAllowedError" || error.name === "PermissionDeniedError") {
+        errorTitle = "Microphone Access Denied";
+        errorDescription =
+          "Please grant microphone permission in your system settings and try again.";
+      } else if (error.code === "AUTH_EXPIRED" || error.code === "AUTH_REQUIRED") {
+        errorTitle = "Sign-in Required";
+        errorDescription =
+          "Your OpenWhispr Cloud session is unavailable. Please sign in again from Settings.";
+      }
+
+      this.onError?.({
+        title: errorTitle,
+        description: errorDescription,
+      });
+
+      await this.cleanupStreaming();
+      return false;
+    }
+  }
+
+  async _startAssemblyAiStreaming() {
+    try {
       const t0 = performance.now();
       const constraints = await this.getAudioConstraints();
       const tConstraints = performance.now();
@@ -1919,6 +1992,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.isStreaming = true;
       this.isRecording = true;
       this.recordingStartTime = Date.now();
+      this.streamingProvider = "assemblyai";
       this.onStateChange?.({ isRecording: true, isProcessing: false, isStreaming: true });
 
       this.streamingFinalText = "";
@@ -1966,29 +2040,241 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       return true;
     } catch (error) {
-      logger.error("Failed to start streaming recording", { error: error.message }, "streaming");
-
-      let errorTitle = "Streaming Error";
-      let errorDescription = `Failed to start streaming: ${error.message}`;
-
-      if (error.name === "NotAllowedError" || error.name === "PermissionDeniedError") {
-        errorTitle = "Microphone Access Denied";
-        errorDescription =
-          "Please grant microphone permission in your system settings and try again.";
-      } else if (error.code === "AUTH_EXPIRED" || error.code === "AUTH_REQUIRED") {
-        errorTitle = "Sign-in Required";
-        errorDescription =
-          "Your OpenWhispr Cloud session is unavailable. Please sign in again from Settings.";
-      }
-
-      this.onError?.({
-        title: errorTitle,
-        description: errorDescription,
-      });
-
-      await this.cleanupStreaming();
-      return false;
+      // Re-throw — handled by startStreamingRecording()
+      throw error;
     }
+  }
+
+  async _startDeepgramStreaming() {
+    const t0 = performance.now();
+    const constraints = await this.getAudioConstraints();
+
+    const [stream, result] = await Promise.all([
+      navigator.mediaDevices.getUserMedia(constraints),
+      window.electronAPI.deepgramStreamingStart({
+        sampleRate: 16000,
+        language: getBaseLanguageCode(localStorage.getItem("preferredLanguage")),
+      }),
+    ]);
+
+    if (!result.success) {
+      stream.getTracks().forEach((track) => track.stop());
+      if (result.code === "NO_API") {
+        logger.debug("Deepgram API not configured, falling back to regular recording", {}, "streaming");
+        return this.startRecording();
+      }
+      throw new Error(result.error || "Failed to start Deepgram streaming");
+    }
+
+    const audioContext = await this.getOrCreateAudioContext();
+    this.streamingAudioContext = audioContext;
+    this.streamingSource = audioContext.createMediaStreamSource(stream);
+    this.streamingStream = stream;
+
+    if (!this.workletModuleLoaded) {
+      const workletUrl = new URL("./pcm-streaming-processor.js", document.baseURI).href;
+      await audioContext.audioWorklet.addModule(workletUrl);
+      this.workletModuleLoaded = true;
+    }
+
+    this.streamingProcessor = new AudioWorkletNode(audioContext, "pcm-streaming-processor");
+
+    this.streamingProcessor.port.onmessage = (event) => {
+      if (!this.isStreaming) return;
+      window.electronAPI.deepgramStreamingSend(event.data);
+    };
+
+    this.streamingSource.connect(this.streamingProcessor);
+
+    logger.info(
+      "Deepgram streaming start timing",
+      { totalMs: Math.round(performance.now() - t0) },
+      "streaming"
+    );
+
+    this.isStreaming = true;
+    this.isRecording = true;
+    this.recordingStartTime = Date.now();
+    this.streamingProvider = "deepgram";
+    this.onStateChange?.({ isRecording: true, isProcessing: false, isStreaming: true });
+
+    this.streamingFinalText = "";
+    this.streamingPartialText = "";
+
+    const partialCleanup = window.electronAPI.onDeepgramPartialTranscript((text) => {
+      this.streamingPartialText = text;
+      this.onPartialTranscript?.(text);
+    });
+
+    const finalCleanup = window.electronAPI.onDeepgramFinalTranscript((text) => {
+      this.streamingFinalText = text;
+      this.streamingPartialText = "";
+      this.onPartialTranscript?.(text);
+    });
+
+    const errorCleanup = window.electronAPI.onDeepgramError((error) => {
+      logger.error("Deepgram streaming error", { error }, "streaming");
+      this.onError?.({
+        title: "Streaming Error",
+        description: error,
+      });
+    });
+
+    this.streamingCleanupFns = [partialCleanup, finalCleanup, errorCleanup];
+
+    return true;
+  }
+
+  async _startOpenAIRealtimeStreaming() {
+    const t0 = performance.now();
+    const constraints = await this.getAudioConstraints();
+
+    const [stream, result] = await Promise.all([
+      navigator.mediaDevices.getUserMedia(constraints),
+      window.electronAPI.openaiRealtimeStreamingStart({
+        language: getBaseLanguageCode(localStorage.getItem("preferredLanguage")),
+      }),
+    ]);
+
+    if (!result.success) {
+      stream.getTracks().forEach((track) => track.stop());
+      if (result.code === "NO_API") {
+        logger.debug("OpenAI API not configured, falling back to regular recording", {}, "streaming");
+        return this.startRecording();
+      }
+      throw new Error(result.error || "Failed to start OpenAI Realtime streaming");
+    }
+
+    const audioContext = await this.getOrCreateAudioContext();
+    this.streamingAudioContext = audioContext;
+    this.streamingSource = audioContext.createMediaStreamSource(stream);
+    this.streamingStream = stream;
+
+    if (!this.workletModuleLoaded) {
+      const workletUrl = new URL("./pcm-streaming-processor.js", document.baseURI).href;
+      await audioContext.audioWorklet.addModule(workletUrl);
+      this.workletModuleLoaded = true;
+    }
+
+    this.streamingProcessor = new AudioWorkletNode(audioContext, "pcm-streaming-processor");
+
+    this.streamingProcessor.port.onmessage = (event) => {
+      if (!this.isStreaming) return;
+      // Main process handles 16kHz→24kHz resampling
+      window.electronAPI.openaiRealtimeStreamingSend(event.data);
+    };
+
+    this.streamingSource.connect(this.streamingProcessor);
+
+    logger.info(
+      "OpenAI Realtime streaming start timing",
+      { totalMs: Math.round(performance.now() - t0) },
+      "streaming"
+    );
+
+    this.isStreaming = true;
+    this.isRecording = true;
+    this.recordingStartTime = Date.now();
+    this.streamingProvider = "openai-realtime";
+    this.onStateChange?.({ isRecording: true, isProcessing: false, isStreaming: true });
+
+    this.streamingFinalText = "";
+    this.streamingPartialText = "";
+
+    const partialCleanup = window.electronAPI.onOpenaiRealtimePartialTranscript((text) => {
+      this.streamingPartialText = text;
+      this.onPartialTranscript?.(text);
+    });
+
+    const finalCleanup = window.electronAPI.onOpenaiRealtimeFinalTranscript((text) => {
+      this.streamingFinalText = text;
+      this.streamingPartialText = "";
+      this.onPartialTranscript?.(text);
+    });
+
+    const errorCleanup = window.electronAPI.onOpenaiRealtimeError((error) => {
+      logger.error("OpenAI Realtime streaming error", { error }, "streaming");
+      this.onError?.({
+        title: "Streaming Error",
+        description: error,
+      });
+    });
+
+    this.streamingCleanupFns = [partialCleanup, finalCleanup, errorCleanup];
+
+    return true;
+  }
+
+  async _startParakeetStreaming() {
+    const t0 = performance.now();
+    const constraints = await this.getAudioConstraints();
+
+    const [stream, result] = await Promise.all([
+      navigator.mediaDevices.getUserMedia(constraints),
+      window.electronAPI.parakeetStreamingStart(),
+    ]);
+
+    if (!result.success) {
+      stream.getTracks().forEach((track) => track.stop());
+      if (result.code === "NO_SERVER") {
+        logger.debug("Parakeet server not running, falling back to regular recording", {}, "streaming");
+        return this.startRecording();
+      }
+      throw new Error(result.error || "Failed to start Parakeet streaming");
+    }
+
+    const audioContext = await this.getOrCreateAudioContext();
+    this.streamingAudioContext = audioContext;
+    this.streamingSource = audioContext.createMediaStreamSource(stream);
+    this.streamingStream = stream;
+
+    if (!this.workletModuleLoaded) {
+      const workletUrl = new URL("./pcm-streaming-processor.js", document.baseURI).href;
+      await audioContext.audioWorklet.addModule(workletUrl);
+      this.workletModuleLoaded = true;
+    }
+
+    this.streamingProcessor = new AudioWorkletNode(audioContext, "pcm-streaming-processor");
+
+    this.streamingProcessor.port.onmessage = (event) => {
+      if (!this.isStreaming) return;
+      window.electronAPI.parakeetStreamingSend(event.data);
+    };
+
+    this.streamingSource.connect(this.streamingProcessor);
+
+    logger.info(
+      "Parakeet streaming start timing",
+      { totalMs: Math.round(performance.now() - t0) },
+      "streaming"
+    );
+
+    this.isStreaming = true;
+    this.isRecording = true;
+    this.recordingStartTime = Date.now();
+    this.streamingProvider = "parakeet";
+    this.onStateChange?.({ isRecording: true, isProcessing: false, isStreaming: true });
+
+    this.streamingFinalText = "";
+    this.streamingPartialText = "";
+
+    const partialCleanup = window.electronAPI.onParakeetPartialTranscript((text) => {
+      this.streamingFinalText = text;
+      this.streamingPartialText = text;
+      this.onPartialTranscript?.(text);
+    });
+
+    const errorCleanup = window.electronAPI.onParakeetError((error) => {
+      logger.error("Parakeet streaming error", { error }, "streaming");
+      this.onError?.({
+        title: "Streaming Error",
+        description: error,
+      });
+    });
+
+    this.streamingCleanupFns = [partialCleanup, errorCleanup];
+
+    return true;
   }
 
   async stopStreamingRecording() {
@@ -2037,16 +2323,42 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     await new Promise((resolve) => setTimeout(resolve, 120));
     this.isStreaming = false;
 
-    // 4. ForceEndpoint finalizes any in-progress turn, then Terminate closes the session.
-    //    The server MUST process ALL remaining audio and send ALL Turn messages before
-    //    responding with Termination — so awaiting this guarantees we get every word.
-    window.electronAPI.assemblyAiStreamingForceEndpoint?.();
-    const tForceEndpoint = performance.now();
+    // 4. Stop the backend connection based on provider
+    const provider = this.streamingProvider || "assemblyai";
 
-    const stopResult = await window.electronAPI.assemblyAiStreamingStop().catch((e) => {
-      logger.debug("Streaming disconnect error", { error: e.message }, "streaming");
-      return { success: false };
-    });
+    let stopResult;
+    if (provider === "deepgram") {
+      const result = await window.electronAPI.deepgramStreamingStop().catch((e) => {
+        logger.debug("Deepgram disconnect error", { error: e.message }, "streaming");
+        return { text: "" };
+      });
+      if (result?.text) {
+        this.streamingFinalText = result.text;
+      }
+    } else if (provider === "parakeet") {
+      const result = await window.electronAPI.parakeetStreamingStop().catch((e) => {
+        logger.debug("Parakeet streaming stop error", { error: e.message }, "streaming");
+        return { text: "" };
+      });
+      if (result?.text) {
+        this.streamingFinalText = result.text;
+      }
+    } else if (provider === "openai-realtime") {
+      const result = await window.electronAPI.openaiRealtimeStreamingStop?.().catch((e) => {
+        logger.debug("OpenAI Realtime disconnect error", { error: e.message }, "streaming");
+        return { text: "" };
+      });
+      if (result?.text) {
+        this.streamingFinalText = result.text;
+      }
+    } else {
+      // AssemblyAI (default)
+      window.electronAPI.assemblyAiStreamingForceEndpoint?.();
+      stopResult = await window.electronAPI.assemblyAiStreamingStop().catch((e) => {
+        logger.debug("Streaming disconnect error", { error: e.message }, "streaming");
+        return { success: false };
+      });
+    }
     const tTerminate = performance.now();
 
     finalText = this.streamingFinalText || "";
@@ -2070,10 +2382,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     logger.info(
       "Streaming stop timing",
       {
+        provider,
         durationSeconds,
         audioCleanupMs: Math.round(tAudioCleanup - t0),
-        flushWaitMs: Math.round(tForceEndpoint - tAudioCleanup),
-        terminateRoundTripMs: Math.round(tTerminate - tForceEndpoint),
+        terminateMs: Math.round(tTerminate - tAudioCleanup),
         totalStopMs: Math.round(tTerminate - t0),
         textLength: finalText.length,
       },
@@ -2147,7 +2459,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.onTranscriptionComplete?.({
         success: true,
         text: finalText,
-        source: "assemblyai-streaming",
+        source: `${provider}-streaming`,
       });
 
       logger.info(
@@ -2200,6 +2512,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     this.isStreaming = false;
+    this.streamingProvider = null;
   }
 
   cleanupStreamingListeners() {

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -660,7 +660,7 @@ class ClipboardManager {
 gi.require_version('Atspi','2.0')
 from gi.repository import Atspi
 d=Atspi.get_desktop(0)
-skip={'gnome-shell',''}
+skip={'gnome-shell','open-whispr',''}
 for i in range(d.get_child_count()):
  a=d.get_child_at_index(i)
  if not a:continue

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -651,6 +651,48 @@ class ClipboardManager {
         "yakuake",
       ];
 
+      // On GNOME Wayland, xdotool can't see native Wayland windows and returns
+      // OpenWhispr's own window instead. Use AT-SPI2 accessibility API first,
+      // which works for both native Wayland and XWayland windows.
+      if (isGnome && isWayland) {
+        try {
+          const atspiScript = `import gi
+gi.require_version('Atspi','2.0')
+from gi.repository import Atspi
+d=Atspi.get_desktop(0)
+skip={'gnome-shell',''}
+for i in range(d.get_child_count()):
+ a=d.get_child_at_index(i)
+ if not a:continue
+ n=a.get_name()
+ if n.lower() in skip:continue
+ for j in range(a.get_child_count()):
+  w=a.get_child_at_index(j)
+  if w and w.get_state_set().contains(Atspi.StateType.ACTIVE):
+   print(n.lower());raise SystemExit(0)`;
+          const result = spawnSync("python3", ["-c", atspiScript], {
+            timeout: 1000,
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+          if (result.status === 0) {
+            const appName = result.stdout.toString().trim();
+            if (appName) {
+              const isTerminalWindow = terminalClasses.some((term) => appName.includes(term));
+              this.safeLog(
+                isTerminalWindow
+                  ? `🖥️ Terminal detected via AT-SPI2: ${appName}`
+                  : `🪟 Non-terminal detected via AT-SPI2: ${appName}`
+              );
+              return isTerminalWindow;
+            }
+          }
+        } catch {
+          // AT-SPI2 detection failed, continue to other methods
+        }
+      }
+
+      // xdotool window class detection (reliable on X11 and for XWayland apps
+      // on non-GNOME Wayland; skipped on GNOME Wayland where AT-SPI2 is used above)
       if (xdotoolWindowClass) {
         const isTerminalWindow = terminalClasses.some((term) => xdotoolWindowClass.includes(term));
         if (isTerminalWindow) {
@@ -707,11 +749,8 @@ class ClipboardManager {
     // On GNOME Wayland, prefer ydotool over xdotool because xdotool can only
     // interact with XWayland windows and may target the wrong window (e.g. OpenWhispr
     // itself) while reporting success, preventing fallback to ydotool.
-    // Also on GNOME Wayland, terminal detection via xdotool/kdotool fails for native
-    // Wayland windows, so ydotool should use Ctrl+Shift+V which works in both
-    // terminals (correct paste) and other apps (paste without formatting).
-    const gnomeWaylandYdotoolArgs = ["key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"];
-
+    // ydotool uses the regular ydotoolArgs which respects terminal detection:
+    // Ctrl+Shift+V for detected terminals, Ctrl+V for everything else.
     const candidates = [
       ...(canUseWtype
         ? [
@@ -725,7 +764,7 @@ class ClipboardManager {
         : []),
       ...(isGnome && isWayland
         ? [
-            ...(canUseYdotool ? [{ cmd: "ydotool", args: gnomeWaylandYdotoolArgs }] : []),
+            ...(canUseYdotool ? [{ cmd: "ydotool", args: ydotoolArgs }] : []),
             ...(canUseXdotool ? [{ cmd: "xdotool", args: xdotoolArgs }] : []),
           ]
         : [

--- a/src/helpers/deepgramStreaming.js
+++ b/src/helpers/deepgramStreaming.js
@@ -1,0 +1,246 @@
+const WebSocket = require("ws");
+const logger = require("./debugLogger");
+
+const WEBSOCKET_TIMEOUT_MS = 30000;
+const CLOSE_TIMEOUT_MS = 5000;
+
+class DeepgramStreaming {
+  constructor() {
+    this.ws = null;
+    this.isConnected = false;
+    this.onPartialTranscript = null;
+    this.onFinalTranscript = null;
+    this.onError = null;
+
+    this.accumulatedText = "";
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.closeResolve = null;
+    this.connectTimeout = null;
+    this.closeTimeout = null;
+  }
+
+  /**
+   * Open a streaming WebSocket to Deepgram Nova-3.
+   * @param {Object} options
+   * @param {string} options.apiKey - Deepgram API key
+   * @param {number} [options.sampleRate=16000]
+   * @param {string} [options.language] - BCP-47 language code (e.g. "en", "es")
+   */
+  async connect(options = {}) {
+    const { apiKey, sampleRate = 16000, language } = options;
+
+    if (!apiKey) {
+      throw new Error("Deepgram API key is required");
+    }
+
+    if (this.isConnected) {
+      await this.disconnect();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.connectResolve = resolve;
+      this.connectReject = reject;
+
+      const params = new URLSearchParams({
+        encoding: "linear16",
+        sample_rate: String(sampleRate),
+        channels: "1",
+        model: "nova-3",
+        punctuate: "true",
+        interim_results: "true",
+        utterance_end_ms: "1000",
+        smart_format: "true",
+      });
+
+      if (language && language !== "auto") {
+        params.set("language", language);
+      } else {
+        params.set("detect_language", "true");
+      }
+
+      const url = `wss://api.deepgram.com/v1/listen?${params.toString()}`;
+
+      try {
+        this.ws = new WebSocket(url, {
+          headers: {
+            Authorization: `Token ${apiKey}`,
+          },
+        });
+      } catch (err) {
+        this.connectResolve = null;
+        this.connectReject = null;
+        reject(err);
+        return;
+      }
+
+      this.connectTimeout = setTimeout(() => {
+        if (this.connectResolve) {
+          const err = new Error("Deepgram connection timeout");
+          this.connectReject?.(err);
+          this.connectResolve = null;
+          this.connectReject = null;
+          this.cleanup();
+        }
+      }, WEBSOCKET_TIMEOUT_MS);
+
+      this.ws.on("open", () => {
+        this.isConnected = true;
+        clearTimeout(this.connectTimeout);
+        this.connectTimeout = null;
+        logger.info("Deepgram streaming connected", {}, "streaming");
+        this.connectResolve?.({ success: true });
+        this.connectResolve = null;
+        this.connectReject = null;
+      });
+
+      this.ws.on("message", (data) => {
+        try {
+          const msg = JSON.parse(data.toString());
+          this._handleMessage(msg);
+        } catch (err) {
+          logger.warn(
+            "Failed to parse Deepgram message",
+            { error: err.message },
+            "streaming"
+          );
+        }
+      });
+
+      this.ws.on("error", (err) => {
+        logger.error("Deepgram WebSocket error", { error: err.message }, "streaming");
+        this.onError?.(err.message);
+        if (this.connectReject) {
+          this.connectReject(err);
+          this.connectResolve = null;
+          this.connectReject = null;
+          clearTimeout(this.connectTimeout);
+          this.connectTimeout = null;
+        }
+      });
+
+      this.ws.on("close", (code, reason) => {
+        logger.debug(
+          "Deepgram WebSocket closed",
+          { code, reason: reason?.toString() },
+          "streaming"
+        );
+        this.isConnected = false;
+        if (this.closeResolve) {
+          this.closeResolve();
+          this.closeResolve = null;
+          clearTimeout(this.closeTimeout);
+          this.closeTimeout = null;
+        }
+      });
+    });
+  }
+
+  _handleMessage(msg) {
+    // Deepgram sends Results messages with channel alternatives
+    if (msg.type === "Results" && msg.channel?.alternatives?.length > 0) {
+      const alt = msg.channel.alternatives[0];
+      const transcript = alt.transcript || "";
+
+      if (!transcript) return;
+
+      if (msg.is_final) {
+        // Final result for this utterance segment — accumulate
+        this.accumulatedText = this.accumulatedText
+          ? `${this.accumulatedText} ${transcript}`
+          : transcript;
+
+        this.onFinalTranscript?.(this.accumulatedText);
+        this.onPartialTranscript?.(this.accumulatedText);
+      } else {
+        // Interim/partial result — show accumulated + current partial
+        const display = this.accumulatedText
+          ? `${this.accumulatedText} ${transcript}`
+          : transcript;
+        this.onPartialTranscript?.(display);
+      }
+    } else if (msg.type === "UtteranceEnd") {
+      // Utterance boundary — emit accumulated as final if present
+      if (this.accumulatedText) {
+        this.onFinalTranscript?.(this.accumulatedText);
+      }
+    } else if (msg.type === "Metadata") {
+      logger.debug("Deepgram metadata", { requestId: msg.request_id }, "streaming");
+    } else if (msg.type === "Error") {
+      logger.error("Deepgram server error", { message: msg.message }, "streaming");
+      this.onError?.(msg.message || "Deepgram server error");
+    }
+  }
+
+  /**
+   * Send raw int16 PCM audio data to Deepgram.
+   * @param {Buffer|ArrayBuffer} pcmBuffer
+   * @returns {boolean}
+   */
+  sendAudio(pcmBuffer) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    this.ws.send(pcmBuffer);
+    return true;
+  }
+
+  /**
+   * Gracefully close the streaming session.
+   * @returns {Promise<{ text: string }>}
+   */
+  async disconnect() {
+    const finalText = this.accumulatedText || "";
+
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      // Send Deepgram's CloseStream message
+      try {
+        this.ws.send(JSON.stringify({ type: "CloseStream" }));
+      } catch (e) {
+        // Ignore send errors during close
+      }
+
+      // Wait for the WebSocket to close gracefully
+      await new Promise((resolve) => {
+        this.closeResolve = resolve;
+        this.closeTimeout = setTimeout(() => {
+          logger.debug("Deepgram close timeout, forcing cleanup", {}, "streaming");
+          this.closeResolve = null;
+          resolve();
+        }, CLOSE_TIMEOUT_MS);
+      });
+    }
+
+    this.cleanup();
+    return { text: finalText };
+  }
+
+  cleanup() {
+    if (this.ws) {
+      try {
+        if (
+          this.ws.readyState === WebSocket.OPEN ||
+          this.ws.readyState === WebSocket.CONNECTING
+        ) {
+          this.ws.close();
+        }
+      } catch (e) {
+        // Ignore
+      }
+      this.ws = null;
+    }
+
+    this.isConnected = false;
+    this.accumulatedText = "";
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.closeResolve = null;
+
+    clearTimeout(this.connectTimeout);
+    clearTimeout(this.closeTimeout);
+    this.connectTimeout = null;
+    this.closeTimeout = null;
+  }
+}
+
+module.exports = DeepgramStreaming;

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -16,6 +16,7 @@ const PERSISTED_KEYS = [
   "LOCAL_WHISPER_MODEL",
   "REASONING_PROVIDER",
   "LOCAL_REASONING_MODEL",
+  "DEEPGRAM_API_KEY",
   "DICTATION_KEY",
   "ACTIVATION_MODE",
   "FLOATING_ICON_AUTO_HIDE",
@@ -114,6 +115,14 @@ class EnvironmentManager {
 
   saveCustomReasoningKey(key) {
     return this._saveKey("CUSTOM_REASONING_API_KEY", key);
+  }
+
+  getDeepgramKey() {
+    return this._getKey("DEEPGRAM_API_KEY");
+  }
+
+  saveDeepgramKey(key) {
+    return this._saveKey("DEEPGRAM_API_KEY", key);
   }
 
   getDictationKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1834,7 +1834,7 @@ class IPCHandlers {
     ipcMain.handle("parakeet-streaming-start", async () => {
       try {
         const status = this.parakeetManager?.serverManager?.wsServer?.getStatus?.();
-        if (!status?.ready) {
+        if (!status?.running) {
           return { success: false, error: "Parakeet server not running", code: "NO_SERVER" };
         }
 

--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -1,0 +1,296 @@
+/**
+ * OpenAI Realtime API streaming client for transcription-only mode.
+ *
+ * IMPORTANT: The OpenAI Realtime API evolves rapidly. The session schema,
+ * event types, and model names used here were verified against the
+ * documentation and community examples available in early 2025:
+ *
+ *   - URL: wss://api.openai.com/v1/realtime?intent=transcription
+ *   - Session type: "transcription"
+ *   - Transcription events: conversation.item.input_audio_transcription.{delta,completed}
+ *   - Audio format: PCM16 @ 24kHz
+ *   - Model: gpt-4o-mini-transcribe
+ *
+ * If streaming fails with schema or event errors, verify the above against
+ * https://platform.openai.com/docs/guides/realtime-transcription
+ */
+const WebSocket = require("ws");
+const logger = require("./debugLogger");
+
+const WEBSOCKET_TIMEOUT_MS = 30000;
+const CLOSE_TIMEOUT_MS = 5000;
+
+class OpenAIRealtimeStreaming {
+  constructor() {
+    this.ws = null;
+    this.isConnected = false;
+    this.onPartialTranscript = null;
+    this.onFinalTranscript = null;
+    this.onError = null;
+
+    this.accumulatedText = "";
+    this.currentDelta = "";
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.connectTimeout = null;
+  }
+
+  /**
+   * Open a WebSocket to the OpenAI Realtime transcription API.
+   * @param {Object} options
+   * @param {string} options.apiKey - OpenAI API key
+   * @param {string} [options.language] - BCP-47 language code
+   * @param {string} [options.model] - Transcription model (default: gpt-4o-mini-transcribe)
+   */
+  async connect(options = {}) {
+    const { apiKey, language, model = "gpt-4o-mini-transcribe" } = options;
+
+    if (!apiKey) {
+      throw new Error("OpenAI API key is required");
+    }
+
+    if (this.isConnected) {
+      await this.disconnect();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.connectResolve = resolve;
+      this.connectReject = reject;
+
+      const url = "wss://api.openai.com/v1/realtime?intent=transcription";
+
+      try {
+        this.ws = new WebSocket(url, {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "OpenAI-Beta": "realtime=v1",
+          },
+        });
+      } catch (err) {
+        this.connectResolve = null;
+        this.connectReject = null;
+        reject(err);
+        return;
+      }
+
+      this.connectTimeout = setTimeout(() => {
+        if (this.connectResolve) {
+          const err = new Error("OpenAI Realtime connection timeout");
+          this.connectReject?.(err);
+          this.connectResolve = null;
+          this.connectReject = null;
+          this.cleanup();
+        }
+      }, WEBSOCKET_TIMEOUT_MS);
+
+      this.ws.on("open", () => {
+        this.isConnected = true;
+        clearTimeout(this.connectTimeout);
+        this.connectTimeout = null;
+
+        // Configure transcription session
+        const sessionConfig = {
+          type: "session.update",
+          session: {
+            type: "transcription",
+            audio: {
+              input: {
+                format: {
+                  type: "audio/pcm",
+                  rate: 24000,
+                },
+                transcription: {
+                  model,
+                },
+                turn_detection: {
+                  type: "server_vad",
+                  threshold: 0.5,
+                  prefix_padding_ms: 300,
+                  silence_duration_ms: 500,
+                },
+              },
+            },
+          },
+        };
+
+        if (language && language !== "auto") {
+          sessionConfig.session.audio.input.transcription.language = language;
+        }
+
+        this.ws.send(JSON.stringify(sessionConfig));
+        logger.info("OpenAI Realtime streaming connected", { model }, "streaming");
+
+        this.connectResolve?.({ success: true });
+        this.connectResolve = null;
+        this.connectReject = null;
+      });
+
+      this.ws.on("message", (data) => {
+        try {
+          const msg = JSON.parse(data.toString());
+          this._handleMessage(msg);
+        } catch (err) {
+          logger.warn(
+            "Failed to parse OpenAI Realtime message",
+            { error: err.message },
+            "streaming"
+          );
+        }
+      });
+
+      this.ws.on("error", (err) => {
+        logger.error("OpenAI Realtime WebSocket error", { error: err.message }, "streaming");
+        this.onError?.(err.message);
+        if (this.connectReject) {
+          this.connectReject(err);
+          this.connectResolve = null;
+          this.connectReject = null;
+          clearTimeout(this.connectTimeout);
+          this.connectTimeout = null;
+        }
+      });
+
+      this.ws.on("close", (code, reason) => {
+        logger.debug(
+          "OpenAI Realtime WebSocket closed",
+          { code, reason: reason?.toString() },
+          "streaming"
+        );
+        this.isConnected = false;
+      });
+    });
+  }
+
+  _handleMessage(msg) {
+    switch (msg.type) {
+      case "session.created":
+      case "session.updated":
+        logger.debug("OpenAI Realtime session event", { type: msg.type }, "streaming");
+        break;
+
+      case "conversation.item.input_audio_transcription.delta":
+        // Partial/streaming transcript delta
+        if (msg.delta) {
+          this.currentDelta += msg.delta;
+          const display = this.accumulatedText
+            ? `${this.accumulatedText} ${this.currentDelta}`
+            : this.currentDelta;
+          this.onPartialTranscript?.(display);
+        }
+        break;
+
+      case "conversation.item.input_audio_transcription.completed":
+        // Final transcription for this utterance
+        if (msg.transcript) {
+          this.accumulatedText = this.accumulatedText
+            ? `${this.accumulatedText} ${msg.transcript}`
+            : msg.transcript;
+          this.currentDelta = "";
+          this.onFinalTranscript?.(this.accumulatedText);
+          this.onPartialTranscript?.(this.accumulatedText);
+        }
+        break;
+
+      case "input_audio_buffer.speech_started":
+        logger.debug("OpenAI Realtime speech started", {}, "streaming");
+        break;
+
+      case "input_audio_buffer.speech_stopped":
+        logger.debug("OpenAI Realtime speech stopped", {}, "streaming");
+        break;
+
+      case "error":
+        logger.error(
+          "OpenAI Realtime server error",
+          { error: msg.error?.message, code: msg.error?.code },
+          "streaming"
+        );
+        this.onError?.(msg.error?.message || "OpenAI Realtime server error");
+        break;
+
+      default:
+        logger.debug("OpenAI Realtime unhandled event", { type: msg.type }, "streaming");
+        break;
+    }
+  }
+
+  /**
+   * Send audio data to OpenAI Realtime API.
+   * Audio must be base64-encoded PCM16 at 24kHz.
+   * @param {Buffer} pcmBuffer - Int16 PCM buffer (will be base64-encoded)
+   * @returns {boolean}
+   */
+  sendAudio(pcmBuffer) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    const base64Audio = Buffer.from(pcmBuffer).toString("base64");
+    this.ws.send(
+      JSON.stringify({
+        type: "input_audio_buffer.append",
+        audio: base64Audio,
+      })
+    );
+    return true;
+  }
+
+  /**
+   * Gracefully close the streaming session.
+   * @returns {Promise<{ text: string }>}
+   */
+  async disconnect() {
+    const finalText = this.accumulatedText || "";
+
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      // Commit any remaining audio buffer
+      try {
+        this.ws.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+      } catch (e) {
+        // Ignore
+      }
+
+      // Brief wait for final transcription
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      try {
+        this.ws.close();
+      } catch (e) {
+        // Ignore
+      }
+
+      // Wait for close
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    this.cleanup();
+    return { text: this.accumulatedText || finalText };
+  }
+
+  cleanup() {
+    if (this.ws) {
+      try {
+        if (
+          this.ws.readyState === WebSocket.OPEN ||
+          this.ws.readyState === WebSocket.CONNECTING
+        ) {
+          this.ws.close();
+        }
+      } catch (e) {
+        // Ignore
+      }
+      this.ws = null;
+    }
+
+    this.isConnected = false;
+    this.accumulatedText = "";
+    this.currentDelta = "";
+    this.connectResolve = null;
+    this.connectReject = null;
+
+    clearTimeout(this.connectTimeout);
+    this.connectTimeout = null;
+  }
+}
+
+module.exports = OpenAIRealtimeStreaming;

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -5,6 +5,7 @@ const WINDOW_SIZES = {
   WITH_MENU: { width: 240, height: 280 },
   WITH_TOAST: { width: 400, height: 500 },
   EXPANDED: { width: 400, height: 500 },
+  WITH_TRANSCRIPT: { width: 480, height: 160 },
 };
 
 // Main dictation window configuration

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -500,8 +500,11 @@ class WindowManager {
   showDictationPanel(options = {}) {
     const { focus = false } = options;
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-      if (!this.mainWindow.isVisible()) {
-        if (typeof this.mainWindow.showInactive === "function") {
+      if (!this.mainWindow.isVisible() || this.mainWindow.isMinimized()) {
+        if (process.platform === "linux") {
+          // showInactive() does not work on GNOME Wayland — use show() instead
+          this.mainWindow.show();
+        } else if (typeof this.mainWindow.showInactive === "function") {
           this.mainWindow.showInactive();
         } else {
           this.mainWindow.show();
@@ -527,11 +530,7 @@ class WindowManager {
 
   hideDictationPanel() {
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-      if (process.platform === "darwin") {
-        this.mainWindow.hide();
-      } else {
-        this.mainWindow.minimize();
-      }
+      this.mainWindow.hide();
     }
   }
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -203,13 +203,21 @@ function useSettingsInternal() {
   // Streaming provider: which backend to use for live transcription
   const [streamingProvider, setStreamingProvider] = useLocalStorage<string>(
     "streamingProvider",
-    "auto"
+    "auto",
+    {
+      serialize: String,
+      deserialize: String,
+    }
   );
 
   // Deepgram API key (stored in localStorage; persisted to .env via main process)
   const [deepgramApiKey, setDeepgramApiKeyRaw] = useLocalStorage<string>(
     "deepgramApiKey",
-    ""
+    "",
+    {
+      serialize: String,
+      deserialize: String,
+    }
   );
 
   // Wrap setter to sync dictionary to SQLite

--- a/src/public/pcm-streaming-processor.js
+++ b/src/public/pcm-streaming-processor.js
@@ -1,0 +1,44 @@
+/**
+ * AudioWorklet processor that converts float32 mic samples to int16 PCM
+ * and posts them to the main thread for streaming to STT services.
+ *
+ * Registered as "pcm-streaming-processor" — used by audioManager.js.
+ */
+class PCMStreamingProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._stopped = false;
+
+    this.port.onmessage = (event) => {
+      if (event.data === "stop") {
+        this._stopped = true;
+        // Flush is implicit — the next process() call (if any) will be the last.
+      }
+    };
+  }
+
+  process(inputs) {
+    if (this._stopped) {
+      return false; // Tell the AudioWorklet to remove this node
+    }
+
+    const input = inputs[0];
+    if (!input || !input[0] || input[0].length === 0) {
+      return true;
+    }
+
+    const float32 = input[0];
+    const int16 = new Int16Array(float32.length);
+
+    for (let i = 0; i < float32.length; i++) {
+      // Clamp to [-1, 1] then scale to int16 range
+      const s = Math.max(-1, Math.min(1, float32[i]));
+      int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+
+    this.port.postMessage(int16.buffer, [int16.buffer]);
+    return true;
+  }
+}
+
+registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -526,6 +526,60 @@ declare global {
       onAssemblyAiSessionEnd?: (
         callback: (data: { audioDuration?: number; text?: string }) => void
       ) => () => void;
+
+      // Deepgram Streaming
+      getDeepgramKey?: () => Promise<string>;
+      saveDeepgramKey?: (key: string) => Promise<{ success: boolean }>;
+      deepgramStreamingStart?: (options?: {
+        sampleRate?: number;
+        language?: string;
+      }) => Promise<{
+        success: boolean;
+        error?: string;
+        code?: string;
+      }>;
+      deepgramStreamingSend?: (audioBuffer: ArrayBuffer) => void;
+      deepgramStreamingStop?: () => Promise<{
+        success: boolean;
+        text?: string;
+        error?: string;
+      }>;
+      onDeepgramPartialTranscript?: (callback: (text: string) => void) => () => void;
+      onDeepgramFinalTranscript?: (callback: (text: string) => void) => () => void;
+      onDeepgramError?: (callback: (error: string) => void) => () => void;
+
+      // Parakeet Chunked Streaming
+      parakeetStreamingStart?: () => Promise<{
+        success: boolean;
+        error?: string;
+        code?: string;
+      }>;
+      parakeetStreamingSend?: (audioBuffer: ArrayBuffer) => void;
+      parakeetStreamingStop?: () => Promise<{
+        success: boolean;
+        text?: string;
+        error?: string;
+      }>;
+      onParakeetPartialTranscript?: (callback: (text: string) => void) => () => void;
+      onParakeetError?: (callback: (error: string) => void) => () => void;
+
+      // OpenAI Realtime Streaming
+      openaiRealtimeStreamingStart?: (options?: {
+        language?: string;
+      }) => Promise<{
+        success: boolean;
+        error?: string;
+        code?: string;
+      }>;
+      openaiRealtimeStreamingSend?: (audioBuffer: ArrayBuffer) => void;
+      openaiRealtimeStreamingStop?: () => Promise<{
+        success: boolean;
+        text?: string;
+        error?: string;
+      }>;
+      onOpenaiRealtimePartialTranscript?: (callback: (text: string) => void) => () => void;
+      onOpenaiRealtimeFinalTranscript?: (callback: (text: string) => void) => () => void;
+      onOpenaiRealtimeError?: (callback: (error: string) => void) => () => void;
     };
 
     api?: {


### PR DESCRIPTION
## Summary

- Add real-time streaming transcription with live text overlay during recording, supporting four backends: AssemblyAI (WebSocket), Deepgram, NVIDIA Parakeet (local via sherpa-onnx), and OpenAI Realtime API
- Add streaming provider selector in Settings with auto-detection and per-provider configuration
- Fix localStorage serialization bug where `useLocalStorage` hook used `JSON.stringify` for string settings, causing double-quoted values that broke provider matching in `audioManager.js`

## Dependencies

This PR includes commits from #202 and #203 for Linux compatibility. Those PRs should be merged first — the overlapping commits will be no-ops on merge.

- #202 — GNOME Wayland paste fix (ydotool preference, AT-SPI2 terminal detection)
- #203 — Transparent window flicker fix and GTK 3/4 symbol crash prevention

## Streaming architecture

- **Renderer**: `AudioWorklet` (`pcm-streaming-processor.js`) captures 16kHz PCM and sends chunks via IPC
- **Main process**: Provider-specific handlers manage WebSocket connections and broadcast partial transcripts back to renderer
- **UI**: `LiveTranscriptOverlay` component shows real-time text; main window auto-resizes during streaming
- **Parakeet**: Chunked re-transcription every 2s against local sherpa-onnx WebSocket server (accumulates full audio buffer)
- **Provider selection**: `getStreamingProvider()` in `audioManager.js` reads `streamingProvider` from localStorage with fallback logic per mode (local/cloud/BYOK)

## Commits

| Commit | Description |
|--------|-------------|
| `16ebeee` | fix(linux): prefer ydotool over xdotool on GNOME Wayland *(from #202)* |
| `1b125d4` | fix(linux): use AT-SPI2 for terminal detection on GNOME Wayland *(from #202)* |
| `605c0a4` | **feat: add real-time streaming transcription with live overlay** |
| `9ee03c3` | fix(linux): fix transparent window flicker and GTK 3/4 symbol crash *(from #203)* |
| `f8f1569` | fix: move useAudioRecording call before showTranscript to fix TDZ crash |
| `7a847cd` | fix: correct OpenAI Realtime transcription API schema and buffer error |
| `758e6d5` | fix: fix Parakeet streaming by correcting status check and localStorage serialization |

## Test plan

- [ ] Verify streaming toggle appears in Settings → Transcription with provider selector
- [ ] Test AssemblyAI streaming (requires OpenWhispr Cloud sign-in)
- [ ] Test Deepgram streaming with BYOK API key
- [ ] Test Parakeet local streaming (requires sherpa-onnx binary + downloaded model)
- [ ] Test OpenAI Realtime streaming with BYOK API key
- [ ] Verify live transcript overlay appears during streaming recording and disappears on stop
- [ ] Verify final transcription is correct after streaming stop
- [ ] Verify non-streaming (regular) transcription still works when streaming is disabled
- [ ] Test on Linux GNOME Wayland: transparent window, hotkey, paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)