### PR TITLE
feat: bulk-import words into the custom dictionary

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Bringe der KI dein Vokabular bei – Namen, Fachbegriffe und Ausdrücke, die sie sonst übersehen könnte",
     "clearTitle": "Wörterbuch leeren?",
     "clearDescription": "Dadurch werden alle Wörter aus deinem benutzerdefinierten Wörterbuch entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
-    "addPlaceholder": "Ein Wort oder eine Phrase hinzufügen..."
+    "addPlaceholder": "Ein Wort oder eine Phrase hinzufügen...",
+    "importButton": "Importieren",
+    "importTitle": "Wörter importieren",
+    "importDescription": "Füge eine Liste von Wörtern oder Begriffen ein. Trenne sie mit Kommas, Semikolons oder Zeilenumbrüchen.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} Wort/Wörter erkannt",
+    "importConfirm": "Importieren",
+    "importCancel": "Abbrechen"
   },
   "sidebar": {
     "home": "Startseite",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1525,7 +1525,14 @@
     "howItWorks": "How it works",
     "howItWorksDetail": "Words are fed as context hints to the speech model, helping it recognize uncommon terms. For difficult words, try adding context like \"The word is Synty\" alongside the word itself.",
     "autoManaged": "Auto-managed — synced from agent name",
-    "inputHint": "Separate multiple words with commas. Add context phrases like \"The word is Synty\" for better recognition."
+    "inputHint": "Separate multiple words with commas. Add context phrases like \"The word is Synty\" for better recognition.",
+    "importButton": "Import",
+    "importTitle": "Import Words",
+    "importDescription": "Paste a list of words or phrases. Separate them with commas, semicolons, or line breaks.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} word(s) detected",
+    "importConfirm": "Import",
+    "importCancel": "Cancel"
   },
   "support": {
     "joinDiscord": "Join Discord",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Enseña a la IA tu vocabulario: nombres, jerga y términos que podría pasar por alto",
     "clearTitle": "¿Borrar el diccionario?",
     "clearDescription": "Esto eliminará todas las palabras de tu diccionario personalizado. Esta acción no se puede deshacer.",
-    "addPlaceholder": "Añadir una palabra o frase..."
+    "addPlaceholder": "Añadir una palabra o frase...",
+    "importButton": "Importar",
+    "importTitle": "Importar palabras",
+    "importDescription": "Pega una lista de palabras o frases. Sepáralas con comas, punto y coma o saltos de línea.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} palabra(s) detectada(s)",
+    "importConfirm": "Importar",
+    "importCancel": "Cancelar"
   },
   "sidebar": {
     "home": "Inicio",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1525,7 +1525,14 @@
     "howItWorks": "Comment ça marche",
     "howItWorksDetail": "Les mots sont transmis comme indices contextuels au modèle vocal, l'aidant à reconnaître les termes peu courants. Pour les mots difficiles, essayez d'ajouter du contexte comme « Le mot est Synty » en plus du mot lui-même.",
     "autoManaged": "Géré automatiquement — synchronisé depuis le nom de l'agent",
-    "inputHint": "Séparez les mots par des virgules. Ajoutez des phrases de contexte comme « Le mot est Synty » pour une meilleure reconnaissance."
+    "inputHint": "Séparez les mots par des virgules. Ajoutez des phrases de contexte comme « Le mot est Synty » pour une meilleure reconnaissance.",
+    "importButton": "Importer",
+    "importTitle": "Importer des mots",
+    "importDescription": "Collez une liste de mots ou d'expressions. Séparez-les par des virgules, des points-virgules ou des retours à la ligne.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} mot(s) détecté(s)",
+    "importConfirm": "Importer",
+    "importCancel": "Annuler"
   },
   "support": {
     "joinDiscord": "Rejoindre Discord",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Insegna all'IA il tuo vocabolario — nomi, gergo e termini che potrebbe altrimenti non riconoscere",
     "clearTitle": "Svuotare il dizionario?",
     "clearDescription": "Verranno rimossi tutti i termini dal tuo dizionario personalizzato. Questa azione non può essere annullata.",
-    "addPlaceholder": "Aggiungi una parola o una frase..."
+    "addPlaceholder": "Aggiungi una parola o una frase...",
+    "importButton": "Importa",
+    "importTitle": "Importa parole",
+    "importDescription": "Incolla un elenco di parole o frasi. Separale con virgole, punto e virgola o a capo.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} parola/e rilevata/e",
+    "importConfirm": "Importa",
+    "importCancel": "Annulla"
   },
   "sidebar": {
     "home": "Home",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1417,7 +1417,14 @@
     "description": "AIに語彙を学習させましょう — 名前、専門用語、見落とされがちな表現など",
     "clearTitle": "辞書をクリアしますか？",
     "clearDescription": "カスタム辞書のすべての単語が削除されます。この操作は元に戻せません。",
-    "addPlaceholder": "単語やフレーズを追加..."
+    "addPlaceholder": "単語やフレーズを追加...",
+    "importButton": "インポート",
+    "importTitle": "単語をインポート",
+    "importDescription": "単語やフレーズのリストを貼り付けてください。カンマ、セミコロン、または改行で区切ります。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} 個の単語を検出",
+    "importConfirm": "インポート",
+    "importCancel": "キャンセル"
   },
   "referral": {
     "title": "紹介して特典をゲット",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Ensine a IA o seu vocabulário — nomes, jargões e termos que ela poderia não reconhecer",
     "clearTitle": "Limpar o dicionário?",
     "clearDescription": "Isso removerá todas as palavras do seu dicionário personalizado. Esta ação não pode ser desfeita.",
-    "addPlaceholder": "Adicionar uma palavra ou frase..."
+    "addPlaceholder": "Adicionar uma palavra ou frase...",
+    "importButton": "Importar",
+    "importTitle": "Importar palavras",
+    "importDescription": "Cole uma lista de palavras ou frases. Separe-as com vírgulas, ponto e vírgula ou quebras de linha.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} palavra(s) detectada(s)",
+    "importConfirm": "Importar",
+    "importCancel": "Cancelar"
   },
   "sidebar": {
     "home": "Início",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1489,7 +1489,14 @@
     "title": "Словарь",
     "description": "Добавьте слова для улучшения транскрипции",
     "clearTitle": "Очистить словарь?",
-    "clearDescription": "Все слова будут удалены без возможности восстановления."
+    "clearDescription": "Все слова будут удалены без возможности восстановления.",
+    "importButton": "Импорт",
+    "importTitle": "Импорт слов",
+    "importDescription": "Вставьте список слов или фраз. Разделяйте их запятыми, точками с запятой или переносами строк.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} слово(а) обнаружено",
+    "importConfirm": "Импортировать",
+    "importCancel": "Отмена"
   },
   "sidebar": {
     "home": "Главная",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1489,7 +1489,14 @@
     "description": "教 AI 学习你的词汇 — 名字、行话和它可能遗漏的术语",
     "clearTitle": "清空词典？",
     "clearDescription": "这将删除自定义词典中的所有词汇，此操作无法撤销。",
-    "addPlaceholder": "添加词语或短语..."
+    "addPlaceholder": "添加词语或短语...",
+    "importButton": "导入",
+    "importTitle": "导入词汇",
+    "importDescription": "粘贴词语或短语列表。使用逗号、分号或换行分隔。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "检测到 {{count}} 个词语",
+    "importConfirm": "导入",
+    "importCancel": "取消"
   },
   "sidebar": {
     "home": "首页",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1485,7 +1485,14 @@
     "description": "教 AI 學習你的詞彙 — 名字、專業術語和它可能遺漏的表達",
     "clearTitle": "清空字典？",
     "clearDescription": "這將移除自訂字典中的所有詞彙。此操作無法復原。",
-    "addPlaceholder": "新增詞語或片語..."
+    "addPlaceholder": "新增詞語或片語...",
+    "importButton": "匯入",
+    "importTitle": "匯入詞彙",
+    "importDescription": "貼上詞語或片語清單。使用逗號、分號或換行分隔。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "偵測到 {{count}} 個詞語",
+    "importConfirm": "匯入",
+    "importCancel": "取消"
   },
   "sidebar": {
     "home": "首頁",


### PR DESCRIPTION
## Summary

Adds a bulk-import dialog to the custom dictionary, allowing users to paste a list of words/phrases separated by commas, semicolons, or line breaks instead of adding them one by one.

## Changes

- **`src/components/DictionaryView.tsx`**: Add import button and dialog with multi-line text input, smart parsing (lines first, then comma/semicolon split), word count preview, and case-insensitive deduplication against existing dictionary
- **All 10 locale files**: Add `importButton`, `importTitle`, `importDescription`, `importPlaceholder`, `importCount`, `importConfirm`, `importCancel` translation keys

## Test plan

1. Open Dictionary → click Import button
2. Paste words separated by commas: `Kubernetes, Docker, Vue.js` → should show 3 words
3. Paste words separated by line breaks → each line becomes a word
4. Paste mixed format (lines + commas) → lines split first, then commas within each line
5. Verify technical terms with dots/special chars are preserved (e.g., `Vue.js`, `.tsx`)
6. Import words that already exist → duplicates should be skipped
7. Verify empty lines and whitespace-only entries are filtered out

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author