### PR TITLE
fix(hotkey): guard previous hotkey unregister to prevent invalid accelerator crash

### DIFF
--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -114,8 +114,14 @@ class HotkeyManager {
       const prevAccelerator = this.currentHotkey.startsWith("Fn+")
         ? this.currentHotkey.slice(3)
         : this.currentHotkey;
-      debugLogger.log(`[HotkeyManager] Unregistering previous hotkey: "${prevAccelerator}"`);
-      globalShortcut.unregister(prevAccelerator);
+      try {
+        debugLogger.log(`[HotkeyManager] Unregistering previous hotkey: "${prevAccelerator}"`);
+        globalShortcut.unregister(prevAccelerator);
+      } catch (error) {
+        debugLogger.warn(
+          `[HotkeyManager] Skipping previous hotkey unregister for non-accelerator "${prevAccelerator}": ${error.message}`
+        );
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- wrap previous hotkey `globalShortcut.unregister(...)` call in `try/catch`
- skip unregister when stored previous hotkey is not a valid Electron accelerator
- keep hotkey update flow running so users can rebind successfully

## Why
Issue #220 reports hotkey rebinding failing with "The accelerator string can only contain one key code". This minimal change prevents the unregister path from aborting the update flow when an invalid previous key string is encountered.

Fixes #220

https://github.com/user-attachments/assets/321ae040-5a34-4a14-b68c-c9401ba2e202