### PR TITLE
fix(macos): resolve paste failure from wrong accessibility check and stale focus

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -123,6 +123,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   createProductionEnvFile: (key) => ipcRenderer.invoke("create-production-env-file", key),
 
   // Clipboard functions
+  checkAccessibilityPermission: () => ipcRenderer.invoke("check-accessibility-permission"),
   readClipboard: () => ipcRenderer.invoke("read-clipboard"),
   writeClipboard: (text) => ipcRenderer.invoke("write-clipboard", text),
   checkPasteTools: () => ipcRenderer.invoke("check-paste-tools"),

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -246,6 +246,17 @@ export const usePermissions = (
     checkPasteToolsAvailability();
   }, [checkPasteToolsAvailability]);
 
+  // On macOS, re-validate accessibility permission on mount to override stale
+  // localStorage values (e.g. after app update changes the code signature).
+  useEffect(() => {
+    if (getPlatform() !== "darwin") return;
+    window.electronAPI?.checkAccessibilityPermission?.().then((granted) => {
+      if (!granted) {
+        setAccessibilityPermissionGranted(false);
+      }
+    });
+  }, [setAccessibilityPermissionGranted]);
+
   const testAccessibilityPermission = useCallback(async () => {
     const platform = getPlatform();
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -345,6 +345,7 @@ declare global {
       }) => Promise<void>;
 
       // Clipboard operations
+      checkAccessibilityPermission: () => Promise<boolean>;
       readClipboard: () => Promise<string>;
       writeClipboard: (text: string) => Promise<{ success: boolean }>;
       checkPasteTools: () => Promise<PasteToolsResult>;


### PR DESCRIPTION
## Summary

- **Permission check tested the wrong binary** — replaced `osascript` spawn with `systemPreferences.isTrustedAccessibilityClient(false)`, which queries the actual Electron app's TCC trust instead of the osascript process
- **UI showed stale "permissions verified"** — added mount-time IPC re-validation that overrides localStorage when macOS reports the permission is actually revoked (common after app updates change the code signature)
- **Paste keystroke had no target** — on macOS, replaced `blur()` with `hide()` + `showInactive()` so the window server activates the previous app before the Cmd+V simulation fires
- **Race condition on first paste** — added a single retry (200ms delay, clipboard re-write) to recover when the keystroke fires before the target app is fully active
- **24-hour permission cache was excessive** — unified to a single 5s TTL since `AXIsProcessTrusted()` is a cheap synchronous syscall; cache only debounces the denial dialog

## Files changed

| File | Change |
|------|--------|
| `src/helpers/clipboard.js` | Native permission check, unified 5s cache, paste retry |
| `src/helpers/ipcHandlers.js` | macOS `hide()`+`showInactive()` focus fix, new `check-accessibility-permission` IPC handler |
| `preload.js` | Expose `checkAccessibilityPermission` bridge method |
| `src/types/electron.ts` | Add type for new IPC method |
| `src/hooks/usePermissions.ts` | Mount-time re-validation useEffect for macOS |

## Impact

- **macOS**: fixes the core paste failure — existing users get the fix on next update with no manual action required (unless they have stale TCC entries, which the UI will now correctly surface)
- **Windows/Linux**: zero changes to their code paths — `blur()` + 80ms remains