### PR TITLE
Remove GlobalShortcutsPortal to fix KDE Wayland hotkey prompt

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,13 +75,15 @@ if (process.platform === "win32") {
   app.commandLine.appendSwitch("disable-gpu-compositing");
 }
 
-// Enable native Wayland support: Ozone platform for native rendering,
-// and GlobalShortcutsPortal for global shortcuts via xdg-desktop-portal
+// Enable native Wayland support: Ozone platform for native rendering.
+// GlobalShortcutsPortal is intentionally omitted — GNOME uses its own
+// D-Bus shortcut manager, and on KDE the portal causes unwanted permission
+// dialogs while XWayland globalShortcut works fine without it.
 if (process.platform === "linux" && process.env.XDG_SESSION_TYPE === "wayland") {
   app.commandLine.appendSwitch("ozone-platform-hint", "auto");
   app.commandLine.appendSwitch(
     "enable-features",
-    "UseOzonePlatform,WaylandWindowDecorations,GlobalShortcutsPortal"
+    "UseOzonePlatform,WaylandWindowDecorations"
   );
 }
 


### PR DESCRIPTION
## Summary

- Remove `GlobalShortcutsPortal` from Chromium feature flags on Linux Wayland
- Electron 39 activates the XDG GlobalShortcuts portal on KDE, causing an unwanted permission dialog at every launch asking to bind Insert/Ctrl+Insert
- GNOME is unaffected (uses its own D-Bus shortcut manager)
- KDE falls back to `globalShortcut` via XWayland, restoring the pre-1.6.3 behavior