### PR TITLE
feat(dictionary): AI-powered term extraction from free-form text

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Bringe der KI dein Vokabular bei – Namen, Fachbegriffe und Ausdrücke, die sie sonst übersehen könnte",
     "clearTitle": "Wörterbuch leeren?",
     "clearDescription": "Dadurch werden alle Wörter aus deinem benutzerdefinierten Wörterbuch entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
-    "addPlaceholder": "Ein Wort oder eine Phrase hinzufügen..."
+    "addPlaceholder": "Ein Wort oder eine Phrase hinzufügen...",
+    "importButton": "Importieren",
+    "importTitle": "Wörter importieren",
+    "importDescription": "Füge eine Liste von Wörtern oder Begriffen ein. Trenne sie mit Kommas, Semikolons oder Zeilenumbrüchen.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} Wort/Wörter erkannt",
+    "importConfirm": "Importieren",
+    "importCancel": "Abbrechen"
   },
   "sidebar": {
     "home": "Startseite",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} Wort/Wörter erkannt",
     "importConfirm": "Importieren",
-    "importCancel": "Abbrechen"
+    "importCancel": "Abbrechen",
+    "tabList": "Liste",
+    "tabExtract": "Aus Text extrahieren",
+    "extractDescription": "Füge beliebigen Text ein (Meetingnotizen, Dokumentation, E-Mails) und lass die KI Fachbegriffe extrahieren.",
+    "extractPlaceholder": "Text hier einfügen — z. B. Meetingnotizen, Dokumentation oder beliebiger Text mit Fachbegriffen…",
+    "extractButton": "Begriffe extrahieren",
+    "extracting": "Extrahiere…",
+    "extractCount": "{{count}} Begriff(e) gefunden",
+    "extractEmpty": "Aus diesem Text konnten keine Begriffe extrahiert werden.",
+    "extractError": "Extraktion fehlgeschlagen. Bitte KI-Modell-Konfiguration prüfen."
   },
   "sidebar": {
     "home": "Startseite",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1532,7 +1532,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} word(s) detected",
     "importConfirm": "Import",
-    "importCancel": "Cancel"
+    "importCancel": "Cancel",
+    "tabList": "List",
+    "tabExtract": "Extract from text",
+    "extractDescription": "Paste any text (meeting notes, documentation, emails) and let AI extract technical terms and jargon.",
+    "extractPlaceholder": "Paste your text here — e.g. meeting notes, documentation, or any text containing domain-specific terms...",
+    "extractButton": "Extract terms",
+    "extracting": "Extracting…",
+    "extractCount": "{{count}} term(s) found",
+    "extractEmpty": "No terms could be extracted from this text.",
+    "extractError": "Failed to extract terms. Please check your AI model configuration."
   },
   "support": {
     "joinDiscord": "Join Discord",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1525,7 +1525,14 @@
     "howItWorks": "How it works",
     "howItWorksDetail": "Words are fed as context hints to the speech model, helping it recognize uncommon terms. For difficult words, try adding context like \"The word is Synty\" alongside the word itself.",
     "autoManaged": "Auto-managed — synced from agent name",
-    "inputHint": "Separate multiple words with commas. Add context phrases like \"The word is Synty\" for better recognition."
+    "inputHint": "Separate multiple words with commas. Add context phrases like \"The word is Synty\" for better recognition.",
+    "importButton": "Import",
+    "importTitle": "Import Words",
+    "importDescription": "Paste a list of words or phrases. Separate them with commas, semicolons, or line breaks.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} word(s) detected",
+    "importConfirm": "Import",
+    "importCancel": "Cancel"
   },
   "support": {
     "joinDiscord": "Join Discord",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Enseña a la IA tu vocabulario: nombres, jerga y términos que podría pasar por alto",
     "clearTitle": "¿Borrar el diccionario?",
     "clearDescription": "Esto eliminará todas las palabras de tu diccionario personalizado. Esta acción no se puede deshacer.",
-    "addPlaceholder": "Añadir una palabra o frase..."
+    "addPlaceholder": "Añadir una palabra o frase...",
+    "importButton": "Importar",
+    "importTitle": "Importar palabras",
+    "importDescription": "Pega una lista de palabras o frases. Sepáralas con comas, punto y coma o saltos de línea.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} palabra(s) detectada(s)",
+    "importConfirm": "Importar",
+    "importCancel": "Cancelar"
   },
   "sidebar": {
     "home": "Inicio",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} palabra(s) detectada(s)",
     "importConfirm": "Importar",
