### PR TITLE
Bump 5 dependencies (yaml, tar, brace-expansion, picomatch, tiptap)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12210,7 +12210,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Patch bumps for five dependencies:

- yaml 2.8.2 -> 2.8.3 (stack overflow fix in YAML parser on deeply nested documents)
- tar 7.5.11 -> 7.5.13 (security fix: prevent raced symlink writes outside cwd)
- brace-expansion 1.1.12 -> 1.1.13 (security backport for GHSA-f886-m6hf-6m8v)
- picomatch 4.0.3 -> 4.0.4 (dev dependency patch)
- @tiptap/extension-task-list 3.20.4 -> 3.21.0 (minor, pulls in tiptap core/pm/list 3.21.0)

Lockfile-only, npm ci verified. Covers dependabot's #501, #518, #527, #528, #529 without regenerating the whole lockfile.