### PR TITLE
Fix KDE Wayland hotkey by forcing X11 via ozone-platform flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,13 +76,13 @@ if (process.platform === "win32") {
 }
 
 // Enable native Wayland support: Ozone platform for native rendering.
-// KDE uses XWayland for reliable clipboard access, with KGlobalAccel D-Bus
-// for global shortcuts. GNOME and Hyprland run native Wayland with their
-// own D-Bus shortcut managers.
+// KDE forces X11/XWayland because globalShortcut only works via X11,
+// and the clipboard needs X11 for reliable paste.
+// GNOME and Hyprland run native Wayland with their own D-Bus shortcut managers.
 if (process.platform === "linux" && process.env.XDG_SESSION_TYPE === "wayland") {
   const desktop = (process.env.XDG_CURRENT_DESKTOP || "").toLowerCase();
   if (desktop.includes("kde")) {
-    app.commandLine.appendSwitch("ozone-platform-hint", "x11");
+    app.commandLine.appendSwitch("ozone-platform", "x11");
   } else {
     app.commandLine.appendSwitch("ozone-platform-hint", "auto");
   }

--- a/scripts/run-electron.js
+++ b/scripts/run-electron.js
@@ -25,8 +25,21 @@ console.log("[run-electron] Electron path:", electronPath);
 console.log("[run-electron] App dir:", appDir);
 console.log("[run-electron] Args:", args);
 
+// On KDE Wayland, force XWayland so globalShortcut works via X11.
+// This must be a command-line flag, not app.commandLine.appendSwitch,
+// because Chromium picks the display backend before main.js runs.
+const chromiumFlags = [];
+if (
+  process.platform === "linux" &&
+  process.env.XDG_SESSION_TYPE === "wayland" &&
+  /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "")
+) {
+  chromiumFlags.push("--ozone-platform=x11");
+  console.log("[run-electron] KDE Wayland detected, forcing XWayland");
+}
+
 // Spawn electron with the cleaned environment
-const child = spawn(electronPath, [appDir, ...args], {
+const child = spawn(electronPath, [...chromiumFlags, appDir, ...args], {
   stdio: "inherit",
   env: process.env,
   cwd: appDir,

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -481,6 +481,18 @@ class HotkeyManager {
   }
 
   async initializeKDEShortcuts(callback) {
+    console.log("[HotkeyManager] KDE init check CONSOLE", {
+      isLinux: process.platform === "linux",
+      isWayland: KDEShortcutManager.isWayland(),
+      isKDE: KDEShortcutManager.isKDE(),
+    });
+    debugLogger.log("[HotkeyManager] KDE init check", {
+      isLinux: process.platform === "linux",
+      isWayland: KDEShortcutManager.isWayland(),
+      isKDE: KDEShortcutManager.isKDE(),
+      XDG_SESSION_TYPE: process.env.XDG_SESSION_TYPE,
+      XDG_CURRENT_DESKTOP: process.env.XDG_CURRENT_DESKTOP,
+    });
     if (
       process.platform !== "linux" ||
       !KDEShortcutManager.isWayland() ||
@@ -559,7 +571,10 @@ class HotkeyManager {
     this.mainWindow = mainWindow;
     this.hotkeyCallback = callback;
 
-    if (process.platform === "linux" && GnomeShortcutManager.isWayland()) {
+    // KDE uses XWayland (ozone-platform=x11) so globalShortcut works directly.
+    // Only enter the Wayland D-Bus path for GNOME and Hyprland.
+    const isKde = /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "");
+    if (process.platform === "linux" && GnomeShortcutManager.isWayland() && !isKde) {
       const gnomeOk = await this.initializeGnomeShortcuts(callback);
 
       if (gnomeOk) {


### PR DESCRIPTION
Electron 39 ignores ozone-platform-hint (both from appendSwitch and env vars), so globalShortcut never worked on KDE Wayland. The app ended up on native Wayland where globalShortcut is blocked by the compositor.

Switched to --ozone-platform=x11 (without "hint") which Chromium respects unconditionally. Added it as a command-line arg in run-electron.js (dev mode) and via appendSwitch in main.js (production). KDE is excluded from the Wayland D-Bus shortcut path in hotkeyManager since globalShortcut works fine on XWayland.

GNOME and Hyprland paths unchanged, they still use native Wayland with their D-Bus managers.