### PR TITLE
fix: bundle macos-media-remote in extraResources

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -90,6 +90,7 @@
     "resources/bin/macos-fast-paste",
     "resources/bin/macos-mic-listener",
     "resources/bin/macos-text-monitor",
+    "resources/bin/macos-media-remote",
     "resources/bin/linux-fast-paste",
     "resources/bin/linux-text-monitor",
     {


### PR DESCRIPTION
## Summary
- `macos-media-remote` binary is compiled by `compile:native` but missing from `extraResources` in `electron-builder.json`
- This causes the "Pause media on dictation" feature to silently fail on macOS
- Without the binary, the app falls back to `osascript key code 100` (media key simulation) which is unreliable, especially with Spotify

## Fix
Added `"resources/bin/macos-media-remote"` to the `extraResources` array alongside the other macOS binaries (`macos-globe-listener`, `macos-fast-paste`, `macos-mic-listener`, `macos-text-monitor`).

## Test plan
- [x] Enable "Pause media on dictation" in Settings
- [x] Play music in Spotify
- [x] Start dictation — music should pause
- [x] Stop dictation — music should resume