### PR TITLE
feat: anti-repetition protection for whisper transcription

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -183,6 +183,8 @@ interface TranscriptionSectionProps {
   setCustomTranscriptionApiKey: (key: string) => void;
   cloudTranscriptionBaseUrl?: string;
   setCloudTranscriptionBaseUrl: (url: string) => void;
+  suppressRepetition: boolean;
+  setSuppressRepetition: (value: boolean) => void;
   toast: (opts: {
     title: string;
     description: string;
@@ -218,6 +220,8 @@ function TranscriptionSection({
   setCustomTranscriptionApiKey,
   cloudTranscriptionBaseUrl,
   setCloudTranscriptionBaseUrl,
+  suppressRepetition,
+  setSuppressRepetition,
   toast,
 }: TranscriptionSectionProps) {
   const { t } = useTranslation();
@@ -398,6 +402,18 @@ function TranscriptionSection({
         />
       )}
       <GpuDeviceSelector purpose="transcription" />
+
+      {/* Suppress Repetition */}
+      <SettingsPanel>
+        <SettingsPanelRow>
+          <SettingsRow
+            label={t("settingsPage.transcription.suppressRepetitionLabel")}
+            description={t("settingsPage.transcription.suppressRepetitionDescription")}
+          >
+            <Toggle checked={suppressRepetition} onChange={setSuppressRepetition} />
+          </SettingsRow>
+        </SettingsPanelRow>
+      </SettingsPanel>
     </div>
   );
 }
@@ -791,6 +807,8 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setNoteFilesEnabled,
     noteFilesPath,
     setNoteFilesPath,
+    suppressRepetition,
+    setSuppressRepetition,
   } = useSettings();
 
   const agentKey = useSettingsStore((s) => s.agentKey);
@@ -3043,6 +3061,8 @@ EOF`,
             setCustomTranscriptionApiKey={setCustomTranscriptionApiKey}
             cloudTranscriptionBaseUrl={cloudTranscriptionBaseUrl}
             setCloudTranscriptionBaseUrl={setCloudTranscriptionBaseUrl}
+            suppressRepetition={suppressRepetition}
+            setSuppressRepetition={setSuppressRepetition}
             toast={toast}
           />
         );

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -919,8 +919,29 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
+  removeRepetitions(text) {
+    let result = text;
+    let prev;
+    do {
+      prev = result;
+      result = result.replace(/(\b.{10,}?)\s+\1(?=\s|$)/g, '$1');
+    } while (result !== prev);
+    return result.trim();
+  }
+
   async processTranscription(text, source) {
-    const normalizedText = typeof text === "string" ? text.trim() : "";
+    let normalizedText = typeof text === "string" ? text.trim() : "";
+
+    if (normalizedText && getSettings().suppressRepetition) {
+      const before = normalizedText;
+      normalizedText = this.removeRepetitions(normalizedText);
+      if (before !== normalizedText) {
+        logger.debug("Removed repeated phrases from transcription", {
+          beforeLength: before.length,
+          afterLength: normalizedText.length,
+        }, "transcription");
+      }
+    }
 
     if (!normalizedText) {
       logger.logReasoning("TRANSCRIPTION_EMPTY_SKIPPING_REASONING", {

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -238,7 +238,13 @@ class WhisperServerManager extends EventEmitter {
       spawnEnv.CUDA_VISIBLE_DEVICES = process.env.TRANSCRIPTION_GPU_INDEX;
     }
 
-    const args = ["--model", modelPath, "--host", "127.0.0.1", "--port", String(this.port)];
+    const args = [
+      "--model", modelPath,
+      "--host", "127.0.0.1",
+      "--port", String(this.port),
+      "--max-context", "128",
+      "--entropy-thold", "2.8",
+    ];
 
     // FFmpeg is required for pre-converting audio to 16kHz mono WAV
     this.canConvert = !!ffmpegPath;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -20,6 +20,7 @@ export interface TranscriptionSettings {
   cloudTranscriptionMode: string;
   customDictionary: string[];
   assemblyAiStreaming: boolean;
+  suppressRepetition: boolean;
 }
 
 export interface ReasoningSettings {
@@ -181,6 +182,8 @@ function useSettingsInternal() {
     customDictionary: store.customDictionary,
     assemblyAiStreaming: store.assemblyAiStreaming,
     setAssemblyAiStreaming: store.setAssemblyAiStreaming,
+    suppressRepetition: store.suppressRepetition,
+    setSuppressRepetition: store.setSuppressRepetition,
     useReasoningModel: store.useReasoningModel,
     reasoningModel: store.reasoningModel,
     reasoningProvider: store.reasoningProvider,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "Transkriptions-GPU",
         "description": "GPU für lokale Spracherkennung"
-      }
+      },
+      "suppressRepetitionLabel": "Wiederholte Phrasen unterdrücken",
+      "suppressRepetitionDescription": "Automatisch wiederholte Phrasen aus Transkriptionen entfernen. Hilft, Halluzinationsschleifen bei längeren Aufnahmen zu verhindern."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1446,7 +1446,9 @@
       "gpuDevice": {
         "title": "Transcription GPU",
         "description": "GPU used for local speech-to-text"
-      }
+      },
+      "suppressRepetitionLabel": "Suppress repeated phrases",
+      "suppressRepetitionDescription": "Automatically remove repeated phrases from transcriptions. Helps prevent hallucination loops in longer recordings."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "GPU de transcripción",
         "description": "GPU usada para transcripción local"
-      }
+      },
+      "suppressRepetitionLabel": "Suprimir frases repetidas",
+      "suppressRepetitionDescription": "Eliminar automáticamente frases repetidas de las transcripciones. Ayuda a prevenir bucles de alucinación en grabaciones largas."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "GPU de transcription",
         "description": "GPU pour la transcription locale"
-      }
+      },
+      "suppressRepetitionLabel": "Supprimer les phrases répétées",
+      "suppressRepetitionDescription": "Supprime automatiquement les phrases répétées des transcriptions. Aide à prévenir les boucles d'hallucination lors d'enregistrements longs."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "GPU trascrizione",
         "description": "GPU usata per la trascrizione locale"
-      }
+      },
+      "suppressRepetitionLabel": "Sopprimi frasi ripetute",
+      "suppressRepetitionDescription": "Rimuovi automaticamente le frasi ripetute dalle trascrizioni. Aiuta a prevenire i loop di allucinazione nelle registrazioni lunghe."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "文字起こしGPU",
         "description": "ローカル音声認識に使用するGPU"
-      }
+      },
+      "suppressRepetitionLabel": "繰り返しフレーズを抑制",
+      "suppressRepetitionDescription": "文字起こしから繰り返しフレーズを自動的に削除します。長い録音でのハルシネーションループを防ぐのに役立ちます。"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1370,7 +1370,9 @@
       "gpuDevice": {
         "title": "GPU de transcrição",
         "description": "GPU usada para transcrição local"
-      }
+      },
+      "suppressRepetitionLabel": "Suprimir frases repetidas",
+      "suppressRepetitionDescription": "Remover automaticamente frases repetidas das transcrições. Ajuda a prevenir loops de alucinação em gravações longas."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1398,7 +1398,9 @@
       "gpuDevice": {
         "title": "GPU транскрипции",
         "description": "GPU для локального распознавания речи"
-      }
+      },
+      "suppressRepetitionLabel": "Подавление повторов",
+      "suppressRepetitionDescription": "Автоматически удалять повторяющиеся фразы из транскрипции. Помогает предотвратить зацикливание при длинных записях."
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1393,7 +1393,9 @@
       "gpuDevice": {
         "title": "转录 GPU",
         "description": "用于本地语音识别的 GPU"
-      }
+      },
+      "suppressRepetitionLabel": "抑制重复短语",
+      "suppressRepetitionDescription": "自动从转录中删除重复的短语。有助于防止长录音中的幻觉循环。"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1393,7 +1393,9 @@
       "gpuDevice": {
         "title": "轉錄 GPU",
         "description": "用於本機語音辨識的 GPU"
-      }
+      },
+      "suppressRepetitionLabel": "抑制重複短語",
+      "suppressRepetitionDescription": "自動從轉錄中刪除重複的短語。有助於防止長錄音中的幻覺循環。"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -66,6 +66,7 @@ const BOOLEAN_SETTINGS = new Set([
   "keepTranscriptionInClipboard",
   "dataRetentionEnabled",
   "noteFilesEnabled",
+  "suppressRepetition",
 ]);
 
 const ARRAY_SETTINGS = new Set(["customDictionary", "gcalAccounts"]);
@@ -250,6 +251,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   cloudReasoningBaseUrl: readString("cloudReasoningBaseUrl", API_ENDPOINTS.OPENAI_BASE),
   customDictionary: readStringArray("customDictionary", []),
   assemblyAiStreaming: readBoolean("assemblyAiStreaming", true),
+  suppressRepetition: readBoolean("suppressRepetition", true),
 
   useReasoningModel: readBoolean("useReasoningModel", true),
   reasoningModel: readString("reasoningModel", ""),
@@ -342,6 +344,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setCloudReasoningMode: createStringSetter("cloudReasoningMode"),
   setCloudReasoningBaseUrl: createStringSetter("cloudReasoningBaseUrl"),
   setAssemblyAiStreaming: createBooleanSetter("assemblyAiStreaming"),
+  setSuppressRepetition: createBooleanSetter("suppressRepetition"),
   setUseReasoningModel: createBooleanSetter("useReasoningModel"),
   setReasoningModel: createStringSetter("reasoningModel"),
   setReasoningProvider: createStringSetter("reasoningProvider"),


### PR DESCRIPTION
### Problem

Whisper (especially large-v3) is prone to hallucination loops — repeating the same phrase indefinitely, particularly during silence or at audio segment boundaries.

The root cause: Whisper uses the previous segment's output as context for the next. A repetition in segment N propagates to N+1, N+2, etc. — creating an exponential feedback loop. This is one of the most widely reported Whisper issues:

- [openai/whisper#679](https://github.com/openai/whisper/discussions/679) — "A possible solution to Whisper hallucination" (37 comments, 147 replies) — foundational discussion on the root cause
- [whisper.cpp#1490](https://github.com/ggml-org/whisper.cpp/discussions/1490) — "Large Model hallucination and repeating", maintainer recommends `-mc` + large-v2
- [whisper.cpp#1507](https://github.com/ggml-org/whisper.cpp/issues/1507) — maintainer recommends `--max-context 64` or `32`, `--beam-size 5`, `--entropy-thold ~2.8`
- [whisper.cpp#1244](https://github.com/ggml-org/whisper.cpp/issues/1244) — confirms `-mc 0` = `condition_on_previous_text=False`

### Solution

Three layers of protection:

**1. `--max-context 128`** — limits cross-segment context to 128 tokens, breaking the feedback loop. Does NOT affect `initial_prompt` (custom prompt and dictionary words are always sent in full). Maintainer recommends 64 ([#1507](https://github.com/ggml-org/whisper.cpp/issues/1507)); we use a more conservative 128 to preserve cross-segment continuity, relying on the regex dedup layer to catch any loops that slip through.

**2. `--entropy-thold 2.8`** — discards segments where model confidence is very low (high entropy = silence/noise/hallucination). Default is 2.4; raised to 2.8 per maintainer recommendation in [#1507](https://github.com/ggml-org/whisper.cpp/issues/1507). Zero performance overhead.

**3. Regex dedup** — post-processing safety net that removes consecutive repeated phrases (10+ chars) from final output. 10-char minimum avoids false positives on common short phrases.

| Parameter | Value | Default | Rationale |
|-----------|-------|---------|-----------|
| `--max-context` | 128 | 224 | Conservative vs maintainer's 64 — regex dedup catches the rest |
| `--entropy-thold` | 2.8 | 2.4 | Per maintainer recommendation ([#1507](https://github.com/ggml-org/whisper.cpp/issues/1507)) |
| Regex min length | 10 chars | — | Avoids false positives on "I think", "you know", etc. |

### How Whisper context works

```
initial_prompt (custom prompt + dictionary)
  → always used in full (up to 224 tokens)
  → NOT affected by --max-context

cross-segment context (previous segment output)
  → fed back to next segment for continuity
  → --max-context limits THIS to prevent loops
```

### UI

New **"Suppress repeated phrases"** toggle in Settings → Transcription (default: **on**). When disabled, only regex dedup is skipped — whisper.cpp flags remain active as they improve quality regardless.

### Files changed

| File | Change |
|------|--------|
| `src/helpers/whisperServer.js` | `--max-context 128` and `--entropy-thold 2.8` flags |
| `src/helpers/audioManager.js` | `removeRepetitions()` regex dedup + wiring in `processTranscription()` |
| `src/components/SettingsPage.tsx` | Toggle UI in Transcription section |
| `src/hooks/useSettings.ts` + `src/stores/settingsStore.ts` | `suppressRepetition` boolean setting |
| `src/locales/*/translation.json` | i18n for all 10 locales |

### Test plan

- [ ] Record 30+ seconds with pauses — verify no hallucination loops
- [ ] Record normal speech — verify transcription quality unchanged
- [ ] Verify custom prompt and dictionary still work with `--max-context 128`
- [ ] Toggle off → verify repeated text passes through
- [ ] Check debug logs for `--max-context 128` and `--entropy-thold 2.8` in server startup args