### PR TITLE
Fix: Settings modal not rendering on Linux GNOME Wayland

### DIFF
--- a/src/components/ui/SidebarModal.tsx
+++ b/src/components/ui/SidebarModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
+import { getCachedPlatform } from "../../utils/platform";
 
 export interface SidebarItem<T extends string> {
   id: T;
@@ -81,7 +82,7 @@ export default function SidebarModal<T extends string>({
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Overlay className={`fixed inset-0 z-50 bg-black/60 ${getCachedPlatform() !== "linux" ? "backdrop-blur-sm" : ""} data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`} />
         <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-4xl translate-x-[-50%] translate-y-[-50%] rounded-xl p-0 overflow-hidden bg-background border border-border shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:bg-surface-1 dark:border-border-subtle dark:shadow-[0_25px_60px_-12px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98">
           <div className="relative h-full max-h-[85vh] overflow-hidden">
             <DialogPrimitive.Close className="absolute right-4 top-4 z-10 rounded-md p-1.5 opacity-40 ring-offset-background transition-[opacity,background-color] hover:opacity-100 bg-transparent hover:bg-muted dark:hover:bg-surface-raised focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
+import { getCachedPlatform } from "../../utils/platform";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -19,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 backdrop-blur-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      `fixed inset-0 z-50 bg-black/60 ${getCachedPlatform() !== "linux" ? "backdrop-blur-lg" : ""} data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
       className
     )}
     {...props}


### PR DESCRIPTION
## Problem

On Linux with GNOME + Wayland, the Settings modal (and other Radix UI dialogs) fail to render when clicked. The overlay and content are invisible, making it impossible to access settings.

## Root Cause

The `SidebarModal` overlay uses `backdrop-blur-sm` and the `DialogOverlay` uses `backdrop-blur-lg` (CSS `backdrop-filter: blur()`). These require GPU compositing to render.

However, `main.js` sets `disable-gpu-compositing` for all Linux platforms:
```js
app.commandLine.appendSwitch('disable-gpu-compositing');
```

On GNOME Wayland with GPU compositing disabled, the `backdrop-filter` CSS property is unsupported and causes the entire Radix Dialog Portal (overlay + content) to fail to render or render as fully transparent.

## Fix

Conditionally exclude `backdrop-blur` classes on Linux using the existing `getCachedPlatform()` utility:
- `SidebarModal.tsx`: `backdrop-blur-sm` only applied on non-Linux platforms
- `dialog.tsx`: `backdrop-blur-lg` only applied on non-Linux platforms

The blur effect is purely cosmetic — the modal renders with a solid dark overlay (`bg-black/60`) instead, which looks nearly identical.

## Files Changed
- `src/components/ui/SidebarModal.tsx`
- `src/components/ui/dialog.tsx`

## Testing
- Tested scenario: Arch Linux + GNOME + Wayland
- The settings modal should now appear when clicking the Settings icon in the sidebar

