### PR TITLE
fix: force GTK3 on Linux to prevent GTK symbol startup crash

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,6 +58,7 @@ configureChannelUserDataPath();
 // the compositor to set up an ARGB visual before any windows are created.
 // --disable-gpu-compositing prevents GPU compositing conflicts with the compositor.
 if (process.platform === "linux") {
+  app.commandLine.appendSwitch("gtk-version", "3");
   app.commandLine.appendSwitch("enable-transparent-visuals");
   app.commandLine.appendSwitch("disable-gpu-compositing");
 }


### PR DESCRIPTION
## Summary
- add a single Linux startup switch to force GTK3: `app.commandLine.appendSwitch("gtk-version", "3")`
- keep the rest of startup behavior unchanged (no refactor, no additional flags)
- addresses the immediate crash reported in #191 on Ubuntu/GNOME Wayland packaged builds

## Why
Electron 36 can initialize with GTK4 while other loaded symbols are GTK2/3, which crashes process startup on some Linux setups. Forcing GTK3 at startup avoids that conflict.

## Validation
- verified local branch starts with `npm start` after this change
- change scope is 1 line in `main.js` (Linux-only path)