### PR TITLE
fix: handle empty transcription and dictionary-only output

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -275,6 +275,30 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         );
       }
 
+      // Silence detection: observe audio energy via AnalyserNode
+      try {
+        this._silenceCtx = new AudioContext();
+        this._silenceAnalyser = this._silenceCtx.createAnalyser();
+        this._silenceAnalyser.fftSize = 2048;
+        const sourceNode = this._silenceCtx.createMediaStreamSource(stream);
+        sourceNode.connect(this._silenceAnalyser);
+        this._peakRms = 0;
+        const dataArray = new Uint8Array(this._silenceAnalyser.fftSize);
+        this._silenceInterval = setInterval(() => {
+          this._silenceAnalyser.getByteTimeDomainData(dataArray);
+          let sum = 0;
+          for (let i = 0; i < dataArray.length; i++) {
+            const v = (dataArray[i] - 128) / 128;
+            sum += v * v;
+          }
+          const rms = Math.sqrt(sum / dataArray.length);
+          if (rms > this._peakRms) this._peakRms = rms;
+        }, 100);
+      } catch (e) {
+        logger.warn("Silence detection setup failed, skipping", { error: e.message }, "audio");
+        this._peakRms = 1; // assume speech if detection fails
+      }
+
       this.mediaRecorder = new MediaRecorder(stream);
       this.audioChunks = [];
       this.recordingStartTime = Date.now();
@@ -285,6 +309,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       };
 
       this.mediaRecorder.onstop = async () => {
+        // Clean up silence detection
+        if (this._silenceInterval) {
+          clearInterval(this._silenceInterval);
+          this._silenceInterval = null;
+        }
+        this._silenceCtx?.close().catch(() => {});
+        this._silenceCtx = null;
+        this._silenceAnalyser = null;
+
         this.isRecording = false;
         this.isProcessing = true;
         this.onStateChange?.({ isRecording: false, isProcessing: true });
@@ -380,6 +413,22 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   async processAudio(audioBlob, metadata = {}) {
     const pipelineStart = performance.now();
+
+    // Skip transcription if recording was silence
+    const SILENCE_THRESHOLD = 0.01;
+    if (this._peakRms != null && this._peakRms < SILENCE_THRESHOLD) {
+      logger.info(
+        "Silence detected, skipping transcription",
+        { peakRms: this._peakRms.toFixed(4), threshold: SILENCE_THRESHOLD },
+        "audio"
+      );
+      this._peakRms = null;
+      this.isProcessing = false;
+      this.onStateChange?.({ isRecording: false, isProcessing: false });
+      this.onTranscriptionComplete?.({ success: true, text: "" });
+      return;
+    }
+    this._peakRms = null;
 
     try {
       const s = getSettings();
@@ -896,6 +945,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   async processTranscription(text, source) {
     const normalizedText = typeof text === "string" ? text.trim() : "";
+
+    if (!normalizedText) {
+      logger.logReasoning("TRANSCRIPTION_EMPTY_SKIPPING_REASONING", {
+        source,
+        reason: "Empty text after normalization",
+      });
+      return normalizedText;
+    }
 
     logger.logReasoning("TRANSCRIPTION_RECEIVED", {
       source,

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -93,6 +93,14 @@ export const useAudioRecording = (toast, options = {}) => {
       },
       onTranscriptionComplete: async (result) => {
         if (result.success) {
+          const transcribedText = result.text?.trim();
+
+          if (!transcribedText) {
+            const fallback = t("hooks.audioRecording.noTranscription");
+            await audioManagerRef.current.safePaste(fallback);
+            return;
+          }
+
           setTranscript(result.text);
 
           const isStreaming = result.source?.includes("streaming");

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "Kein Audio erkannt",
         "description": "Die Aufnahme enthielt kein erkennbares Audio. Bitte versuchen Sie es erneut."
-      }
+      },
+      "noTranscription": "Keine Transkription verfügbar"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "No Audio Detected",
         "description": "The recording contained no detectable audio. Please try again."
-      }
+      },
+      "noTranscription": "No transcription available"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "No se detectó audio",
         "description": "La grabación no contiene audio detectable. Inténtalo de nuevo."
-      }
+      },
+      "noTranscription": "No hay transcripción disponible"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "Aucun audio détecté",
         "description": "L'enregistrement ne contient pas d'audio détectable. Réessayez."
-      }
+      },
+      "noTranscription": "Aucune transcription disponible"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "Nessun audio rilevato",
         "description": "La registrazione non contiene audio rilevabile. Riprova."
-      }
+      },
+      "noTranscription": "Nessuna trascrizione disponibile"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "音声が検出されませんでした",
         "description": "録音に音声が含まれていませんでした。もう一度お試しください。"
-      }
+      },
+      "noTranscription": "文字起こしは利用できません"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -279,7 +279,8 @@
       "noAudio": {
         "title": "Nenhum áudio detectado",
         "description": "A gravação não contém áudio detectável. Tente novamente."
-      }
+      },
+      "noTranscription": "Nenhuma transcrição disponível"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "Звук не обнаружен",
         "description": "В записи не обнаружен звук. Попробуйте ещё раз."
-      }
+      },
+      "noTranscription": "Транскрипция недоступна"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "未检测到音频",
         "description": "录音中未检测到音频，请重试。"
-      }
+      },
+      "noTranscription": "无可用转录"
     },
     "clipboard": {
       "pasteFailed": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -307,7 +307,8 @@
       "noAudio": {
         "title": "未偵測到音訊",
         "description": "錄音中未偵測到聲音。請再試一次。"
-      }
+      },
+      "noTranscription": "無可用轉錄"
     },
     "clipboard": {
       "pasteFailed": {


### PR DESCRIPTION
## Summary

- If a recording contains audio too short or empty to produce a meaningful transcription result, custom dictionary words leak through the post-processing pipeline and get pasted as if they were real transcribed text
- Added pre-transcription silence detection via Web Audio API `AnalyserNode`: audio energy (RMS) is sampled during recording, and if it never crosses a minimum threshold, transcription is skipped entirely
- Added an empty text guard in `processTranscription()` to skip the reasoning pipeline when there's nothing to process
- Simplified the hook callback to a single `if (!transcribedText)` check that pastes a localized fallback message