### PR TITLE
fix: preserve images and HTML in clipboard during paste-and-restore

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -505,6 +505,29 @@ class ClipboardManager {
     return null;
   }
 
+  _saveClipboard() {
+    const formats = clipboard.availableFormats();
+    if (formats.some((f) => f.startsWith("image/"))) {
+      return { type: "image", data: clipboard.readImage() };
+    } else if (formats.includes("text/html")) {
+      return { type: "html", text: clipboard.readText(), html: clipboard.readHTML() };
+    } else {
+      return { type: "text", data: clipboard.readText() };
+    }
+  }
+
+  _restoreClipboard(original) {
+    if (!original) return;
+    if (original.type === "image") {
+      if (!original.data.isEmpty()) clipboard.writeImage(original.data);
+    } else if (original.type === "html") {
+      clipboard.write({ text: original.text, html: original.html });
+    } else {
+      clipboard.writeText(original.data);
+    }
+    this.safeLog("🔄 Clipboard restored");
+  }
+
   safeLog(...args) {
     if (process.env.NODE_ENV === "development") {
       try {
@@ -551,12 +574,9 @@ class ClipboardManager {
 
     try {
       const shouldRestore = options.restoreClipboard !== false;
-      const originalClipboard = shouldRestore ? clipboard.readText() : null;
+      const originalClipboard = shouldRestore ? this._saveClipboard() : null;
       if (shouldRestore) {
-        this.safeLog(
-          "💾 Saved original clipboard content:",
-          originalClipboard.substring(0, 50) + "..."
-        );
+        this.safeLog("💾 Saved original clipboard:", originalClipboard.type);
       }
 
       if (platform === "linux" && this._isWayland()) {
@@ -647,7 +667,7 @@ class ClipboardManager {
             this.safeLog(`Text pasted successfully via ${useFastPaste ? "CGEvent" : "osascript"}`);
             if (originalClipboard != null) {
               setTimeout(() => {
-                clipboard.writeText(originalClipboard);
+                this._restoreClipboard(originalClipboard);
               }, RESTORE_DELAYS.darwin);
             }
             resolve();
@@ -713,7 +733,7 @@ class ClipboardManager {
           this.safeLog("Text pasted successfully via osascript fallback");
           if (originalClipboard != null) {
             setTimeout(() => {
-              clipboard.writeText(originalClipboard);
+              this._restoreClipboard(originalClipboard);
             }, RESTORE_DELAYS.darwin);
           }
           resolve();
@@ -793,8 +813,7 @@ class ClipboardManager {
             });
             if (originalClipboard != null) {
               setTimeout(() => {
-                clipboard.writeText(originalClipboard);
-                this.safeLog("🔄 Clipboard restored");
+                this._restoreClipboard(originalClipboard);
               }, RESTORE_DELAYS.win32_nircmd);
             }
             resolve();
@@ -868,8 +887,7 @@ class ClipboardManager {
             });
             if (originalClipboard != null) {
               setTimeout(() => {
-                clipboard.writeText(originalClipboard);
-                this.safeLog("🔄 Clipboard restored");
+                this._restoreClipboard(originalClipboard);
               }, restoreDelay);
             }
             resolve();
@@ -946,8 +964,7 @@ class ClipboardManager {
             });
             if (originalClipboard != null) {
               setTimeout(() => {
-                clipboard.writeText(originalClipboard);
-                this.safeLog("🔄 Clipboard restored");
+                this._restoreClipboard(originalClipboard);
               }, restoreDelay);
             }
             resolve();
@@ -1030,10 +1047,10 @@ class ClipboardManager {
     const restoreClipboard = () => {
       if (originalClipboard == null) return;
       setTimeout(() => {
-        if (isWayland) {
-          this._writeClipboardWayland(originalClipboard, webContents);
+        if (isWayland && originalClipboard.type === "text") {
+          this._writeClipboardWayland(originalClipboard.data, webContents);
         } else {
-          clipboard.writeText(originalClipboard);
+          this._restoreClipboard(originalClipboard);
         }
       }, RESTORE_DELAYS.linux);
     };


### PR DESCRIPTION
## Summary
- Clipboard save/restore now handles **images** (screenshots), **HTML** (rich text from browser), and plain text — previously only plain text was preserved
- Added `_saveClipboard()` that detects content type via `clipboard.availableFormats()` and reads the appropriate format
- Added `_restoreClipboard()` helper that writes back the correct format after paste completes
- All 6 platform-specific restore callsites (macOS CGEvent, macOS osascript, Windows fast-paste, Windows nircmd, Windows PowerShell, Linux) updated to use the new helper

## Problem
If a user had a screenshot (Win+Shift+S) or rich HTML in the clipboard before dictation, `readText()` returned `""`, and after paste `writeText("")` overwrote the image/HTML with nothing.

## Test plan
- [ ] Copy a screenshot to clipboard → dictate → verify screenshot restores (Ctrl+V pastes the image)
- [ ] Copy plain text to clipboard → dictate → verify text restores
- [ ] Copy rich HTML from browser → dictate → verify HTML restores when pasting into a rich text editor
- [ ] Verify dictated text still gets pasted correctly into the active app

🤖 Generated with [Claude Code](https://claude.com/claude-code)