### PR TITLE
fix(linux): force XWayland on KDE Wayland (Electron 39)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,21 @@
+// KDE Wayland: force XWayland before Electron initializes Chromium.
+// On Electron 39+, appendSwitch("ozone-platform-hint") is too late and
+// process.argv.push() doesn't propagate to native argc/argv. The only way
+// is to self-relaunch with the flag on the actual command line.
+if (
+  process.platform === "linux" &&
+  process.env.XDG_SESSION_TYPE === "wayland" &&
+  /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "") &&
+  !process.argv.includes("--ozone-platform=x11")
+) {
+  const { spawn } = require("child_process");
+  spawn(process.execPath, [...process.argv.slice(1), "--ozone-platform=x11"], {
+    stdio: "inherit",
+    detached: true,
+  }).unref();
+  process.exit(0);
+}
+
 const {
   app,
   globalShortcut,
@@ -75,17 +93,10 @@ if (process.platform === "win32") {
   app.commandLine.appendSwitch("disable-gpu-compositing");
 }
 
-// Enable native Wayland support: Ozone platform for native rendering.
-// KDE uses XWayland for reliable clipboard access, with KGlobalAccel D-Bus
-// for global shortcuts. GNOME and Hyprland run native Wayland with their
-// own D-Bus shortcut managers.
+// Enable native Wayland support for non-KDE desktops (GNOME, Hyprland, etc.).
+// KDE is handled by the self-relaunch guard above (--ozone-platform=x11).
 if (process.platform === "linux" && process.env.XDG_SESSION_TYPE === "wayland") {
-  const desktop = (process.env.XDG_CURRENT_DESKTOP || "").toLowerCase();
-  if (desktop.includes("kde")) {
-    app.commandLine.appendSwitch("ozone-platform-hint", "x11");
-  } else {
-    app.commandLine.appendSwitch("ozone-platform-hint", "auto");
-  }
+  app.commandLine.appendSwitch("ozone-platform-hint", "auto");
   app.commandLine.appendSwitch("enable-features", "UseOzonePlatform,WaylandWindowDecorations");
 }
 


### PR DESCRIPTION
## Summary

On Electron 39 the app silently ends up on native Wayland on KDE, which breaks the overlay bubble (centered instead of corner, steals focus, doesn't stay on top). This replaces the broken `appendSwitch` approach with a self-relaunch that actually gets the flag to Chromium in time.

## Problem

PR #470 used `appendSwitch("ozone-platform-hint", "x11")` to force XWayland on KDE. On E39 this does nothing because the ozone platform is selected during Chromium init, before any JS runs. `ELECTRON_OZONE_PLATFORM_HINT` env var was also removed in E39 ([electron#48001](https://github.com/electron/electron/issues/48001)).

On native Wayland, overlay windows are fundamentally broken:
- `setPosition()`/`setBounds()` ignored by the compositor ([electron#40886](https://github.com/electron/electron/issues/40886))
- `showInactive()` not supported on Wayland ([electron#48436](https://github.com/electron/electron/issues/48436))
- `focusable: false` is X11-only
- KDE focus stealing prevention doesn't work for native Wayland apps ([KDE Bug #488060](https://bugs.kde.org/show_bug.cgi?id=488060))

VS Code hit the same wall with `appendSwitch` for ozone and closed it as "not planned" ([microsoft/vscode#135191](https://github.com/microsoft/vscode/pull/135191)).

## Solution

Self-relaunch with `--ozone-platform=x11` before `require("electron")`, so the flag is on the real command line when Chromium initializes. The old `appendSwitch` KDE branch is removed since it has no effect on E39.

Side effects are minor: extra PID (parent exits immediately), `Ctrl+C` in terminal doesn't kill child (detached). Doesn't matter for `.desktop` launches.

An alternative used by some Electron apps is a bash wrapper script that `exec`s the real binary with the flag (no extra process, `Ctrl+C` works). Cleaner but requires an `afterPack` hook and touches the packaging pipeline. Could be a follow-up.

## Test plan

- [x] KDE Wayland: overlay in correct position, no focus steal
- [x] KDE Wayland: KGlobalAccel shortcut + paste work
- [x] GNOME/Hyprland/macOS/Windows: no behavior change

Tested on Kubuntu 25.10, KDE Plasma 6, E39.8.1 / E39.8.3.
