### PR TITLE
fix(settings): stop model/provider setters from overriding inference mode

### DIFF
--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -21,6 +21,7 @@ import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { createExternalLinkHandler } from "../utils/externalLinks";
 import { getCachedPlatform } from "../utils/platform";
+import { useSettingsStore } from "../stores/settingsStore";
 
 type CloudModelOption = {
   value: string;
@@ -645,6 +646,7 @@ export default function ReasoningModelSelector({
 
   const handleModeChange = async (newMode: "cloud" | "local") => {
     setSelectedMode(newMode);
+    useSettingsStore.getState().setReasoningMode(newMode === "local" ? "local" : "providers");
 
     if (newMode === "cloud") {
       window.electronAPI?.llamaServerStop?.();

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -286,13 +286,6 @@ function createBooleanSetter(key: string) {
   };
 }
 
-const LOCAL_PROVIDERS = new Set(["qwen", "llama", "mistral", "openai-oss", "gemma"]);
-
-function inferenceModeForProvider(provider: string): Exclude<InferenceMode, "openwhispr"> {
-  if (provider === "custom") return "self-hosted";
-  if (LOCAL_PROVIDERS.has(provider)) return "local";
-  return "providers";
-}
 
 let envPersistTimer: ReturnType<typeof setTimeout> | null = null;
 function debouncedPersistToEnv() {
@@ -488,34 +481,12 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setAssemblyAiStreaming: createBooleanSetter("assemblyAiStreaming"),
   setUseReasoningModel: createBooleanSetter("useReasoningModel"),
   setReasoningProvider: (value: string) => {
-    const mode = inferenceModeForProvider(value);
-    if (isBrowser) {
-      localStorage.setItem("reasoningProvider", value);
-      localStorage.setItem("reasoningMode", mode);
-      localStorage.setItem("cloudReasoningMode", "byok");
-    }
-    useSettingsStore.setState({
-      reasoningProvider: value,
-      reasoningMode: mode,
-      cloudReasoningMode: "byok",
-    });
+    if (isBrowser) localStorage.setItem("reasoningProvider", value);
+    useSettingsStore.setState({ reasoningProvider: value });
   },
   setReasoningModel: (value: string) => {
     if (isBrowser) localStorage.setItem("reasoningModel", value);
-    if (!value) {
-      useSettingsStore.setState({ reasoningModel: value });
-      return;
-    }
-    const mode = inferenceModeForProvider(useSettingsStore.getState().reasoningProvider);
-    if (isBrowser) {
-      localStorage.setItem("reasoningMode", mode);
-      localStorage.setItem("cloudReasoningMode", "byok");
-    }
-    useSettingsStore.setState({
-      reasoningModel: value,
-      reasoningMode: mode,
-      cloudReasoningMode: "byok",
-    });
+    useSettingsStore.setState({ reasoningModel: value });
   },
 
   setCustomDictionary: (words: string[]) => {
@@ -688,33 +659,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setAgentModel: (value: string) => {
     if (isBrowser) localStorage.setItem("agentModel", value);
-    if (!value) {
-      useSettingsStore.setState({ agentModel: value });
-      return;
-    }
-    const mode = inferenceModeForProvider(useSettingsStore.getState().agentProvider);
-    if (isBrowser) {
-      localStorage.setItem("agentInferenceMode", mode);
-      localStorage.setItem("cloudAgentMode", "byok");
-    }
-    useSettingsStore.setState({
-      agentModel: value,
-      agentInferenceMode: mode,
-      cloudAgentMode: "byok",
-    });
+    useSettingsStore.setState({ agentModel: value });
   },
   setAgentProvider: (value: string) => {
-    const mode = inferenceModeForProvider(value);
-    if (isBrowser) {
-      localStorage.setItem("agentProvider", value);
-      localStorage.setItem("agentInferenceMode", mode);
-      localStorage.setItem("cloudAgentMode", "byok");
-    }
-    useSettingsStore.setState({
-      agentProvider: value,
-      agentInferenceMode: mode,
-      cloudAgentMode: "byok",
-    });
+    if (isBrowser) localStorage.setItem("agentProvider", value);
+    useSettingsStore.setState({ agentProvider: value });
   },
   setAgentKey: (key: string) => {
     if (!isBrowser) {


### PR DESCRIPTION
## Summary

Selecting a model or switching provider tabs inside Cloud Providers (or Local) was overriding the active inference mode, causing the UI to jump to Self-hosted or Local unexpectedly. The root cause was in the store setters: setReasoningModel, setReasoningProvider, setAgentModel, and setAgentProvider all recalculated reasoningMode/agentInferenceMode via inferenceModeForProvider() on every call, even when the user had already picked a mode through the outer tab selector.

Now the mode is only controlled by the explicit tab handlers (handleReasoningModeSelect, handleAgentModeSelect). The setters just set their value without side effects.

## Changes

- src/stores/settingsStore.ts: simplify setReasoningModel, setReasoningProvider, setAgentModel, setAgentProvider to plain setters. Remove inferenceModeForProvider and LOCAL_PROVIDERS (no longer needed).
- src/components/ReasoningModelSelector.tsx: handleModeChange now sets reasoningMode explicitly in the store for the non-signed-in flow where outer tabs don't exist.