### PR TITLE
Refactor control panel close event handling Fixes #242

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -495,12 +495,8 @@ class WindowManager {
     this.controlPanelWindow.on("close", (event) => {
       if (!this.isQuitting) {
         event.preventDefault();
-        if (process.platform === "darwin") {
-          this.hideControlPanelToTray();
-        } else {
-          this.controlPanelWindow.minimize();
+        this.hideControlPanelToTray();
         }
-      }
     });
 
     this.controlPanelWindow.on("closed", () => {


### PR DESCRIPTION
## Problem
On Windows, clicking the ✕ close button had the same behavior as the minimize button — the window stayed visible in the taskbar instead of disappearing while the app kept running in the background as describe in the Issue #242 

## Root Cause
In `windowManager.js`, the `close` event handler called `minimize()` on non-macOS platforms instead of `hide()`.

## Fix
Replaced the platform-specific logic with a single call to `hideControlPanelToTray()` which already calls `window.hide()` and handles the macOS dock case internally.

## Changes
- `src/helpers/windowManager.js`: 4 lines removed, no new logic added

## Testing
- [x] Windows: ✕ hides the window (not in taskbar), app still in tray
- [x] Windows: minimize button still minimizes to taskbar
- [x] macOS: behavior unchanged