### PR TITLE
fix: add JS fallback for bzip2 extraction on Windows 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "tailwind-merge": "^3.3.1",
         "tar": "^7.4.3",
         "tw-animate-css": "^1.3.4",
+        "unbzip2-stream": "^1.4.3",
         "unzipper": "^0.12.3",
         "ws": "^8.19.0",
         "zustand": "^5.0.11"
@@ -16031,6 +16032,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "tailwind-merge": "^3.3.1",
     "tar": "^7.4.3",
     "tw-animate-css": "^1.3.4",
+    "unbzip2-stream": "^1.4.3",
     "unzipper": "^0.12.3",
     "ws": "^8.19.0",
     "zustand": "^5.0.11"

--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const fsPromises = require("fs").promises;
 const path = require("path");
 const { spawn } = require("child_process");
+const { pipeline } = require("stream/promises");
 const debugLogger = require("./debugLogger");
 const {
   downloadFile,
@@ -433,7 +434,22 @@ class ParakeetManager {
     }
   }
 
-  _runTarExtract(archivePath, extractDir) {
+  async _runTarExtract(archivePath, extractDir) {
+    try {
+      await this._runSystemTar(archivePath, extractDir);
+      return;
+    } catch (err) {
+      debugLogger.debug("System tar failed, falling back to JS extraction", {
+        error: err.message,
+      });
+    }
+
+    const unbzip2 = require("unbzip2-stream");
+    const tar = require("tar");
+    await pipeline(fs.createReadStream(archivePath), unbzip2(), tar.x({ cwd: extractDir }));
+  }
+
+  _runSystemTar(archivePath, extractDir) {
     return new Promise((resolve, reject) => {
       const tarProcess = spawn("tar", ["-xjf", archivePath, "-C", extractDir], {
         stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary

- Windows 10's system tar doesn't include bzip2 support, so Parakeet model extraction fails
- Added unbzip2-stream as a JS fallback when system tar can't handle .tar.bz2 archives
- System tar is still tried first, the fallback only kicks in on failure