### PR TITLE
feat: add start minimized option

### DIFF
--- a/main.js
+++ b/main.js
@@ -525,6 +525,11 @@ async function startApp() {
     }
   });
 
+  ipcMain.on("start-minimized-changed", (_event, enabled) => {
+    if (debugLogger) debugLogger.info("Start minimized changed", { enabled });
+    environmentManager.saveStartMinimized(enabled);
+  });
+
   ipcMain.on("panel-start-position-changed", (_event, position) => {
     windowManager.setPanelStartPosition(position);
   });
@@ -539,8 +544,12 @@ async function startApp() {
   }
 
   // Create windows FIRST so the user sees UI as soon as possible
+  const startMinimized = environmentManager.getStartMinimized();
+  if (debugLogger) debugLogger.info("Start minimized", { enabled: startMinimized });
   await windowManager.createMainWindow();
-  await windowManager.createControlPanelWindow();
+  if (!startMinimized) {
+    await windowManager.createControlPanelWindow();
+  }
 
   // Create agent window (hidden) and set up agent hotkey
   await windowManager.createAgentWindow();

--- a/preload.js
+++ b/preload.js
@@ -513,6 +513,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   notifyPanelStartPositionChanged: (position) =>
     ipcRenderer.send("panel-start-position-changed", position),
 
+  // Start minimized
+  notifyStartMinimizedChanged: (enabled) =>
+    ipcRenderer.send("start-minimized-changed", enabled),
+
   // Auto-start management
   getAutoStartEnabled: () => ipcRenderer.invoke("get-auto-start-enabled"),
   setAutoStartEnabled: (enabled) => ipcRenderer.invoke("set-auto-start-enabled", enabled),

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -698,6 +698,8 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setAutoPasteEnabled,
     floatingIconAutoHide,
     setFloatingIconAutoHide,
+    startMinimized,
+    setStartMinimized,
     panelStartPosition,
     setPanelStartPosition,
     cloudBackupEnabled,
@@ -1867,10 +1869,13 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
             </div>
 
             {/* Startup */}
-            {platform !== "linux" && (
-              <div>
-                <SectionHeader title={t("settingsPage.general.startup.title")} />
-                <SettingsPanel>
+            <div>
+              <SectionHeader
+                title={t("settingsPage.general.startup.title")}
+                description={t("settingsPage.general.startup.description")}
+              />
+              <SettingsPanel>
+                {platform !== "linux" && (
                   <SettingsPanelRow>
                     <SettingsRow
                       label={t("settingsPage.general.startup.launchAtLogin")}
@@ -1883,9 +1888,17 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
                       />
                     </SettingsRow>
                   </SettingsPanelRow>
-                </SettingsPanel>
-              </div>
-            )}
+                )}
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.general.startup.startMinimized")}
+                    description={t("settingsPage.general.startup.startMinimizedDescription")}
+                  >
+                    <Toggle checked={startMinimized} onChange={setStartMinimized} />
+                  </SettingsRow>
+                </SettingsPanelRow>
+              </SettingsPanel>
+            </div>
 
             {/* Microphone */}
             <div>

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -23,6 +23,7 @@ const PERSISTED_KEYS = [
   "AGENT_KEY",
   "ACTIVATION_MODE",
   "FLOATING_ICON_AUTO_HIDE",
+  "START_MINIMIZED",
   "UI_LANGUAGE",
   "WHISPER_CUDA_ENABLED",
 ];
