### PR TITLE
feat: Add model-aware reasoning effort overrides

### DIFF
--- a/src/components/AgentOverlay.tsx
+++ b/src/components/AgentOverlay.tsx
@@ -103,7 +103,10 @@ export default function AgentOverlay() {
             llmMessages,
             settings.agentModel,
             settings.agentProvider,
-            { systemPrompt }
+            {
+              systemPrompt,
+              reasoningEffort: settings.agentReasoningEffort,
+            }
           );
 
       for await (const chunk of streamSource) {

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -17,10 +17,19 @@ import { API_ENDPOINTS, buildApiUrl, normalizeBaseUrl } from "../config/constant
 import logger from "../utils/logger";
 import { REASONING_PROVIDERS } from "../models/ModelRegistry";
 import { modelRegistry } from "../models/ModelRegistry";
+import type { ReasoningEffortCapability } from "../models/ModelRegistry";
+import {
+  AUTO_REASONING_EFFORT,
+  extractDynamicReasoningEffortCapability,
+  getModelReasoningEffortCapability,
+  hasSelectableReasoningEffort,
+  isReasoningEffortSupported,
+} from "../models/reasoningEffort";
 import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { createExternalLinkHandler } from "../utils/externalLinks";
 import { getCachedPlatform } from "../utils/platform";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 
 type CloudModelOption = {
   value: string;
@@ -30,6 +39,7 @@ type CloudModelOption = {
   icon?: string;
   ownedBy?: string;
   invertInDark?: boolean;
+  reasoningEffortCapability?: ReasoningEffortCapability | null;
 };
 
 interface ReasoningModelSelectorProps {
@@ -49,7 +59,25 @@ interface ReasoningModelSelectorProps {
   setGroqApiKey: (key: string) => void;
   customReasoningApiKey?: string;
   setCustomReasoningApiKey?: (key: string) => void;
+  reasoningEffort?: string;
+  setReasoningEffort?: (value: string) => void;
 }
+
+function getReasoningEffortLabel(
+  effort: string,
+  t: (key: string, options?: Record<string, unknown>) => string
+) {
+  return t(`reasoning.effort.options.${effort}`, { defaultValue: effort });
+}
+
+function getReasoningEffortDescription(
+  effort: string,
+  t: (key: string, options?: Record<string, unknown>) => string
+) {
+  return t(`reasoning.effort.optionDescriptions.${effort}`, { defaultValue: "" });
+}
+
+const AUTO_REASONING_EFFORT_VALUE = "__auto__";
 
 function GpuStatusBadge() {
   const { t } = useTranslation();
@@ -319,6 +347,8 @@ export default function ReasoningModelSelector({
   setGroqApiKey,
   customReasoningApiKey = "",
   setCustomReasoningApiKey,
+  reasoningEffort = "",
+  setReasoningEffort,
 }: ReasoningModelSelectorProps) {
   const { t } = useTranslation();
   const [selectedMode, setSelectedMode] = useState<"cloud" | "local">("cloud");
@@ -444,6 +474,7 @@ export default function ReasoningModelSelector({
                 (item?.description as string) ||
                 (ownedBy ? t("reasoning.custom.ownerLabel", { owner: ownedBy }) : undefined),
               ownedBy,
+              reasoningEffortCapability: extractDynamicReasoningEffortCapability(item),
             } as CloudModelOption;
           })
           .filter(Boolean) as CloudModelOption[];
@@ -526,6 +557,7 @@ export default function ReasoningModelSelector({
         : model.description,
       icon: iconUrl,
       invertInDark: true,
+      reasoningEffortCapability: getModelReasoningEffortCapability(model.value),
     }));
   }, [t]);
 
@@ -545,6 +577,7 @@ export default function ReasoningModelSelector({
         : model.description,
       icon: iconUrl,
       invertInDark,
+      reasoningEffortCapability: getModelReasoningEffortCapability(model.value),
     }));
   }, [selectedCloudProvider, openaiModelOptions, displayedCustomModels, t]);
 
@@ -716,6 +749,56 @@ export default function ReasoningModelSelector({
       }
     }
   };
