### PR TITLE
Auto-label speakers in 1-on-1 meetings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.10] - 2026-04-16
+
+### Added
+
+- **Auto-Label 1-on-1 Speakers**: Automatically label system audio speakers in 1-on-1 meetings when exactly two participants are detected (user + one other), creating voice fingerprint profiles and triggering retroactive mapping across past notes
+
 ## [1.6.9] - 2026-04-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-whispr",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-whispr",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-whispr",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "A desktop dictation application using whisper.cpp for speech-to-text transcription",
   "main": "main.js",
   "private": true,

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -683,6 +683,7 @@ class IPCHandlers {
         setImmediate(() => this.broadcastToWindows("note-updated", result.note));
         this._asyncVectorUpsert(result.note);
         this._asyncMirrorWrite(result.note);
+        if (updates.participants) this._tryAutoLabelOneOnOne(id);
       }
       return result;
     });
@@ -6540,6 +6541,7 @@ class IPCHandlers {
         buffers[speakerId] = Buffer.from(new Float32Array(arr).buffer);
       }
       this.databaseManager.saveNoteSpeakerEmbeddings(noteId, buffers);
+      this._tryAutoLabelOneOnOne(noteId);
       return { success: true };
     });
   }
@@ -6609,6 +6611,93 @@ class IPCHandlers {
         }
       } catch (err) {
         debugLogger.warn("Retroactive speaker mapping failed", { error: err.message });
+      }
+    });
+  }
+
+  _tryAutoLabelOneOnOne(noteId) {
+    setImmediate(async () => {
+      try {
+        const note = this.databaseManager.getNote(noteId);
+        if (!note?.participants) return;
+
+        let participants;
+        try {
+          participants = JSON.parse(note.participants);
+        } catch (_) {
+          return;
+        }
+        if (!Array.isArray(participants) || participants.length === 0) return;
+
+        const googleEmails = new Set(
+          this.databaseManager.getGoogleAccounts().map((a) => a.email.toLowerCase())
+        );
+        const isSelf = (p) => p.self === true || googleEmails.has((p.email || "").toLowerCase());
+        const otherParticipants = participants.filter((p) => !isSelf(p));
+        if (otherParticipants.length !== 1) return;
+
+        const other = otherParticipants[0];
+        const displayName = other.displayName || other.email;
+        if (!displayName) return;
+        const email = (other.email || "").toLowerCase().trim() || null;
+
+        const embeddings = this.databaseManager.getNoteSpeakerEmbeddings(noteId);
+        if (!embeddings.length) return;
+
+        const existingMappings = this.databaseManager.getSpeakerMappings(noteId);
+        const mappedSpeakers = new Set(existingMappings.map((m) => m.speaker_id));
+
+        const transcript = note.transcript ? JSON.parse(note.transcript) : [];
+        const systemSpeakers = new Set(
+          transcript.filter((s) => s.source !== "mic" && s.speaker).map((s) => s.speaker)
+        );
+
+        const unmapped = embeddings.filter(
+          (e) => !mappedSpeakers.has(e.speaker_id) && systemSpeakers.has(e.speaker_id)
+        );
+        if (!unmapped.length) return;
+
+        let profile = null;
+        for (const emb of unmapped) {
+          profile = this.databaseManager.upsertSpeakerProfile(
+            displayName,
+            email,
+            emb.embedding,
+            profile?.id ?? null
+          );
+          this.databaseManager.setSpeakerMapping(noteId, emb.speaker_id, profile.id, displayName);
+          liveSpeakerIdentifier.mapSpeaker(emb.speaker_id, profile.id, displayName, noteId);
+        }
+
+        const unmappedSystemSpeakers = new Set(unmapped.map((e) => e.speaker_id));
+        let changed = false;
+        for (const seg of transcript) {
+          if (!unmappedSystemSpeakers.has(seg.speaker)) continue;
+          if (seg.speakerName && !seg.speakerIsPlaceholder) continue;
+          if (canAutoRelabelSpeaker(seg)) {
+            applyConfirmedSpeaker(seg, { speakerName: displayName, speakerIsPlaceholder: false });
+          } else {
+            seg.speakerName = displayName;
+            seg.speakerIsPlaceholder = false;
+          }
+          changed = true;
+        }
+
+        if (changed) {
+          this.databaseManager.updateNote(noteId, { transcript: JSON.stringify(transcript) });
+          const updated = this.databaseManager.getNote(noteId);
+          if (updated) this.broadcastToWindows("note-updated", updated);
+        }
+
+        if (profile) this._retroactiveMapping(profile);
+
+        debugLogger.info(
+          "Auto-labeled 1-on-1 meeting speakers",
+          { noteId, displayName, speakerCount: unmapped.length },
+          "speaker"
+        );
+      } catch (err) {
+        debugLogger.warn("Auto-label 1-on-1 failed", { noteId, error: err.message }, "speaker");
       }
     });
   }


### PR DESCRIPTION
## Summary

- In 1-on-1 meetings (exactly 2 participants), all system audio speakers are now automatically labeled as the other attendee, with voice fingerprint profiles created and retroactive mapping triggered across past notes
- Triggers after diarization completes (`save-note-speaker-embeddings`) and when participants are manually updated (`db-update-note`)
- Identifies "self" via the `self: true` calendar flag and Google account emails; guards against locked speakers, missing data, and 3+ participant meetings
- Bumps version to 1.6.10 with changelog entry