### PR TITLE
fix: set cloudTranscriptionMode to BYOK during onboarding for non-signed-in users (local but remote)

### DIFF
--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -268,12 +268,8 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     localStorage.setItem("onboardingCompleted", "true");
     localStorage.setItem("skipAuth", skippedAuth.toString());
 
-    // Non-signed-in users using cloud mode need BYOK mode set,
-    // otherwise audioManager routes to OpenWhispr Cloud and demands sign-in.
-    // This covers users with their own API keys as well as users pointing at
-    // local inference appliances on another device (e.g. lemonade-server.ai)
-    // via a custom base URL — a future UI update should better surface this
-    // "local-but-remote" use case.
+    // Non-signed-in users in cloud mode default to BYOK to avoid
+    // "OpenWhispr Cloud requires sign-in" errors.
     if (!isSignedIn && !useLocalWhisper) {
       updateTranscriptionSettings({ cloudTranscriptionMode: "byok" });
     }
@@ -285,7 +281,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     }
 
     return true;
-  }, [hotkey, agentName, setDictationKey, ensureHotkeyRegistered]);
+  }, [hotkey, agentName, setDictationKey, ensureHotkeyRegistered, isSignedIn, useLocalWhisper, updateTranscriptionSettings]);
 
   const nextStep = useCallback(async () => {
     if (currentStep >= steps.length - 1) {
@@ -487,10 +483,10 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
               }
               useLocalWhisper={useLocalWhisper}
               onModeChange={(isLocal) => {
-                updateTranscriptionSettings({ useLocalWhisper: isLocal });
-                if (!isLocal) {
-                  updateTranscriptionSettings({ cloudTranscriptionMode: "byok" });
-                }
+                updateTranscriptionSettings({
+                  useLocalWhisper: isLocal,
+                  ...(!isLocal && !isSignedIn ? { cloudTranscriptionMode: "byok" } : {}),
+                });
               }}
               openaiApiKey={openaiApiKey}
               setOpenaiApiKey={setOpenaiApiKey}


### PR DESCRIPTION
## Summary
- Non-signed-in users completing the setup wizard in cloud mode were left with `cloudTranscriptionMode` defaulting to `"openwhispr"`, causing transcription to fail with "OpenWhispr Cloud requires sign-in".
- This affected both BYOK API key users and users pointing at local inference appliances on another device (e.g. lemonade-server.ai) via a custom base URL.
- Sets `cloudTranscriptionMode: "byok"` in two places: on mode toggle and as a safety net in `saveSettings`.

## Test plan
- [x] Tested on Ubuntu 25.10
- [x] Fresh onboarding — skip sign-in — cloud mode with custom base URL — transcription routes to custom endpoint
- [ ] Signed-in users unaffected (OpenWhispr Cloud mode still works)

## Rationale
Without this, you get to the end of the setup wizard, and it says you need to switch to BYOK mode, which isn't possible in the setup wizard.  I actually couldn't figure out where the BYOK mode is set at all for Custom Endpoint URL, as even putting in a key did not change the outcome; Ultimately I was not interested in BYOK but the error doesn't really line up with any flag or setting explicitly, as both cloud and custom endpoints could use an API key. 

On the upside, this now just works on Ubuntu 25.10, without any of the additional steps described in #310 ; no permission changes, or ydotoold upgrades, which I had performed on my other laptop.  Neither laptop have any AI capabilities, so a local Strix Halo appliance does all the work running lemonade-server.ai   

<img width="1795" height="1356" alt="image" src="https://github.com/user-attachments/assets/76a96424-7299-4814-99be-793f981b257f" />

Since lemonade supports a bunch of llm backends concurrently, in this case I can choose to use the whistper.cpp (GPU) or FastFlowLM (NPU) engine using the default quants from lemonade for either engine+checkpoint of the Wisperv3Turbo model, or any of the many others available from huggingface. 

```xml
http://1291.68.79.18:8000/api/v1/models
...
    {
      "checkpoint": "ggerganov/whisper.cpp:ggml-large-v3-turbo.bin",
      "checkpoints": {
        "main": "ggerganov/whisper.cpp:ggml-large-v3-turbo.bin",
        "npu_cache": "amd/whisper-large-turbo-onnx-npu:ggml-large-v3-turbo-encoder-vitisai.rai"
      },
      "composite_models": [],
      "created": 1234567890,
      "downloaded": true,
      "id": "Whisper-Large-v3-Turbo",
      "labels": [
        "audio",
        "transcription",
        "hot"
      ],
      "object": "model",
      "owned_by": "lemonade",
      "recipe": "whispercpp",
      "recipe_options": {

      },
      "size": 1.55,
      "suggested": true
    },
...
    {
      "checkpoint": "whisper-v3:turbo",
      "checkpoints": {
        "main": "whisper-v3:turbo"
      },
      "composite_models": [],
      "created": 1234567890,
      "downloaded": true,
      "id": "whisper-v3-turbo-FLM",
      "labels": [
        "audio",
        "transcription"
      ],
      "object": "model",
      "owned_by": "lemonade",
      "recipe": "flm",
      "recipe_options": {

      },
      "size": 0.62,
      "suggested": true
    }
    ...
```
    
## Comments

One feature that builds on the current UI hooks, that might be a good fit for expansion is to do TTS using the Kokoro backend, further expanding local capabilities to match the expanding model and backend frameworks available via llmaid.  

```
    {
      "checkpoint": "mikkoph/kokoro-onnx",
      "checkpoints": {
        "main": "mikkoph/kokoro-onnx"
      },
      "composite_models": [],
      "created": 1234567890,
      "downloaded": true,
      "id": "kokoro-v1",
      "labels": [
        "tts",
        "speech"
      ],
      "object": "model",
      "owned_by": "lemonade",
      "recipe": "kokoro",
      "recipe_options": {

      },
      "size": 0.34,
      "suggested": true
    }
```