### PR TITLE
chore: add at-spi2-core as required dependency for Linux packages

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -166,7 +166,9 @@
       "--deb-suggests",
       "wtype",
       "--deb-recommends",
-      "wl-clipboard"
+      "wl-clipboard",
+      "--deb-depends",
+      "at-spi2-core"
     ]
   },
   "rpm": {
@@ -176,7 +178,9 @@
       "--rpm-tag",
       "Suggests: wtype",
       "--rpm-tag",
-      "Recommends: wl-clipboard"
+      "Recommends: wl-clipboard",
+      "--rpm-tag",
+      "Requires: at-spi2-core"
     ]
   },
   "nsis": {


### PR DESCRIPTION
## Summary
- Adds `at-spi2-core` as a **required** dependency for `.deb` and `.rpm` packages
- Needed for the auto-learn correction monitoring feature — the `linux-text-monitor` binary uses the AT-SPI2 D-Bus interface to detect user edits after paste and update the custom dictionary

## Changes
- `electron-builder.json`: `--deb-depends at-spi2-core` (deb) and `Requires: at-spi2-core` (rpm)