### PR TITLE
feat: add configurable minimize to tray behavior

### DIFF
--- a/main.js
+++ b/main.js
@@ -462,6 +462,14 @@ async function startApp() {
     }
   });
 
+  ipcMain.on("minimize-to-tray-changed", (_event, enabled) => {
+    windowManager.setMinimizeToTray(enabled);
+  });
+
+  ipcMain.handle("get-minimize-to-tray", () => {
+    return windowManager.getMinimizeToTray();
+  });
+
   if (process.platform === "darwin") {
     app.setActivationPolicy("regular");
   }

--- a/preload.js
+++ b/preload.js
@@ -312,6 +312,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     (callback) => (_event, enabled) => callback(enabled)
   ),
 
+  notifyMinimizeToTrayChanged: (enabled) =>
+    ipcRenderer.send("minimize-to-tray-changed", enabled),
+  getMinimizeToTray: () => ipcRenderer.invoke("get-minimize-to-tray"),
+
   // Auto-start management
   getAutoStartEnabled: () => ipcRenderer.invoke("get-auto-start-enabled"),
   setAutoStartEnabled: (enabled) => ipcRenderer.invoke("set-auto-start-enabled", enabled),

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -675,6 +675,8 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setAudioCuesEnabled,
     floatingIconAutoHide,
     setFloatingIconAutoHide,
+    minimizeToTray,
+    setMinimizeToTray,
     cloudBackupEnabled,
     setCloudBackupEnabled,
     telemetryEnabled,
@@ -1576,6 +1578,14 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
                     description={t("settingsPage.general.floatingIcon.autoHideDescription")}
                   >
                     <Toggle checked={floatingIconAutoHide} onChange={setFloatingIconAutoHide} />
+                  </SettingsRow>
+                </SettingsPanelRow>
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.general.minimizeToTray.label")}
+                    description={t("settingsPage.general.minimizeToTray.description")}
+                  >
+                    <Toggle checked={minimizeToTray} onChange={setMinimizeToTray} />
                   </SettingsRow>
                 </SettingsPanelRow>
               </SettingsPanel>

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -26,6 +26,7 @@ class WindowManager {
     this.winPushState = null;
     this._cachedActivationMode = "tap";
     this._floatingIconAutoHide = false;
+    this._minimizeToTray = true;
 
     app.on("before-quit", () => {
       this.isQuitting = true;
@@ -392,6 +393,14 @@ class WindowManager {
     this._floatingIconAutoHide = Boolean(enabled);
   }
 
+  setMinimizeToTray(enabled) {
+    this._minimizeToTray = Boolean(enabled);
+  }
+
+  getMinimizeToTray() {
+    return this._minimizeToTray;
+  }
+
   setHotkeyListeningMode(enabled) {
     this.hotkeyManager.setListeningMode(enabled);
   }
@@ -495,7 +504,7 @@ class WindowManager {
     this.controlPanelWindow.on("close", (event) => {
       if (!this.isQuitting) {
         event.preventDefault();
-        if (process.platform === "darwin") {
+        if (this._minimizeToTray) {
           this.hideControlPanelToTray();
         } else {
           this.controlPanelWindow.minimize();

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -640,6 +640,25 @@ function useSettingsInternal() {
     [setFloatingIconAutoHideLocal]
   );
 
+  const [minimizeToTray, setMinimizeToTrayLocal] = useLocalStorage(
+    "minimizeToTray",
+    true,
+    {
+      serialize: String,
+      deserialize: (value) => value === "true",
+    }
+  );
+
+  const setMinimizeToTray = useCallback(
+    (enabled: boolean) => {
+      setMinimizeToTrayLocal(enabled);
+      if (typeof window !== "undefined" && window.electronAPI?.notifyMinimizeToTrayChanged) {
+        window.electronAPI.notifyMinimizeToTrayChanged(enabled);
+      }
+    },
+    [setMinimizeToTrayLocal]
+  );
+
   // Microphone settings
   const [preferBuiltInMic, setPreferBuiltInMic] = useLocalStorage("preferBuiltInMic", true, {
     serialize: String,
@@ -819,6 +838,8 @@ function useSettingsInternal() {
     setAudioCuesEnabled,
     floatingIconAutoHide,
     setFloatingIconAutoHide,
+    minimizeToTray,
+    setMinimizeToTray,
     preferBuiltInMic,
     selectedMicDeviceId,
     setPreferBuiltInMic,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1059,6 +1059,10 @@
         "description": "Control when the dictation icon is visible on your screen",
         "title": "Floating Icon"
       },
+      "minimizeToTray": {
+        "label": "Minimize to system tray",
+        "description": "When enabled, closing the Control Panel hides it to the system tray. When disabled, it minimizes to the taskbar instead."
+      },
       "hotkey": {
         "activationMode": "Activation Mode",
         "description": "The key combination that starts and stops voice dictation",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -425,6 +425,9 @@ declare global {
       notifyFloatingIconAutoHideChanged?: (enabled: boolean) => void;
       onFloatingIconAutoHideChanged?: (callback: (enabled: boolean) => void) => () => void;
 
+      notifyMinimizeToTrayChanged?: (enabled: boolean) => void;
+      getMinimizeToTray?: () => Promise<boolean>;
+
       // Auto-start at login
       getAutoStartEnabled?: () => Promise<boolean>;
       setAutoStartEnabled?: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary
Adds a user-configurable setting to control whether the Control Panel minimizes to the system tray or the taskbar when closed.

## Changes
- Add `minimizeToTray` setting (default: `true`) in useSettings hook
- Add IPC handlers for `minimize-to-tray-changed` and `get-minimize-to-tray`
- Update windowManager close handler to check setting before deciding behavior
- Add toggle in Control Panel → General settings
- Add English translations for the new setting

## Behavior
- **When enabled (default)**: Closing the Control Panel hides it to the system tray
- **When disabled**: Closing the Control Panel minimizes it to the taskbar like a normal window

## Test plan
- [ ] Toggle the "Minimize to system tray" setting in Control Panel → General
- [ ] Close the Control Panel window
- [ ] Verify behavior matches the setting:
  - Enabled: Window hides completely (accessible via tray icon)
  - Disabled: Window appears minimized in taskbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)