### PR TITLE
feat: add thinking mode toggle for local Qwen models

### DIFF
--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -21,6 +21,7 @@ import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { createExternalLinkHandler } from "../utils/externalLinks";
 import { getCachedPlatform } from "../utils/platform";
+import { useSettingsStore } from "../stores/settingsStore";
 
 type CloudModelOption = {
   value: string;
@@ -284,6 +285,7 @@ function GpuStatusBadge() {
                 {t("gpu.enableButton")}
               </Button>
               <button
+                type="button"
                 onClick={() => {
                   localStorage.setItem("llamaVulkanBannerDismissed", "true");
                   setDismissed(true);
@@ -331,6 +333,8 @@ export default function ReasoningModelSelector({
   const lastLoadedBaseRef = useRef<string | null>(null);
   const pendingBaseRef = useRef<string | null>(null);
   const isMountedRef = useRef(true);
+  const localThinkingEnabled = useSettingsStore((s) => s.localThinkingEnabled);
+  const setLocalThinkingEnabled = useSettingsStore((s) => s.setLocalThinkingEnabled);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -492,7 +496,7 @@ export default function ReasoningModelSelector({
     return customModelOptions;
   }, [isCustomBaseDirty, customModelOptions]);
 
-  const cloudProviderIds = ["openai", "anthropic", "gemini", "groq", "custom"];
+  const cloudProviderIds = useMemo(() => ["openai", "anthropic", "gemini", "groq", "custom"], []);
   const cloudProviders = cloudProviderIds.map((id) => ({
     id,
     name:
@@ -516,6 +520,19 @@ export default function ReasoningModelSelector({
       })),
     }));
   }, []);
+
+  const selectedModelDef = useMemo(() => {
+    for (const provider of localProviders) {
+      const model = provider.models.find((m) => m.id === reasoningModel);
+      if (model) return model;
+    }
+    return null;
+  }, [localProviders, reasoningModel]);
+
+  const modelSupportsThinking = useMemo(() => {
+    const result = modelRegistry.getModel(reasoningModel);
+    return result?.model?.supportsThinking ?? false;
+  }, [reasoningModel]);
 
   const openaiModelOptions = useMemo<CloudModelOption[]>(() => {
     const iconUrl = getProviderIcon("openai");
@@ -586,14 +603,15 @@ export default function ReasoningModelSelector({
 
   useEffect(() => {
     const localProviderIds = localProviders.map((p) => p.id);
+    const isCloudProvider = cloudProviderIds.includes(localReasoningProvider);
     if (localProviderIds.includes(localReasoningProvider)) {
       setSelectedMode("local");
       setSelectedLocalProvider(localReasoningProvider);
-    } else if (cloudProviderIds.includes(localReasoningProvider)) {
+    } else if (isCloudProvider) {
       setSelectedMode("cloud");
       setSelectedCloudProvider(localReasoningProvider);
     }
-  }, [localProviders, localReasoningProvider]);
+  }, [cloudProviderIds, localProviders, localReasoningProvider]);
 
   useEffect(() => {
     if (selectedCloudProvider !== "custom") return;
@@ -613,7 +631,7 @@ export default function ReasoningModelSelector({
     loadRemoteModels();
   }, [selectedCloudProvider, hasCustomBase, normalizedCustomReasoningBase, loadRemoteModels]);
 
-  const [downloadedModels, setDownloadedModels] = useState<Set<string>>(new Set());
+  const [, setDownloadedModels] = useState<Set<string>>(new Set());
 
   const loadDownloadedModels = useCallback(async () => {
     try {
@@ -990,6 +1008,29 @@ export default function ReasoningModelSelector({
             colorScheme="purple"
             onDownloadComplete={loadDownloadedModels}
           />
+          {selectedMode === "local" && selectedModelDef && modelSupportsThinking && (
+            <div className="flex items-center justify-between px-1 mt-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-medium text-foreground">
+                  {t("reasoning.thinkingMode.label")}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t("reasoning.thinkingMode.description")}
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={localThinkingEnabled}
+                onClick={() => setLocalThinkingEnabled(!localThinkingEnabled)}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${localThinkingEnabled ? "bg-primary" : "bg-input"}`}
+              >
+                <span
+                  className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${localThinkingEnabled ? "translate-x-4" : "translate-x-0"}`}
+                />
+              </button>
+            </div>
+          )}
           <GpuStatusBadge />
         </>
       )}

--- a/src/helpers/modelManagerBridge.js
+++ b/src/helpers/modelManagerBridge.js
@@ -385,6 +385,13 @@ class ModelManager {
       { role: "user", content: prompt },
     ];
 
+    if (options.enableThinking === false && modelInfo.model.supportsThinking) {
+      const lastUserMsg = messages.find((m) => m.role === "user");
+      if (lastUserMsg) {
+        lastUserMsg.content = lastUserMsg.content + " /no_think";
+      }
+    }
+
     debugLogger.logReasoning("INFERENCE_SENDING_REQUEST", {
       messageCount: messages.length,
       systemPromptLength: (options.systemPrompt || "").length,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -26,6 +26,7 @@ export interface ReasoningSettings {
   useReasoningModel: boolean;
   reasoningModel: string;
   reasoningProvider: string;
+  localThinkingEnabled: boolean;
   cloudReasoningBaseUrl?: string;
   cloudReasoningMode: string;
 }
@@ -121,8 +122,7 @@ function useSettingsInternal() {
   // Sync auto-learn state to main process on mount
   useEffect(() => {
     window.electronAPI?.setAutoLearnEnabled?.(autoLearnCorrections);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [autoLearnCorrections]);
 
   // Sync startup pre-warming preferences to main process
   const {
@@ -184,6 +184,7 @@ function useSettingsInternal() {
     useReasoningModel: store.useReasoningModel,
     reasoningModel: store.reasoningModel,
     reasoningProvider: store.reasoningProvider,
+    localThinkingEnabled: store.localThinkingEnabled,
     openaiApiKey: store.openaiApiKey,
     anthropicApiKey: store.anthropicApiKey,
     geminiApiKey: store.geminiApiKey,
@@ -211,6 +212,7 @@ function useSettingsInternal() {
     setUseReasoningModel: store.setUseReasoningModel,
     setReasoningModel: store.setReasoningModel,
     setReasoningProvider: store.setReasoningProvider,
+    setLocalThinkingEnabled: store.setLocalThinkingEnabled,
     setOpenaiApiKey: store.setOpenaiApiKey,
     setAnthropicApiKey: store.setAnthropicApiKey,
     setGeminiApiKey: store.setGeminiApiKey,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "API-Schlüssel holen ->",
     "selectModel": "Modell auswählen",
-    "availableModels": "Verfügbare Modelle"
+    "availableModels": "Verfügbare Modelle",
+    "thinkingMode": {
+      "label": "Denkmodus",
+      "description": "Erweitertes Denken vor der Antwort. Deaktivieren für schnellere Antworten."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "Get your API key ->",
     "selectModel": "Select Model",
-    "availableModels": "Available Models"
+    "availableModels": "Available Models",
+    "thinkingMode": {
+      "label": "Thinking Mode",
+      "description": "Extended reasoning before responding. Disable for faster responses."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "Obtener clave API ->",
     "selectModel": "Seleccionar modelo",
-    "availableModels": "Modelos disponibles"
+    "availableModels": "Modelos disponibles",
+    "thinkingMode": {
+      "label": "Modo de razonamiento",
+      "description": "Razonamiento extendido antes de responder. Deshabilitar para respuestas más rápidas."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "Obtenir la clé API ->",
     "selectModel": "Sélectionner un modèle",
-    "availableModels": "Modèles disponibles"
+    "availableModels": "Modèles disponibles",
+    "thinkingMode": {
+      "label": "Mode de réflexion",
+      "description": "Raisonnement étendu avant de répondre. Désactiver pour des réponses plus rapides."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "Ottieni la chiave API ->",
     "selectModel": "Seleziona modello",
-    "availableModels": "Modelli disponibili"
+    "availableModels": "Modelli disponibili",
+    "thinkingMode": {
+      "label": "Modalità di ragionamento",
+      "description": "Ragionamento esteso prima di rispondere. Disattivare per risposte più veloci."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "API キーを取得 ->",
     "selectModel": "モデルを選択",
-    "availableModels": "利用可能なモデル"
+    "availableModels": "利用可能なモデル",
+    "thinkingMode": {
+      "label": "思考モード",
+      "description": "応答前に拡張推論を行います。より高速な応答のために無効にしてください。"
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -283,7 +283,11 @@
     },
     "getApiKey": "Obter chave API ->",
     "selectModel": "Selecionar modelo",
-    "availableModels": "Modelos disponíveis"
+    "availableModels": "Modelos disponíveis",
+    "thinkingMode": {
+      "label": "Modo de raciocínio",
+      "description": "Raciocínio estendido antes de responder. Desativar para respostas mais rápidas."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "Получить API-ключ ->",
     "selectModel": "Выберите модель",
-    "availableModels": "Доступные модели"
+    "availableModels": "Доступные модели",
+    "thinkingMode": {
+      "label": "Режим размышления",
+      "description": "Расширенное рассуждение перед ответом. Отключите для более быстрых ответов."
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "获取你的 API Key ->",
     "selectModel": "选择模型",
-    "availableModels": "可用模型"
+    "availableModels": "可用模型",
+    "thinkingMode": {
+      "label": "思考模式",
+      "description": "回复前进行扩展推理。禁用以获得更快的响应。"
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -311,7 +311,11 @@
     },
     "getApiKey": "取得 API Key ->",
     "selectModel": "選擇模型",
-    "availableModels": "可用模型"
+    "availableModels": "可用模型",
+    "thinkingMode": {
+      "label": "思考模式",
+      "description": "回覆前進行擴展推理。停用以獲得更快的回應。"
+    }
   },
   "transcription": {
     "deleteModel": {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -13,6 +13,7 @@ export interface ModelDefinition {
   contextLength: number;
   hfRepo: string;
   recommended?: boolean;
+  supportsThinking?: boolean;
 }
 
 export interface LocalProviderData {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -352,6 +352,7 @@
           "contextLength": 262144,
           "hfRepo": "bartowski/Qwen_Qwen3.5-9B-GGUF",
           "recommended": true,
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_5_9b_q4_k_m"
         },
         {
@@ -364,6 +365,7 @@
           "quantization": "q4_k_m",
           "contextLength": 262144,
           "hfRepo": "bartowski/Qwen_Qwen3.5-4B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_5_4b_q4_k_m"
         },
         {
@@ -376,6 +378,7 @@
           "quantization": "q4_k_m",
           "contextLength": 262144,
           "hfRepo": "bartowski/Qwen_Qwen3.5-2B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_5_2b_q4_k_m"
         },
         {
@@ -388,6 +391,7 @@
           "quantization": "q4_k_m",
           "contextLength": 131072,
           "hfRepo": "Qwen/Qwen3-8B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_8b_q4_k_m"
         },
         {
@@ -400,6 +404,7 @@
           "quantization": "q5_k_m",
           "contextLength": 131072,
           "hfRepo": "Qwen/Qwen3-8B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_8b_q5_k_m"
         },
         {
@@ -412,6 +417,7 @@
           "quantization": "q4_k_m",
           "contextLength": 131072,
           "hfRepo": "Qwen/Qwen3-4B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_4b_q4_k_m"
         },
         {
@@ -424,6 +430,7 @@
           "quantization": "q8_0",
           "contextLength": 131072,
           "hfRepo": "Qwen/Qwen3-1.7B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_1_7b_q8_0"
         },
         {
@@ -436,6 +443,7 @@
           "quantization": "q4_k_m",
           "contextLength": 131072,
           "hfRepo": "Qwen/Qwen3-32B-GGUF",
+          "supportsThinking": true,
           "descriptionKey": "models.descriptions.local.qwen_qwen3_32b_q4_k_m"
         },
         {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,4 +1,9 @@
-import { getModelProvider, getCloudModel, getOpenAiApiConfig } from "../models/ModelRegistry";
+import {
+  getModelProvider,
+  getCloudModel,
+  getOpenAiApiConfig,
+  modelRegistry,
+} from "../models/ModelRegistry";
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy } from "../utils/retry";
@@ -782,9 +787,11 @@ class ReasoningService extends BaseReasoningService {
       });
 
       const systemPrompt = config.systemPrompt || this.getSystemPrompt(agentName, text);
+      const settings = getSettings();
       const result = await window.electronAPI.processLocalReasoning(text, model, agentName, {
         ...config,
         systemPrompt,
+        enableThinking: settings.localThinkingEnabled,
       });
 
       const processingTime = Date.now() - startTime;
@@ -1143,6 +1150,17 @@ class ReasoningService extends BaseReasoningService {
 
     const apiConfig = getOpenAiApiConfig(model);
     const useOldTokenParam = isLocalProvider || provider === "groq";
+
+    if (isLocalProvider) {
+      const settings = getSettings();
+      const modelSupportsThinking = modelRegistry.getModel(model)?.model?.supportsThinking ?? false;
+      if (!settings.localThinkingEnabled && modelSupportsThinking) {
+        const lastUserMsg = messages.findLast((m) => m.role === "user");
+        if (lastUserMsg) {
+          lastUserMsg.content = lastUserMsg.content + " /no_think";
+        }
+      }
+    }
 
     const requestBody: Record<string, unknown> = {
       model,

--- a/src/services/localReasoningBridge.js
+++ b/src/services/localReasoningBridge.js
@@ -40,6 +40,7 @@ class LocalReasoningService {
         contextSize: config.contextSize || 4096,
         threads: config.threads || 4,
         systemPrompt: config.systemPrompt || "",
+        enableThinking: config.enableThinking,
       };
 
       debugLogger.logReasoning("LOCAL_BRIDGE_INFERENCE", {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -65,6 +65,7 @@ const BOOLEAN_SETTINGS = new Set([
   "agentEnabled",
   "keepTranscriptionInClipboard",
   "dataRetentionEnabled",
+  "localThinkingEnabled",
 ]);
 
 const ARRAY_SETTINGS = new Set(["customDictionary", "gcalAccounts"]);
@@ -105,6 +106,7 @@ export interface SettingsState
   meetingAudioDetection: boolean;
   panelStartPosition: "bottom-right" | "center" | "bottom-left";
   keepTranscriptionInClipboard: boolean;
+  localThinkingEnabled: boolean;
 
   setUseLocalWhisper: (value: boolean) => void;
   setWhisperModel: (value: string) => void;
@@ -125,6 +127,7 @@ export interface SettingsState
   setUseReasoningModel: (value: boolean) => void;
   setReasoningModel: (value: string) => void;
   setReasoningProvider: (value: string) => void;
+  setLocalThinkingEnabled: (value: boolean) => void;
   setUiLanguage: (language: string) => void;
 
   setOpenaiApiKey: (key: string) => void;
@@ -249,6 +252,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   useReasoningModel: readBoolean("useReasoningModel", true),
   reasoningModel: readString("reasoningModel", ""),
   reasoningProvider: readString("reasoningProvider", "openai"),
+  localThinkingEnabled: readBoolean("localThinkingEnabled", false),
 
   openaiApiKey: readString("openaiApiKey", ""),
   anthropicApiKey: readString("anthropicApiKey", ""),
@@ -338,6 +342,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setUseReasoningModel: createBooleanSetter("useReasoningModel"),
   setReasoningModel: createStringSetter("reasoningModel"),
   setReasoningProvider: createStringSetter("reasoningProvider"),
+  setLocalThinkingEnabled: createBooleanSetter("localThinkingEnabled"),
 
   setCustomDictionary: (words: string[]) => {
     if (isBrowser) localStorage.setItem("customDictionary", JSON.stringify(words));
@@ -587,6 +592,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (settings.reasoningModel !== undefined) s.setReasoningModel(settings.reasoningModel);
     if (settings.reasoningProvider !== undefined)
       s.setReasoningProvider(settings.reasoningProvider);
+    if (settings.localThinkingEnabled !== undefined)
+      s.setLocalThinkingEnabled(settings.localThinkingEnabled);
     if (settings.cloudReasoningBaseUrl !== undefined)
       s.setCloudReasoningBaseUrl(settings.cloudReasoningBaseUrl);
     if (settings.cloudReasoningMode !== undefined)


### PR DESCRIPTION
## Summary

- Adds a UI toggle to enable/disable thinking mode for local Qwen3/3.5 models
- When disabled, appends `/no_think` to user messages so the model skips the `<think>` reasoning phase
- Significantly improves inference speed on consumer hardware by avoiding unnecessary reasoning token generation
- Toggle only appears when a model with thinking support is selected

## Changes

- **Model registry**: Added `supportsThinking: true` flag to all Qwen3 and Qwen3.5 local models
- **Settings store**: New `localThinkingEnabled` boolean setting (default: `false`) persisted in localStorage
- **Inference pipeline**: When thinking is disabled, `/no_think` is appended to user messages in both non-streaming (`modelManagerBridge.js`) and streaming (`ReasoningService.ts`) paths
- **UI**: Compact toggle row in the local model section of `ReasoningModelSelector`, visible only when a thinking-capable model is selected
- **i18n**: Translations added for all 10 supported languages

## How it works

Qwen3/3.5 models support hybrid thinking via the `/no_think` message suffix. When the user disables thinking mode:
1. Non-streaming: `modelManagerBridge.runInference()` appends `/no_think` to the user message before sending to llama.cpp
2. Streaming: `ReasoningService.processTextStreaming()` appends `/no_think` to the last user message
3. The existing `<think>` block stripping in `localReasoningBridge.js` and `ReasoningService.ts` remains as a safety net

## Testing

- `npm run build` passes
- No new LSP diagnostics introduced
- Tested locally with Electron app running

Closes #512