### PR TITLE
Fix media pause toggle on Windows when GSMTC is unavailable

### DIFF
--- a/src/helpers/mediaPlayer.js
+++ b/src/helpers/mediaPlayer.js
@@ -453,6 +453,69 @@ try {
 }`.trim();
   }
 
+  _isWindowsAudioPlaying() {
+    const script = `
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public class AudioPeakMeter {
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IMMDeviceEnumerator {
+        int EnumAudioEndpoints(int dataFlow, int stateMask, out IntPtr devices);
+        int GetDefaultAudioEndpoint(int dataFlow, int role, out IntPtr device);
+    }
+
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IMMDevice {
+        int Activate([MarshalAs(UnmanagedType.LPStruct)] Guid iid, int clsCtx, IntPtr activationParams, [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
+    }
+
+    [Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IAudioMeterInformation {
+        int GetPeakValue(out float peak);
+    }
+
+    public static float GetPeak() {
+        var type = Type.GetTypeFromCLSID(new Guid("BCDE0395-E52F-467C-8E3D-C4579291692E"));
+        var enumerator = (IMMDeviceEnumerator)Activator.CreateInstance(type);
+        IntPtr devicePtr;
+        enumerator.GetDefaultAudioEndpoint(0, 1, out devicePtr);
+        var device = (IMMDevice)Marshal.GetObjectForIUnknown(devicePtr);
+        Marshal.Release(devicePtr);
+        object activated;
+        device.Activate(new Guid("C02216F6-8C67-4B5B-9D00-D008E73E0064"), 1, IntPtr.Zero, out activated);
+        var meter = (IAudioMeterInformation)activated;
+        float peak;
+        meter.GetPeakValue(out peak);
+        return peak;
+    }
+}
+'@
+try {
+    $peak = [AudioPeakMeter]::GetPeak()
+    if ($peak -gt 0) { Write-Output 'PLAYING' } else { Write-Output 'SILENT' }
+} catch {
+    Write-Output 'UNKNOWN'
+}`.trim();
+
+    const result = spawnSync(
+      "powershell",
+      ["-NoProfile", "-NonInteractive", "-Command", script],
+      { stdio: "pipe", timeout: 5000 }
+    );
+
+    if (result.status === 0) {
+      const output = (result.stdout?.toString() || "").trim();
+      if (output === "PLAYING") return true;
+      if (output === "SILENT") return false;
+    }
+    return null; // unknown
+  }
+
   _sendWindowsMediaKey() {
     const nircmd = this._resolveNircmd();
     if (nircmd) {
@@ -502,9 +565,18 @@ try {
       }
     }
 
-    // Fallback to media key toggle
-    debugLogger.debug("GSMTC unavailable, falling back to media key", {}, "media");
+    // Fallback: check if audio is actually playing before sending toggle key
+    debugLogger.debug("GSMTC unavailable, checking audio peak meter", {}, "media");
     this._didPause = false;
+    const isPlaying = this._isWindowsAudioPlaying();
+    if (isPlaying === false) {
+      debugLogger.debug("No audio playing, skipping media key to avoid starting playback", {}, "media");
+      return false;
+    }
+    if (isPlaying === null) {
+      debugLogger.debug("Could not detect audio state, skipping media key to be safe", {}, "media");
+      return false;
+    }
     if (this._sendWindowsMediaKey()) {
       debugLogger.debug("Media paused via Windows media key", {}, "media");
       this._didPause = true;


### PR DESCRIPTION
## Summary

On Windows 10, when GSMTC (Global System Media Transport Controls) isn't available, the fallback sends a blind play/pause media key. If nothing is playing, this accidentally starts playback during dictation.

This adds a check using the Core Audio peak meter API before sending the media key. If there's no audio output, we skip the key entirely.

- Uses `IAudioMeterInformation.GetPeakValue()` via COM interop to detect active audio
- If audio is playing, pause it
- If silent or detection fails, do nothing (safe default)

Fixes #401