@@ -160,6 +161,16 @@ class EnvironmentManager {
 
   saveFloatingIconAutoHide(enabled) {
     const result = this._saveKey("FLOATING_ICON_AUTO_HIDE", String(enabled));
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getStartMinimized() {
+    return this._getKey("START_MINIMIZED") === "true";
+  }
+
+  saveStartMinimized(enabled) {
+    const result = this._saveKey("START_MINIMIZED", String(enabled));
     this.saveAllKeysToEnvFile().catch(() => {});
     return result;
   }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -227,6 +227,8 @@ function useSettingsInternal() {
     setPauseMediaOnDictation: store.setPauseMediaOnDictation,
     floatingIconAutoHide: store.floatingIconAutoHide,
     setFloatingIconAutoHide: store.setFloatingIconAutoHide,
+    startMinimized: store.startMinimized,
+    setStartMinimized: store.setStartMinimized,
     panelStartPosition: store.panelStartPosition,
     setPanelStartPosition: store.setPanelStartPosition,
     preferBuiltInMic: store.preferBuiltInMic,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1101,7 +1101,10 @@
       "startup": {
         "launchAtLogin": "Beim Anmelden starten",
         "launchAtLoginDescription": "OpenWhispr automatisch starten, wenn Sie sich anmelden",
-        "title": "Autostart"
+        "title": "Autostart",
+        "description": "Steuern Sie das Verhalten von OpenWhispr beim Start",
+        "startMinimized": "Minimiert starten",
+        "startMinimizedDescription": "Starten, ohne das Einstellungsfenster anzuzeigen"
       },
       "waylandPaste": {
         "title": "Wayland-Einfügen einrichten",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1164,7 +1164,10 @@
       "startup": {
         "launchAtLogin": "Launch at login",
         "launchAtLoginDescription": "Start OpenWhispr automatically when you log in",
-        "title": "Startup"
+        "title": "Startup",
+        "description": "Control how OpenWhispr behaves when it launches",
+        "startMinimized": "Start minimized",
+        "startMinimizedDescription": "Launch without showing the control panel window"
       },
       "waylandPaste": {
         "title": "Wayland Paste Setup",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1105,7 +1105,10 @@
       "startup": {
         "launchAtLogin": "Abrir al iniciar sesión",
         "launchAtLoginDescription": "Inicia OpenWhispr automáticamente al iniciar sesión",
-        "title": "Inicio"
+        "title": "Inicio",
+        "description": "Controla el comportamiento de OpenWhispr al iniciar",
+        "startMinimized": "Iniciar minimizado",
+        "startMinimizedDescription": "Iniciar sin mostrar la ventana del panel de control"
       },
       "waylandPaste": {
         "title": "Configuración de pegado en Wayland",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1105,7 +1105,10 @@
       "startup": {
         "launchAtLogin": "Lancer au démarrage",
         "launchAtLoginDescription": "Démarrer OpenWhispr automatiquement à la connexion",
-        "title": "Démarrage"
+        "title": "Démarrage",
+        "description": "Contrôlez le comportement d'OpenWhispr au lancement",
+        "startMinimized": "Démarrer réduit",
+        "startMinimizedDescription": "Lancer sans afficher la fenêtre du panneau de contrôle"
       },
       "waylandPaste": {
         "title": "Configuration du collage Wayland",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1105,7 +1105,10 @@
       "startup": {
         "launchAtLogin": "Avvia all'accesso",
         "launchAtLoginDescription": "Avvia OpenWhispr automaticamente all'accesso",
-        "title": "Avvio"
+        "title": "Avvio",
+        "description": "Controlla il comportamento di OpenWhispr all'avvio",
+        "startMinimized": "Avvia ridotto a icona",
+        "startMinimizedDescription": "Avvia senza mostrare la finestra del pannello di controllo"
       },
       "waylandPaste": {
         "title": "Configurazione incolla su Wayland",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1101,7 +1101,10 @@
       "startup": {
         "launchAtLogin": "ログイン時に起動",
         "launchAtLoginDescription": "ログイン時に OpenWhispr を自動的に起動",
-        "title": "起動設定"
+        "title": "起動設定",
+        "description": "OpenWhispr の起動時の動作を制御",
+        "startMinimized": "最小化で起動",
+        "startMinimizedDescription": "コントロールパネルウィンドウを表示せずに起動"
       },
       "waylandPaste": {
         "title": "Wayland 貼り付け設定",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1077,7 +1077,10 @@
       "startup": {
         "launchAtLogin": "Iniciar ao fazer login",
         "launchAtLoginDescription": "Iniciar o OpenWhispr automaticamente ao fazer login",
-        "title": "Inicialização"
+        "title": "Inicialização",
+        "description": "Controle o comportamento do OpenWhispr ao iniciar",
+        "startMinimized": "Iniciar minimizado",
+        "startMinimizedDescription": "Iniciar sem mostrar a janela do painel de controle"
       },
       "waylandPaste": {
         "title": "Configuração de colagem no Wayland",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1105,7 +1105,10 @@
       "startup": {
         "launchAtLogin": "Запускать при входе",
         "launchAtLoginDescription": "Автоматически запускать OpenWhispr при входе в систему",
-        "title": "Автозапуск"
+        "title": "Автозапуск",
+        "description": "Управляйте поведением OpenWhispr при запуске",
+        "startMinimized": "Запуск в свёрнутом виде",
+        "startMinimizedDescription": "Запускать без отображения окна панели управления"
       },
       "waylandPaste": {
         "title": "Настройка вставки в Wayland",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1101,7 +1101,10 @@
       "startup": {
         "launchAtLogin": "登录时启动",
         "launchAtLoginDescription": "登录时自动启动 OpenWhispr",
-        "title": "启动"
+        "title": "启动",
+        "description": "控制 OpenWhispr 启动时的行为",
+        "startMinimized": "启动时最小化",
+        "startMinimizedDescription": "启动时不显示控制面板窗口"
       },
       "waylandPaste": {
         "title": "Wayland 粘贴设置",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1101,7 +1101,10 @@
       "startup": {
         "launchAtLogin": "登入時啟動",
         "launchAtLoginDescription": "登入時自動啟動 OpenWhispr",
-        "title": "啟動"
+        "title": "啟動",
+        "description": "控制 OpenWhispr 啟動時的行為",
+        "startMinimized": "啟動時最小化",
+        "startMinimizedDescription": "啟動時不顯示控制面板視窗"
       },
       "waylandPaste": {
         "title": "Wayland 貼上設定",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -58,6 +58,7 @@ const BOOLEAN_SETTINGS = new Set([
   "audioCuesEnabled",
   "pauseMediaOnDictation",
   "floatingIconAutoHide",
+  "startMinimized",
   "meetingProcessDetection",
   "meetingAudioDetection",
   "isSignedIn",
@@ -95,6 +96,7 @@ export interface SettingsState
   audioCuesEnabled: boolean;
   pauseMediaOnDictation: boolean;
   floatingIconAutoHide: boolean;
+  startMinimized: boolean;
   gcalAccounts: GoogleCalendarAccount[];
   gcalConnected: boolean;
   gcalEmail: string;
@@ -145,6 +147,7 @@ export interface SettingsState
   setAudioCuesEnabled: (value: boolean) => void;
   setPauseMediaOnDictation: (value: boolean) => void;
   setFloatingIconAutoHide: (enabled: boolean) => void;
+  setStartMinimized: (enabled: boolean) => void;
   setGcalAccounts: (accounts: GoogleCalendarAccount[]) => void;
   setMeetingProcessDetection: (value: boolean) => void;
   setMeetingAudioDetection: (value: boolean) => void;
@@ -277,6 +280,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   audioCuesEnabled: readBoolean("audioCuesEnabled", true),
   pauseMediaOnDictation: readBoolean("pauseMediaOnDictation", false),
   floatingIconAutoHide: readBoolean("floatingIconAutoHide", false),
+  startMinimized: readBoolean("startMinimized", false),
   ...(() => {
     let accounts: GoogleCalendarAccount[] = [];
     try {
@@ -441,6 +445,15 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ floatingIconAutoHide: enabled });
     if (isBrowser) {
       window.electronAPI?.notifyFloatingIconAutoHideChanged?.(enabled);
+    }
+  },
+
+  setStartMinimized: (enabled: boolean) => {
+    if (get().startMinimized === enabled) return;
+    if (isBrowser) localStorage.setItem("startMinimized", String(enabled));
+    set({ startMinimized: enabled });
+    if (isBrowser) {
+      window.electronAPI?.notifyStartMinimizedChanged?.(enabled);
     }
   },
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -737,6 +737,7 @@ declare global {
       notifyHotkeyChanged?: (hotkey: string) => void;
       notifyFloatingIconAutoHideChanged?: (enabled: boolean) => void;
       onFloatingIconAutoHideChanged?: (callback: (enabled: boolean) => void) => () => void;
+      notifyStartMinimizedChanged?: (enabled: boolean) => void;
       notifyPanelStartPositionChanged?: (position: string) => void;
 
       // Auto-start at login


### PR DESCRIPTION
## Summary
- Add "Start minimized" toggle in Settings → Startup to launch without opening the control panel
- Setting persisted via .env file and localStorage
- Translations added for all 10 supported languages

Closes #348