### PR TITLE
Fix transcription log accuracy and add client e2e latency tracking

### DIFF
--- a/src/helpers/deepgramStreaming.js
+++ b/src/helpers/deepgramStreaming.js
@@ -99,6 +99,7 @@ class DeepgramStreaming {
     this.proactiveRefreshTimer = null;
     this._generation = 0;
     this.audioBytesSent = 0;
+    this.currentModel = "nova-3";
     this.resultsReceived = 0;
     this.livenessTimer = null;
     this.replayBuffer = [];
@@ -116,6 +117,7 @@ class DeepgramStreaming {
     const baseLang = lang ? lang.split("-")[0].toLowerCase() : null;
     const useNova3 = !lang || NOVA3_LANGUAGES.has(lang) || NOVA3_LANGUAGES.has(baseLang);
     const model = useNova3 ? "nova-3" : "nova-2";
+    this.currentModel = model;
 
     if (!useNova3) {
       debugLogger.debug("Deepgram falling back to nova-2", { language: lang });

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1700,6 +1700,8 @@ class IPCHandlers {
           sttProvider: data.data.sttProvider,
           sttModel: data.data.sttModel,
           sttProcessingMs: data.data.sttProcessingMs,
+          sttWordCount: data.data.sttWordCount,
+          sttLanguage: data.data.sttLanguage,
           audioDurationMs: data.data.audioDurationMs,
         };
       } catch (error) {
@@ -1748,9 +1750,12 @@ class IPCHandlers {
             sttProvider: opts.sttProvider,
             sttModel: opts.sttModel,
             sttProcessingMs: opts.sttProcessingMs,
+            sttWordCount: opts.sttWordCount,
+            sttLanguage: opts.sttLanguage,
             audioDurationMs: opts.audioDurationMs,
             audioSizeBytes: opts.audioSizeBytes,
             audioFormat: opts.audioFormat,
+            clientTotalMs: opts.clientTotalMs,
           }),
         });
 
@@ -1802,6 +1807,13 @@ class IPCHandlers {
               clientType: "desktop",
               appVersion: app.getVersion(),
               clientVersion: app.getVersion(),
+              sttProvider: opts.sttProvider,
+              sttModel: opts.sttModel,
+              sttProcessingMs: opts.sttProcessingMs,
+              sttLanguage: opts.sttLanguage,
+              audioSizeBytes: opts.audioSizeBytes,
+              audioFormat: opts.audioFormat,
+              clientTotalMs: opts.clientTotalMs,
               sendLogs: opts.sendLogs,
             }),
           });
@@ -2631,12 +2643,14 @@ class IPCHandlers {
 
     ipcMain.handle("deepgram-streaming-stop", async () => {
       try {
+        const model = this.deepgramStreaming?.currentModel || "nova-3";
+        const audioBytesSent = this.deepgramStreaming?.audioBytesSent || 0;
         let result = { text: "" };
         if (this.deepgramStreaming) {
           result = await this.deepgramStreaming.disconnect(true);
         }
 
-        return { success: true, text: result?.text || "" };
+        return { success: true, text: result?.text || "", model, audioBytesSent };
       } catch (error) {
         debugLogger.error("Deepgram streaming stop error", { error: error.message });
         return { success: false, error: error.message };

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -703,7 +703,16 @@ declare global {
       cloudStreamingUsage?: (
         text: string,
         audioDurationSeconds: number,
-        opts?: { sendLogs?: boolean }
+        opts?: {
+          sendLogs?: boolean;
+          sttProvider?: string;
+          sttModel?: string;
+          sttProcessingMs?: number;
+          sttLanguage?: string;
+          audioSizeBytes?: number;
+          audioFormat?: string;
+          clientTotalMs?: number;
+        }
       ) => Promise<{
         success: boolean;
         wordsUsed?: number;


### PR DESCRIPTION
## Summary

- **Fix BYOK + cloud STT producing zero log rows**: `sendLogs` was suppressed unconditionally when reasoning was enabled, even for BYOK reasoning which never calls `/api/reason`. Now only suppresses when `cloudReasoningMode === "openwhispr"`
- **Forward `sttWordCount` and `sttLanguage` through reasoning path**: When AI enhancement is on, the transcribe log is suppressed and reason creates the only row — but word count and language were lost. Now forwarded from `/api/transcribe` response through IPC to `/api/reason`
- **Report actual Deepgram model**: Streaming always reported `nova-3` even when `nova-2` was selected for unsupported languages. `deepgramStreaming.js` now stores `currentModel` and returns it from the stop handler
- **Populate streaming STT metadata**: `stt_processing_ms` (stop-to-transcript), `stt_language`, `audio_size_bytes`, and `audio_format` were NULL for all streaming rows. Now computed client-side and forwarded to both `/api/reason` and `/api/streaming-usage`
- **Add `client_total_ms` for true press-to-paste latency**: Measured on the desktop from recording start to paste completion. Sent via `cloudStreamingUsage` — either inserted directly or used to UPDATE the existing reason-created row