### PR TITLE
fix: lower silence detection threshold to avoid rejecting valid speech

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -433,7 +433,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const pipelineStart = performance.now();
 
     // Skip transcription if recording was silence
-    const SILENCE_THRESHOLD = 0.01;
+    const SILENCE_THRESHOLD = 0.002;
     if (this._peakRms != null && this._peakRms < SILENCE_THRESHOLD) {
       logger.info(
         "Silence detected, skipping transcription",


### PR DESCRIPTION
Some microphones (e.g., Surface Pro built-in mic) produce peak RMS values below 0.01 even at full input level, causing all recordings to be discarded as silence. Lower threshold from 0.01 to 0.002.

I faced this issue in v1.5.5. It still exists in v1.6.1

Fixes https://github.com/OpenWhispr/openwhispr/issues/367
