### PR TITLE
fix: prevent stuck recording when push-to-talk key-up is missed

### DIFF
--- a/main.js
+++ b/main.js
@@ -973,11 +973,15 @@ async function startApp() {
     });
 
     windowsKeyManager.on("key-up", () => {
-      if (!isLiveWindow(windowManager.mainWindow)) return;
-
-      const activationMode = windowManager.getActivationMode();
-      if (activationMode === "push") {
+      // Always process key-up to avoid stuck recording state, even if the
+      // window is temporarily unavailable (minimized, busy with transcription).
+      if (windowManager.winPushState?.active) {
         windowManager.handleWindowsPushKeyUp();
+      } else if (isLiveWindow(windowManager.mainWindow)) {
+        const activationMode = windowManager.getActivationMode();
+        if (activationMode === "push") {
+          windowManager.handleWindowsPushKeyUp();
+        }
       }
     });
 

--- a/main.js
+++ b/main.js
@@ -942,7 +942,6 @@ async function startApp() {
     });
   }
 
-  // Set up Windows Push-to-Talk handling
   if (process.platform === "win32") {
     debugLogger.debug("[Push-to-Talk] Windows Push-to-Talk setup starting");
 
@@ -973,8 +972,6 @@ async function startApp() {
     });
 
     windowsKeyManager.on("key-up", () => {
-      // Always process key-up to avoid stuck recording state, even if the
-      // window is temporarily unavailable (minimized, busy with transcription).
       if (windowManager.winPushState?.active) {
         windowManager.handleWindowsPushKeyUp();
       } else if (isLiveWindow(windowManager.mainWindow)) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -374,14 +374,23 @@ class WindowManager {
     }
 
     const MIN_HOLD_DURATION_MS = 150;
+    const MAX_PUSH_DURATION_MS = 120_000;
     const downTime = Date.now();
 
     this.showDictationPanel();
+
+    const safetyTimer = setTimeout(() => {
+      if (this.winPushState?.active) {
+        debugLogger.warn("[WindowManager] Push-to-talk safety timeout, force stopping");
+        this.handleWindowsPushKeyUp();
+      }
+    }, MAX_PUSH_DURATION_MS);
 
     this.winPushState = {
       active: true,
       downTime,
       isRecording: false,
+      safetyTimer,
     };
 
     setTimeout(() => {
@@ -402,6 +411,9 @@ class WindowManager {
     }
 
     const wasRecording = this.winPushState.isRecording;
+    if (this.winPushState.safetyTimer) {
+      clearTimeout(this.winPushState.safetyTimer);
+    }
     this.winPushState = null;
 
     if (wasRecording) {
@@ -412,6 +424,9 @@ class WindowManager {
   }
 
   resetWindowsPushState() {
+    if (this.winPushState?.safetyTimer) {
+      clearTimeout(this.winPushState.safetyTimer);
+    }
     this.winPushState = null;
   }
 

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -374,23 +374,14 @@ class WindowManager {
     }
 
     const MIN_HOLD_DURATION_MS = 150;
-    const MAX_PUSH_DURATION_MS = 120_000;
     const downTime = Date.now();
 
     this.showDictationPanel();
-
-    const safetyTimer = setTimeout(() => {
-      if (this.winPushState?.active) {
-        debugLogger.warn("[WindowManager] Push-to-talk safety timeout, force stopping");
-        this.handleWindowsPushKeyUp();
-      }
-    }, MAX_PUSH_DURATION_MS);
 
     this.winPushState = {
       active: true,
       downTime,
       isRecording: false,
-      safetyTimer,
     };
 
     setTimeout(() => {
@@ -411,9 +402,6 @@ class WindowManager {
     }
 
     const wasRecording = this.winPushState.isRecording;
-    if (this.winPushState.safetyTimer) {
-      clearTimeout(this.winPushState.safetyTimer);
-    }
     this.winPushState = null;
 
     if (wasRecording) {
@@ -424,10 +412,11 @@ class WindowManager {
   }
 
   resetWindowsPushState() {
-    if (this.winPushState?.safetyTimer) {
-      clearTimeout(this.winPushState.safetyTimer);
+    if (!this.winPushState?.active) {
+      return;
     }
-    this.winPushState = null;
+
+    this.handleWindowsPushKeyUp();
   }
 
   sendToggleDictation() {

--- a/src/helpers/windowsKeyManager.js
+++ b/src/helpers/windowsKeyManager.js
@@ -65,28 +65,29 @@ class WindowsKeyManager extends EventEmitter {
       return;
     }
 
+    let lineBuffer = "";
     this.process.stdout.setEncoding("utf8");
     this.process.stdout.on("data", (chunk) => {
-      chunk
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .forEach((line) => {
-          if (line === "READY") {
-            debugLogger.debug("[WindowsKeyManager] Listener ready", { key });
-            this.isReady = true;
-            this.emit("ready");
-          } else if (line === "KEY_DOWN") {
-            debugLogger.debug("[WindowsKeyManager] KEY_DOWN detected", { key });
-            this.emit("key-down", key);
-          } else if (line === "KEY_UP") {
-            debugLogger.debug("[WindowsKeyManager] KEY_UP detected", { key });
-            this.emit("key-up", key);
-          } else {
-            // Log unknown output at debug level (could be native binary's stderr info)
-            debugLogger.debug("[WindowsKeyManager] Unknown output", { line });
-          }
-        });
+      lineBuffer += chunk;
+      const lines = lineBuffer.split(/\r?\n/);
+      lineBuffer = lines.pop(); // keep incomplete trailing data for next chunk
+      for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+        if (line === "READY") {
+          debugLogger.debug("[WindowsKeyManager] Listener ready", { key });
+          this.isReady = true;
+          this.emit("ready");
+        } else if (line === "KEY_DOWN") {
+          debugLogger.debug("[WindowsKeyManager] KEY_DOWN detected", { key });
+          this.emit("key-down", key);
+        } else if (line === "KEY_UP") {
+          debugLogger.debug("[WindowsKeyManager] KEY_UP detected", { key });
+          this.emit("key-up", key);
+        } else {
+          debugLogger.debug("[WindowsKeyManager] Unknown output", { line });
+        }
+      }
     });
 
     this.process.stderr.setEncoding("utf8");

--- a/src/helpers/windowsKeyManager.js
+++ b/src/helpers/windowsKeyManager.js
@@ -21,6 +21,29 @@ class WindowsKeyManager extends EventEmitter {
     this.isReady = false;
   }
 
+  handleOutputLine(line, key) {
+    if (line === "READY") {
+      debugLogger.debug("[WindowsKeyManager] Listener ready", { key });
+      this.isReady = true;
+      this.emit("ready");
+      return;
+    }
+
+    if (line === "KEY_DOWN") {
+      debugLogger.debug("[WindowsKeyManager] KEY_DOWN detected", { key });
+      this.emit("key-down", key);
+      return;
+    }
+
+    if (line === "KEY_UP") {
+      debugLogger.debug("[WindowsKeyManager] KEY_UP detected", { key });
+      this.emit("key-up", key);
+      return;
+    }
+
+    debugLogger.debug("[WindowsKeyManager] Unknown output", { line });
+  }
+
   /**
    * Start listening for the specified key
    * @param {string} key - The key to listen for (e.g., "`", "F8", "F11", "CommandOrControl+F11")
@@ -70,23 +93,11 @@ class WindowsKeyManager extends EventEmitter {
     this.process.stdout.on("data", (chunk) => {
       lineBuffer += chunk;
       const lines = lineBuffer.split(/\r?\n/);
-      lineBuffer = lines.pop(); // keep incomplete trailing data for next chunk
+      lineBuffer = lines.pop();
       for (const raw of lines) {
         const line = raw.trim();
         if (!line) continue;
-        if (line === "READY") {
-          debugLogger.debug("[WindowsKeyManager] Listener ready", { key });
-          this.isReady = true;
-          this.emit("ready");
-        } else if (line === "KEY_DOWN") {
-          debugLogger.debug("[WindowsKeyManager] KEY_DOWN detected", { key });
-          this.emit("key-down", key);
-        } else if (line === "KEY_UP") {
-          debugLogger.debug("[WindowsKeyManager] KEY_UP detected", { key });
-          this.emit("key-up", key);
-        } else {
-          debugLogger.debug("[WindowsKeyManager] Unknown output", { line });
-        }
+        this.handleOutputLine(line, key);
       }
     });
 
@@ -107,6 +118,12 @@ class WindowsKeyManager extends EventEmitter {
     });
 
     proc.on("exit", (code, signal) => {
+      const trailingLine = lineBuffer.trim();
+      if (trailingLine) {
+        this.handleOutputLine(trailingLine, key);
+        lineBuffer = "";
+      }
+
       if (this.process === proc) {
         this.process = null;
         this.isReady = false;


### PR DESCRIPTION
## Summary

On Windows, push-to-talk with hold mode occasionally gets stuck recording after releasing the key (~5-10% of the time, reported with ScrollLock). Three issues contribute to this.

## Changes

- `src/helpers/windowsKeyManager.js` now buffers partial lines from the native binary's stdout. The old parser split each `data` chunk by newlines without accounting for chunks that arrive split across two events, which could silently drop a KEY_UP message.
- `main.js` key-up handler no longer gates on `isLiveWindow` when push state is active. If the main window is temporarily unavailable during key release, the cleanup still runs instead of silently discarding the event.
- `src/helpers/windowManager.js` adds a 120s safety timeout to push-to-talk. If key-up never arrives for any reason, recording stops automatically instead of hanging indefinitely. The timer is cleared on normal key-up and on state reset.

Closes #586