### PR TITLE
Force XWayland on KDE Wayland to fix hotkey registration

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,11 +76,17 @@ if (process.platform === "win32") {
 }
 
 // Enable native Wayland support: Ozone platform for native rendering.
-// GlobalShortcutsPortal is intentionally omitted — GNOME uses its own
-// D-Bus shortcut manager, and on KDE the portal causes unwanted permission
-// dialogs while XWayland globalShortcut works fine without it.
+// KDE is forced to XWayland because globalShortcut doesn't work on native
+// Wayland without the GlobalShortcuts portal, and the portal causes unwanted
+// permission dialogs with broken hotkey registration.
+// GNOME and Hyprland use their own D-Bus shortcut managers so they're fine.
 if (process.platform === "linux" && process.env.XDG_SESSION_TYPE === "wayland") {
-  app.commandLine.appendSwitch("ozone-platform-hint", "auto");
+  const desktop = (process.env.XDG_CURRENT_DESKTOP || "").toLowerCase();
+  if (desktop.includes("kde")) {
+    app.commandLine.appendSwitch("ozone-platform-hint", "x11");
+  } else {
+    app.commandLine.appendSwitch("ozone-platform-hint", "auto");
+  }
   app.commandLine.appendSwitch(
     "enable-features",
     "UseOzonePlatform,WaylandWindowDecorations"


### PR DESCRIPTION
## Summary

- On KDE Wayland, globalShortcut.register() doesn't work on native Wayland because Wayland blocks global input grabs, and the GlobalShortcuts portal shows broken permission dialogs
- Force ozone-platform-hint to x11 on KDE so Electron runs via XWayland, where globalShortcut works the same way it did before the Electron 36 to 39 upgrade
- GNOME and Hyprland are unaffected, they use their own D-Bus shortcut managers and don't go through globalShortcut at all
- linux-fast-paste portal paste is also unaffected since it uses D-Bus directly, independent of how Electron renders

Root cause was commit 1e3ed5d which added ozone-platform-hint: auto for all Wayland desktops. This made Electron run as a native Wayland app on KDE, breaking globalShortcut which only works via X11.