### PR TITLE
fix: prevent false hotkey activation after Win+L lock/unlock

### DIFF
--- a/resources/windows-key-listener.c
+++ b/resources/windows-key-listener.c
@@ -80,8 +80,23 @@ static BOOL IsRequiredModifierEvent(DWORD vkCode) {
            (g_requireWin && IsWinVk(vkCode));
 }
 
-// Track modifier state inside the hook instead of using GetAsyncKeyState().
-// For low-level hooks, async state is not yet updated for the current event.
+// Sync tracked modifier state with actual key state for keys that are NOT
+// the current hook event. GetAsyncKeyState() is unreliable for the key that
+// triggered the current hook callback, but accurate for all other keys.
+// This corrects stale state caused by missed key-up events (e.g. Win+L lock).
+static void SyncModifierState(DWORD currentVkCode) {
+    if (!IsCtrlVk(currentVkCode))
+        g_ctrlDown = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+    if (!IsAltVk(currentVkCode))
+        g_altDown = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+    if (!IsShiftVk(currentVkCode))
+        g_shiftDown = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+    if (currentVkCode != VK_LWIN)
+        g_leftWinDown = (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0;
+    if (currentVkCode != VK_RWIN)
+        g_rightWinDown = (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0;
+}
+
 static BOOL AreRequiredModifiersPressed(void) {
     if (g_requireCtrl && !g_ctrlDown) return FALSE;
     if (g_requireAlt && !g_altDown) return FALSE;
@@ -183,6 +198,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
 
         if ((isKeyDown || isKeyUp) && isModifierEvent) {
             UpdateModifierState(kbd->vkCode, isKeyDown);
+            SyncModifierState(kbd->vkCode);
         }
 
         // Stop an active press as soon as one of its required modifiers is released.


### PR DESCRIPTION
## Summary

- Fixes modifier-only hotkeys (e.g. `Control+Super`) falsely activating after Windows lock/unlock
- The low-level keyboard hook tracked modifier state via static variables that became stale when the OS consumed key-up events during lock screen transitions (e.g. Win+L lock, fingerprint/PIN unlock)
- Added `SyncModifierState()` which verifies tracked state against `GetAsyncKeyState()` for non-current modifier keys on every hook callback, correcting any drift

## Details

The root cause: when a user locks with Win+L, the hook sees Win key-down but never receives Win key-up (the lock screen consumes it). After unlock, the hook still thinks Win is held — so pressing Ctrl alone looks like Ctrl+Win and fires the hotkey.

The fix verifies the real-time state of all modifier keys (except the one currently being processed, since `GetAsyncKeyState` is unreliable for the in-flight event) on every modifier key event. This is a zero-cost Win32 API call that reads the kernel key state table directly.

**Scope**: Windows only, `windows-key-listener.c` only. No changes to JS, IPC, or other platforms.

Closes #535