### PR TITLE
fix(clipboard): use uinput before portal on KDE Wayland

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -81,6 +81,12 @@ class ClipboardManager {
     this.linuxFastPasteChecked = false;
     this.portalDenied = false;
     this._kwinScriptPath = null;
+
+    process.on("exit", () => {
+      if (this._kwinScriptPath) {
+        try { fs.unlinkSync(this._kwinScriptPath); } catch {}
+      }
+    });
   }
 
   _isWayland() {
@@ -419,9 +425,8 @@ class ClipboardManager {
             ["org.kde.KWin", `/Scripting/Script${scriptId}`, "run"],
             { timeout: 1000, stdio: "pipe" }
           );
-          // KWin script executes in the compositor; 30ms lets the journal flush.
-          const waitEnd = Date.now() + 30;
-          while (Date.now() < waitEnd) {}
+          // KWin script executes in the compositor; brief pause lets the journal flush.
+          spawnSync("sleep", ["0.03"], { timeout: 100 });
 
           const journalResult = spawnSync(
             "journalctl",
@@ -454,7 +459,7 @@ class ClipboardManager {
           }
         }
       } catch (err) {
-        debugLogger.debug("KWin script fallback failed", { error: err?.message }, "clipboard");
+        debugLogger.warn("KWin script fallback failed", { error: err?.message }, "clipboard");
       }
     }
 


### PR DESCRIPTION
## Summary

Auto-paste fails silently in Chromium/Electron apps on KDE Wayland, and terminal detection (Ctrl+Shift+V vs Ctrl+V) is broken on KDE Plasma 6 without kdotool

## Problem

Two issues on KDE Wayland:

1. **Paste fails in Chrome/Chromium/Electron**: the RemoteDesktop portal sends Ctrl+V and reports success (exit 0), but Chromium on native Wayland silently ignores the synthesized keystroke. Users see the text copied to clipboard but nothing pasted. Affects all Chromium-based apps (Chrome, Chromium, Electron apps) running on native Wayland (not XWayland).

2. **Wrong paste shortcut in terminals on KDE 6**: the qdbus `supportInformation` fallback for window class detection returns no per-window data on KDE Plasma 6. Without knowing the focused app, terminals like Ghostty receive Ctrl+V instead of Ctrl+Shift+V, inserting a literal `^V` instead of pasting.

Both issues only affect KDE Wayland. GNOME, wlroots, X11, macOS, and Windows paths are unchanged.

No external tools (kdotool, xdotool, ydotool) are required after this fix.

## Solution

1. **Prefer uinput over portal on KDE**: `linux-fast-paste --uinput` creates a kernel-level virtual keyboard via `/dev/uinput`, which KWin routes like a real device. This works for all apps including Chromium. Portal is kept as a fallback if uinput fails. GNOME path is unchanged (portal first, since Mutter doesn't reliably route uinput to native Wayland windows).

2. **KWin scripting fallback for window class detection**: when kdotool is not installed, a one-line KWin script is loaded via D-Bus that prints the active window's `resourceClass` to the systemd journal. Only requires `qdbus6`, which ships with KDE.

## Test plan

- [x] KDE Wayland + Chrome/Chromium: dictate text, verify it pastes into an input field
- [x] KDE Wayland + terminal (Ghostty/Konsole): verify paste uses Ctrl+Shift+V (no `^V`)
- [x] KDE Wayland + native Wayland apps (Kate, Discord, Telegram): verify paste works
- [x] KDE Wayland + XWayland apps (Typora): verify paste works