### PR TITLE
chore(deps): bump @xmldom/xmldom from 0.8.11 to 0.8.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6907,7 +6907,7 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
+      "version": "0.8.12",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bumps transitive dependency @xmldom/xmldom from 0.8.11 to 0.8.12 (via plist → electron-builder).

Supersedes #536 (dependabot regenerated the entire lockfile, this is a minimal one-line change).