### PR TITLE
fix: validate JSON.parse result type before calling .replace()

### DIFF
--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -106,7 +106,10 @@ export function getSystemPrompt(
     const customPrompt = window.localStorage.getItem("customUnifiedPrompt");
     if (customPrompt) {
       try {
-        promptTemplate = JSON.parse(customPrompt);
+        const parsed = JSON.parse(customPrompt);
+        if (typeof parsed === "string") {
+          promptTemplate = parsed;
+        }
       } catch {}
     }
   }


### PR DESCRIPTION
## Summary
`JSON.parse(customPrompt)` assigns the result directly to `promptTemplate` (typed `string | null`), but JSON.parse can return any type (number, array, object, null). If localStorage contains valid JSON that isn't a string (e.g., `123` or `[1,2]`), calling `.replace()` on line 116 throws a TypeError.

Added `typeof parsed === "string"` check before assignment.

## Test plan
- [ ] Custom prompt stored as JSON string still works
- [ ] Non-string JSON in localStorage doesn't crash
- [ ] Missing/invalid localStorage gracefully falls back to default