### PR TITLE
feat(agent): auto-create folders on create_note / update_note

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -234,7 +234,10 @@ export default function ControlPanel() {
 
   useEffect(() => {
     const cleanup = window.electronAPI?.onNavigateToNote?.((data) => {
-      if (data.folderId) setActiveFolderId(data.folderId);
+      if (data.folderId) {
+        setActiveFolderId(data.folderId);
+        initializeNotes(null, 50, data.folderId);
+      }
       setActiveNoteId(data.noteId);
       setActiveView("personal-notes");
     });

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -153,11 +153,11 @@ const TOOL_INSTRUCTIONS: Record<string, string> = {
   get_note:
     "Use get_note to fetch the full content of a specific note by ID. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID.",
   create_note:
-    "Use create_note when the user asks you to create, write, or draft a new note. If the user specifies a folder, call list_folders first and reuse a matching existing folder (case-insensitive, tolerant of plurals/typos) instead of creating a near-duplicate. Only pass a new folder name when no existing folder is a reasonable fit.",
+    "Use create_note when the user asks you to create, write, or draft a new note. Whenever the note will go into a folder, call list_folders first and reuse an existing folder whose name is a reasonable fit for the note's topic (e.g. a new story belongs in an existing 'Stories' folder) — do this even when the user didn't name a folder but the content clearly fits one. Only pass a new folder name when nothing existing fits. Be tolerant of case, plurals, and typos.",
   update_note:
-    "Use update_note to modify an existing note's title, content, or move it to a different folder. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID. When moving to a folder, call list_folders first and prefer an existing folder over creating a new one.",
+    "Use update_note to modify an existing note's title, content, or move it to a different folder. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID. When moving to a folder, call list_folders first and reuse an existing folder whose name fits the note's topic; only create a new folder when nothing existing fits.",
   list_folders:
-    "Use list_folders before create_note or update_note whenever the user mentions a folder, so you can reuse an existing folder instead of creating a near-duplicate.",
+    "Use list_folders before create_note or update_note whenever a note is going into a folder, so you can reuse an existing folder whose name fits the note's topic instead of creating a near-duplicate.",
   web_search:
     "Use web_search for questions about current events, facts you're unsure about, or anything requiring up-to-date information.",
   copy_to_clipboard:

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -152,9 +152,12 @@ const TOOL_INSTRUCTIONS: Record<string, string> = {
     "Use search_notes to find information from the user's past meetings, discussions, or personal notes before answering from memory.",
   get_note:
     "Use get_note to fetch the full content of a specific note by ID. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID.",
-  create_note: "Use create_note when the user asks you to create, write, or draft a new note.",
+  create_note:
+    "Use create_note when the user asks you to create, write, or draft a new note. If the user specifies a folder, call list_folders first and reuse a matching existing folder (case-insensitive, tolerant of plurals/typos) instead of creating a near-duplicate. Only pass a new folder name when no existing folder is a reasonable fit.",
   update_note:
-    "Use update_note to modify an existing note's title, content, or move it to a different folder. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID.",
+    "Use update_note to modify an existing note's title, content, or move it to a different folder. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID. When moving to a folder, call list_folders first and prefer an existing folder over creating a new one.",
+  list_folders:
+    "Use list_folders before create_note or update_note whenever the user mentions a folder, so you can reuse an existing folder instead of creating a near-duplicate.",
   web_search:
     "Use web_search for questions about current events, facts you're unsure about, or anything requiring up-to-date information.",
   copy_to_clipboard:

--- a/src/services/tools/createNoteTool.ts
+++ b/src/services/tools/createNoteTool.ts
@@ -4,7 +4,8 @@ import { syncNoteToCloud } from "../../stores/noteStore";
 
 export const createNoteTool: ToolDefinition = {
   name: "create_note",
-  description: "Create a new note with a title and content, optionally in a specific folder.",
+  description:
+    "Create a new note with a title and content, optionally in a specific folder. If the folder does not exist, it is created automatically. Use list_folders first to avoid creating near-duplicates of existing folders.",
   parameters: {
     type: "object",
     properties: {
@@ -18,7 +19,7 @@ export const createNoteTool: ToolDefinition = {
       },
       folder: {
         type: "string",
-        description: "The folder name to create the note in (optional)",
+        description: "Folder name for the note. Created automatically if it does not exist.",
       },
     },
     required: ["title", "content"],
@@ -33,13 +34,15 @@ export const createNoteTool: ToolDefinition = {
 
     try {
       let folderId: number | null = null;
+      let folderCreated = false;
 
       if (folderName) {
-        const resolved = await resolveFolderId(folderName);
+        const resolved = await resolveFolderId(folderName, { createIfMissing: true });
         if (resolved.error) {
           return { success: false, data: null, displayText: resolved.error };
         }
         folderId = resolved.folderId;
+        folderCreated = resolved.created;
       }
 
       const result = await window.electronAPI.saveNote(
@@ -57,10 +60,11 @@ export const createNoteTool: ToolDefinition = {
 
       syncNoteToCloud(result.note).catch(() => {});
 
+      const suffix = folderCreated ? ` in new folder "${folderName}"` : "";
       return {
         success: true,
-        data: { id: result.note.id, title: result.note.title },
-        displayText: `Created note: "${title}"`,
+        data: { id: result.note.id, title: result.note.title, folder_id: folderId },
+        displayText: `Created note: "${title}"${suffix}`,
       };
     } catch (error) {
       return {

--- a/src/services/tools/createNoteTool.ts
+++ b/src/services/tools/createNoteTool.ts
@@ -5,7 +5,7 @@ import { syncNoteToCloud } from "../../stores/noteStore";
 export const createNoteTool: ToolDefinition = {
   name: "create_note",
   description:
-    "Create a new note with a title and content, optionally in a specific folder. If the folder does not exist, it is created automatically. Use list_folders first to avoid creating near-duplicates of existing folders.",
+    "Always call list_folders first and reuse an existing folder when the user mentions one; only pass a new folder name when none fits. Creates a note with title, content, and optional folder (auto-created if missing).",
   parameters: {
     type: "object",
     properties: {

--- a/src/services/tools/createNoteTool.ts
+++ b/src/services/tools/createNoteTool.ts
@@ -5,7 +5,7 @@ import { syncNoteToCloud } from "../../stores/noteStore";
 export const createNoteTool: ToolDefinition = {
   name: "create_note",
   description:
-    "Always call list_folders first and reuse an existing folder when the user mentions one; only pass a new folder name when none fits. Creates a note with title, content, and optional folder (auto-created if missing).",
+    "Always call list_folders first. Reuse an existing folder whenever one is a reasonable semantic fit for the note's topic (e.g. a story goes into an existing 'Stories' folder), even if the user didn't name it. Only pass a new folder name when nothing existing fits. Creates a note with title, content, and optional folder (auto-created if missing).",
   parameters: {
     type: "object",
     properties: {

--- a/src/services/tools/index.ts
+++ b/src/services/tools/index.ts
@@ -3,6 +3,7 @@ import { createSearchNotesTool } from "./searchNotesTool";
 import { getNoteTool } from "./getNoteTool";
 import { createNoteTool } from "./createNoteTool";
 import { updateNoteTool } from "./updateNoteTool";
+import { listFoldersTool } from "./listFoldersTool";
 import { clipboardTool } from "./clipboardTool";
 import { webSearchTool } from "./webSearchTool";
 import { calendarTool } from "./calendarTool";
@@ -24,6 +25,7 @@ export function createToolRegistry(settings: ToolRegistrySettings): ToolRegistry
   registry.register(getNoteTool);
   registry.register(createNoteTool);
   registry.register(updateNoteTool);
+  registry.register(listFoldersTool);
   registry.register(clipboardTool);
 
   if (settings.isSignedIn) {

--- a/src/services/tools/listFoldersTool.ts
+++ b/src/services/tools/listFoldersTool.ts
@@ -1,0 +1,30 @@
+import type { ToolDefinition, ToolResult } from "./ToolRegistry";
+
+export const listFoldersTool: ToolDefinition = {
+  name: "list_folders",
+  description:
+    "List all available note folders. Use before create_note or update_note to reuse an existing folder instead of creating a near-duplicate.",
+  parameters: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+  readOnly: true,
+
+  async execute(): Promise<ToolResult> {
+    try {
+      const folders = await window.electronAPI.getFolders();
+      const data = folders.map((f) => ({ id: f.id, name: f.name }));
+      const displayText = folders.length
+        ? `Folders: ${folders.map((f) => f.name).join(", ")}`
+        : "No folders";
+      return { success: true, data, displayText };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        displayText: `Failed to list folders: ${(error as Error).message}`,
+      };
+    }
+  },
+};

--- a/src/services/tools/updateNoteTool.ts
+++ b/src/services/tools/updateNoteTool.ts
@@ -23,7 +23,7 @@ export const updateNoteTool: ToolDefinition = {
       },
       folder: {
         type: "string",
-        description: "Folder name to move the note to (optional)",
+        description: "Folder name to move the note to. Created automatically if it does not exist.",
       },
     },
     required: ["id"],
@@ -55,12 +55,14 @@ export const updateNoteTool: ToolDefinition = {
       if (title) updates.title = title;
       if (content) updates.content = content;
 
+      let folderCreated = false;
       if (folderName) {
-        const resolved = await resolveFolderId(folderName);
+        const resolved = await resolveFolderId(folderName, { createIfMissing: true });
         if (resolved.error) {
           return { success: false, data: null, displayText: resolved.error };
         }
         updates.folder_id = resolved.folderId;
+        folderCreated = resolved.created;
       }
 
       const result = await window.electronAPI.updateNote(id, updates);
@@ -71,10 +73,11 @@ export const updateNoteTool: ToolDefinition = {
 
       syncNoteUpdateToCloud(note, updates).catch(() => {});
 
+      const suffix = folderCreated ? ` (moved to new folder "${folderName}")` : "";
       return {
         success: true,
         data: { id, title: title || note.title },
-        displayText: `Updated note: "${title || note.title}"`,
+        displayText: `Updated note: "${title || note.title}"${suffix}`,
       };
     } catch (error) {
       return {

--- a/src/services/tools/updateNoteTool.ts
+++ b/src/services/tools/updateNoteTool.ts
@@ -5,7 +5,7 @@ import { syncNoteUpdateToCloud } from "../../stores/noteStore";
 export const updateNoteTool: ToolDefinition = {
   name: "update_note",
   description:
-    "Update an existing note's title, content, or move it to a different folder. If the current note's ID is provided in the context, use it directly. Otherwise, use search_notes first to find the note ID.",
+    "Before moving to a folder, always call list_folders first and reuse an existing folder when the user mentions one; only pass a new folder name when none fits. Updates a note's title, content, or folder (auto-created if missing). Use the note ID from context if provided; otherwise search_notes first.",
   parameters: {
     type: "object",
     properties: {

--- a/src/services/tools/updateNoteTool.ts
+++ b/src/services/tools/updateNoteTool.ts
@@ -5,7 +5,7 @@ import { syncNoteUpdateToCloud } from "../../stores/noteStore";
 export const updateNoteTool: ToolDefinition = {
   name: "update_note",
   description:
-    "Before moving to a folder, always call list_folders first and reuse an existing folder when the user mentions one; only pass a new folder name when none fits. Updates a note's title, content, or folder (auto-created if missing). Use the note ID from context if provided; otherwise search_notes first.",
+    "Before moving to a folder, always call list_folders first. Reuse an existing folder whenever one is a reasonable semantic fit for the note's topic, even if the user didn't name it. Only pass a new folder name when nothing existing fits. Updates a note's title, content, or folder (auto-created if missing). Use the note ID from context if provided; otherwise search_notes first.",
   parameters: {
     type: "object",
     properties: {

--- a/src/services/tools/utils.ts
+++ b/src/services/tools/utils.ts
@@ -1,11 +1,28 @@
+type ResolveFolderResult =
+  | { folderId: number; created: boolean; error?: undefined }
+  | { folderId?: undefined; created?: undefined; error: string };
+
 export async function resolveFolderId(
-  folderName: string
-): Promise<{ folderId: number; error?: undefined } | { folderId?: undefined; error: string }> {
+  folderName: string,
+  options: { createIfMissing?: boolean } = {}
+): Promise<ResolveFolderResult> {
   const folders = await window.electronAPI.getFolders();
-
   const match = folders.find((f) => f.name.toLowerCase() === folderName.toLowerCase());
-  if (match) return { folderId: match.id };
+  if (match) return { folderId: match.id, created: false };
 
-  const available = folders.map((f) => f.name).join(", ");
-  return { error: `Folder "${folderName}" not found. Available folders: ${available}` };
+  if (!options.createIfMissing) {
+    const available = folders.map((f) => f.name).join(", ");
+    return { error: `Folder "${folderName}" not found. Available folders: ${available}` };
+  }
+
+  const result = await window.electronAPI.createFolder(folderName);
+  if (result.success && result.folder) {
+    return { folderId: result.folder.id, created: true };
+  }
+
+  const retry = await window.electronAPI.getFolders();
+  const reMatch = retry.find((f) => f.name.toLowerCase() === folderName.toLowerCase());
+  if (reMatch) return { folderId: reMatch.id, created: false };
+
+  return { error: result.error || `Failed to create folder "${folderName}"` };
 }


### PR DESCRIPTION
## Summary
- `resolveFolderId` now accepts `{ createIfMissing: true }` and creates the folder when no case-insensitive match exists; returns a `created` flag so callers can surface it in the UI.
- `create_note` and `update_note` pass `createIfMissing: true` and append `in new folder "X"` to their display text when a folder is created on the fly.
- New `list_folders` read-only tool so the agent can check existing folders before passing a name — mitigates the risk of spawning near-duplicates (e.g. `meeting` vs `Meetings`).

## Test plan
- [x] Ask the agent to create a note in an existing folder by name → note lands in that folder (no new folder).
- [x] Ask the agent to create a note in a folder that doesn't exist → folder is created, note lands in it, chat surfaces `in new folder "X"`.
- [x] Ask the agent to move an existing note (`update_note`) into a new folder name → folder is created and note is moved.
- [x] Ask the agent "what folders do I have?" → agent calls `list_folders` and lists them.
- [x] Rapid-fire two `create_note` calls with the same new folder name → no duplicate folder created (race fallback re-matches).