+
+  const currentReasoningEffortCapability = useMemo(() => {
+    if (selectedMode !== "cloud" || !reasoningModel) return null;
+    if (selectedCloudProvider === "custom") {
+      return (
+        customModelOptions.find((model) => model.value === reasoningModel)?.reasoningEffortCapability ||
+        null
+      );
+    }
+    return getModelReasoningEffortCapability(reasoningModel);
+  }, [customModelOptions, reasoningModel, selectedCloudProvider, selectedMode]);
+
+  const canResolveCurrentCapability =
+    selectedMode !== "cloud"
+      ? true
+      : selectedCloudProvider !== "custom"
+        ? true
+        : !customModelsLoading &&
+          !isCustomBaseDirty &&
+          (!hasCustomBase || lastLoadedBaseRef.current === normalizedCustomReasoningBase);
+
+  useEffect(() => {
+    if (!setReasoningEffort || !reasoningEffort) return;
+    if (!canResolveCurrentCapability) return;
+    if (
+      !hasSelectableReasoningEffort(currentReasoningEffortCapability) ||
+      !isReasoningEffortSupported(currentReasoningEffortCapability, reasoningEffort)
+    ) {
+      setReasoningEffort(AUTO_REASONING_EFFORT);
+    }
+  }, [
+    canResolveCurrentCapability,
+    currentReasoningEffortCapability,
+    reasoningEffort,
+    setReasoningEffort,
+  ]);
+
+  const reasoningEffortOptions = useMemo(() => {
+    if (!hasSelectableReasoningEffort(currentReasoningEffortCapability)) return [];
+
+    return currentReasoningEffortCapability.options.map((effort) => ({
+      value: effort,
+      label: getReasoningEffortLabel(effort, t),
+      description: getReasoningEffortDescription(effort, t),
+    }));
+  }, [currentReasoningEffortCapability, t]);
+
+  const defaultReasoningEffortLabel = currentReasoningEffortCapability?.defaultValue
+    ? getReasoningEffortLabel(currentReasoningEffortCapability.defaultValue, t)
+    : null;
 
   const MODE_TABS = [
     { id: "cloud", name: t("reasoning.mode.cloud") },
@@ -992,6 +1075,51 @@ export default function ReasoningModelSelector({
           />
           <GpuStatusBadge />
         </>
+      )}
+
+      {setReasoningEffort && hasSelectableReasoningEffort(currentReasoningEffortCapability) && (
+        <div className="rounded-lg border border-border/50 bg-card/50 px-4 py-3 space-y-2.5">
+          <div className="space-y-1">
+            <div className="flex items-center justify-between gap-3">
+              <h4 className="text-sm font-medium text-foreground">{t("reasoning.effort.title")}</h4>
+              {defaultReasoningEffortLabel && (
+                <span className="text-[11px] text-muted-foreground">
+                  {t("reasoning.effort.defaultValue", {
+                    value: defaultReasoningEffortLabel,
+                  })}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t("reasoning.effort.description")}
+            </p>
+          </div>
+
+          <Select
+            value={reasoningEffort || AUTO_REASONING_EFFORT_VALUE}
+            onValueChange={(value) =>
+              setReasoningEffort(
+                value === AUTO_REASONING_EFFORT_VALUE ? AUTO_REASONING_EFFORT : value
+              )
+            }
+          >
+            <SelectTrigger className="h-9 text-sm">
+              <SelectValue placeholder={t("reasoning.effort.auto")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AUTO_REASONING_EFFORT_VALUE}>
+                {t("reasoning.effort.auto")}
+              </SelectItem>
+              {reasoningEffortOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.description
+                    ? `${option.label} - ${option.description}`
+                    : option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       )}
     </div>
   );

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -772,6 +772,7 @@ export default function ReasoningModelSelector({
 
   useEffect(() => {
     if (!setReasoningEffort || !reasoningEffort) return;
+    if (selectedMode !== "cloud") return;
     if (!canResolveCurrentCapability) return;
     if (
       !hasSelectableReasoningEffort(currentReasoningEffortCapability) ||
@@ -783,6 +784,7 @@ export default function ReasoningModelSelector({
     canResolveCurrentCapability,
     currentReasoningEffortCapability,
     reasoningEffort,
+    selectedMode,
     setReasoningEffort,
   ]);
 

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -406,6 +406,8 @@ interface AiModelsSectionProps {
   setReasoningModel: (model: string) => void;
   reasoningProvider: string;
   setReasoningProvider: (provider: string) => void;
+  reasoningEffort: string;
+  setReasoningEffort: (value: string) => void;
   cloudReasoningBaseUrl: string;
   setCloudReasoningBaseUrl: (url: string) => void;
   openaiApiKey: string;
@@ -436,6 +438,8 @@ function AiModelsSection({
   setReasoningModel,
   reasoningProvider,
   setReasoningProvider,
+  reasoningEffort,
+  setReasoningEffort,
   cloudReasoningBaseUrl,
   setCloudReasoningBaseUrl,
   openaiApiKey,
@@ -617,6 +621,8 @@ function AiModelsSection({
               setGroqApiKey={setGroqApiKey}
               customReasoningApiKey={customReasoningApiKey}
               setCustomReasoningApiKey={setCustomReasoningApiKey}
+              reasoningEffort={reasoningEffort}
+              setReasoningEffort={setReasoningEffort}
             />
           )}
         </>
@@ -649,6 +655,7 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     useReasoningModel,
     reasoningModel,
     reasoningProvider,
+    reasoningEffort,
     openaiApiKey,
     anthropicApiKey,
     geminiApiKey,
@@ -673,6 +680,7 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setUseReasoningModel,
     setReasoningModel,
     setReasoningProvider,
+    setReasoningEffort,
     setOpenaiApiKey,
     setAnthropicApiKey,
     setGeminiApiKey,
@@ -2616,7 +2624,7 @@ EOF`,
                       desc: t("settingsPage.general.waylandPaste.xclipDesc", {
                         defaultValue: "Clipboard tool for KDE Wayland paste (xclip or xsel)",
                       }),
-                      guide: [
+                      steps: [
                         {
                           title: t("settingsPage.general.waylandPaste.guide.xclip.step1Title", {
                             defaultValue: "Install xclip",
@@ -2908,6 +2916,8 @@ EOF`,
             setReasoningModel={setReasoningModel}
             reasoningProvider={reasoningProvider}
             setReasoningProvider={setReasoningProvider}
+            reasoningEffort={reasoningEffort}
+            setReasoningEffort={setReasoningEffort}
             cloudReasoningBaseUrl={cloudReasoningBaseUrl}
             setCloudReasoningBaseUrl={setCloudReasoningBaseUrl}
             openaiApiKey={openaiApiKey}
@@ -3049,6 +3059,8 @@ EOF`,
               setReasoningModel={setReasoningModel}
               reasoningProvider={reasoningProvider}
               setReasoningProvider={setReasoningProvider}
+              reasoningEffort={reasoningEffort}
+              setReasoningEffort={setReasoningEffort}
               cloudReasoningBaseUrl={cloudReasoningBaseUrl}
               setCloudReasoningBaseUrl={setCloudReasoningBaseUrl}
               openaiApiKey={openaiApiKey}

--- a/src/components/settings/AgentModeSettings.tsx
+++ b/src/components/settings/AgentModeSettings.tsx
@@ -22,6 +22,8 @@ export default function AgentModeSettings() {
     setAgentModel,
     agentProvider,
     setAgentProvider,
+    agentReasoningEffort,
+    setAgentReasoningEffort,
     agentSystemPrompt,
     setAgentSystemPrompt,
     cloudAgentMode,
@@ -223,6 +225,8 @@ export default function AgentModeSettings() {
                 setGroqApiKey={setGroqApiKey}
                 customReasoningApiKey={customReasoningApiKey}
                 setCustomReasoningApiKey={setCustomReasoningApiKey}
+                reasoningEffort={agentReasoningEffort}
+                setReasoningEffort={setAgentReasoningEffort}
               />
             </div>
           )}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -26,6 +26,7 @@ export interface ReasoningSettings {
   useReasoningModel: boolean;
   reasoningModel: string;
   reasoningProvider: string;
+  reasoningEffort: string;
   cloudReasoningBaseUrl?: string;
   cloudReasoningMode: string;
 }
@@ -65,6 +66,7 @@ export interface ThemeSettings {
 export interface AgentModeSettings {
   agentModel: string;
   agentProvider: string;
+  agentReasoningEffort: string;
   agentKey: string;
   agentSystemPrompt: string;
   agentEnabled: boolean;
@@ -184,6 +186,7 @@ function useSettingsInternal() {
     useReasoningModel: store.useReasoningModel,
     reasoningModel: store.reasoningModel,
     reasoningProvider: store.reasoningProvider,
+    reasoningEffort: store.reasoningEffort,
     openaiApiKey: store.openaiApiKey,
     anthropicApiKey: store.anthropicApiKey,
     geminiApiKey: store.geminiApiKey,
@@ -211,6 +214,7 @@ function useSettingsInternal() {
     setUseReasoningModel: store.setUseReasoningModel,
     setReasoningModel: store.setReasoningModel,
     setReasoningProvider: store.setReasoningProvider,
+    setReasoningEffort: store.setReasoningEffort,
     setOpenaiApiKey: store.setOpenaiApiKey,
     setAnthropicApiKey: store.setAnthropicApiKey,
     setGeminiApiKey: store.setGeminiApiKey,
@@ -243,6 +247,8 @@ function useSettingsInternal() {
     setAutoLearnCorrections,
     keepTranscriptionInClipboard: store.keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard: store.setKeepTranscriptionInClipboard,
+    agentReasoningEffort: store.agentReasoningEffort,
+    setAgentReasoningEffort: store.setAgentReasoningEffort,
     cloudBackupEnabled: store.cloudBackupEnabled,
     setCloudBackupEnabled: store.setCloudBackupEnabled,
     telemetryEnabled: store.telemetryEnabled,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "Anbieter: {{owner}}",
       "unableToLoadModels": "Modelle konnten nicht vom Endpoint geladen werden."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "API-Schlüssel holen ->",
     "selectModel": "Modell auswählen",
     "availableModels": "Verfügbare Modelle"

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "API-Schlüssel holen ->",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -329,7 +329,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Get your API key ->",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -306,6 +306,32 @@
       "ownerLabel": "Owner: {{owner}}",
       "unableToLoadModels": "Unable to load models from endpoint."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Get your API key ->",
     "selectModel": "Select Model",
     "availableModels": "Available Models"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "Propietario: {{owner}}",
       "unableToLoadModels": "No se pudieron cargar modelos desde el endpoint."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Obtener clave API ->",
     "selectModel": "Seleccionar modelo",
     "availableModels": "Modelos disponibles"

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Obtener clave API ->",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "Propriétaire : {{owner}}",
       "unableToLoadModels": "Impossible de charger les modèles depuis le endpoint."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Obtenir la clé API ->",
     "selectModel": "Sélectionner un modèle",
     "availableModels": "Modèles disponibles"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Obtenir la clé API ->",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "Proprietario: {{owner}}",
       "unableToLoadModels": "Impossibile caricare i modelli dall'endpoint."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Ottieni la chiave API ->",
     "selectModel": "Seleziona modello",
     "availableModels": "Modelli disponibili"

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Ottieni la chiave API ->",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "提供元: {{owner}}",
       "unableToLoadModels": "エンドポイントからモデルを読み込めませんでした。"
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "API キーを取得 ->",
     "selectModel": "モデルを選択",
     "availableModels": "利用可能なモデル"

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "API キーを取得 ->",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -265,6 +265,32 @@
       "ownerLabel": "Proprietário: {{owner}}",
       "unableToLoadModels": "Não foi possível carregar modelos do endpoint."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Obter chave API ->",
     "selectModel": "Selecionar modelo",
     "availableModels": "Modelos disponíveis"

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -288,7 +288,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Obter chave API ->",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "Автор: {{owner}}",
       "unableToLoadModels": "Не удалось загрузить модели с конечной точки."
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "Получить API-ключ ->",
     "selectModel": "Выберите модель",
     "availableModels": "Доступные модели"

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -316,7 +316,7 @@
         "medium": "Balanced speed and reasoning depth",
         "high": "More deliberate reasoning for harder tasks",
         "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "max": "Highest available reasoning depth on supported models"
       }
     },
     "getApiKey": "Получить API-ключ ->",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -294,29 +294,29 @@
       "unableToLoadModels": "无法从端点加载模型。"
     },
     "effort": {
-      "title": "Reasoning Effort",
-      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
-      "auto": "Auto (Provider Default)",
-      "defaultValue": "Default: {{value}}",
+      "title": "推理强度",
+      "description": "仅受支持的模型会显示此选项。保持自动以使用提供商默认值。",
+      "auto": "自动（提供商默认）",
+      "defaultValue": "默认值：{{value}}",
       "options": {
-        "none": "None",
-        "default": "Default",
-        "minimal": "Minimal",
-        "low": "Low",
-        "medium": "Medium",
-        "high": "High",
-        "xhigh": "X-High",
-        "max": "Max"
+        "none": "关闭",
+        "default": "默认",
+        "minimal": "极低",
+        "low": "低",
+        "medium": "中",
+        "high": "高",
+        "xhigh": "极高",
+        "max": "最高"
       },
       "optionDescriptions": {
-        "none": "Turns reasoning off when the model allows it",
-        "default": "Uses the provider's default reasoning behavior",
-        "minimal": "Closest to no thinking, optimized for speed",
-        "low": "Lower cost and latency for simpler tasks",
-        "medium": "Balanced speed and reasoning depth",
-        "high": "More deliberate reasoning for harder tasks",
-        "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "none": "当模型允许时关闭推理",
+        "default": "使用提供商的默认推理行为",
+        "minimal": "尽量减少思考，以速度为先",
+        "low": "适合简单任务的更低成本和延迟",
+        "medium": "在速度与推理深度之间取得平衡",
+        "high": "为更难的任务进行更充分的推理",
+        "xhigh": "在受支持的 OpenAI 模型上使用最深推理",
+        "max": "在受支持的模型上使用可用的最高推理深度"
       }
     },
     "getApiKey": "获取你的 API Key ->",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "所有者：{{owner}}",
       "unableToLoadModels": "无法从端点加载模型。"
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "获取你的 API Key ->",
     "selectModel": "选择模型",
     "availableModels": "可用模型"

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -294,29 +294,29 @@
       "unableToLoadModels": "無法從端點載入模型。"
     },
     "effort": {
-      "title": "Reasoning Effort",
-      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
-      "auto": "Auto (Provider Default)",
-      "defaultValue": "Default: {{value}}",
+      "title": "推理強度",
+      "description": "僅支援的模型會顯示此選項。保持自動以使用提供者預設值。",
+      "auto": "自動（提供者預設）",
+      "defaultValue": "預設值：{{value}}",
       "options": {
-        "none": "None",
-        "default": "Default",
-        "minimal": "Minimal",
-        "low": "Low",
-        "medium": "Medium",
-        "high": "High",
-        "xhigh": "X-High",
-        "max": "Max"
+        "none": "關閉",
+        "default": "預設",
+        "minimal": "極低",
+        "low": "低",
+        "medium": "中",
+        "high": "高",
+        "xhigh": "極高",
+        "max": "最高"
       },
       "optionDescriptions": {
-        "none": "Turns reasoning off when the model allows it",
-        "default": "Uses the provider's default reasoning behavior",
-        "minimal": "Closest to no thinking, optimized for speed",
-        "low": "Lower cost and latency for simpler tasks",
-        "medium": "Balanced speed and reasoning depth",
-        "high": "More deliberate reasoning for harder tasks",
-        "xhigh": "Maximum reasoning depth on supported OpenAI models",
-        "max": "Maximum reasoning depth on supported Claude models"
+        "none": "當模型允許時關閉推理",
+        "default": "使用提供者的預設推理行為",
+        "minimal": "盡量減少思考，以速度為優先",
+        "low": "適合簡單任務的更低成本與延遲",
+        "medium": "在速度與推理深度之間取得平衡",
+        "high": "為較困難的任務進行更充分的推理",
+        "xhigh": "在支援的 OpenAI 模型上使用最深推理",
+        "max": "在支援的模型上使用可用的最高推理深度"
       }
     },
     "getApiKey": "取得 API Key ->",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -293,6 +293,32 @@
       "ownerLabel": "擁有者：{{owner}}",
       "unableToLoadModels": "無法從端點載入模型。"
     },
+    "effort": {
+      "title": "Reasoning Effort",
+      "description": "Only supported models expose this. Leave it on Auto to use the provider default.",
+      "auto": "Auto (Provider Default)",
+      "defaultValue": "Default: {{value}}",
+      "options": {
+        "none": "None",
+        "default": "Default",
+        "minimal": "Minimal",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "xhigh": "X-High",
+        "max": "Max"
+      },
+      "optionDescriptions": {
+        "none": "Turns reasoning off when the model allows it",
+        "default": "Uses the provider's default reasoning behavior",
+        "minimal": "Closest to no thinking, optimized for speed",
+        "low": "Lower cost and latency for simpler tasks",
+        "medium": "Balanced speed and reasoning depth",
+        "high": "More deliberate reasoning for harder tasks",
+        "xhigh": "Maximum reasoning depth on supported OpenAI models",
+        "max": "Maximum reasoning depth on supported Claude models"
+      }
+    },
     "getApiKey": "取得 API Key ->",
     "selectModel": "選擇模型",
     "availableModels": "可用模型"

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -40,6 +40,15 @@ export interface CloudModelDefinition {
   disableThinking?: boolean;
   tokenParam?: "max_tokens" | "max_completion_tokens";
   supportsTemperature?: boolean;
+  reasoningEffort?: ReasoningEffortCapability;
+}
+
+export type ReasoningEffortProvider = "openai" | "anthropic" | "gemini";
+
+export interface ReasoningEffortCapability {
+  provider: ReasoningEffortProvider;
+  options: string[];
+  defaultValue?: string;
 }
 
 export interface CloudProviderData {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -198,7 +198,12 @@
           "description": "Fast and cost-efficient",
           "descriptionKey": "models.descriptions.cloud.openai_gpt_5_mini",
           "tokenParam": "max_completion_tokens",
-          "supportsTemperature": false
+          "supportsTemperature": false,
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["medium"],
+            "defaultValue": "medium"
+          }
         },
         {
           "id": "gpt-5-nano",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -172,7 +172,12 @@
           "description": "Frontier model for complex reasoning",
           "descriptionKey": "models.descriptions.cloud.openai_gpt_5_4",
           "tokenParam": "max_completion_tokens",
-          "supportsTemperature": false
+          "supportsTemperature": false,
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["none", "low", "medium", "high", "xhigh"],
+            "defaultValue": "none"
+          }
         },
         {
           "id": "gpt-5.2",
@@ -180,7 +185,12 @@
           "description": "Strong reasoning model",
           "descriptionKey": "models.descriptions.cloud.openai_gpt_5_2",
           "tokenParam": "max_completion_tokens",
-          "supportsTemperature": false
+          "supportsTemperature": false,
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["none", "low", "medium", "high", "xhigh"],
+            "defaultValue": "none"
+          }
         },
         {
           "id": "gpt-5-mini",
@@ -256,13 +266,21 @@
           "id": "gemini-3.1-pro-preview",
           "name": "Gemini 3.1 Pro",
           "description": "Next-gen flagship model for complex reasoning",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_1_pro_preview"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_1_pro_preview",
+          "reasoningEffort": {
+            "provider": "gemini",
+            "options": ["low", "high"]
+          }
         },
         {
           "id": "gemini-3-flash-preview",
           "name": "Gemini 3 Flash",
           "description": "Ultra-fast, high-capability next-gen model",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_flash_preview"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_flash_preview",
+          "reasoningEffort": {
+            "provider": "gemini",
+            "options": ["minimal", "low", "medium", "high"]
+          }
         },
         {
           "id": "gemini-2.5-flash-lite",
@@ -281,19 +299,32 @@
           "name": "Qwen3 32B",
           "description": "Powerful reasoning model, 131K context",
           "disableThinking": true,
-          "descriptionKey": "models.descriptions.cloud.groq_qwen_qwen3_32b"
+          "descriptionKey": "models.descriptions.cloud.groq_qwen_qwen3_32b",
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["none", "default"],
+            "defaultValue": "default"
+          }
         },
         {
           "id": "openai/gpt-oss-120b",
           "name": "GPT-OSS 120B",
           "description": "OpenAI's open-source flagship, 500 T/sec",
-          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_120b"
+          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_120b",
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["low", "medium", "high"]
+          }
         },
         {
           "id": "openai/gpt-oss-20b",
           "name": "GPT-OSS 20B",
           "description": "Fast open-source model, 1000 T/sec",
-          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_20b"
+          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_20b",
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["low", "medium", "high"]
+          }
         },
         {
           "id": "llama-3.3-70b-versatile",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -201,8 +201,7 @@
           "supportsTemperature": false,
           "reasoningEffort": {
             "provider": "openai",
-            "options": ["medium"],
-            "defaultValue": "medium"
+            "options": ["minimal", "low", "medium", "high"]
           }
         },
         {
@@ -211,7 +210,11 @@
           "description": "Ultra-fast, low latency",
           "descriptionKey": "models.descriptions.cloud.openai_gpt_5_nano",
           "tokenParam": "max_completion_tokens",
-          "supportsTemperature": false
+          "supportsTemperature": false,
+          "reasoningEffort": {
+            "provider": "openai",
+            "options": ["minimal", "low", "medium", "high"]
+          }
         },
         {
           "id": "gpt-4.1",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -310,8 +310,8 @@
           "descriptionKey": "models.descriptions.cloud.groq_qwen_qwen3_32b",
           "reasoningEffort": {
             "provider": "openai",
-            "options": ["none", "default"],
-            "defaultValue": "default"
+            "options": ["none"],
+            "defaultValue": "none"
           }
         },
         {

--- a/src/models/reasoningEffort.ts
+++ b/src/models/reasoningEffort.ts
@@ -70,8 +70,14 @@ const OPENAI_REASONING_PATTERNS: SnapshotCapabilityPattern[] = [
     pattern: /^gpt-5-mini(?:-\d{4}-\d{2}-\d{2})?$/,
     capability: {
       provider: "openai",
-      options: ["medium"],
-      defaultValue: "medium",
+      options: ["minimal", "low", "medium", "high"],
+    },
+  },
+  {
+    pattern: /^gpt-5-nano(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["minimal", "low", "medium", "high"],
     },
   },
 ];

--- a/src/models/reasoningEffort.ts
+++ b/src/models/reasoningEffort.ts
@@ -1,0 +1,120 @@
+import {
+  getCloudModel,
+  type ReasoningEffortCapability,
+  type ReasoningEffortProvider,
+} from "./ModelRegistry";
+
+export const AUTO_REASONING_EFFORT = "";
+
+type DynamicModelPayload = Record<string, unknown>;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isNonEmptyString).map((entry) => entry.trim());
+}
+
+function getNestedValue(
+  source: DynamicModelPayload,
+  keys: Array<string | readonly string[]>
+): unknown | undefined {
+  for (const key of keys) {
+    if (typeof key === "string" && key in source) {
+      return source[key];
+    }
+
+    if (Array.isArray(key)) {
+      let current: unknown = source;
+      let missing = false;
+      for (const part of key) {
+        if (!current || typeof current !== "object" || !(part in current)) {
+          missing = true;
+          break;
+        }
+        current = (current as Record<string, unknown>)[part];
+      }
+      if (!missing) return current;
+    }
+  }
+  return undefined;
+}
+
+function normalizeProvider(value: unknown): ReasoningEffortProvider | null {
+  if (!isNonEmptyString(value)) return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "openai" || normalized === "anthropic" || normalized === "gemini") {
+    return normalized;
+  }
+  return null;
+}
+
+export function getModelReasoningEffortCapability(modelId: string): ReasoningEffortCapability | null {
+  return getCloudModel(modelId)?.reasoningEffort ?? null;
+}
+
+export function isReasoningEffortSupported(
+  capability: ReasoningEffortCapability | null | undefined,
+  value: string | null | undefined
+): boolean {
+  if (!capability || !isNonEmptyString(value)) return false;
+  return capability.options.includes(value);
+}
+
+export function hasSelectableReasoningEffort(
+  capability: ReasoningEffortCapability | null | undefined
+): boolean {
+  return Boolean(capability && capability.options.length > 1);
+}
+
+export function extractDynamicReasoningEffortCapability(
+  source: DynamicModelPayload
+): ReasoningEffortCapability | null {
+  const options =
+    toStringArray(
+      getNestedValue(source, [
+        "supportedReasoningEfforts",
+        "supported_reasoning_efforts",
+        "reasoningEfforts",
+        "reasoning_efforts",
+        ["capabilities", "supportedReasoningEfforts"],
+        ["capabilities", "supported_reasoning_efforts"],
+        ["capabilities", "reasoningEfforts"],
+        ["capabilities", "reasoning_efforts"],
+        ["reasoning", "supportedEfforts"],
+        ["reasoning", "supported_efforts"],
+      ])
+    ) ||
+    [];
+
+  if (options.length === 0) return null;
+
+  const provider =
+    normalizeProvider(
+      getNestedValue(source, [
+        "reasoningProvider",
+        "reasoning_provider",
+        "reasoningMode",
+        "reasoning_mode",
+        ["capabilities", "reasoningProvider"],
+        ["capabilities", "reasoning_provider"],
+      ])
+    ) || "openai";
+
+  const defaultValue = getNestedValue(source, [
+    "defaultReasoningEffort",
+    "default_reasoning_effort",
+    ["capabilities", "defaultReasoningEffort"],
+    ["capabilities", "default_reasoning_effort"],
+    ["reasoning", "defaultEffort"],
+    ["reasoning", "default_effort"],
+  ]);
+
+  return {
+    provider,
+    options,
+    defaultValue: isNonEmptyString(defaultValue) ? defaultValue.trim() : undefined,
+  };
+}

--- a/src/models/reasoningEffort.ts
+++ b/src/models/reasoningEffort.ts
@@ -7,6 +7,74 @@ import {
 export const AUTO_REASONING_EFFORT = "";
 
 type DynamicModelPayload = Record<string, unknown>;
+type SnapshotCapabilityPattern = {
+  pattern: RegExp;
+  capability: ReasoningEffortCapability;
+};
+
+const OPENAI_REASONING_PATTERNS: SnapshotCapabilityPattern[] = [
+  {
+    pattern: /^gpt-5\.4-pro(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["medium", "high", "xhigh"],
+    },
+  },
+  {
+    pattern: /^gpt-5\.2-pro(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["medium", "high", "xhigh"],
+    },
+  },
+  {
+    pattern: /^gpt-5-pro(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["high"],
+      defaultValue: "high",
+    },
+  },
+  {
+    pattern: /^gpt-5\.4(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["none", "low", "medium", "high", "xhigh"],
+      defaultValue: "none",
+    },
+  },
+  {
+    pattern: /^gpt-5\.2(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["none", "low", "medium", "high", "xhigh"],
+      defaultValue: "none",
+    },
+  },
+  {
+    pattern: /^gpt-5\.1(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["none", "low", "medium", "high"],
+      defaultValue: "none",
+    },
+  },
+  {
+    pattern: /^gpt-5(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["minimal", "low", "medium", "high"],
+    },
+  },
+  {
+    pattern: /^gpt-5-mini(?:-\d{4}-\d{2}-\d{2})?$/,
+    capability: {
+      provider: "openai",
+      options: ["medium"],
+      defaultValue: "medium",
+    },
+  },
+];
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
@@ -51,8 +119,14 @@ function normalizeProvider(value: unknown): ReasoningEffortProvider | null {
   return null;
 }
 
+function inferOpenAiReasoningEffortCapability(modelId: string): ReasoningEffortCapability | null {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  const matched = OPENAI_REASONING_PATTERNS.find(({ pattern }) => pattern.test(normalizedModelId));
+  return matched?.capability ?? null;
+}
+
 export function getModelReasoningEffortCapability(modelId: string): ReasoningEffortCapability | null {
-  return getCloudModel(modelId)?.reasoningEffort ?? null;
+  return getCloudModel(modelId)?.reasoningEffort ?? inferOpenAiReasoningEffortCapability(modelId);
 }
 
 export function isReasoningEffortSupported(
@@ -72,6 +146,9 @@ export function hasSelectableReasoningEffort(
 export function extractDynamicReasoningEffortCapability(
   source: DynamicModelPayload
 ): ReasoningEffortCapability | null {
+  const modelId =
+    (isNonEmptyString(source.id) ? source.id.trim() : null) ||
+    (isNonEmptyString(source.name) ? source.name.trim() : null);
   const options =
     toStringArray(
       getNestedValue(source, [
@@ -89,7 +166,9 @@ export function extractDynamicReasoningEffortCapability(
     ) ||
     [];
 
-  if (options.length === 0) return null;
+  if (options.length === 0) {
+    return modelId ? inferOpenAiReasoningEffortCapability(modelId) : null;
+  }
 
   const provider =
     normalizeProvider(

--- a/src/services/BaseReasoningService.ts
+++ b/src/services/BaseReasoningService.ts
@@ -6,6 +6,7 @@ export interface ReasoningConfig {
   temperature?: number;
   contextSize?: number;
   systemPrompt?: string;
+  reasoningEffort?: string;
 }
 
 export abstract class BaseReasoningService {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,4 +1,8 @@
-import { getModelProvider, getCloudModel, getOpenAiApiConfig } from "../models/ModelRegistry";
+import { getModelProvider, getOpenAiApiConfig } from "../models/ModelRegistry";
+import {
+  getModelReasoningEffortCapability,
+  isReasoningEffortSupported,
+} from "../models/reasoningEffort";
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy } from "../utils/retry";
@@ -7,6 +11,11 @@ import logger from "../utils/logger";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/neonAuth";
 import { getSettings, isCloudReasoningMode } from "../stores/settingsStore";
+
+type ResolvedReasoningEffort = {
+  provider: "openai" | "anthropic" | "gemini";
+  value: string;
+};
 
 class ReasoningService extends BaseReasoningService {
   private apiKeyCache: SecureCache<string>;
@@ -24,7 +33,59 @@ class ReasoningService extends BaseReasoningService {
     }
   }
 
-  private getConfiguredOpenAIBase(): string {
+  private resolveReasoningEffort(
+    model: string,
+    provider: string,
+    config: ReasoningConfig,
+    fallbackToStoredSetting = false
+  ): ResolvedReasoningEffort | null {
+    const requested =
+      config.reasoningEffort?.trim() ||
+      (fallbackToStoredSetting ? getSettings().reasoningEffort?.trim() : "") ||
+      "";
+
+    if (!requested) return null;
+
+    if (provider === "custom") {
+      return {
+        provider: "openai",
+        value: requested,
+      };
+    }
+
+    const capability = getModelReasoningEffortCapability(model);
+    if (!capability || !isReasoningEffortSupported(capability, requested)) {
+      logger.logReasoning("REASONING_EFFORT_SKIPPED", {
+        provider,
+        model,
+        requested,
+        hasCapability: Boolean(capability),
+      });
+      return null;
+    }
+
+    return {
+      provider: capability.provider,
+      value: requested,
+    };
+  }
+
+  private applyOpenAiReasoningEffort(
+    requestBody: Record<string, unknown>,
+    reasoningEffort: ResolvedReasoningEffort | null,
+    apiType: "chat" | "responses"
+  ) {
+    if (!reasoningEffort || reasoningEffort.provider !== "openai") return;
+
+    if (apiType === "responses") {
+      requestBody.reasoning = { effort: reasoningEffort.value };
+      return;
+    }
+
+    requestBody.reasoning_effort = reasoningEffort.value;
+  }
+
+  private getConfiguredOpenAIBase(isCustomProviderOverride?: boolean): string {
     if (typeof window === "undefined") {
       return API_ENDPOINTS.OPENAI_BASE;
     }
@@ -32,7 +93,7 @@ class ReasoningService extends BaseReasoningService {
     try {
       const settings = getSettings();
       const provider = settings.reasoningProvider || "";
-      const isCustomProvider = provider === "custom";
+      const isCustomProvider = isCustomProviderOverride ?? provider === "custom";
 
       if (!isCustomProvider) {
         logger.logReasoning("CUSTOM_REASONING_ENDPOINT_CHECK", {
@@ -257,7 +318,8 @@ class ReasoningService extends BaseReasoningService {
     text: string,
     agentName: string | null,
     config: ReasoningConfig,
-    providerName: string
+    providerName: string,
+    reasoningEffort: ResolvedReasoningEffort | null = null
   ): Promise<string> {
     const systemPrompt = config.systemPrompt || this.getSystemPrompt(agentName, text);
     const userPrompt = text;
@@ -284,11 +346,7 @@ class ReasoningService extends BaseReasoningService {
         ),
     };
 
-    // Disable thinking for Groq Qwen models
-    const modelDef = getCloudModel(model);
-    if (modelDef?.disableThinking && providerName.toLowerCase() === "groq") {
-      requestBody.reasoning_effort = "none";
-    }
+    this.applyOpenAiReasoningEffort(requestBody, reasoningEffort, "chat");
 
     logger.logReasoning(`${providerName.toUpperCase()}_REQUEST`, {
       endpoint,
@@ -502,13 +560,19 @@ class ReasoningService extends BaseReasoningService {
     try {
       const systemPrompt = config.systemPrompt || this.getSystemPrompt(agentName, text);
       const userPrompt = text;
+      const resolvedReasoningEffort = this.resolveReasoningEffort(
+        model,
+        isCustomProvider ? "custom" : "openai",
+        config,
+        true
+      );
 
       const messages = [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ];
 
-      const openAiBase = this.getConfiguredOpenAIBase();
+      const openAiBase = this.getConfiguredOpenAIBase(isCustomProvider);
       const endpointCandidates = this.getOpenAIEndpointCandidates(openAiBase);
       const isCustomEndpoint = openAiBase !== API_ENDPOINTS.OPENAI_BASE;
 
@@ -563,6 +627,12 @@ class ReasoningService extends BaseReasoningService {
             if (apiConfig.supportsTemperature) {
               requestBody.temperature = config.temperature || 0.3;
             }
+
+            this.applyOpenAiReasoningEffort(
+              requestBody,
+              resolvedReasoningEffort,
+              type === "responses" ? "responses" : "chat"
+            );
 
             const res = await fetch(endpoint, {
               method: "POST",
@@ -840,6 +910,7 @@ class ReasoningService extends BaseReasoningService {
     try {
       const systemPrompt = config.systemPrompt || this.getSystemPrompt(agentName, text);
       const userPrompt = text;
+      const resolvedReasoningEffort = this.resolveReasoningEffort(model, "gemini", config, true);
 
       const requestBody = {
         contents: [
@@ -864,6 +935,13 @@ class ReasoningService extends BaseReasoningService {
                 TOKEN_LIMITS.TOKEN_MULTIPLIER
               )
             ),
+          ...(resolvedReasoningEffort?.provider === "gemini"
+            ? {
+                thinkingConfig: {
+                  thinkingLevel: resolvedReasoningEffort.value,
+                },
+              }
+            : {}),
         },
       };
 
@@ -1011,6 +1089,7 @@ class ReasoningService extends BaseReasoningService {
 
     try {
       const endpoint = buildApiUrl(API_ENDPOINTS.GROQ_BASE, "/chat/completions");
+      const resolvedReasoningEffort = this.resolveReasoningEffort(model, "groq", config, true);
       return await this.callChatCompletionsApi(
         endpoint,
         apiKey,
@@ -1018,7 +1097,8 @@ class ReasoningService extends BaseReasoningService {
         text,
         agentName,
         config,
-        "Groq"
+        "Groq",
+        resolvedReasoningEffort
       );
     } catch (error) {
       logger.logReasoning("GROQ_ERROR", {
@@ -1101,6 +1181,91 @@ class ReasoningService extends BaseReasoningService {
     }
   }
 
+  private async *processAnthropicStreaming(
+    messages: Array<{ role: string; content: string }>,
+    model: string,
+    apiKey: string,
+    config: ReasoningConfig & { systemPrompt: string }
+  ): AsyncGenerator<string, void, unknown> {
+    const requestBody: Record<string, unknown> = {
+      model,
+      stream: true,
+      system: config.systemPrompt,
+      messages: messages
+        .filter((message) => message.role !== "system")
+        .map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      max_tokens: config.maxTokens || Math.max(4096, TOKEN_LIMITS.MAX_TOKENS),
+      temperature: config.temperature ?? 0.3,
+    };
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage: string;
+      try {
+        const errorData = JSON.parse(errorText);
+        errorMessage =
+          errorData.error?.message ||
+          errorData.message ||
+          errorData.error ||
+          `Anthropic API error: ${response.status}`;
+      } catch {
+        errorMessage = errorText || `Anthropic API error: ${response.status}`;
+      }
+      throw new Error(errorMessage);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+          const data = trimmed.slice(6);
+          if (data === "[DONE]") return;
+
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.type === "content_block_delta" && parsed.delta?.type === "text_delta") {
+              if (typeof parsed.delta.text === "string" && parsed.delta.text) {
+                yield parsed.delta.text;
+              }
+            }
+          } catch {
+            // skip malformed SSE chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   async *processTextStreaming(
     messages: Array<{ role: string; content: string }>,
     model: string,
@@ -1109,6 +1274,7 @@ class ReasoningService extends BaseReasoningService {
   ): AsyncGenerator<string, void, unknown> {
     const cloudProviders = ["openai", "groq", "gemini", "anthropic", "custom"];
     const isLocalProvider = !cloudProviders.includes(provider);
+    const resolvedReasoningEffort = this.resolveReasoningEffort(model, provider, config);
 
     let endpoint: string;
     let apiKey = "";
@@ -1124,6 +1290,11 @@ class ReasoningService extends BaseReasoningService {
       const providerKey = provider as "openai" | "groq" | "gemini" | "anthropic" | "custom";
       apiKey = await this.getApiKey(providerKey);
 
+      if (providerKey === "anthropic") {
+        yield* this.processAnthropicStreaming(messages, model, apiKey, config);
+        return;
+      }
+
       switch (providerKey) {
         case "groq":
           endpoint = buildApiUrl(API_ENDPOINTS.GROQ_BASE, "/chat/completions");
@@ -1133,7 +1304,10 @@ class ReasoningService extends BaseReasoningService {
           break;
         case "openai":
         case "custom":
-          endpoint = buildApiUrl(this.getConfiguredOpenAIBase(), "/chat/completions");
+          endpoint = buildApiUrl(
+            this.getConfiguredOpenAIBase(providerKey === "custom"),
+            "/chat/completions"
+          );
           break;
         default:
           endpoint = buildApiUrl(API_ENDPOINTS.OPENAI_BASE, "/chat/completions");
@@ -1160,6 +1334,11 @@ class ReasoningService extends BaseReasoningService {
       if (apiConfig.supportsTemperature) {
         requestBody.temperature = config.temperature ?? 0.3;
       }
+    }
+
+    this.applyOpenAiReasoningEffort(requestBody, resolvedReasoningEffort, "chat");
+    if (provider === "gemini" && resolvedReasoningEffort?.provider === "gemini") {
+      requestBody.reasoning_effort = resolvedReasoningEffort.value;
     }
 
     logger.logReasoning("AGENT_STREAM_REQUEST", {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,4 +1,4 @@
-import { getModelProvider, getOpenAiApiConfig } from "../models/ModelRegistry";
+import { getCloudModel, getModelProvider, getOpenAiApiConfig } from "../models/ModelRegistry";
 import {
   getModelReasoningEffortCapability,
   isReasoningEffortSupported,
@@ -6,7 +6,13 @@ import {
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy } from "../utils/retry";
-import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, normalizeBaseUrl } from "../config/constants";
+import {
+  API_ENDPOINTS,
+  API_VERSIONS,
+  TOKEN_LIMITS,
+  buildApiUrl,
+  normalizeBaseUrl,
+} from "../config/constants";
 import logger from "../utils/logger";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/neonAuth";
@@ -71,18 +77,25 @@ class ReasoningService extends BaseReasoningService {
   }
 
   private applyOpenAiReasoningEffort(
+    model: string,
     requestBody: Record<string, unknown>,
     reasoningEffort: ResolvedReasoningEffort | null,
     apiType: "chat" | "responses"
   ) {
-    if (!reasoningEffort || reasoningEffort.provider !== "openai") return;
+    const modelDef = getCloudModel(model);
+    const effectiveReasoningEffort =
+      modelDef?.disableThinking && (!reasoningEffort || reasoningEffort.provider === "openai")
+        ? { provider: "openai" as const, value: "none" }
+        : reasoningEffort;
+
+    if (!effectiveReasoningEffort || effectiveReasoningEffort.provider !== "openai") return;
 
     if (apiType === "responses") {
-      requestBody.reasoning = { effort: reasoningEffort.value };
+      requestBody.reasoning = { effort: effectiveReasoningEffort.value };
       return;
     }
 
-    requestBody.reasoning_effort = reasoningEffort.value;
+    requestBody.reasoning_effort = effectiveReasoningEffort.value;
   }
 
   private getConfiguredOpenAIBase(isCustomProviderOverride?: boolean): string {
@@ -346,7 +359,7 @@ class ReasoningService extends BaseReasoningService {
         ),
     };
 
-    this.applyOpenAiReasoningEffort(requestBody, reasoningEffort, "chat");
+    this.applyOpenAiReasoningEffort(model, requestBody, reasoningEffort, "chat");
 
     logger.logReasoning(`${providerName.toUpperCase()}_REQUEST`, {
       endpoint,
@@ -629,6 +642,7 @@ class ReasoningService extends BaseReasoningService {
             }
 
             this.applyOpenAiReasoningEffort(
+              model,
               requestBody,
               resolvedReasoningEffort,
               type === "responses" ? "responses" : "chat"
@@ -1201,12 +1215,12 @@ class ReasoningService extends BaseReasoningService {
       temperature: config.temperature ?? 0.3,
     };
 
-    const response = await fetch("https://api.anthropic.com/v1/messages", {
+    const response = await fetch(API_ENDPOINTS.ANTHROPIC, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
-        "anthropic-version": "2023-06-01",
+        "anthropic-version": API_VERSIONS.ANTHROPIC,
       },
       body: JSON.stringify(requestBody),
     });
@@ -1336,7 +1350,7 @@ class ReasoningService extends BaseReasoningService {
       }
     }
 
-    this.applyOpenAiReasoningEffort(requestBody, resolvedReasoningEffort, "chat");
+    this.applyOpenAiReasoningEffort(model, requestBody, resolvedReasoningEffort, "chat");
     if (provider === "gemini" && resolvedReasoningEffort?.provider === "gemini") {
       requestBody.reasoning_effort = resolvedReasoningEffort.value;
     }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -125,6 +125,7 @@ export interface SettingsState
   setUseReasoningModel: (value: boolean) => void;
   setReasoningModel: (value: string) => void;
   setReasoningProvider: (value: string) => void;
+  setReasoningEffort: (value: string) => void;
   setUiLanguage: (language: string) => void;
 
   setOpenaiApiKey: (key: string) => void;
@@ -160,6 +161,7 @@ export interface SettingsState
 
   setAgentModel: (value: string) => void;
   setAgentProvider: (value: string) => void;
+  setAgentReasoningEffort: (value: string) => void;
   setAgentKey: (key: string) => void;
   setAgentSystemPrompt: (value: string) => void;
   setAgentEnabled: (value: boolean) => void;
@@ -249,6 +251,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   useReasoningModel: readBoolean("useReasoningModel", true),
   reasoningModel: readString("reasoningModel", ""),
   reasoningProvider: readString("reasoningProvider", "openai"),
+  reasoningEffort: readString("reasoningEffort", ""),
 
   openaiApiKey: readString("openaiApiKey", ""),
   anthropicApiKey: readString("anthropicApiKey", ""),
@@ -312,6 +315,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   agentModel: readString("agentModel", "openai/gpt-oss-120b"),
   agentProvider: readString("agentProvider", "groq"),
+  agentReasoningEffort: readString("agentReasoningEffort", ""),
   agentKey: readString("agentKey", ""),
   agentSystemPrompt: readString("agentSystemPrompt", ""),
   agentEnabled: readBoolean("agentEnabled", true),
@@ -338,6 +342,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setUseReasoningModel: createBooleanSetter("useReasoningModel"),
   setReasoningModel: createStringSetter("reasoningModel"),
   setReasoningProvider: createStringSetter("reasoningProvider"),
+  setReasoningEffort: createStringSetter("reasoningEffort"),
 
   setCustomDictionary: (words: string[]) => {
     if (isBrowser) localStorage.setItem("customDictionary", JSON.stringify(words));
@@ -507,6 +512,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setAgentModel: createStringSetter("agentModel"),
   setAgentProvider: createStringSetter("agentProvider"),
+  setAgentReasoningEffort: createStringSetter("agentReasoningEffort"),
   setAgentKey: (key: string) => {
     if (!isBrowser) {
       useSettingsStore.setState({ agentKey: key });
@@ -587,6 +593,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (settings.reasoningModel !== undefined) s.setReasoningModel(settings.reasoningModel);
     if (settings.reasoningProvider !== undefined)
       s.setReasoningProvider(settings.reasoningProvider);
+    if (settings.reasoningEffort !== undefined) s.setReasoningEffort(settings.reasoningEffort);
     if (settings.cloudReasoningBaseUrl !== undefined)
       s.setCloudReasoningBaseUrl(settings.cloudReasoningBaseUrl);
     if (settings.cloudReasoningMode !== undefined)
@@ -610,6 +617,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const s = useSettingsStore.getState();
     if (settings.agentModel !== undefined) s.setAgentModel(settings.agentModel);
     if (settings.agentProvider !== undefined) s.setAgentProvider(settings.agentProvider);
+    if (settings.agentReasoningEffort !== undefined)
+      s.setAgentReasoningEffort(settings.agentReasoningEffort);
     if (settings.agentKey !== undefined) s.setAgentKey(settings.agentKey);
     if (settings.agentSystemPrompt !== undefined)
       s.setAgentSystemPrompt(settings.agentSystemPrompt);


### PR DESCRIPTION
## Summary
- add configurable reasoning-effort overrides for BYOK Intelligence and Agent Mode
- show the selector only for cloud models that expose supported effort levels
- persist separate overrides for Intelligence and Agent Mode
- send valid overrides to OpenAI-compatible and Gemini requests while leaving provider defaults in place when no override is selected

## How options are determined
- built-in model capabilities are defined in `src/models/modelRegistryData.json` from provider documentation
- custom endpoint capabilities are parsed dynamically from `/models` metadata when those endpoints expose supported reasoning-effort fields
- Anthropic is excluded because the API exposes extended thinking via token budgets rather than effort enums

<img width="870" height="544" alt="image" src="https://github.com/user-attachments/assets/b1f9e8f7-d8fe-45c5-b928-0b334e17ca07" />

<img width="900" height="647" alt="image" src="https://github.com/user-attachments/assets/b1b906ae-5981-4d76-bcf6-c22d238f754e" />
