### PR TITLE
Redesign provider tabs and restore live transcription preview

### DIFF
--- a/src/components/LocalModelPicker.tsx
+++ b/src/components/LocalModelPicker.tsx
@@ -155,7 +155,7 @@ export default function LocalModelPicker({
   }, [downloadingModel, downloadProgress, models]);
 
   return (
-    <div className={`${styles.container} ${className}`}>
+    <div className={className}>
       <ProviderTabs
         providers={providers}
         selectedId={selectedProvider}
@@ -166,7 +166,7 @@ export default function LocalModelPicker({
 
       {progressDisplay}
 
-      <div className="p-3">
+      <div className="mt-2">
         <h5 className={`${styles.header} mb-2`}>{t("common.availableModels")}</h5>
 
         <ModelCardList

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -753,236 +753,230 @@ export default function ReasoningModelSelector({
 
       {effectiveMode === "cloud" ? (
         <div className="space-y-2">
-          <div className="border border-border rounded-lg overflow-hidden">
-            <ProviderTabs
-              providers={cloudProviders}
-              selectedId={selectedCloudProvider}
-              onSelect={handleCloudProviderChange}
-              colorScheme="purple"
-            />
+          <ProviderTabs
+            providers={cloudProviders}
+            selectedId={selectedCloudProvider}
+            onSelect={handleCloudProviderChange}
+            colorScheme="purple"
+          />
 
-            <div className="p-3">
-              {selectedCloudProvider === "custom" ? (
-                <>
-                  <div className="space-y-2">
-                    <h4 className="font-medium text-foreground">
-                      {t("reasoning.custom.endpointTitle")}
-                    </h4>
-                    <Input
-                      value={customBaseInput}
-                      onChange={(event) => setCustomBaseInput(event.target.value)}
-                      onBlur={handleBaseUrlBlur}
-                      placeholder="https://api.openai.com/v1"
-                      className="text-sm"
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      {t("reasoning.custom.endpointExamples")}{" "}
-                      <code className="text-primary">http://localhost:11434/v1</code>{" "}
-                      {t("reasoning.custom.ollama")},{" "}
-                      <code className="text-primary">http://localhost:8080/v1</code>{" "}
-                      {t("reasoning.custom.localAi")}.
-                    </p>
-                  </div>
+          <div>
+            {selectedCloudProvider === "custom" ? (
+              <>
+                <div className="space-y-2">
+                  <h4 className="font-medium text-foreground">
+                    {t("reasoning.custom.endpointTitle")}
+                  </h4>
+                  <Input
+                    value={customBaseInput}
+                    onChange={(event) => setCustomBaseInput(event.target.value)}
+                    onBlur={handleBaseUrlBlur}
+                    placeholder="https://api.openai.com/v1"
+                    className="text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t("reasoning.custom.endpointExamples")}{" "}
+                    <code className="text-primary">http://localhost:11434/v1</code>{" "}
+                    {t("reasoning.custom.ollama")},{" "}
+                    <code className="text-primary">http://localhost:8080/v1</code>{" "}
+                    {t("reasoning.custom.localAi")}.
+                  </p>
+                </div>
 
-                  <div className="space-y-2 pt-3">
-                    <h4 className="font-medium text-foreground">
-                      {t("reasoning.custom.apiKeyOptional")}
-                    </h4>
-                    <ApiKeyInput
-                      apiKey={customReasoningApiKey}
-                      setApiKey={setCustomReasoningApiKey || (() => {})}
-                      label=""
-                      helpText={t("reasoning.custom.apiKeyHelp")}
-                    />
-                  </div>
+                <div className="space-y-2 pt-3">
+                  <h4 className="font-medium text-foreground">
+                    {t("reasoning.custom.apiKeyOptional")}
+                  </h4>
+                  <ApiKeyInput
+                    apiKey={customReasoningApiKey}
+                    setApiKey={setCustomReasoningApiKey || (() => {})}
+                    label=""
+                    helpText={t("reasoning.custom.apiKeyHelp")}
+                  />
+                </div>
 
-                  <div className="space-y-2 pt-3">
-                    <div className="flex items-center justify-between">
-                      <h4 className="text-sm font-medium text-foreground">
-                        {t("reasoning.availableModels")}
-                      </h4>
-                      <div className="flex gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={handleResetCustomBase}
-                          className="text-xs"
-                        >
-                          {t("common.reset")}
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={handleRefreshCustomModels}
-                          disabled={
-                            customModelsLoading || (!trimmedCustomBase && !hasSavedCustomBase)
-                          }
-                          className="text-xs"
-                        >
-                          {customModelsLoading
-                            ? t("common.loading")
-                            : isCustomBaseDirty
-                              ? t("reasoning.custom.applyAndRefresh")
-                              : t("common.refresh")}
-                        </Button>
-                      </div>
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {t("reasoning.custom.queryPrefix")}{" "}
-                      <code className="break-all">
-                        {hasCustomBase
-                          ? `${effectiveReasoningBase}/models`
-                          : `${defaultOpenAIBase}/models`}
-                      </code>{" "}
-                      {t("reasoning.custom.querySuffix")}
-                    </p>
-                    {isCustomBaseDirty && (
-                      <p className="text-xs text-primary">
-                        {t("reasoning.custom.modelsReloadHint")}
-                      </p>
-                    )}
-                    {!hasCustomBase && (
-                      <p className="text-xs text-warning">{t("reasoning.custom.enterEndpoint")}</p>
-                    )}
-                    {hasCustomBase && (
-                      <>
-                        {customModelsLoading && (
-                          <p className="text-xs text-primary">
-                            {t("reasoning.custom.fetchingModels")}
-                          </p>
-                        )}
-                        {customModelsError && (
-                          <p className="text-xs text-destructive">{customModelsError}</p>
-                        )}
-                        {!customModelsLoading &&
-                          !customModelsError &&
-                          customModelOptions.length === 0 && (
-                            <p className="text-xs text-warning">{t("reasoning.custom.noModels")}</p>
-                          )}
-                      </>
-                    )}
-                    <ModelCardList
-                      models={selectedCloudModels}
-                      selectedModel={reasoningModel}
-                      onModelSelect={setReasoningModel}
-                    />
-                  </div>
-                </>
-              ) : (
-                <>
-                  {selectedCloudProvider === "openai" && (
-                    <div className="space-y-2">
-                      <div className="flex items-baseline justify-between">
-                        <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
-                        <a
-                          href="https://platform.openai.com/api-keys"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={createExternalLinkHandler(
-                            "https://platform.openai.com/api-keys"
-                          )}
-                          className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
-                        >
-                          {t("reasoning.getApiKey")}
-                        </a>
-                      </div>
-                      <ApiKeyInput
-                        apiKey={openaiApiKey}
-                        setApiKey={setOpenaiApiKey}
-                        label=""
-                        helpText=""
-                      />
-                    </div>
-                  )}
-
-                  {selectedCloudProvider === "anthropic" && (
-                    <div className="space-y-2">
-                      <div className="flex items-baseline justify-between">
-                        <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
-                        <a
-                          href="https://console.anthropic.com/settings/keys"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={createExternalLinkHandler(
-                            "https://console.anthropic.com/settings/keys"
-                          )}
-                          className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
-                        >
-                          {t("reasoning.getApiKey")}
-                        </a>
-                      </div>
-                      <ApiKeyInput
-                        apiKey={anthropicApiKey}
-                        setApiKey={setAnthropicApiKey}
-                        label=""
-                        helpText=""
-                      />
-                    </div>
-                  )}
-
-                  {selectedCloudProvider === "gemini" && (
-                    <div className="space-y-2">
-                      <div className="flex items-baseline justify-between">
-                        <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
-                        <a
-                          href="https://aistudio.google.com/app/api-keys"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={createExternalLinkHandler(
-                            "https://aistudio.google.com/app/api-keys"
-                          )}
-                          className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
-                        >
-                          {t("reasoning.getApiKey")}
-                        </a>
-                      </div>
-                      <ApiKeyInput
-                        apiKey={geminiApiKey}
-                        setApiKey={setGeminiApiKey}
-                        label=""
-                        helpText=""
-                      />
-                    </div>
-                  )}
-
-                  {selectedCloudProvider === "groq" && (
-                    <div className="space-y-2">
-                      <div className="flex items-baseline justify-between">
-                        <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
-                        <a
-                          href="https://console.groq.com/keys"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={createExternalLinkHandler("https://console.groq.com/keys")}
-                          className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
-                        >
-                          {t("reasoning.getApiKey")}
-                        </a>
-                      </div>
-                      <ApiKeyInput
-                        apiKey={groqApiKey}
-                        setApiKey={setGroqApiKey}
-                        label=""
-                        helpText=""
-                      />
-                    </div>
-                  )}
-
-                  <div className="pt-3 space-y-2">
+                <div className="space-y-2 pt-3">
+                  <div className="flex items-center justify-between">
                     <h4 className="text-sm font-medium text-foreground">
-                      {t("reasoning.selectModel")}
+                      {t("reasoning.availableModels")}
                     </h4>
-                    <ModelCardList
-                      models={selectedCloudModels}
-                      selectedModel={reasoningModel}
-                      onModelSelect={setReasoningModel}
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={handleResetCustomBase}
+                        className="text-xs"
+                      >
+                        {t("common.reset")}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={handleRefreshCustomModels}
+                        disabled={
+                          customModelsLoading || (!trimmedCustomBase && !hasSavedCustomBase)
+                        }
+                        className="text-xs"
+                      >
+                        {customModelsLoading
+                          ? t("common.loading")
+                          : isCustomBaseDirty
+                            ? t("reasoning.custom.applyAndRefresh")
+                            : t("common.refresh")}
+                      </Button>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t("reasoning.custom.queryPrefix")}{" "}
+                    <code className="break-all">
+                      {hasCustomBase
+                        ? `${effectiveReasoningBase}/models`
+                        : `${defaultOpenAIBase}/models`}
+                    </code>{" "}
+                    {t("reasoning.custom.querySuffix")}
+                  </p>
+                  {isCustomBaseDirty && (
+                    <p className="text-xs text-primary">{t("reasoning.custom.modelsReloadHint")}</p>
+                  )}
+                  {!hasCustomBase && (
+                    <p className="text-xs text-warning">{t("reasoning.custom.enterEndpoint")}</p>
+                  )}
+                  {hasCustomBase && (
+                    <>
+                      {customModelsLoading && (
+                        <p className="text-xs text-primary">
+                          {t("reasoning.custom.fetchingModels")}
+                        </p>
+                      )}
+                      {customModelsError && (
+                        <p className="text-xs text-destructive">{customModelsError}</p>
+                      )}
+                      {!customModelsLoading &&
+                        !customModelsError &&
+                        customModelOptions.length === 0 && (
+                          <p className="text-xs text-warning">{t("reasoning.custom.noModels")}</p>
+                        )}
+                    </>
+                  )}
+                  <ModelCardList
+                    models={selectedCloudModels}
+                    selectedModel={reasoningModel}
+                    onModelSelect={setReasoningModel}
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                {selectedCloudProvider === "openai" && (
+                  <div className="space-y-2">
+                    <div className="flex items-baseline justify-between">
+                      <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
+                      <a
+                        href="https://platform.openai.com/api-keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={createExternalLinkHandler("https://platform.openai.com/api-keys")}
+                        className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
+                      >
+                        {t("reasoning.getApiKey")}
+                      </a>
+                    </div>
+                    <ApiKeyInput
+                      apiKey={openaiApiKey}
+                      setApiKey={setOpenaiApiKey}
+                      label=""
+                      helpText=""
                     />
                   </div>
-                </>
-              )}
-            </div>
+                )}
+
+                {selectedCloudProvider === "anthropic" && (
+                  <div className="space-y-2">
+                    <div className="flex items-baseline justify-between">
+                      <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
+                      <a
+                        href="https://console.anthropic.com/settings/keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={createExternalLinkHandler(
+                          "https://console.anthropic.com/settings/keys"
+                        )}
+                        className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
+                      >
+                        {t("reasoning.getApiKey")}
+                      </a>
+                    </div>
+                    <ApiKeyInput
+                      apiKey={anthropicApiKey}
+                      setApiKey={setAnthropicApiKey}
+                      label=""
+                      helpText=""
+                    />
+                  </div>
+                )}
+
+                {selectedCloudProvider === "gemini" && (
+                  <div className="space-y-2">
+                    <div className="flex items-baseline justify-between">
+                      <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
+                      <a
+                        href="https://aistudio.google.com/app/api-keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={createExternalLinkHandler(
+                          "https://aistudio.google.com/app/api-keys"
+                        )}
+                        className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
+                      >
+                        {t("reasoning.getApiKey")}
+                      </a>
+                    </div>
+                    <ApiKeyInput
+                      apiKey={geminiApiKey}
+                      setApiKey={setGeminiApiKey}
+                      label=""
+                      helpText=""
+                    />
+                  </div>
+                )}
+
+                {selectedCloudProvider === "groq" && (
+                  <div className="space-y-2">
+                    <div className="flex items-baseline justify-between">
+                      <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
+                      <a
+                        href="https://console.groq.com/keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={createExternalLinkHandler("https://console.groq.com/keys")}
+                        className="text-xs text-link underline decoration-link/30 hover:decoration-link/60 cursor-pointer transition-colors"
+                      >
+                        {t("reasoning.getApiKey")}
+                      </a>
+                    </div>
+                    <ApiKeyInput
+                      apiKey={groqApiKey}
+                      setApiKey={setGroqApiKey}
+                      label=""
+                      helpText=""
+                    />
+                  </div>
+                )}
+
+                <div className="pt-3 space-y-2">
+                  <h4 className="text-sm font-medium text-foreground">
+                    {t("reasoning.selectModel")}
+                  </h4>
+                  <ModelCardList
+                    models={selectedCloudModels}
+                    selectedModel={reasoningModel}
+                    onModelSelect={setReasoningModel}
+                  />
+                </div>
+              </>
+            )}
           </div>
         </div>
       ) : (

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -194,6 +194,8 @@ interface TranscriptionSectionProps {
   setTranscriptionMode: (mode: InferenceMode) => void;
   remoteTranscriptionUrl: string;
   setRemoteTranscriptionUrl: (url: string) => void;
+  showTranscriptionPreview: boolean;
+  setShowTranscriptionPreview: (value: boolean) => void;
   toast: (opts: {
     title: string;
     description: string;
@@ -233,6 +235,8 @@ function TranscriptionSection({
   setTranscriptionMode,
   remoteTranscriptionUrl,
   setRemoteTranscriptionUrl,
+  showTranscriptionPreview,
+  setShowTranscriptionPreview,
   toast,
 }: TranscriptionSectionProps) {
   const { t } = useTranslation();
@@ -296,6 +300,19 @@ function TranscriptionSection({
     [localTranscriptionProvider, setParakeetModel, setWhisperModel]
   );
 
+  const renderPreviewToggle = () => (
+    <SettingsPanel>
+      <SettingsPanelRow>
+        <SettingsRow
+          label={t("settingsPage.transcription.transcriptionPreview")}
+          description={t("settingsPage.transcription.transcriptionPreviewDescription")}
+        >
+          <Toggle checked={showTranscriptionPreview} onChange={setShowTranscriptionPreview} />
+        </SettingsRow>
+      </SettingsPanelRow>
+    </SettingsPanel>
+  );
+
   const renderTranscriptionPicker = (mode?: "cloud" | "local") => (
     <TranscriptionModelPicker
       selectedCloudProvider={cloudTranscriptionProvider}
@@ -347,7 +364,12 @@ function TranscriptionSection({
           />
 
           {transcriptionMode === "providers" && renderTranscriptionPicker("cloud")}
-          {transcriptionMode === "local" && renderTranscriptionPicker("local")}
+          {transcriptionMode === "local" && (
+            <>
+              {renderTranscriptionPicker("local")}
+              {renderPreviewToggle()}
+            </>
+          )}
 
           {transcriptionMode === "self-hosted" && (
             <SelfHostedPanel
@@ -358,7 +380,10 @@ function TranscriptionSection({
           )}
         </>
       ) : (
-        renderTranscriptionPicker()
+        <>
+          {renderTranscriptionPicker()}
+          {useLocalWhisper && renderPreviewToggle()}
+        </>
       )}
 
       <GpuDeviceSelector purpose="transcription" />
@@ -695,6 +720,8 @@ export default function SettingsPage({ activeSection = "general" }: SettingsPage
     setAudioCuesEnabled,
     pauseMediaOnDictation,
     setPauseMediaOnDictation,
+    showTranscriptionPreview,
+    setShowTranscriptionPreview,
     keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard,
     floatingIconAutoHide,
@@ -2982,6 +3009,8 @@ EOF`,
             setTranscriptionMode={setTranscriptionMode}
             remoteTranscriptionUrl={remoteTranscriptionUrl}
             setRemoteTranscriptionUrl={setRemoteTranscriptionUrl}
+            showTranscriptionPreview={showTranscriptionPreview}
+            setShowTranscriptionPreview={setShowTranscriptionPreview}
             toast={toast}
           />
         );

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -88,10 +88,7 @@ function LocalModelCard({
         isSelected ? cardStyles.modelCard.selected : cardStyles.modelCard.default
       } ${isDownloaded && !isSelected ? "cursor-pointer" : ""}`}
     >
-      {isSelected && (
-        <div className="absolute left-0 top-0 bottom-0 w-1 bg-linear-to-b from-primary via-primary to-primary/80 rounded-l-md" />
-      )}
-      <div className="flex items-center gap-1.5 p-2 pl-2.5">
+      <div className="flex items-center gap-1.5 p-2">
         <div className="shrink-0">
           {isDownloaded ? (
             <div
@@ -208,7 +205,7 @@ interface TranscriptionModelPickerProps {
 
 const CLOUD_PROVIDER_TABS = [
   { id: "openai", name: "OpenAI" },
-  { id: "groq", name: "Groq", recommended: true },
+  { id: "groq", name: "Groq" },
   { id: "mistral", name: "Mistral" },
   { id: "custom", name: "Custom" },
 ];
@@ -216,8 +213,8 @@ const CLOUD_PROVIDER_TABS = [
 const VALID_CLOUD_PROVIDER_IDS = CLOUD_PROVIDER_TABS.map((p) => p.id);
 
 const LOCAL_PROVIDER_TABS: Array<{ id: string; name: string; disabled?: boolean }> = [
-  { id: "whisper", name: "OpenAI Whisper" },
-  { id: "nvidia", name: "NVIDIA Parakeet" },
+  { id: "whisper", name: "OpenAI" },
+  { id: "nvidia", name: "NVIDIA" },
 ];
 
 interface ModeToggleProps {
@@ -754,12 +751,6 @@ export default function TranscriptionModelPicker({
     [showConfirmDialog, deleteParakeetModel, t]
   );
 
-  const getParakeetLanguageLabel = (language: string) => {
-    return language === "multilingual"
-      ? t("transcription.parakeet.multilingual")
-      : t("transcription.parakeet.english");
-  };
-
   const renderParakeetModels = () => {
     const modelsToRender =
       parakeetModels.length === 0
@@ -796,7 +787,6 @@ export default function TranscriptionModelPicker({
               isCancelling={isCancellingParakeet}
               recommended={info.recommended}
               provider="nvidia"
-              languageLabel={getParakeetLanguageLabel(info.language)}
               onSelect={() => handleParakeetModelSelect(modelId)}
               onDelete={() => handleParakeetDelete(modelId)}
               onDownload={() =>
@@ -821,18 +811,16 @@ export default function TranscriptionModelPicker({
       {!mode && <ModeToggle useLocalWhisper={effectiveLocal} onModeChange={handleModeChange} />}
 
       {!effectiveLocal ? (
-        <div className={styles.container}>
-          <div className="p-2 pb-0">
-            <ProviderTabs
-              providers={cloudProviderTabs}
-              selectedId={selectedCloudProvider}
-              onSelect={handleCloudProviderChange}
-              colorScheme="purple"
-              scrollable
-            />
-          </div>
+        <>
+          <ProviderTabs
+            providers={cloudProviderTabs}
+            selectedId={selectedCloudProvider}
+            onSelect={handleCloudProviderChange}
+            colorScheme="purple"
+            scrollable
+          />
 
-          <div className="p-2">
+          <div>
             {selectedCloudProvider === "custom" ? (
               <div className="space-y-2">
                 <div className="space-y-1.5">
@@ -916,17 +904,15 @@ export default function TranscriptionModelPicker({
               </div>
             )}
           </div>
-        </div>
+        </>
       ) : (
-        <div className={styles.container}>
-          <div className="p-2 pb-0">
-            <ProviderTabs
-              providers={LOCAL_PROVIDER_TABS}
-              selectedId={internalLocalProvider}
-              onSelect={handleLocalProviderChange}
-              colorScheme="purple"
-            />
-          </div>
+        <>
+          <ProviderTabs
+            providers={LOCAL_PROVIDER_TABS}
+            selectedId={internalLocalProvider}
+            onSelect={handleLocalProviderChange}
+            colorScheme="purple"
+          />
 
           {progressDisplay}
 
@@ -949,7 +935,7 @@ export default function TranscriptionModelPicker({
             !cudaDownloading &&
             getCachedPlatform() !== "darwin" &&
             cudaStatus?.gpuInfo.hasNvidiaGpu && (
-              <div className="mx-2 mt-2 rounded-md border border-border bg-surface-1 p-2.5">
+              <div className="rounded-md border border-border bg-surface-1 p-2.5">
                 {cudaStatus.downloaded ? (
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1.5">
@@ -994,11 +980,11 @@ export default function TranscriptionModelPicker({
               </div>
             )}
 
-          <div className="p-2">
+          <div>
             {internalLocalProvider === "whisper" && renderLocalModels()}
             {internalLocalProvider === "nvidia" && renderParakeetModels()}
           </div>
-        </div>
+        </>
       )}
 
       <ConfirmDialog

--- a/src/components/TranscriptionPreviewOverlay.tsx
+++ b/src/components/TranscriptionPreviewOverlay.tsx
@@ -196,24 +196,20 @@ export default function TranscriptionPreviewOverlay() {
     try {
       const result = await window.electronAPI?.writeClipboard?.(textToCopy);
       if (result?.success === false) throw new Error("clipboard-write-failed");
-      setCopied(true);
-      resetCopyState();
-      if (phaseRef.current === "final") {
-        startHideTimer(FINAL_HIDE_DURATION_MS);
-        setCountdownKey((k) => k + 1);
-      }
     } catch {
       try {
         await navigator.clipboard.writeText(textToCopy);
-        setCopied(true);
-        resetCopyState();
-        if (phaseRef.current === "final") {
-          startHideTimer(FINAL_HIDE_DURATION_MS);
-          setCountdownKey((k) => k + 1);
-        }
       } catch {
         setCopied(false);
+        return;
       }
+    }
+
+    setCopied(true);
+    resetCopyState();
+    if (phaseRef.current === "final") {
+      startHideTimer(FINAL_HIDE_DURATION_MS);
+      setCountdownKey((k) => k + 1);
     }
   }, [activeText, resetCopyState, startHideTimer]);
 

--- a/src/components/ui/ModelCardList.tsx
+++ b/src/components/ui/ModelCardList.tsx
@@ -110,15 +110,10 @@ export default function ModelCardList({
           <div
             key={model.value}
             onClick={handleCardClick}
-            className={`relative w-full p-2 pl-2.5 rounded-md border text-left transition-colors duration-200 group overflow-hidden ${
+            className={`relative w-full p-2 rounded-md border text-left transition-colors duration-200 group overflow-hidden ${
               isSelected ? styles.selected : styles.default
             } ${!isLocalMode || (isDownloaded && !isSelected) ? "cursor-pointer" : ""}`}
           >
-            {/* Left accent bar for selected */}
-            {isSelected && (
-              <div className="absolute left-0 top-0 bottom-0 w-1 bg-linear-to-b from-primary via-primary to-primary/80 rounded-l-md" />
-            )}
-
             <div className="flex items-center gap-1.5">
               {/* Status dot with LED glow */}
               <div

--- a/src/components/ui/ProviderTabs.tsx
+++ b/src/components/ui/ProviderTabs.tsx
@@ -70,12 +70,11 @@ export function ProviderTabs({
   return (
     <div
       ref={containerRef}
-      className={`relative flex p-0.5 rounded-md bg-surface-raised dark:bg-surface-1 ${scrollable ? "overflow-x-auto" : ""}`}
+      className={`relative inline-flex items-center gap-0.5 p-0.5 ${scrollable ? "overflow-x-auto" : ""}`}
     >
-      {/* Sliding indicator - frosted glass treatment */}
       <div
         ref={indicatorRef}
-        className="absolute top-0.5 left-0 rounded-md bg-card border border-border dark:border-border-subtle shadow-sm dark:shadow-(--shadow-card) transition-[width,height,transform,opacity] duration-200 ease-out pointer-events-none"
+        className="absolute top-0.5 left-0 rounded-full bg-primary/10 dark:bg-primary/15 ring-1 ring-primary/30 dark:ring-primary/25 transition-[width,height,transform,opacity] duration-200 ease-out pointer-events-none"
         style={{ opacity: 0 }}
       />
 
@@ -87,14 +86,16 @@ export function ProviderTabs({
             key={provider.id}
             data-tab-button
             onClick={() => onSelect(provider.id)}
-            className={`relative z-10 flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md font-medium text-xs transition-colors duration-150 ${
+            className={`relative z-10 flex items-center gap-1 px-2.5 py-1 rounded-full font-medium text-xs transition-colors duration-150 ${
               scrollable ? "whitespace-nowrap" : ""
-            } ${isSelected ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+            } ${isSelected ? "text-foreground [&_svg]:text-primary" : "text-muted-foreground ring-1 ring-border/60 dark:ring-white/10 hover:text-foreground hover:bg-foreground/4 dark:hover:bg-white/5"}`}
           >
             {renderIcon ? renderIcon(provider.id) : <ProviderIcon provider={provider.id} />}
             <span>{provider.name}</span>
             {provider.recommended && (
-              <span className="text-xs text-primary/70 font-medium">{t("common.recommended")}</span>
+              <span className="text-[10px] text-primary/70 font-medium">
+                {t("common.recommended")}
+              </span>
             )}
           </button>
         );

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3836,6 +3836,84 @@ class IPCHandlers {
       meetingEchoLeakDetector.reset();
     };
 
+    let dictationPreviewMode = false;
+    let dictationPreviewBuffer = [];
+    let dictationPreviewTimer = null;
+    let dictationPreviewTranscribing = false;
+    let dictationPreviewProvider = null;
+    let dictationPreviewModel = null;
+    let dictationPreviewSessionActive = false;
+    let dictationPreviewChunkCount = 0;
+
+    const resetDictationPreviewState = ({ preserveSession = false } = {}) => {
+      if (dictationPreviewTimer) {
+        clearInterval(dictationPreviewTimer);
+        dictationPreviewTimer = null;
+      }
+      dictationPreviewMode = false;
+      if (!preserveSession) {
+        dictationPreviewSessionActive = false;
+      }
+      dictationPreviewBuffer = [];
+      dictationPreviewTranscribing = false;
+      dictationPreviewProvider = null;
+      dictationPreviewModel = null;
+    };
+
+    const transcribeDictationPreviewChunk = async () => {
+      if (dictationPreviewTranscribing) return;
+      if (!dictationPreviewBuffer.length) return;
+
+      dictationPreviewTranscribing = true;
+      try {
+        const pcm = Buffer.concat(dictationPreviewBuffer);
+        dictationPreviewBuffer = [];
+
+        const samples = new Int16Array(pcm.buffer, pcm.byteOffset, pcm.length / 2);
+        let sumSq = 0;
+        for (let i = 0; i < samples.length; i++) {
+          const n = samples[i] / 0x7fff;
+          sumSq += n * n;
+        }
+        const rms = Math.sqrt(sumSq / samples.length);
+        debugLogger.debug("Dictation preview chunk", {
+          pcmBytes: pcm.length,
+          rms: rms.toFixed(6),
+          samples: samples.length,
+        });
+        if (rms < 0.002) return;
+
+        const wav = pcm16ToWav(pcm);
+
+        let result;
+        if (dictationPreviewProvider === "nvidia") {
+          result = await this.parakeetManager.transcribeLocalParakeet(wav, {
+            model: dictationPreviewModel,
+          });
+        } else {
+          result = await this.whisperManager.transcribeLocalWhisper(wav, {
+            model: dictationPreviewModel,
+          });
+        }
+
+        if (result?.success && result.text?.trim()) {
+          this.windowManager.appendTranscriptionPreview(result.text.trim());
+        } else if (result && !result.success) {
+          debugLogger.warn("Dictation preview chunk returned failure", {
+            error: result.error || result.message,
+            provider: dictationPreviewProvider,
+          });
+        }
+      } catch (error) {
+        debugLogger.error("Dictation preview transcription chunk failed", {
+          error: error.message,
+          provider: dictationPreviewProvider,
+        });
+      } finally {
+        dictationPreviewTranscribing = false;
+      }
+    };
+
     const resetMeetingStreamingState = () => {
       this._meetingMicStreaming = null;
       this._meetingSystemStreaming = null;
@@ -4271,6 +4349,80 @@ class IPCHandlers {
       const result = await this._dictationStreaming.disconnect().catch(() => ({ text: "" }));
       this._dictationStreaming = null;
       return { success: true, text: result.text || "" };
+    });
+
+    ipcMain.handle("start-dictation-preview", async (_event, { provider, model }) => {
+      resetDictationPreviewState();
+      dictationPreviewMode = true;
+      dictationPreviewSessionActive = true;
+      dictationPreviewProvider = provider;
+      dictationPreviewModel = model;
+      dictationPreviewChunkCount = 0;
+      this.windowManager.showTranscriptionPreview("");
+      dictationPreviewTimer = setInterval(() => transcribeDictationPreviewChunk(), 1500);
+      return { success: true };
+    });
+
+    ipcMain.on("dictation-preview-audio", (_event, audioBuffer) => {
+      if (!dictationPreviewMode) return;
+      dictationPreviewChunkCount++;
+      if (dictationPreviewChunkCount <= 3 || dictationPreviewChunkCount % 50 === 0) {
+        debugLogger.debug("Dictation preview audio received", {
+          bytes: audioBuffer?.byteLength || audioBuffer?.length,
+          count: dictationPreviewChunkCount,
+          bufferSize: dictationPreviewBuffer.length,
+        });
+      }
+      dictationPreviewBuffer.push(
+        Buffer.isBuffer(audioBuffer) ? audioBuffer : Buffer.from(audioBuffer)
+      );
+    });
+
+    ipcMain.handle("dismiss-dictation-preview", async () => {
+      resetDictationPreviewState();
+      this.windowManager.hideTranscriptionPreview();
+      return { success: true };
+    });
+
+    ipcMain.handle("complete-dictation-preview", async (_event, { text } = {}) => {
+      if (!dictationPreviewSessionActive) {
+        return { success: true };
+      }
+      if (typeof text === "string" && text.trim()) {
+        this.windowManager.completeTranscriptionPreview(text);
+      } else {
+        resetDictationPreviewState();
+        this.windowManager.hideTranscriptionPreview();
+      }
+      return { success: true };
+    });
+
+    ipcMain.handle("hide-dictation-preview", async () => {
+      resetDictationPreviewState();
+      this.windowManager.hideTranscriptionPreview();
+      return { success: true };
+    });
+
+    ipcMain.handle("resize-transcription-preview-window", async (_event, width, height) => {
+      if (!dictationPreviewSessionActive) {
+        return { success: false, error: "Preview session not active" };
+      }
+      return this.windowManager.resizeTranscriptionPreview(width, height);
+    });
+
+    ipcMain.handle("stop-dictation-preview", async (_event, options = {}) => {
+      if (!dictationPreviewMode && !dictationPreviewSessionActive) {
+        return { success: true };
+      }
+      clearInterval(dictationPreviewTimer);
+      dictationPreviewTimer = null;
+      await transcribeDictationPreviewChunk();
+      resetDictationPreviewState({ preserveSession: true });
+      if (!dictationPreviewSessionActive) {
+        return { success: true };
+      }
+      this.windowManager.holdTranscriptionPreview(options);
+      return { success: true };
     });
 
     ipcMain.handle("update-transcription-text", async (_event, id, text, rawText) => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -23,6 +23,7 @@ export interface TranscriptionSettings {
   remoteTranscriptionUrl: string;
   customDictionary: string[];
   assemblyAiStreaming: boolean;
+  showTranscriptionPreview: boolean;
 }
 
 export interface ReasoningSettings {
@@ -262,6 +263,8 @@ function useSettingsInternal() {
     setSelectedMicDeviceId: store.setSelectedMicDeviceId,
     autoLearnCorrections,
     setAutoLearnCorrections,
+    showTranscriptionPreview: store.showTranscriptionPreview,
+    setShowTranscriptionPreview: store.setShowTranscriptionPreview,
     keepTranscriptionInClipboard: store.keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard: store.setKeepTranscriptionInClipboard,
     noteFilesEnabled: store.noteFilesEnabled,

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1453,7 +1453,7 @@
         "deleteModels": "Delete Models"
       },
       "transcriptionPreview": "リアルタイム文字起こしプレビュー",
-      "transcriptionPreviewDescription": "補正前にフローティングウィンドウで文字起こしを表示"
+      "transcriptionPreviewDescription": "クリーンアップ前にフローティングウィンドウで文字起こしを表示"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1425,7 +1425,7 @@
         "deleteModels": "Delete Models"
       },
       "transcriptionPreview": "Pré-visualização ao vivo",
-      "transcriptionPreviewDescription": "Mostrar transcrição em janela flutuante antes da correção"
+      "transcriptionPreviewDescription": "Mostrar transcrição em janela flutuante antes da limpeza"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1453,7 +1453,7 @@
         "deleteModels": "Delete Models"
       },
       "transcriptionPreview": "Предпросмотр транскрипции",
-      "transcriptionPreviewDescription": "Показывать транскрипцию в плавающем окне перед обработкой"
+      "transcriptionPreviewDescription": "Показывать транскрипцию в плавающем окне перед очисткой"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1448,7 +1448,7 @@
         "deleteModels": "Delete Models"
       },
       "transcriptionPreview": "实时转录预览",
-      "transcriptionPreviewDescription": "在浮动窗口中显示转录结果，然后再进行优化"
+      "transcriptionPreviewDescription": "在浮动窗口中显示转录结果，然后再进行文本整理"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1448,7 +1448,7 @@
         "deleteModels": "Delete Models"
       },
       "transcriptionPreview": "即時轉錄預覽",
-      "transcriptionPreviewDescription": "在浮動視窗中顯示轉錄結果，再進行校正"
+      "transcriptionPreviewDescription": "在浮動視窗中顯示轉錄結果，再進行文字整理"
     },
     "intelligence": {
       "gpuDevice": {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -2,7 +2,7 @@
   "parakeetModels": {
     "parakeet-tdt-0.6b-v3": {
       "name": "Parakeet TDT 0.6B",
-      "description": "Fast multilingual ASR with auto language detection (25 languages)",
+      "description": "Fast multilingual ASR with auto language detection",
       "size": "680MB",
       "sizeMb": 680,
       "language": "multilingual",
@@ -33,7 +33,6 @@
         "ru",
         "uk"
       ],
-      "recommended": true,
       "downloadUrl": "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8.tar.bz2",
       "extractDir": "sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
       "descriptionKey": "models.descriptions.parakeet.parakeet_tdt_0_6b_v3"
@@ -510,7 +509,7 @@
     },
     {
       "id": "mistral",
-      "name": "Mistral AI",
+      "name": "Mistral",
       "baseUrl": "https://huggingface.co",
       "promptTemplate": "[INST] {system}\n\n{user} [/INST]",
       "models": [
@@ -600,7 +599,7 @@
     },
     {
       "id": "openai-oss",
-      "name": "OpenAI OSS",
+      "name": "OpenAI",
       "baseUrl": "https://huggingface.co",
       "promptTemplate": "<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n",
       "models": [

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -66,6 +66,7 @@ const BOOLEAN_SETTINGS = new Set([
   "keepTranscriptionInClipboard",
   "dataRetentionEnabled",
   "noteFilesEnabled",
+  "showTranscriptionPreview",
 ]);
 
 const ARRAY_SETTINGS = new Set(["customDictionary", "gcalAccounts"]);
@@ -179,6 +180,7 @@ export interface SettingsState
   meetingProcessDetection: boolean;
   meetingAudioDetection: boolean;
   panelStartPosition: "bottom-right" | "center" | "bottom-left";
+  showTranscriptionPreview: boolean;
   keepTranscriptionInClipboard: boolean;
   noteFilesEnabled: boolean;
   noteFilesPath: string;
@@ -246,6 +248,7 @@ export interface SettingsState
   setMeetingProcessDetection: (value: boolean) => void;
   setMeetingAudioDetection: (value: boolean) => void;
   setPanelStartPosition: (position: "bottom-right" | "center" | "bottom-left") => void;
+  setShowTranscriptionPreview: (value: boolean) => void;
   setKeepTranscriptionInClipboard: (value: boolean) => void;
   setNoteFilesEnabled: (value: boolean) => void;
   setNoteFilesPath: (value: string) => void;
@@ -410,6 +413,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (v === "bottom-right" || v === "center" || v === "bottom-left") return v;
     return "bottom-right" as const;
   })(),
+  showTranscriptionPreview: readBoolean("showTranscriptionPreview", false),
   keepTranscriptionInClipboard: readBoolean("keepTranscriptionInClipboard", false),
   noteFilesEnabled: readBoolean("noteFilesEnabled", false),
   noteFilesPath: readString("noteFilesPath", ""),
@@ -669,6 +673,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     }
   },
 
+  setShowTranscriptionPreview: createBooleanSetter("showTranscriptionPreview"),
   setKeepTranscriptionInClipboard: createBooleanSetter("keepTranscriptionInClipboard"),
   setNoteFilesEnabled: createBooleanSetter("noteFilesEnabled"),
   setNoteFilesPath: createStringSetter("noteFilesPath"),
@@ -781,6 +786,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (settings.customDictionary !== undefined) s.setCustomDictionary(settings.customDictionary);
     if (settings.assemblyAiStreaming !== undefined)
       s.setAssemblyAiStreaming(settings.assemblyAiStreaming);
+    if (settings.showTranscriptionPreview !== undefined)
+      s.setShowTranscriptionPreview(settings.showTranscriptionPreview);
   },
 
   updateReasoningSettings: (settings: Partial<ReasoningSettings>) => {


### PR DESCRIPTION
## Summary

- **Provider tabs redesign**: Replaces the full-width tab bar with compact pill-style buttons across TranscriptionModelPicker, ReasoningModelSelector, and LocalModelPicker. Reduces visual weight while keeping provider switching discoverable. Shared `ProviderTabs` component extracted and reused across all three pickers.

- **Live transcription preview toggle**: Wires up the `showTranscriptionPreview` setting that was lost during a prior merge conflict resolution (PR #567). Adds the boolean to the settings store, exposes a toggle in Transcription settings (only visible in local mode), and restores all 7 missing IPC handlers in the main process (`start/stop/dismiss/complete/hide/resize/audio`).

- **Overlay cleanup**: Deduplicates clipboard copy success logic in `TranscriptionPreviewOverlay.tsx`.

- **i18n fixes**: Aligns transcription preview description translations in 5 locales (pt, ru, zh-CN, zh-TW, ja) with each language's existing cleanup terminology for consistency.

## Changed files

- `ProviderTabs.tsx` — new shared pill-button tab component
- `TranscriptionModelPicker.tsx` / `ReasoningModelSelector.tsx` / `LocalModelPicker.tsx` / `ModelCardList.tsx` — adopt ProviderTabs
- `settingsStore.ts` / `useSettings.ts` / `SettingsPage.tsx` — `showTranscriptionPreview` boolean + toggle (local mode only)
- `ipcHandlers.js` — restored dictation preview state, chunk transcription, and all IPC handlers
- `TranscriptionPreviewOverlay.tsx` — deduplicated copy logic
- 5 locale files — terminology alignment
- `modelRegistryData.json` — minor model metadata update