### PR TITLE
Bump undici to 6.24.1 (CVE-2026-1526)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16620,9 +16620,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
undici 6.23.0 has a DoS bug in PerMessageDeflate.decompress() on the WebSocket client. OpenWhispr uses `ws` for all WebSocket connections so the vulnerable code path never runs, but bumping to 6.24.1 clears the advisory from dependency scanners.

Only the lockfile changes. Dependabot's #443 does the same bump but regenerates the whole lockfile (2000+ lines), this one just touches the 3 undici lines.

Closes #466