-    "importCancel": "Cancelar"
+    "importCancel": "Cancelar",
+    "tabList": "Lista",
+    "tabExtract": "Extraer del texto",
+    "extractDescription": "Pega cualquier texto (notas de reunión, documentación, correos) y deja que la IA extraiga términos técnicos.",
+    "extractPlaceholder": "Pega tu texto aquí — p. ej. notas de reunión, documentación o cualquier texto con términos especializados…",
+    "extractButton": "Extraer términos",
+    "extracting": "Extrayendo…",
+    "extractCount": "{{count}} término(s) encontrado(s)",
+    "extractEmpty": "No se pudieron extraer términos de este texto.",
+    "extractError": "Error al extraer términos. Verifica la configuración del modelo de IA."
   },
   "sidebar": {
     "home": "Inicio",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1525,7 +1525,14 @@
     "howItWorks": "Comment ça marche",
     "howItWorksDetail": "Les mots sont transmis comme indices contextuels au modèle vocal, l'aidant à reconnaître les termes peu courants. Pour les mots difficiles, essayez d'ajouter du contexte comme « Le mot est Synty » en plus du mot lui-même.",
     "autoManaged": "Géré automatiquement — synchronisé depuis le nom de l'agent",
-    "inputHint": "Séparez les mots par des virgules. Ajoutez des phrases de contexte comme « Le mot est Synty » pour une meilleure reconnaissance."
+    "inputHint": "Séparez les mots par des virgules. Ajoutez des phrases de contexte comme « Le mot est Synty » pour une meilleure reconnaissance.",
+    "importButton": "Importer",
+    "importTitle": "Importer des mots",
+    "importDescription": "Collez une liste de mots ou d'expressions. Séparez-les par des virgules, des points-virgules ou des retours à la ligne.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} mot(s) détecté(s)",
+    "importConfirm": "Importer",
+    "importCancel": "Annuler"
   },
   "support": {
     "joinDiscord": "Rejoindre Discord",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1532,7 +1532,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} mot(s) détecté(s)",
     "importConfirm": "Importer",
-    "importCancel": "Annuler"
+    "importCancel": "Annuler",
+    "tabList": "Liste",
+    "tabExtract": "Extraire du texte",
+    "extractDescription": "Collez n'importe quel texte (notes de réunion, documentation, e-mails) et laissez l'IA extraire les termes techniques.",
+    "extractPlaceholder": "Collez votre texte ici — p. ex. notes de réunion, documentation ou tout texte contenant des termes spécialisés…",
+    "extractButton": "Extraire les termes",
+    "extracting": "Extraction…",
+    "extractCount": "{{count}} terme(s) trouvé(s)",
+    "extractEmpty": "Aucun terme n'a pu être extrait de ce texte.",
+    "extractError": "Échec de l'extraction. Vérifiez la configuration du modèle IA."
   },
   "support": {
     "joinDiscord": "Rejoindre Discord",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Insegna all'IA il tuo vocabolario — nomi, gergo e termini che potrebbe altrimenti non riconoscere",
     "clearTitle": "Svuotare il dizionario?",
     "clearDescription": "Verranno rimossi tutti i termini dal tuo dizionario personalizzato. Questa azione non può essere annullata.",
-    "addPlaceholder": "Aggiungi una parola o una frase..."
+    "addPlaceholder": "Aggiungi una parola o una frase...",
+    "importButton": "Importa",
+    "importTitle": "Importa parole",
+    "importDescription": "Incolla un elenco di parole o frasi. Separale con virgole, punto e virgola o a capo.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} parola/e rilevata/e",
+    "importConfirm": "Importa",
+    "importCancel": "Annulla"
   },
   "sidebar": {
     "home": "Home",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} parola/e rilevata/e",
     "importConfirm": "Importa",
-    "importCancel": "Annulla"
+    "importCancel": "Annulla",
+    "tabList": "Elenco",
+    "tabExtract": "Estrai dal testo",
+    "extractDescription": "Incolla qualsiasi testo (appunti di riunione, documentazione, email) e lascia che l'IA estragga i termini tecnici.",
+    "extractPlaceholder": "Incolla il tuo testo qui — ad es. appunti di riunione, documentazione o qualsiasi testo con termini specialistici…",
+    "extractButton": "Estrai termini",
+    "extracting": "Estrazione…",
+    "extractCount": "{{count}} termine/i trovato/i",
+    "extractEmpty": "Non è stato possibile estrarre termini da questo testo.",
+    "extractError": "Estrazione fallita. Controlla la configurazione del modello IA."
   },
   "sidebar": {
     "home": "Home",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1417,7 +1417,14 @@
     "description": "AIに語彙を学習させましょう — 名前、専門用語、見落とされがちな表現など",
     "clearTitle": "辞書をクリアしますか？",
     "clearDescription": "カスタム辞書のすべての単語が削除されます。この操作は元に戻せません。",
-    "addPlaceholder": "単語やフレーズを追加..."
+    "addPlaceholder": "単語やフレーズを追加...",
+    "importButton": "インポート",
+    "importTitle": "単語をインポート",
+    "importDescription": "単語やフレーズのリストを貼り付けてください。カンマ、セミコロン、または改行で区切ります。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} 個の単語を検出",
+    "importConfirm": "インポート",
+    "importCancel": "キャンセル"
   },
   "referral": {
     "title": "紹介して特典をゲット",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1424,7 +1424,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} 個の単語を検出",
     "importConfirm": "インポート",
