### PR TITLE
fix: set SUID bit on chrome-sandbox during Linux package install

### DIFF
--- a/resources/linux/after-install.sh
+++ b/resources/linux/after-install.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 # Post-install script for OpenWhispr (deb/rpm)
-# Sets up ydotool daemon prerequisites for Wayland paste support
+# Sets up chrome-sandbox permissions and ydotool daemon prerequisites
 
 set -euo pipefail
+
+# 0. Set SUID bit on chrome-sandbox (required by Electron for Linux sandboxing)
+#    Find it wherever dpkg placed the package files, rather than hardcoding /opt/...
+CHROME_SANDBOX=$(dpkg -L open-whispr 2>/dev/null | grep chrome-sandbox || echo "")
+if [ -z "$CHROME_SANDBOX" ]; then
+  # Fallback: conventional electron-builder install path
+  CHROME_SANDBOX="/opt/OpenWhispr/chrome-sandbox"
+fi
+if [ -f "$CHROME_SANDBOX" ]; then
+  chown root:root "$CHROME_SANDBOX"
+  chmod 4755 "$CHROME_SANDBOX"
+fi
 
 UDEV_RULE='KERNEL=="uinput", GROUP="input", MODE="0660", TAG+="uaccess"'
 UDEV_RULE_PATH="/etc/udev/rules.d/70-uinput.rules"


### PR DESCRIPTION
## Summary
- Electron on Linux requires `chrome-sandbox` to have SUID permissions (mode 4755, owned by root). Without this, the app crashes on launch with a fatal sandbox configuration error.
- The deb/rpm post-install script now sets `chown root:root` and `chmod 4755` on the binary during package installation.
- Uses `dpkg -L` to dynamically locate the binary, with a fallback to the default electron-builder install path.

## Test plan
- [x] Build deb with `npm run build:linux:deb`
- [x] Install with `sudo apt install ./dist/OpenWhispr-*.deb`
- [x] Verify `stat -c '%a %U:%G' /opt/OpenWhispr/chrome-sandbox` shows `4755 root:root`
- [x] Launch app — no sandbox crash ; Working on Ubuntu 25.10

The app launches the setup immediately on installation, which I expect was the desired workflow.   Closes #395 