### PR TITLE
fix: release held modifier keys before SendInput paste on Windows

### DIFF
--- a/resources/windows-fast-paste.c
+++ b/resources/windows-fast-paste.c
@@ -91,14 +91,54 @@ static void SetKey(INPUT* input, WORD vk, DWORD flags) {
     input->ki.dwFlags = flags;
 }
 
+/* Modifier keys that may interfere with SendInput if held by the user's
+   hotkey.  We check left/right-specific variants since GetAsyncKeyState
+   reports physical key state per side. */
+static const WORD MODIFIER_VKS[] = {
+    VK_LCONTROL, VK_RCONTROL,
+    VK_LSHIFT,   VK_RSHIFT,
+    VK_LMENU,    VK_RMENU,
+    VK_LWIN,     VK_RWIN,
+};
+#define NUM_MODIFIERS (sizeof(MODIFIER_VKS) / sizeof(MODIFIER_VKS[0]))
+
+/* Release any modifier keys that are currently held down so they don't
+   contaminate the paste keystroke.  Returns the count of keys released;
+   the caller must pass the same arrays back to RestoreModifiers(). */
+static int ReleaseModifiers(INPUT* released, WORD* releasedVKs) {
+    int count = 0;
+    for (int i = 0; i < (int)NUM_MODIFIERS; i++) {
+        if (GetAsyncKeyState(MODIFIER_VKS[i]) & 0x8000) {
+            releasedVKs[count] = MODIFIER_VKS[i];
+            SetKey(&released[count], MODIFIER_VKS[i], KEYEVENTF_KEYUP);
+            count++;
+        }
+    }
+    if (count > 0) {
+        SendInput((UINT)count, released, sizeof(INPUT));
+    }
+    return count;
+}
+
+/* Re-press modifier keys that were released by ReleaseModifiers(). */
+static void RestoreModifiers(WORD* releasedVKs, int count) {
+    if (count == 0) return;
+    INPUT restore[NUM_MODIFIERS];
+    ZeroMemory(restore, sizeof(restore));
+    for (int i = 0; i < count; i++) {
+        SetKey(&restore[i], releasedVKs[i], 0);
+    }
+    SendInput((UINT)count, restore, sizeof(INPUT));
+}
+
 static int SendPasteNormal(void) {
     INPUT inputs[4];
     ZeroMemory(inputs, sizeof(inputs));
 
-    SetKey(&inputs[0], VK_CONTROL, 0);
+    SetKey(&inputs[0], VK_LCONTROL, 0);
     SetKey(&inputs[1], 'V', 0);
     SetKey(&inputs[2], 'V', KEYEVENTF_KEYUP);
-    SetKey(&inputs[3], VK_CONTROL, KEYEVENTF_KEYUP);
+    SetKey(&inputs[3], VK_LCONTROL, KEYEVENTF_KEYUP);
 
     UINT sent = SendInput(4, inputs, sizeof(INPUT));
     return (sent == 4) ? 0 : 1;
@@ -108,12 +148,12 @@ static int SendPasteTerminal(void) {
     INPUT inputs[6];
     ZeroMemory(inputs, sizeof(inputs));
 
-    SetKey(&inputs[0], VK_CONTROL, 0);
-    SetKey(&inputs[1], VK_SHIFT, 0);
+    SetKey(&inputs[0], VK_LCONTROL, 0);
+    SetKey(&inputs[1], VK_LSHIFT, 0);
     SetKey(&inputs[2], 'V', 0);
     SetKey(&inputs[3], 'V', KEYEVENTF_KEYUP);
-    SetKey(&inputs[4], VK_SHIFT, KEYEVENTF_KEYUP);
-    SetKey(&inputs[5], VK_CONTROL, KEYEVENTF_KEYUP);
+    SetKey(&inputs[4], VK_LSHIFT, KEYEVENTF_KEYUP);
+    SetKey(&inputs[5], VK_LCONTROL, KEYEVENTF_KEYUP);
 
     UINT sent = SendInput(6, inputs, sizeof(INPUT));
     return (sent == 6) ? 0 : 1;
@@ -160,7 +200,14 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    Sleep(5);
+    Sleep(10);
+
+    /* Release any modifier keys held by the user's hotkey so they don't
+       contaminate the paste keystroke (e.g. Ctrl+Win held → Ctrl+Win+V). */
+    INPUT releasedInputs[NUM_MODIFIERS];
+    WORD  releasedVKs[NUM_MODIFIERS];
+    ZeroMemory(releasedInputs, sizeof(releasedInputs));
+    int releasedCount = ReleaseModifiers(releasedInputs, releasedVKs);
 
     int result;
     if (isTerminal) {
@@ -168,6 +215,8 @@ int main(int argc, char* argv[]) {
     } else {
         result = SendPasteNormal();
     }
+
+    RestoreModifiers(releasedVKs, releasedCount);
 
     if (result != 0) {
         fprintf(stderr, "ERROR: SendInput failed (error %lu)\n", GetLastError());


### PR DESCRIPTION
## Summary

- Fixes paste outputting only `v` in Windows Terminal / Claude Code CLI (#438) by releasing any held modifier keys (from the user's hotkey) before sending the paste keystroke via `SendInput`
- Uses left-specific virtual key codes (`VK_LCONTROL`, `VK_LSHIFT`) in both `SendPasteNormal` and `SendPasteTerminal` for correct physical key simulation
- Restores previously-held modifiers after paste completes so the user's keyboard state isn't corrupted

## Root cause

`SendInput` [does not reset the keyboard's current state](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput) — any keys already held interfere with generated events. When a user's hotkey (e.g. `Ctrl+Win`) is still held when the paste fires, Windows sees `Ctrl+Win+V` instead of `Ctrl+V`, so only `v` arrives at the terminal.

This is the standard fix used by AutoHotkey (`SetModifierLRState`), KeePassXC, and other input automation tools.

## Test plan

- [ ] Windows Terminal (WSL) — dictate and verify full text pastes, not just `v`
- [ ] Regular app (Notepad, browser) — verify Ctrl+V paste still works
- [ ] Terminal with Ctrl+Shift+V (mintty, Alacritty) — verify paste works
- [ ] Try with different hotkeys (Ctrl+Win, Alt+R, F8) — verify modifiers are released and restored

Closes #438