### PR TITLE
fix: paste not working on KDE when no token exists

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1060,7 +1060,10 @@ class ClipboardManager {
         // On GNOME/KDE Wayland, try portal mode first (RemoteDesktop D-Bus portal).
         // uinput events are accepted by the kernel but Mutter doesn't reliably
         // route them to focused native Wayland windows (issue #292).
-        if ((isGnome || isKde) && linuxFastPaste && !this.portalDenied) {
+        // On KDE, skip portal when no token — the binary exits 0 without
+        // actually pasting, silently swallowing the text.
+        const hasPortalToken = !!this._readPortalToken();
+        if ((isGnome || (isKde && hasPortalToken)) && linuxFastPaste && !this.portalDenied) {
           const MAX_PORTAL_RETRIES = 3;
           for (let attempt = 0; attempt < MAX_PORTAL_RETRIES; attempt++) {
             try {


### PR DESCRIPTION
### Summary

- On KDE Wayland, `linux-fast-paste --portal` exits with code 0 even when no RemoteDesktop portal token is available, causing the paste to silently succeed in logs while nothing is actually typed at the cursor
- This patch skips the portal method on KDE when no token exists, allowing the fallback to the uinput method which works correctly

### Problem

On KDE Wayland, the paste pipeline tries the RemoteDesktop D-Bus portal first (line 1039 in `clipboard.js`). The `linux-fast-paste --portal` binary exits with code 0 regardless of whether it has a valid portal token. Without a token, the portal call completes "successfully" but no keystrokes are emitted — the transcribed text is silently lost.

**Logs before fix** (transcription works, paste silently fails):
```
[DEBUG][clipboard] Linux paste environment {
  "isWayland": true,
  "isKde": true,
  "canAccessUinput": true,
  "ydotoolExists": true,
  "ydotoolDaemonRunning": true
}
[DEBUG][clipboard] Attempting linux-fast-paste --portal (RemoteDesktop D-Bus) {
  "hasToken": false
}
[INFO][clipboard] Paste successful {
  "tool": "linux-fast-paste",
  "method": "portal",
  "token": false
}
```

The text is transcribed correctly but never pasted. The portal method reports success (exit code 0) despite doing nothing.

### Root cause

The `_runPortalPaste` method in `clipboard.js` treats any exit code 0 from `linux-fast-paste --portal` as a successful paste (line 343). On KDE, when no portal token exists and no authorization dialog is shown, the binary exits 0 without emitting any keystrokes. This prevents the fallback chain (uinput → XTest → ydotool) from ever being reached.

The deeper issue is in the `linux-fast-paste` native binary itself — it should exit non-zero when the portal session fails to produce a paste. A long-term fix would be to update the binary to return a distinct exit code (e.g., 6) when the portal call completes without actually pasting. This JS-side guard is the right immediate fix since it doesn't require rebuilding the native binary.

### Fix

Check for an existing portal token before attempting the portal method on KDE. When no token exists, skip portal and fall through to the uinput paste method, which works reliably when the user has `/dev/uinput` access.

```diff
-        if ((isGnome || isKde) && linuxFastPaste) {
+        // On KDE, skip portal when no token — the binary exits 0 without
+        // actually pasting, silently swallowing the text.
+        const hasPortalToken = !!this._readPortalToken();
+        if ((isGnome || (isKde && hasPortalToken)) && linuxFastPaste) {
```

### Bug fix scope

The bug affects **all KDE Wayland users** running OpenWhispr without a pre-existing portal token.

1. `clipboard.js:1039` — portal is attempted for all KDE users unconditionally
2. `clipboard.js:306-365` — `_runPortalPaste` spawns `linux-fast-paste --portal` without a token (`--restore-token` flag is only added when a token exists)
3. `clipboard.js:343-348` — exit code 0 resolves the promise as success, returning `"portal"` at line 1049
4. `clipboard.js:1049` — the function returns early, **never reaching** the uinput fallback at line 1063 or ydotool/wtype/xdotool fallbacks at line 1147+

The only way a KDE user gets a working paste today is if they already have a portal token saved at the path returned by `_readPortalToken()` (line 282: `~/.cache/openwhispr/portal-paste-token`). Since KDE doesn't show a portal authorization dialog the way GNOME does, no token is ever generated — making this a dead path for all KDE users.

GNOME is unaffected because its RemoteDesktop portal shows an authorization dialog on first use, which produces a token and makes subsequent portal calls work.

### Test that `linux-fast-paste --portal` silently exits 0 on KDE

Reproducible on any KDE Wayland system with OpenWhispr installed:

```bash
# Without token — exits 0, pastes nothing
/opt/OpenWhispr/resources/resources/bin/linux-fast-paste --portal
echo $?  # 0

# With a fake token — also exits 0, pastes nothing
/opt/OpenWhispr/resources/resources/bin/linux-fast-paste --portal --restore-token "fake"
echo $?  # 0
```

Both cases exit with code 0 and produce no output or keystrokes. The binary never signals failure, so `clipboard.js` treats it as a successful paste and skips all fallback methods.

### Environment tested

- KDE Plasma 6, Wayland session
- ydotool with daemon running
- `/dev/uinput` accessible via `input` group + udev rule
- OpenWhispr 1.5.5
