### PR TITLE
fix: add missing Linux build deps to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,10 @@ jobs:
           key: linux-electron-${{ hashFiles('**/package-lock.json') }}
           restore-keys: linux-electron-
 
-      - name: Install Linux packaging dependencies
+      - name: Install Linux build and packaging dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm libx11-dev libxtst-dev libatspi2.0-dev libglib2.0-dev
 
       - name: Build Application
         run: npm run build:linux -- --publish always


### PR DESCRIPTION
## Summary
- The release workflow only installed `rpm`, missing the dev libraries needed to compile `linux-fast-paste` with full support (X11, XTest, GIO/D-Bus portal, AT-SPI)
- Without these, release builds ship without portal paste support, so the persist token for RemoteDesktop doesn't work
- Aligns `release.yml` with `build-and-notarize.yml` which already had the correct packages