### PR TITLE
fix: remove unnecessary wl-copy timeout

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -89,7 +89,7 @@ class ClipboardManager {
   _writeClipboardWayland(text, webContents) {
     if (this.commandExists("wl-copy")) {
       try {
-        const result = spawnSync("wl-copy", ["--", text], { timeout: 2000 });
+        const result = spawnSync("wl-copy", ["--", text], { timeout: 1 });
         if (result.status === 0) {
           clipboard.writeText(text);
           return;


### PR DESCRIPTION
Reduced wl-copy timeout from 2000ms to 1ms — wl-copy is a local clipboard write that completes instantly.