### PR TITLE
Remove URL truncation from download log and add failure logging

### DIFF
--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -255,7 +255,7 @@ async function downloadFile(url, destPath, options = {}) {
 
   const tempPath = `${destPath}.tmp`;
 
-  debugLogger.info("Download starting", { url: url.substring(0, 80), destPath });
+  debugLogger.info("Download starting", { url, destPath });
 
   let startOffset = 0;
   try {
@@ -333,6 +333,11 @@ async function downloadFile(url, destPath, options = {}) {
     }
   }
 
+  debugLogger.error("Download failed after all retries", {
+    url,
+    error: lastError?.message,
+    code: lastError?.code,
+  });
   await fsPromises.unlink(tempPath).catch(() => {});
   throw lastError;
 }


### PR DESCRIPTION
downloadUtils.js truncated URLs to 80 characters in the debug log (substring(0, 80)). The turbo model URL is 81 characters, so the log showed ggml-large-v3-turbo.bi instead of .bin. Same for Qwen3.5-9B. Users thought the download was using a broken URL.

Removed the truncation so the full URL shows in logs. Also added an error log when a download fails after all retries, since before it threw silently.

Closes #520