### PR TITLE
fix: restore widget margin to 24px

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -108,7 +108,7 @@ const NOTIFICATION_WINDOW_CONFIG = {
 class WindowPositionUtil {
   static getMainWindowPosition(display, customSize = null, position = "bottom-right") {
     const { width, height } = customSize || WINDOW_SIZES.BASE;
-    const MARGIN = 4;
+    const MARGIN = 24;
     const workArea = display.workArea || display.bounds;
 
     let x, y;


### PR DESCRIPTION
## Summary
- Restore floating widget margin from 4px back to 24px (was reduced in the start position feature)
- Prevents the widget from being too close to screen edges on bottom-left and bottom-right positions