### PR TITLE
fix: let app config override system env vars for API keys

### DIFF
--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -34,11 +34,12 @@ class EnvironmentManager {
   }
 
   loadEnvironmentVariables() {
-    // Loaded in priority order - dotenv won't override, so first file wins per variable.
+    // App config (.env in userData) takes precedence over system env vars,
+    // so keys saved by the user in Settings always win.
     const userDataEnv = path.join(app.getPath("userData"), ".env");
     try {
       if (fs.existsSync(userDataEnv)) {
-        require("dotenv").config({ path: userDataEnv });
+        require("dotenv").config({ path: userDataEnv, override: true });
       }
     } catch {}
 


### PR DESCRIPTION
## Summary

API keys changed through Settings are ignored after app restart if the same key is exported in the user's shell environment

## Problem

When a user changes an API key in Settings, it's saved to the app's `.env` file. But `dotenv.config()` was called without `override`, so any matching environment variable (e.g. `OPENAI_API_KEY` in `~/.profile` or `~/.bashrc`) always took precedence after restart. The user sees the new key in the UI but the app uses the old one.

Affects all API keys on any platform where the user exports keys in their shell.

## Solution

Add `override: true` to `dotenv.config()` for the userData `.env` file only. Fallback `.env` files (development, resources, legacy) keep the default behavior so they don't override anything.

## Test plan

- [x] Export an API key in shell profile (e.g. `export OPENAI_API_KEY=old`), set a different key in Settings, restart app, verify new key is used
