### PR TITLE
Add CGNAT range to private host allowlist for Tailscale support

### DIFF
--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -8,6 +8,7 @@ function isPrivateHost(hostname: string): boolean {
     const octet = parseInt(h.split(".")[1], 10);
     if (octet >= 16 && octet <= 31) return true;
   }
+  if (/^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])\./.test(h)) return true;
   if (h.startsWith("169.254.")) return true;
 
   const isIPv6 = h.includes(":");


### PR DESCRIPTION
## Summary

- Add RFC 6598 CGNAT range (100.64.0.0/10) to isPrivateHost() in urlUtils.ts
- Tailscale VPN assigns IPs from this range (100.64.x.x to 100.127.x.x) which were rejected as non-private, causing silent fallback to OpenAI
- Tested with a real Tailscale IP (100.116.75.39) and a local whisper-server

Closes #430