### PR TITLE
fix(hotkeys): use Control+Shift+Space as non-mac default

### DIFF
--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -38,12 +38,12 @@ function isModifierOnlyHotkey(hotkey) {
 // Suggested alternative hotkeys when registration fails
 const SUGGESTED_HOTKEYS = {
   single: ["F8", "F9", "F10", "Pause", "ScrollLock"],
-  compound: ["Control+Super", "Control+Alt", "Control+Shift+Space", "Alt+F7"],
+  compound: ["Control+Shift+Space", "Control+Alt", "Control+Shift+K", "Alt+F7"],
 };
 
 class HotkeyManager {
   constructor() {
-    this.currentHotkey = process.platform === "darwin" ? "GLOBE" : "Control+Super";
+    this.currentHotkey = process.platform === "darwin" ? "GLOBE" : "Control+Shift+Space";
     this.isInitialized = false;
     this.isListeningMode = false;
     this.gnomeManager = null;
@@ -94,15 +94,15 @@ class HotkeyManager {
     if (process.platform === "darwin" && isCompound) {
       suggestions = ["Control+Alt", "Alt+Command", "Command+Shift+Space"];
     } else if (process.platform === "win32" && isCompound) {
-      suggestions = ["Control+Super", "Control+Alt", "Control+Shift+K"];
+      suggestions = ["Control+Shift+Space", "Control+Alt", "Control+Shift+K"];
     } else if (process.platform === "linux" && isCompound) {
-      suggestions = ["Control+Super", "Control+Shift+K", "Super+Shift+R"];
+      suggestions = ["Control+Shift+Space", "Control+Shift+K", "Super+Shift+R"];
     }
 
     return suggestions.filter((s) => s !== failedHotkey).slice(0, 3);
   }
 
-  setupShortcuts(hotkey = "Control+Super", callback) {
+  setupShortcuts(hotkey = "Control+Shift+Space", callback) {
     if (!callback) {
       throw new Error("Callback function is required for hotkey setup");
     }
@@ -266,7 +266,8 @@ class HotkeyManager {
             const savedHotkey = await mainWindow.webContents.executeJavaScript(`
               localStorage.getItem("dictationKey") || ""
             `);
-            const hotkey = savedHotkey && savedHotkey.trim() !== "" ? savedHotkey : "Control+Super";
+            const hotkey =
+              savedHotkey && savedHotkey.trim() !== "" ? savedHotkey : "Control+Shift+Space";
             const gnomeHotkey = GnomeShortcutManager.convertToGnomeFormat(hotkey);
 
             const success = await this.gnomeManager.registerKeybinding(gnomeHotkey);
@@ -335,7 +336,7 @@ class HotkeyManager {
         this.notifyHotkeyFailure(savedHotkey, result);
       }
 
-      const defaultHotkey = process.platform === "darwin" ? "GLOBE" : "Control+Super";
+      const defaultHotkey = process.platform === "darwin" ? "GLOBE" : "Control+Shift+Space";
 
       if (defaultHotkey === "GLOBE") {
         this.currentHotkey = "GLOBE";

--- a/src/utils/hotkeyValidator.ts
+++ b/src/utils/hotkeyValidator.ts
@@ -255,14 +255,14 @@ const MAC_RECOMMENDED = [
 ] as const;
 
 const WINDOWS_RECOMMENDED = [
-  "Ctrl + Win",
+  "Ctrl + Shift + Space",
   "Ctrl + Alt",
   "Ctrl (right) or Alt (right)",
   "Modifier + rarely used key (e.g., Ctrl + Page Up)",
 ] as const;
 
 const LINUX_RECOMMENDED = [
-  "Ctrl + Super",
+  "Ctrl + Shift + Space",
   "Ctrl + Shift + Super",
   "Super + Shift",
   "Ctrl (right) or Alt (right)",

--- a/src/utils/hotkeys.ts
+++ b/src/utils/hotkeys.ts
@@ -129,11 +129,11 @@ export function isCompoundHotkey(hotkey: string): boolean {
 /**
  * Gets the default hotkey for the current platform.
  * - macOS: GLOBE key (Fn key on modern Macs)
- * - Windows/Linux: Control+Super (Ctrl+Win / Ctrl+Super)
+ * - Windows/Linux: Control+Shift+Space
  */
 export function getDefaultHotkey(): string {
   const platform = getPlatform();
-  return platform === "darwin" ? "GLOBE" : "Control+Super";
+  return platform === "darwin" ? "GLOBE" : "Control+Shift+Space";
 }
 
 /**


### PR DESCRIPTION
## Summary
- change non-mac default hotkey from "Ctrl+super" to "Ctrl+shift+space" 
- update startup and fallback defaults in hotkey manager to the same value
- update hotkey guidance/recommendations to avoid steering users toward wrong hotkeys 

## Why this fixes #220
"Ctrl+super" is a modifier-only shortcut. Modifier-only combos are less reliable across platforms and paths because they require native-listener special handling and are more likely to be reserved by the OS/desktop environment. That made the default fragile and led to onboarding/registration failures in real setups.

 "Ctrl+shift+space" is a standard chord with a base key, works with the normal shortcut registration path, and is materially more consistent as a default.

Fixes #220

https://github.com/user-attachments/assets/31644c9a-c915-40ec-8b76-8bce791d0137
