### PR TITLE
fix: expose auto-learn toggle in Preferences settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1779,6 +1779,30 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
                 </SettingsPanelRow>
               </SettingsPanel>
             </div>
+
+            {/* Dictionary */}
+            <div>
+              <SectionHeader
+                title={t("settingsPage.dictionary.autoLearnTitle", {
+                  defaultValue: "Auto-learn from corrections",
+                })}
+              />
+              <SettingsPanel>
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.dictionary.autoLearnTitle", {
+                      defaultValue: "Auto-learn from corrections",
+                    })}
+                    description={t("settingsPage.dictionary.autoLearnDescription", {
+                      defaultValue:
+                        "When you correct a transcription in the target app, the corrected word is automatically added to your dictionary.",
+                    })}
+                  >
+                    <Toggle checked={autoLearnCorrections} onChange={setAutoLearnCorrections} />
+                  </SettingsRow>
+                </SettingsPanelRow>
+              </SettingsPanel>
+            </div>
           </div>
         );
 


### PR DESCRIPTION
Closes https://github.com/OpenWhispr/openwhispr/issues/358

## Summary

- The auto-learn feature had no visible toggle in the settings UI, so users had no way to disable it
- Added the auto-learn toggle to the **Preferences** section, using the same `Toggle` component and `SettingsRow` pattern as the other preferences

## Context

The backend logic for auto-learn already existed and was fully functional:

- `useSettings.ts` (lines 92–113): `autoLearnCorrections` state stored in localStorage (default: `true`), synced to the main process via `window.electronAPI.setAutoLearnEnabled()`
- `ipcHandlers.js` (line 178): `_processCorrections()` checks `this._autoLearnEnabled` and skips correction processing if disabled
- `ipcHandlers.js` (line 350): `auto-learn-changed` IPC listener receives the toggle state from the renderer
- `SettingsPage.tsx` (lines 1906–1939): a `case "dictionary"` section contained a toggle UI for auto-learn, but this section was never linked in the settings sidebar (`SettingsModal.tsx`), making it completely unreachable

This PR surfaces the existing toggle in the Preferences section so it's actually accessible to users.