### PR TITLE
fix(linux): Hyprland global shortcut fails under XWayland

### DIFF
--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -636,8 +636,11 @@ class HotkeyManager {
         this.isInitialized = true;
         return;
       }
+    }
 
-      // Try Hyprland native shortcuts if GNOME/KDE paths were not applicable
+    // Hyprland uses hyprctl + dbus-send, which works regardless of XWayland,
+    // so it must be tried outside the !isXWayland gate above.
+    if (process.platform === "linux" && HyprlandShortcutManager.isHyprland()) {
       const hyprlandOk = await this.initializeHyprlandShortcuts(callback);
 
       if (hyprlandOk) {


### PR DESCRIPTION
**Summary**
  v1.6.7 added a wrapper script that forces --ozone-platform=x11 on Wayland sessions, and dc4ac9d added an isXWayland guard that skips all D-Bus shortcut managers when that flag is present. This is correct for GNOME/KDE (their D-Bus paths require native Wayland), but the Hyprland path uses hyprctl keyword bind + dbus-send, which works regardless of XWayland.

Moves the Hyprland shortcut initialization outside the !isXWayland gate so it is always attempted on Hyprland.

**Changes**

| File | What |
| --- | --- |
|  `src/helpers/hotkeyManager.js` | Move Hyprland init block after the `!isXWayland` GNOME/KDE gate,  guarded by `HyprlandShortcutManager.isHyprland()` |

**Platform Impact**
| Platform | Change | 
| -- | -- |
| GNOME Wayland | None — still skipped under XWayland |
|  KDE Wayland | None — still skipped under XWayland |
| Hyprland | Fixed — shortcut init runs regardless of `--ozone-platform=x11` |
| macOS/Windows | None — Linux-only code path |

 **Related:** #547

**Test**
 - Launch OpenWhispr on Hyprland (XWayland mode) — D-Bus service registers, hyprctl binds shows the keybinding
  - Press configured hotkey — dictation toggles
  - GNOME/KDE unaffected (no behavioral change when not on Hyprland)