### PR TITLE
fix: set desktop name on Linux for portal permission persistence

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,12 @@ if (process.platform === "linux" && process.env.XDG_SESSION_TYPE === "wayland") 
   );
 }
 
+// Set desktop filename so Wayland compositors can match windows to the .desktop entry.
+// This allows XDG portals (e.g. PipeWire) to persist permissions across sessions.
+if (process.platform === "linux") {
+  app.setDesktopName("open-whispr.desktop");
+}
+
 // Group all windows under single taskbar entry on Windows
 if (process.platform === "win32") {
   const windowsAppId =


### PR DESCRIPTION
## Summary
- Set `app.setDesktopName("open-whispr.desktop")` on Linux so Wayland compositors match windows to the `.desktop` entry
- Allows XDG portals (e.g. PipeWire, RemoteDesktop) to offer the "Allow restoring in future sessions" option in permission dialogs
- Without this, portals can't identify the app, so the persistent permission option is unavailable in production builds