### PR TITLE
Disable RPM build-id links to fix install conflicts with other Electron apps

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -181,6 +181,8 @@
     "fpm": [
       "--after-install",
       "resources/linux/after-install.sh",
+      "--rpm-rpmbuild-define",
+      "_build_id_links none",
       "--rpm-tag",
       "Requires: ydotool",
       "--rpm-tag",


### PR DESCRIPTION
## Summary

- Add _build_id_links none to RPM build config to prevent /usr/lib/.build-id file conflicts
- Electron apps sharing Chromium binaries produce identical build-id hashes, causing dnf install to fail when other Electron apps (Unity Hub, Fluxer, etc.) are installed
- Known issue in electron-builder (#5227)