### PR TITLE
fix(streaming): resume media playback after silence

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -2635,6 +2635,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         },
         "streaming"
       );
+    } else {
+      // Silence: still fire callback so media playback resumes.
+      this.onTranscriptionComplete?.({ success: true, text: "" });
     }
 
     this.isProcessing = false;


### PR DESCRIPTION
## Summary

- Media stayed paused after recording silence with "Pause media on dictation" enabled. Streaming transcription skipped the completion callback when no text was produced, so media never resumed.

## Problem

When streaming transcription captures only silence, `stopStreamingRecording()` never calls `onTranscriptionComplete`. The `useAudioRecording` hook relies on this callback to call `resumeMediaPlayback()`. Without it, any media player paused at recording start stays paused indefinitely.

Non-streaming `processAudio()` already calls the callback with empty text on silence. The streaming path did not.

Affects all platforms (Linux/macOS/Windows) — the missing callback is in shared JS code, not platform-specific.

## Solution

Add an `else` branch to the existing `if (finalText)` block in `stopStreamingRecording()` that fires `onTranscriptionComplete({ success: true, text: "" })` when no text was produced. The hook's callback handles empty text correctly (resumes media, skips paste).

## Test plan

- [x] Enable "Pause media on dictation" in settings
- [x] Play media (e.g. Firefox/Spotify), start streaming recording, stay silent, stop
- [x] Verify media resumes after recording stops
- [x] Record with actual speech, verify transcription and paste still work normally