-    "importCancel": "キャンセル"
+    "importCancel": "キャンセル",
+    "tabList": "リスト",
+    "tabExtract": "テキストから抽出",
+    "extractDescription": "任意のテキスト（会議メモ、ドキュメント、メール）を貼り付けて、AIに専門用語を抽出させます。",
+    "extractPlaceholder": "ここにテキストを貼り付けてください — 例：会議メモ、ドキュメント、専門用語を含むテキスト…",
+    "extractButton": "用語を抽出",
+    "extracting": "抽出中…",
+    "extractCount": "{{count}}件の用語が見つかりました",
+    "extractEmpty": "このテキストから用語を抽出できませんでした。",
+    "extractError": "用語の抽出に失敗しました。AIモデルの設定を確認してください。"
   },
   "referral": {
     "title": "紹介して特典をゲット",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} palavra(s) detectada(s)",
     "importConfirm": "Importar",
-    "importCancel": "Cancelar"
+    "importCancel": "Cancelar",
+    "tabList": "Lista",
+    "tabExtract": "Extrair do texto",
+    "extractDescription": "Cole qualquer texto (notas de reunião, documentação, e-mails) e deixe a IA extrair termos técnicos.",
+    "extractPlaceholder": "Cole seu texto aqui — ex.: notas de reunião, documentação ou qualquer texto com termos especializados…",
+    "extractButton": "Extrair termos",
+    "extracting": "Extraindo…",
+    "extractCount": "{{count}} termo(s) encontrado(s)",
+    "extractEmpty": "Não foi possível extrair termos deste texto.",
+    "extractError": "Falha ao extrair termos. Verifique a configuração do modelo de IA."
   },
   "sidebar": {
     "home": "Início",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1489,7 +1489,14 @@
     "description": "Ensine a IA o seu vocabulário — nomes, jargões e termos que ela poderia não reconhecer",
     "clearTitle": "Limpar o dicionário?",
     "clearDescription": "Isso removerá todas as palavras do seu dicionário personalizado. Esta ação não pode ser desfeita.",
-    "addPlaceholder": "Adicionar uma palavra ou frase..."
+    "addPlaceholder": "Adicionar uma palavra ou frase...",
+    "importButton": "Importar",
+    "importTitle": "Importar palavras",
+    "importDescription": "Cole uma lista de palavras ou frases. Separe-as com vírgulas, ponto e vírgula ou quebras de linha.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} palavra(s) detectada(s)",
+    "importConfirm": "Importar",
+    "importCancel": "Cancelar"
   },
   "sidebar": {
     "home": "Início",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1489,7 +1489,14 @@
     "title": "Словарь",
     "description": "Добавьте слова для улучшения транскрипции",
     "clearTitle": "Очистить словарь?",
-    "clearDescription": "Все слова будут удалены без возможности восстановления."
+    "clearDescription": "Все слова будут удалены без возможности восстановления.",
+    "importButton": "Импорт",
+    "importTitle": "Импорт слов",
+    "importDescription": "Вставьте список слов или фраз. Разделяйте их запятыми, точками с запятой или переносами строк.",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "{{count}} слово(а) обнаружено",
+    "importConfirm": "Импортировать",
+    "importCancel": "Отмена"
   },
   "sidebar": {
     "home": "Главная",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "{{count}} слово(а) обнаружено",
     "importConfirm": "Импортировать",
-    "importCancel": "Отмена"
+    "importCancel": "Отмена",
+    "tabList": "Список",
+    "tabExtract": "Извлечь из текста",
+    "extractDescription": "Вставьте любой текст (заметки с совещаний, документацию, письма) и позвольте ИИ извлечь технические термины.",
+    "extractPlaceholder": "Вставьте текст сюда — например, заметки с совещаний, документацию или любой текст со специальными терминами…",
+    "extractButton": "Извлечь термины",
+    "extracting": "Извлечение…",
+    "extractCount": "Найдено терминов: {{count}}",
+    "extractEmpty": "Не удалось извлечь термины из этого текста.",
+    "extractError": "Ошибка извлечения. Проверьте настройки модели ИИ."
   },
   "sidebar": {
     "home": "Главная",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1496,7 +1496,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "检测到 {{count}} 个词语",
     "importConfirm": "导入",
-    "importCancel": "取消"
+    "importCancel": "取消",
+    "tabList": "列表",
+    "tabExtract": "从文本提取",
+    "extractDescription": "粘贴任意文本（会议记录、文档、邮件），让AI提取专业术语。",
+    "extractPlaceholder": "在此粘贴文本 — 例如会议记录、文档或包含专业术语的任何文本…",
+    "extractButton": "提取术语",
+    "extracting": "提取中…",
+    "extractCount": "找到 {{count}} 个术语",
+    "extractEmpty": "无法从此文本中提取术语。",
+    "extractError": "术语提取失败。请检查AI模型配置。"
   },
   "sidebar": {
     "home": "首页",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1489,7 +1489,14 @@
     "description": "教 AI 学习你的词汇 — 名字、行话和它可能遗漏的术语",
     "clearTitle": "清空词典？",
     "clearDescription": "这将删除自定义词典中的所有词汇，此操作无法撤销。",
-    "addPlaceholder": "添加词语或短语..."
+    "addPlaceholder": "添加词语或短语...",
+    "importButton": "导入",
+    "importTitle": "导入词汇",
+    "importDescription": "粘贴词语或短语列表。使用逗号、分号或换行分隔。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "检测到 {{count}} 个词语",
+    "importConfirm": "导入",
+    "importCancel": "取消"
   },
   "sidebar": {
     "home": "首页",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1492,7 +1492,16 @@
     "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
     "importCount": "偵測到 {{count}} 個詞語",
     "importConfirm": "匯入",
-    "importCancel": "取消"
+    "importCancel": "取消",
+    "tabList": "清單",
+    "tabExtract": "從文字擷取",
+    "extractDescription": "貼上任意文字（會議記錄、文件、郵件），讓AI擷取專業術語。",
+    "extractPlaceholder": "在此貼上文字 — 例如會議記錄、文件或包含專業術語的任何文字…",
+    "extractButton": "擷取術語",
+    "extracting": "擷取中…",
+    "extractCount": "找到 {{count}} 個術語",
+    "extractEmpty": "無法從此文字中擷取術語。",
+    "extractError": "術語擷取失敗。請檢查AI模型設定。"
   },
   "sidebar": {
     "home": "首頁",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1485,7 +1485,14 @@
     "description": "教 AI 學習你的詞彙 — 名字、專業術語和它可能遺漏的表達",
     "clearTitle": "清空字典？",
     "clearDescription": "這將移除自訂字典中的所有詞彙。此操作無法復原。",
-    "addPlaceholder": "新增詞語或片語..."
+    "addPlaceholder": "新增詞語或片語...",
+    "importButton": "匯入",
+    "importTitle": "匯入詞彙",
+    "importDescription": "貼上詞語或片語清單。使用逗號、分號或換行分隔。",
+    "importPlaceholder": "Kubernetes, Docker, GraphQL\nTypeScript\nMicroservice; Deployment",
+    "importCount": "偵測到 {{count}} 個詞語",
+    "importConfirm": "匯入",
+    "importCancel": "取消"
   },
   "sidebar": {
     "home": "首頁",


### PR DESCRIPTION
## Summary

Extends the dictionary import dialog (from #343) with a second tab that uses the configured AI model to extract domain-specific terms from free-form text (meeting notes, documentation, emails). This makes it easy to build a custom dictionary from existing content.

**Depends on:** #343 (`feat/dictionary-import`)

## Changes

- **`src/components/DictionaryView.tsx`**: Add tabbed import dialog ("List" / "Extract from text"), AI extraction via `ReasoningService.processText()` with a terminology-extraction system prompt, extracted terms shown as removable chips before import confirmation
- **All 10 locale files**: Add `tabList`, `tabExtract`, `extractDescription`, `extractPlaceholder`, `extractButton`, `extracting`, `extractCount`, `extractEmpty`, `extractError` translation keys

## Test plan

1. Open Dictionary → Import → select "Extract from text" tab
2. Paste a paragraph containing technical jargon, names, abbreviations
3. Click "Extract terms" → AI extracts domain-specific words as chips
4. Remove unwanted terms by clicking ×
5. Click Import → terms are added to dictionary with deduplication
6. Verify it works with OpenAI, Anthropic, and Gemini providers
7. Verify error state when no AI model is configured

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author