### PR TITLE
Fix vite build error: 'Rollup failed to resolve import "@neondatabase/auth"'

### DIFF
--- a/src/vite.config.mjs
+++ b/src/vite.config.mjs
@@ -75,7 +75,9 @@ export default defineConfig(({ mode }) => {
           'zlib',
           'tar',
           'unzipper',
-          '@aws-sdk/client-s3'
+          '@aws-sdk/client-s3',
+          '@neondatabase/auth',
+          '@neondatabase/auth/react'
         ],
         output: {
           manualChunks: {


### PR DESCRIPTION
Fixes broken builds since 173642e60814b64ff507286e879f9857ffe37752.

Closes #255.