### PR TITLE
fix: use unzipper instead of tar for Windows key listener extraction

### DIFF
--- a/scripts/download-windows-key-listener.js
+++ b/scripts/download-windows-key-listener.js
@@ -80,7 +80,7 @@ async function main() {
     fs.mkdirSync(extractDir, { recursive: true });
 
     console.log("  Extracting...");
-    extractZip(zipPath, extractDir);
+    await extractZip(zipPath, extractDir);
 
     // Find and copy the binary
     const binaryPath = path.join(extractDir, BINARY_NAME);

--- a/scripts/lib/download-utils.js
+++ b/scripts/lib/download-utils.js
@@ -227,9 +227,14 @@ function downloadFile(url, dest, retryCount = 0) {
   });
 }
 
-function extractZip(zipPath, destDir) {
+async function extractZip(zipPath, destDir) {
   if (process.platform === "win32") {
-    execSync(`tar -xf "${zipPath}" -C "${destDir}"`, { stdio: "inherit" });
+    // Use unzipper package on Windows for better path handling
+    const unzipper = require("unzipper");
+    await fs
+      .createReadStream(zipPath)
+      .pipe(unzipper.Extract({ path: destDir }))
+      .promise();
   } else {
     execSync(`unzip -o "${zipPath}" -d "${destDir}"`, { stdio: "inherit" });
   }


### PR DESCRIPTION
Windows' built-in tar command fails with path resolution errors when extracting the windows-key-listener binary:
  tar: Cannot connect to c: resolve failed

This change switches to the unzipper npm package (already in dependencies) which properly handles Windows paths and provides more reliable extraction.

Benefits:
- Eliminates error messages during npm run dev
- Enables push-to-talk for fresh Windows installations
- More reliable cross-platform extraction

Tested on Windows 11 with successful extraction.