### PR TITLE
fix(cloud): chunk transcription above 4 MB + upload UX polish + settings fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@tiptap/extension-task-list": "^3.22.3",
         "@tiptap/react": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
-        "@vercel/blob": "^2.3.0",
         "ai": "^6.0.116",
         "better-sqlite3": "^12.8.0",
         "class-variance-authority": "^0.7.1",
@@ -7393,22 +7392,6 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
-    "node_modules/@vercel/blob": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
-      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async-retry": "^1.3.3",
-        "is-buffer": "^2.0.5",
-        "is-node-process": "^1.2.0",
-        "throttleit": "^2.1.0",
-        "undici": "^6.23.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -8107,15 +8090,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "license": "MIT",
-      "dependencies": {
-        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -11812,29 +11786,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -11912,12 +11863,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "license": "MIT"
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -15729,15 +15674,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -16672,18 +16608,6 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "@tiptap/extension-task-list": "^3.22.3",
     "@tiptap/react": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
-    "@vercel/blob": "^2.3.0",
     "ai": "^6.0.116",
     "better-sqlite3": "^12.8.0",
     "class-variance-authority": "^0.7.1",

--- a/preload.js
+++ b/preload.js
@@ -506,10 +506,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
     (callback) => (_event, data) => callback(data)
   ),
 
-  // Meeting chain transcription (BaseTen)
-  meetingTranscribeChain: (blobUrl, opts) =>
-    ipcRenderer.invoke("meeting-transcribe-chain", blobUrl, opts),
-
   // Meeting transcription (streaming, dual-channel)
   meetingTranscriptionPrepare: (options) =>
     ipcRenderer.invoke("meeting-transcription-prepare", options),

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -616,7 +616,6 @@ export default function ControlPanel() {
               setSettingsSection("plansBilling");
               setShowSettings(true);
             }}
-            onUpgradeCheckout={() => usage?.openCheckout()}
             isOverLimit={usage?.isOverLimit ?? false}
             userName={user?.name}
             userEmail={user?.email}

--- a/src/components/ControlPanelSidebar.tsx
+++ b/src/components/ControlPanelSidebar.tsx
@@ -36,7 +36,6 @@ interface ControlPanelSidebarProps {
   onOpenSearch?: () => void;
   onOpenReferrals?: () => void;
   onUpgrade?: () => void;
-  onUpgradeCheckout?: () => void;
   isOverLimit?: boolean;
   userName?: string | null;
   userEmail?: string | null;
@@ -55,7 +54,6 @@ export default function ControlPanelSidebar({
   onOpenSearch,
   onOpenReferrals,
   onUpgrade,
-  onUpgradeCheckout,
   isOverLimit,
   userName,
   userEmail,
@@ -176,10 +174,10 @@ export default function ControlPanelSidebar({
                 {t("sidebar.limitReachedDescription")}
               </p>
               <button
-                onClick={onUpgradeCheckout}
+                onClick={onUpgrade}
                 className="w-full h-7 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors"
               >
-                {t("sidebar.upgradeToPro")}
+                {t("sidebar.viewPlans")}
               </button>
             </div>
           </div>

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -21,6 +21,7 @@ import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { createExternalLinkHandler } from "../utils/externalLinks";
 import { getCachedPlatform } from "../utils/platform";
+import { useSettingsStore } from "../stores/settingsStore";
 
 type CloudModelOption = {
   value: string;
@@ -645,6 +646,7 @@ export default function ReasoningModelSelector({
 
   const handleModeChange = async (newMode: "cloud" | "local") => {
     setSelectedMode(newMode);
+    useSettingsStore.getState().setReasoningMode(newMode === "local" ? "local" : "providers");
 
     if (newMode === "cloud") {
       window.electronAPI?.llamaServerStop?.();

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -406,7 +406,11 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         setState("complete");
       } else {
         setProgress(0);
-        setError(res.error || t("notes.upload.transcriptionFailed"));
+        setError(
+          res.code === "NO_SPEECH_DETECTED"
+            ? t("notes.upload.noSpeechDetected")
+            : res.error || t("notes.upload.transcriptionFailed")
+        );
         setState("error");
       }
     } catch (err) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5337,6 +5337,11 @@ class IPCHandlers {
                   ...data.data,
                 });
               }
+              if (data.statusCode === 422 && data.data?.code === "NO_SPEECH_DETECTED") {
+                throw Object.assign(new Error(data.data.error || "No speech detected"), {
+                  code: "NO_SPEECH_DETECTED",
+                });
+              }
               if (data.statusCode !== 200) {
                 throw new Error(data.data?.error || `API error: ${data.statusCode}`);
               }
@@ -5353,6 +5358,7 @@ class IPCHandlers {
 
             const indices = Array.from({ length: totalChunks }, (_, i) => i);
             const executing = new Set();
+            const failureCodes = new Set();
 
             for (const index of indices) {
               const p = transcribeChunk(index).then(
@@ -5360,7 +5366,11 @@ class IPCHandlers {
                 (err) => {
                   executing.delete(p);
                   if (err.code === "AUTH_EXPIRED" || err.code === "LIMIT_REACHED") throw err;
-                  debugLogger.warn(`Chunk ${index} failed`, { error: err.message });
+                  if (err.code) failureCodes.add(err.code);
+                  debugLogger.warn(`Chunk ${index} failed`, {
+                    error: err.message,
+                    code: err.code,
+                  });
                 }
               );
               executing.add(p);
@@ -5372,6 +5382,13 @@ class IPCHandlers {
 
             const succeeded = results.filter((r) => r !== null);
             if (succeeded.length === 0) {
+              if (failureCodes.size === 1 && failureCodes.has("NO_SPEECH_DETECTED")) {
+                return {
+                  success: false,
+                  error: "No speech detected in audio",
+                  code: "NO_SPEECH_DETECTED",
+                };
+              }
               throw new Error("All chunks failed to transcribe");
             }
 
@@ -5431,6 +5448,13 @@ class IPCHandlers {
             ...data.data,
           };
         }
+        if (data.statusCode === 422 && data.data?.code === "NO_SPEECH_DETECTED") {
+          return {
+            success: false,
+            error: data.data.error || "No speech detected in audio",
+            code: "NO_SPEECH_DETECTED",
+          };
+        }
         if (data.statusCode !== 200) {
           throw new Error(data.data?.error || `API error: ${data.statusCode}`);
         }
@@ -5438,7 +5462,11 @@ class IPCHandlers {
         return { success: true, text: data.data.text };
       } catch (error) {
         debugLogger.error("Cloud audio file transcription error", { error: error.message });
-        if (error.code === "AUTH_EXPIRED" || error.code === "LIMIT_REACHED") {
+        if (
+          error.code === "AUTH_EXPIRED" ||
+          error.code === "LIMIT_REACHED" ||
+          error.code === "NO_SPEECH_DETECTED"
+        ) {
           return { success: false, error: error.message, code: error.code, ...error };
         }
         return { success: false, error: error.message };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1,5 +1,7 @@
 const { ipcMain, app, shell, BrowserWindow, systemPreferences } = require("electron");
 const path = require("path");
+const fs = require("fs");
+const os = require("os");
 const http = require("http");
 const https = require("https");
 const crypto = require("crypto");
@@ -40,6 +42,10 @@ const AUDIO_MIME_TYPES = {
   flac: "audio/flac",
   aac: "audio/aac",
 };
+
+const CLOUD_INLINE_LIMIT = 4 * 1024 * 1024;
+const CLOUD_CHUNK_CONCURRENCY = 5;
+const CLOUD_CHUNK_SEGMENT_SECONDS = 240;
 
 function buildMultipartBody(fileBuffer, fileName, contentType, fields = {}) {
   const boundary = `----OpenWhispr${Date.now()}`;
@@ -100,6 +106,146 @@ function postMultipart(url, body, boundary, headers = {}) {
     req.write(body);
     req.end();
   });
+}
+
+function interpretTranscribeResponse(data) {
+  if (data.statusCode === 401) {
+    throw Object.assign(new Error("Session expired"), { code: "AUTH_EXPIRED" });
+  }
+  if (data.statusCode === 503) {
+    throw Object.assign(new Error("Request timed out"), { code: "SERVER_ERROR" });
+  }
+  if (data.statusCode === 429) {
+    throw Object.assign(new Error("Daily word limit reached"), {
+      code: "LIMIT_REACHED",
+      ...data.data,
+    });
+  }
+  if (data.statusCode === 422 && data.data?.code === "NO_SPEECH_DETECTED") {
+    throw Object.assign(new Error(data.data.error || "No speech detected in audio"), {
+      code: "NO_SPEECH_DETECTED",
+    });
+  }
+  if (data.statusCode !== 200) {
+    throw new Error(data.data?.error || `API error: ${data.statusCode}`);
+  }
+  return data.data;
+}
+
+async function chunkedCloudTranscribe({
+  buffer = null,
+  filePath = null,
+  apiUrl,
+  cookieHeader,
+  multipartFields = {},
+  onProgress,
+  concurrencyLimit = CLOUD_CHUNK_CONCURRENCY,
+  segmentDuration = CLOUD_CHUNK_SEGMENT_SECONDS,
+}) {
+  const { splitAudioFile } = require("./ffmpegUtils");
+
+  const jobId = `${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+  const chunkDir = path.join(os.tmpdir(), `ow-chunks-${jobId}`);
+  let tmpInputPath = null;
+
+  let inputPath = filePath;
+  if (!inputPath && buffer) {
+    tmpInputPath = path.join(os.tmpdir(), `ow-audio-${jobId}.webm`);
+    fs.writeFileSync(tmpInputPath, buffer);
+    inputPath = tmpInputPath;
+  }
+
+  fs.mkdirSync(chunkDir, { recursive: true });
+
+  try {
+    onProgress?.({ stage: "splitting", chunksTotal: 0, chunksCompleted: 0 });
+
+    const chunkPaths = await splitAudioFile(inputPath, chunkDir, { segmentDuration });
+    const totalChunks = chunkPaths.length;
+
+    onProgress?.({ stage: "transcribing", chunksTotal: totalChunks, chunksCompleted: 0 });
+
+    const results = new Array(totalChunks).fill(null);
+    const failureCodes = new Set();
+    let completedCount = 0;
+
+    const transcribeChunk = async (index) => {
+      const chunkBuffer = fs.readFileSync(chunkPaths[index]);
+      const chunkName = path.basename(chunkPaths[index]);
+      const { body, boundary } = buildMultipartBody(
+        chunkBuffer,
+        chunkName,
+        "audio/mpeg",
+        multipartFields
+      );
+      const url = new URL(`${apiUrl}/api/transcribe`);
+      const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
+
+      results[index] = interpretTranscribeResponse(data);
+      completedCount++;
+      onProgress?.({
+        stage: "transcribing",
+        chunksTotal: totalChunks,
+        chunksCompleted: completedCount,
+      });
+    };
+
+    const executing = new Set();
+    for (let index = 0; index < totalChunks; index++) {
+      const p = transcribeChunk(index).then(
+        () => executing.delete(p),
+        (err) => {
+          executing.delete(p);
+          if (err.code === "AUTH_EXPIRED" || err.code === "LIMIT_REACHED") throw err;
+          if (err.code) failureCodes.add(err.code);
+          debugLogger.warn(`Chunk ${index} failed`, { error: err.message, code: err.code });
+        }
+      );
+      executing.add(p);
+      if (executing.size >= concurrencyLimit) {
+        await Promise.race(executing);
+      }
+    }
+    await Promise.all(executing);
+
+    const succeeded = results.filter((r) => r !== null);
+    if (succeeded.length === 0) {
+      if (failureCodes.size === 1 && failureCodes.has("NO_SPEECH_DETECTED")) {
+        throw Object.assign(new Error("No speech detected in audio"), {
+          code: "NO_SPEECH_DETECTED",
+        });
+      }
+      throw new Error("All chunks failed to transcribe");
+    }
+
+    const text = results
+      .filter((r) => r !== null)
+      .map((r) => r.text)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const failed = totalChunks - succeeded.length;
+    return {
+      text,
+      responses: succeeded,
+      lastResponse: succeeded[succeeded.length - 1],
+      ...(failed > 0 ? { warning: `${failed} of ${totalChunks} chunks failed` } : {}),
+    };
+  } finally {
+    if (tmpInputPath) {
+      try {
+        fs.unlinkSync(tmpInputPath);
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      fs.rmSync(chunkDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      debugLogger.warn("Failed to cleanup chunk dir", { error: cleanupErr.message });
+    }
+  }
 }
 
 class IPCHandlers {
@@ -2942,7 +3088,7 @@ class IPCHandlers {
         if (!cookieHeader) throw new Error("No session cookies available");
 
         const audioData = Buffer.from(audioBuffer);
-        const { body, boundary } = buildMultipartBody(audioData, "audio.webm", "audio/webm", {
+        const multipartFields = {
           language: opts.language,
           prompt: opts.prompt,
           sendLogs: opts.sendLogs,
@@ -2950,14 +3096,40 @@ class IPCHandlers {
           appVersion: app.getVersion(),
           clientVersion: app.getVersion(),
           sessionId: this.sessionId,
-        });
+        };
 
-        debugLogger.debug(
-          "Cloud transcribe request",
-          { audioSize: audioData.length, bodySize: body.length },
-          "cloud-api"
+        debugLogger.debug("Cloud transcribe request", { audioSize: audioData.length }, "cloud-api");
+
+        if (audioData.length > CLOUD_INLINE_LIMIT) {
+          const { text, responses, lastResponse } = await chunkedCloudTranscribe({
+            buffer: audioData,
+            apiUrl,
+            cookieHeader,
+            multipartFields,
+          });
+          const sum = (field) => responses.reduce((s, r) => s + (r?.[field] || 0), 0);
+          return {
+            success: true,
+            text,
+            wordsUsed: lastResponse?.wordsUsed,
+            wordsRemaining: lastResponse?.wordsRemaining,
+            plan: lastResponse?.plan,
+            limitReached: lastResponse?.limitReached || false,
+            sttProvider: lastResponse?.sttProvider,
+            sttModel: lastResponse?.sttModel,
+            sttProcessingMs: sum("sttProcessingMs"),
+            sttWordCount: sum("sttWordCount"),
+            sttLanguage: lastResponse?.sttLanguage,
+            audioDurationMs: sum("audioDurationMs"),
+          };
+        }
+
+        const { body, boundary } = buildMultipartBody(
+          audioData,
+          "audio.webm",
+          "audio/webm",
+          multipartFields
         );
-
         const url = new URL(`${apiUrl}/api/transcribe`);
         const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
 
@@ -2967,41 +3139,26 @@ class IPCHandlers {
           "cloud-api"
         );
 
-        if (data.statusCode === 401) {
-          return { success: false, error: "Session expired", code: "AUTH_EXPIRED" };
-        }
-        if (data.statusCode === 503) {
-          return { success: false, error: "Request timed out", code: "SERVER_ERROR" };
-        }
-        if (data.statusCode === 429) {
-          return {
-            success: false,
-            error: "Daily word limit reached",
-            code: "LIMIT_REACHED",
-            limitReached: true,
-            ...data.data,
-          };
-        }
-        if (data.statusCode !== 200) {
-          throw new Error(data.data?.error || `API error: ${data.statusCode}`);
-        }
-
+        const result = interpretTranscribeResponse(data);
         return {
           success: true,
-          text: data.data.text,
-          wordsUsed: data.data.wordsUsed,
-          wordsRemaining: data.data.wordsRemaining,
-          plan: data.data.plan,
-          limitReached: data.data.limitReached || false,
-          sttProvider: data.data.sttProvider,
-          sttModel: data.data.sttModel,
-          sttProcessingMs: data.data.sttProcessingMs,
-          sttWordCount: data.data.sttWordCount,
-          sttLanguage: data.data.sttLanguage,
-          audioDurationMs: data.data.audioDurationMs,
+          text: result.text,
+          wordsUsed: result.wordsUsed,
+          wordsRemaining: result.wordsRemaining,
+          plan: result.plan,
+          limitReached: result.limitReached || false,
+          sttProvider: result.sttProvider,
+          sttModel: result.sttModel,
+          sttProcessingMs: result.sttProcessingMs,
+          sttWordCount: result.sttWordCount,
+          sttLanguage: result.sttLanguage,
+          audioDurationMs: result.audioDurationMs,
         };
       } catch (error) {
         debugLogger.error("Cloud transcription error", { error: error.message }, "cloud-api");
+        if (error.code) {
+          return { success: false, error: error.message, code: error.code, ...error };
+        }
         return { success: false, error: error.message };
       }
     });
@@ -3077,17 +3234,36 @@ class IPCHandlers {
             if (cookieHeader) {
               const apiUrl = getApiUrl();
               if (apiUrl) {
-                const { body, boundary } = buildMultipartBody(buffer, "audio.webm", "audio/webm", {
+                const multipartFields = {
                   clientType: "desktop",
                   appVersion: app.getVersion(),
                   sessionId: this.sessionId,
-                });
-                const url = new URL(`${apiUrl}/api/transcribe`);
-                const data = await postMultipart(url, body, boundary, {
-                  Cookie: cookieHeader,
-                });
-                if (data.statusCode === 200 && data.data?.text) {
-                  result = { text: data.data.text, source: "openwhispr", model: "cloud" };
+                };
+                if (buffer.length > CLOUD_INLINE_LIMIT) {
+                  const { text } = await chunkedCloudTranscribe({
+                    buffer,
+                    apiUrl,
+                    cookieHeader,
+                    multipartFields,
+                  });
+                  result = { text, source: "openwhispr", model: "cloud" };
+                } else {
+                  const { body, boundary } = buildMultipartBody(
+                    buffer,
+                    "audio.webm",
+                    "audio/webm",
+                    multipartFields
+                  );
+                  const url = new URL(`${apiUrl}/api/transcribe`);
+                  const data = await postMultipart(url, body, boundary, {
+                    Cookie: cookieHeader,
+                  });
+                  const responseData = interpretTranscribeResponse(data);
+                  result = {
+                    text: responseData.text,
+                    source: "openwhispr",
+                    model: "cloud",
+                  };
                 }
               }
             }
@@ -3164,9 +3340,12 @@ class IPCHandlers {
       } catch (error) {
         debugLogger.error(
           "Retry transcription failed",
-          { id, error: error.message },
+          { id, error: error.message, code: error.code },
           "audio-storage"
         );
+        if (error.code) {
+          return { success: false, error: error.message, code: error.code, ...error };
+        }
         return { success: false, error: error.message };
       }
     });
@@ -5264,11 +5443,6 @@ class IPCHandlers {
     });
 
     ipcMain.handle("transcribe-audio-file-cloud", async (event, filePath) => {
-      const fs = require("fs");
-      const os = require("os");
-      const { splitAudioFile } = require("./ffmpegUtils");
-      const FILE_SIZE_LIMIT = 4 * 1024 * 1024; // 4 MB — Vercel function body limit is ~4.5 MB
-      const CONCURRENCY_LIMIT = 5;
       try {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
@@ -5276,146 +5450,29 @@ class IPCHandlers {
         const cookieHeader = await getSessionCookies(event);
         if (!cookieHeader) throw new Error("No session cookies available");
 
+        const multipartFields = {
+          source: "file_upload",
+          clientType: "desktop",
+          appVersion: app.getVersion(),
+          clientVersion: app.getVersion(),
+          sessionId: this.sessionId,
+        };
+
         const fileSize = fs.statSync(filePath).size;
 
-        if (fileSize > FILE_SIZE_LIMIT) {
+        if (fileSize > CLOUD_INLINE_LIMIT) {
           debugLogger.debug("Large file detected, using client-side chunking", {
             fileSize,
             filePath: path.basename(filePath),
           });
-
-          const chunkDir = path.join(os.tmpdir(), `ow-chunks-${Date.now()}`);
-          fs.mkdirSync(chunkDir, { recursive: true });
-
-          try {
-            event.sender.send("upload-transcription-progress", {
-              stage: "splitting",
-              chunksTotal: 0,
-              chunksCompleted: 0,
-            });
-
-            const chunkPaths = await splitAudioFile(filePath, chunkDir, {
-              segmentDuration: 240, // ~3.75 MB/chunk, under Vercel's 4.5 MB payload limit
-            });
-            const totalChunks = chunkPaths.length;
-
-            debugLogger.debug("Audio split into chunks", { totalChunks });
-
-            event.sender.send("upload-transcription-progress", {
-              stage: "transcribing",
-              chunksTotal: totalChunks,
-              chunksCompleted: 0,
-            });
-
-            const results = new Array(totalChunks).fill(null);
-            let completedCount = 0;
-
-            const transcribeChunk = async (index) => {
-              const chunkBuffer = fs.readFileSync(chunkPaths[index]);
-              const chunkName = path.basename(chunkPaths[index]);
-
-              const { body, boundary } = buildMultipartBody(chunkBuffer, chunkName, "audio/mpeg", {
-                source: "file_upload",
-                clientType: "desktop",
-                appVersion: app.getVersion(),
-                clientVersion: app.getVersion(),
-                sessionId: this.sessionId,
-              });
-
-              const url = new URL(`${apiUrl}/api/transcribe`);
-              const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
-
-              if (data.statusCode === 401) {
-                throw Object.assign(new Error("Session expired"), { code: "AUTH_EXPIRED" });
-              }
-              if (data.statusCode === 503) {
-                throw Object.assign(new Error("Request timed out"), { code: "SERVER_ERROR" });
-              }
-              if (data.statusCode === 429) {
-                throw Object.assign(new Error("Daily word limit reached"), {
-                  code: "LIMIT_REACHED",
-                  ...data.data,
-                });
-              }
-              if (data.statusCode === 422 && data.data?.code === "NO_SPEECH_DETECTED") {
-                throw Object.assign(new Error(data.data.error || "No speech detected"), {
-                  code: "NO_SPEECH_DETECTED",
-                });
-              }
-              if (data.statusCode !== 200) {
-                throw new Error(data.data?.error || `API error: ${data.statusCode}`);
-              }
-
-              results[index] = data.data;
-              completedCount++;
-
-              event.sender.send("upload-transcription-progress", {
-                stage: "transcribing",
-                chunksTotal: totalChunks,
-                chunksCompleted: completedCount,
-              });
-            };
-
-            const indices = Array.from({ length: totalChunks }, (_, i) => i);
-            const executing = new Set();
-            const failureCodes = new Set();
-
-            for (const index of indices) {
-              const p = transcribeChunk(index).then(
-                () => executing.delete(p),
-                (err) => {
-                  executing.delete(p);
-                  if (err.code === "AUTH_EXPIRED" || err.code === "LIMIT_REACHED") throw err;
-                  if (err.code) failureCodes.add(err.code);
-                  debugLogger.warn(`Chunk ${index} failed`, {
-                    error: err.message,
-                    code: err.code,
-                  });
-                }
-              );
-              executing.add(p);
-              if (executing.size >= CONCURRENCY_LIMIT) {
-                await Promise.race(executing);
-              }
-            }
-            await Promise.all(executing);
-
-            const succeeded = results.filter((r) => r !== null);
-            if (succeeded.length === 0) {
-              if (failureCodes.size === 1 && failureCodes.has("NO_SPEECH_DETECTED")) {
-                return {
-                  success: false,
-                  error: "No speech detected in audio",
-                  code: "NO_SPEECH_DETECTED",
-                };
-              }
-              throw new Error("All chunks failed to transcribe");
-            }
-
-            const fullText = results
-              .filter((r) => r !== null)
-              .map((r) => r.text)
-              .join(" ")
-              .replace(/\s+/g, " ")
-              .trim();
-
-            const failed = results.filter((r) => r === null).length;
-            if (failed > 0) {
-              debugLogger.warn("Some chunks failed", { failed, total: totalChunks });
-            }
-
-            return {
-              success: true,
-              text: fullText,
-              ...(failed > 0 ? { warning: `${failed} of ${totalChunks} chunks failed` } : {}),
-            };
-          } finally {
-            try {
-              fs.rmSync(chunkDir, { recursive: true, force: true });
-            } catch (cleanupErr) {
-              debugLogger.warn("Failed to cleanup chunk dir", { error: cleanupErr.message });
-            }
-          }
+          const { text, warning } = await chunkedCloudTranscribe({
+            filePath,
+            apiUrl,
+            cookieHeader,
+            multipartFields,
+            onProgress: (payload) => event.sender.send("upload-transcription-progress", payload),
+          });
+          return { success: true, text, ...(warning ? { warning } : {}) };
         }
 
         const audioBuffer = fs.readFileSync(filePath);
@@ -5423,50 +5480,20 @@ class IPCHandlers {
         const contentType = AUDIO_MIME_TYPES[ext] || "audio/mpeg";
         const fileName = path.basename(filePath);
 
-        const { body, boundary } = buildMultipartBody(audioBuffer, fileName, contentType, {
-          source: "file_upload",
-          clientType: "desktop",
-          appVersion: app.getVersion(),
-          clientVersion: app.getVersion(),
-          sessionId: this.sessionId,
-        });
-
+        const { body, boundary } = buildMultipartBody(
+          audioBuffer,
+          fileName,
+          contentType,
+          multipartFields
+        );
         const url = new URL(`${apiUrl}/api/transcribe`);
         const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
+        const result = interpretTranscribeResponse(data);
 
-        if (data.statusCode === 401) {
-          return { success: false, error: "Session expired", code: "AUTH_EXPIRED" };
-        }
-        if (data.statusCode === 503) {
-          return { success: false, error: "Request timed out", code: "SERVER_ERROR" };
-        }
-        if (data.statusCode === 429) {
-          return {
-            success: false,
-            error: "Daily word limit reached",
-            code: "LIMIT_REACHED",
-            ...data.data,
-          };
-        }
-        if (data.statusCode === 422 && data.data?.code === "NO_SPEECH_DETECTED") {
-          return {
-            success: false,
-            error: data.data.error || "No speech detected in audio",
-            code: "NO_SPEECH_DETECTED",
-          };
-        }
-        if (data.statusCode !== 200) {
-          throw new Error(data.data?.error || `API error: ${data.statusCode}`);
-        }
-
-        return { success: true, text: data.data.text };
+        return { success: true, text: result.text };
       } catch (error) {
         debugLogger.error("Cloud audio file transcription error", { error: error.message });
-        if (
-          error.code === "AUTH_EXPIRED" ||
-          error.code === "LIMIT_REACHED" ||
-          error.code === "NO_SPEECH_DETECTED"
-        ) {
+        if (error.code) {
           return { success: false, error: error.message, code: error.code, ...error };
         }
         return { success: false, error: error.message };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3163,54 +3163,6 @@ class IPCHandlers {
       }
     });
 
-    ipcMain.handle("meeting-transcribe-chain", async (event, blobUrl, opts = {}) => {
-      try {
-        const apiUrl = getApiUrl();
-        if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
-
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
-
-        const response = await fetch(`${apiUrl}/api/transcribe-chain`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Cookie: cookieHeader,
-          },
-          body: JSON.stringify({
-            mediaUrl: blobUrl,
-            skipCleanup: opts.skipCleanup ?? false,
-            agentName: opts.agentName,
-            customDictionary: opts.customDictionary,
-          }),
-        });
-
-        const data = await response.json();
-
-        if (!response.ok) {
-          throw new Error(data.error || `Chain failed: ${response.status}`);
-        }
-
-        fetch(`${apiUrl}/api/delete-audio`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Cookie: cookieHeader },
-          body: JSON.stringify({ url: blobUrl }),
-        }).catch((err) => debugLogger.warn("Blob cleanup failed", { error: err.message }));
-
-        return {
-          success: true,
-          text: data.text,
-          rawText: data.rawText,
-          cleanedText: data.cleanedText,
-          processingDurationSec: data.processingDurationSec,
-          speedupFactor: data.speedupFactor,
-        };
-      } catch (error) {
-        debugLogger.error("Meeting chain transcription error", { error: error.message });
-        return { success: false, error: error.message };
-      }
-    });
-
     ipcMain.handle("retry-transcription", async (event, id, settings) => {
       const buffer = this.audioStorageManager.getAudioBuffer(id);
       if (!buffer) return { success: false, error: "Audio file not found" };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5267,7 +5267,7 @@ class IPCHandlers {
       const fs = require("fs");
       const os = require("os");
       const { splitAudioFile } = require("./ffmpegUtils");
-      const FILE_SIZE_LIMIT = 25 * 1024 * 1024;
+      const FILE_SIZE_LIMIT = 4 * 1024 * 1024; // 4 MB — Vercel function body limit is ~4.5 MB
       const CONCURRENCY_LIMIT = 5;
       try {
         const apiUrl = getApiUrl();

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1733,6 +1733,7 @@
       "selectFolder": "Ordner auswählen",
       "transcriptionFailed": "Transkription fehlgeschlagen",
       "errorOccurred": "Ein Fehler ist aufgetreten",
+      "noSpeechDetected": "In dieser Audiodatei wurde keine Sprache erkannt.",
       "noProviderTitle": "Kein Transkriptionsanbieter eingerichtet",
       "noProviderDescription": "Fügen Sie einen API-Schlüssel hinzu oder laden Sie ein lokales Modell herunter, um mit der Transkription zu beginnen.",
       "noProviderAction": "Transkriptionseinstellungen öffnen",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1894,7 +1894,7 @@
     "support": "Support",
     "limitReached": "Wochenlimit erreicht",
     "limitReachedDescription": "Upgraden Sie auf Pro für unbegrenzte Transkriptionen.",
-    "upgradeToPro": "Auf Pro upgraden",
+    "viewPlans": "Tarife ansehen",
     "upgradeTitle": "Auf Pro upgraden",
     "upgradeDescription": "Unbegrenzte Transkriptionen und mehr.",
     "learnMore": "Mehr erfahren",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1890,6 +1890,7 @@
       "selectFolder": "Select folder",
       "transcriptionFailed": "Transcription failed",
       "errorOccurred": "An error occurred",
+      "noSpeechDetected": "No speech detected in this audio.",
       "noProviderTitle": "No transcription provider set up",
       "noProviderDescription": "Add an API key or download a local model to start transcribing.",
       "noProviderAction": "Open Transcription Settings",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1681,7 +1681,7 @@
     "support": "Support",
     "limitReached": "Weekly limit reached",
     "limitReachedDescription": "Upgrade to Pro for unlimited transcriptions.",
-    "upgradeToPro": "Upgrade to Pro",
+    "viewPlans": "View Plans",
     "upgradeTitle": "Upgrade to Pro",
     "upgradeDescription": "Unlimited transcriptions and premium features.",
     "learnMore": "Learn more",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1781,6 +1781,7 @@
       "selectFolder": "Seleccionar carpeta",
       "transcriptionFailed": "Error en la transcripción",
       "errorOccurred": "Se produjo un error",
+      "noSpeechDetected": "No se detectó voz en este audio.",
       "noProviderTitle": "No se ha configurado un proveedor de transcripción",
       "noProviderDescription": "Agrega una clave API o descarga un modelo local para comenzar a transcribir.",
       "noProviderAction": "Abrir configuración de transcripción",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1942,7 +1942,7 @@
     "support": "Soporte",
     "limitReached": "Límite semanal alcanzado",
     "limitReachedDescription": "Mejora a Pro para transcripciones ilimitadas.",
-    "upgradeToPro": "Mejorar a Pro",
+    "viewPlans": "Ver planes",
     "upgradeTitle": "Mejorar a Pro",
     "upgradeDescription": "Transcripciones ilimitadas y más.",
     "learnMore": "Más información",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1842,6 +1842,7 @@
       "selectFolder": "Sélectionner un dossier",
       "transcriptionFailed": "Échec de la transcription",
       "errorOccurred": "Une erreur est survenue",
+      "noSpeechDetected": "Aucune parole détectée dans cet audio.",
       "noProviderTitle": "Aucun fournisseur de transcription configuré",
       "noProviderDescription": "Ajoutez une clé API ou téléchargez un modèle local pour commencer à transcrire.",
       "noProviderAction": "Ouvrir les paramètres de transcription",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1633,7 +1633,7 @@
     "support": "Assistance",
     "limitReached": "Limite hebdomadaire atteinte",
     "limitReachedDescription": "Passez à Pro pour des transcriptions illimitées.",
-    "upgradeToPro": "Passer à Pro",
+    "viewPlans": "Voir les forfaits",
     "upgradeTitle": "Passer à Pro",
     "upgradeDescription": "Transcriptions illimitées et fonctionnalités premium.",
     "learnMore": "En savoir plus",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1733,6 +1733,7 @@
       "selectFolder": "Seleziona cartella",
       "transcriptionFailed": "Trascrizione non riuscita",
       "errorOccurred": "Si è verificato un errore",
+      "noSpeechDetected": "Nessun parlato rilevato in questo audio.",
       "noProviderTitle": "Nessun provider di trascrizione configurato",
       "noProviderDescription": "Aggiungi una chiave API o scarica un modello locale per iniziare a trascrivere.",
       "noProviderAction": "Apri impostazioni di trascrizione",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1894,7 +1894,7 @@
     "support": "Assistenza",
     "limitReached": "Limite settimanale raggiunto",
     "limitReachedDescription": "Passa a Pro per trascrizioni illimitate.",
-    "upgradeToPro": "Passa a Pro",
+    "viewPlans": "Vedi i piani",
     "upgradeTitle": "Passa a Pro",
     "upgradeDescription": "Trascrizioni illimitate e funzionalità avanzate.",
     "learnMore": "Scopri di più",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1716,6 +1716,7 @@
       "selectFolder": "フォルダを選択",
       "transcriptionFailed": "文字起こしに失敗しました",
       "errorOccurred": "エラーが発生しました",
+      "noSpeechDetected": "この音声から発話を検出できませんでした。",
       "noProviderTitle": "文字起こしプロバイダーが設定されていません",
       "noProviderDescription": "API キーを追加するか、ローカルモデルをダウンロードして文字起こしを開始してください。",
       "noProviderAction": "文字起こし設定を開く",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1894,7 +1894,7 @@
     "support": "サポート",
     "limitReached": "週間の利用上限に達しました",
     "limitReachedDescription": "Pro にアップグレードして無制限の文字起こしをご利用ください。",
-    "upgradeToPro": "Pro にアップグレード",
+    "viewPlans": "プランを見る",
     "upgradeTitle": "Pro にアップグレード",
     "upgradeDescription": "無制限の文字起こしと最新の AI モデルをご利用いただけます。",
     "learnMore": "詳しく見る",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1733,6 +1733,7 @@
       "selectFolder": "Selecionar pasta",
       "transcriptionFailed": "Falha na transcrição",
       "errorOccurred": "Ocorreu um erro",
+      "noSpeechDetected": "Nenhuma fala detectada neste áudio.",
       "noProviderTitle": "Nenhum provedor de transcrição configurado",
       "noProviderDescription": "Adicione uma chave API ou baixe um modelo local para começar a transcrever.",
       "noProviderAction": "Abrir configurações de transcrição",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1894,7 +1894,7 @@
     "support": "Suporte",
     "limitReached": "Limite semanal atingido",
     "limitReachedDescription": "Faça upgrade para Pro para transcrições ilimitadas.",
-    "upgradeToPro": "Fazer upgrade para Pro",
+    "viewPlans": "Ver planos",
     "upgradeTitle": "Fazer upgrade para Pro",
     "upgradeDescription": "Transcrições ilimitadas e recursos avançados.",
     "learnMore": "Saiba mais",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1733,6 +1733,7 @@
       "selectFolder": "Выбрать папку",
       "transcriptionFailed": "Ошибка транскрибирования",
       "errorOccurred": "Произошла ошибка",
+      "noSpeechDetected": "В этой аудиозаписи речь не обнаружена.",
       "noProviderTitle": "Провайдер транскрипции не настроен",
       "noProviderDescription": "Добавьте API-ключ или скачайте локальную модель, чтобы начать транскрипцию.",
       "noProviderAction": "Открыть настройки транскрипции",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1894,7 +1894,7 @@
     "support": "Поддержка",
     "limitReached": "Недельный лимит достигнут",
     "limitReachedDescription": "Перейдите на Pro для безлимитных транскрипций.",
-    "upgradeToPro": "Перейти на Pro",
+    "viewPlans": "Посмотреть тарифы",
     "upgradeTitle": "Перейдите на Pro",
     "upgradeDescription": "Безлимитные транскрипции, транскрипция в реальном времени и многое другое.",
     "learnMore": "Узнать больше",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1728,6 +1728,7 @@
       "selectFolder": "选择文件夹",
       "transcriptionFailed": "转录失败",
       "errorOccurred": "发生错误",
+      "noSpeechDetected": "未在此音频中检测到语音。",
       "noProviderTitle": "尚未设置转录服务商",
       "noProviderDescription": "添加 API Key 或下载本地模型以开始转录。",
       "noProviderAction": "打开转录设置",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1889,7 +1889,7 @@
     "support": "支持",
     "limitReached": "已达每周上限",
     "limitReachedDescription": "升级到 Pro 即可无限转录。",
-    "upgradeToPro": "升级到 Pro",
+    "viewPlans": "查看套餐",
     "upgradeTitle": "升级到 Pro",
     "upgradeDescription": "无限转录、实时转录等更多功能。",
     "learnMore": "了解更多",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1728,6 +1728,7 @@
       "selectFolder": "選擇資料夾",
       "transcriptionFailed": "轉錄失敗",
       "errorOccurred": "發生錯誤",
+      "noSpeechDetected": "未在此音訊中偵測到語音。",
       "noProviderTitle": "尚未設定轉錄服務供應商",
       "noProviderDescription": "新增 API Key 或下載本機模型以開始轉錄。",
       "noProviderAction": "開啟轉錄設定",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1889,7 +1889,7 @@
     "support": "支援",
     "limitReached": "已達每週上限",
     "limitReachedDescription": "升級至 Pro 即可無限轉錄。",
-    "upgradeToPro": "升級至 Pro",
+    "viewPlans": "查看方案",
     "upgradeTitle": "升級至 Pro",
     "upgradeDescription": "無限轉錄、即時轉錄等更多功能。",
     "learnMore": "瞭解更多",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -286,13 +286,6 @@ function createBooleanSetter(key: string) {
   };
 }
 
-const LOCAL_PROVIDERS = new Set(["qwen", "llama", "mistral", "openai-oss", "gemma"]);
-
-function inferenceModeForProvider(provider: string): Exclude<InferenceMode, "openwhispr"> {
-  if (provider === "custom") return "self-hosted";
-  if (LOCAL_PROVIDERS.has(provider)) return "local";
-  return "providers";
-}
 
 let envPersistTimer: ReturnType<typeof setTimeout> | null = null;
 function debouncedPersistToEnv() {
@@ -488,34 +481,12 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setAssemblyAiStreaming: createBooleanSetter("assemblyAiStreaming"),
   setUseReasoningModel: createBooleanSetter("useReasoningModel"),
   setReasoningProvider: (value: string) => {
-    const mode = inferenceModeForProvider(value);
-    if (isBrowser) {
-      localStorage.setItem("reasoningProvider", value);
-      localStorage.setItem("reasoningMode", mode);
-      localStorage.setItem("cloudReasoningMode", "byok");
-    }
-    useSettingsStore.setState({
-      reasoningProvider: value,
-      reasoningMode: mode,
-      cloudReasoningMode: "byok",
-    });
+    if (isBrowser) localStorage.setItem("reasoningProvider", value);
+    useSettingsStore.setState({ reasoningProvider: value });
   },
   setReasoningModel: (value: string) => {
     if (isBrowser) localStorage.setItem("reasoningModel", value);
-    if (!value) {
-      useSettingsStore.setState({ reasoningModel: value });
-      return;
-    }
-    const mode = inferenceModeForProvider(useSettingsStore.getState().reasoningProvider);
-    if (isBrowser) {
-      localStorage.setItem("reasoningMode", mode);
-      localStorage.setItem("cloudReasoningMode", "byok");
-    }
-    useSettingsStore.setState({
-      reasoningModel: value,
-      reasoningMode: mode,
-      cloudReasoningMode: "byok",
-    });
+    useSettingsStore.setState({ reasoningModel: value });
   },
 
   setCustomDictionary: (words: string[]) => {
@@ -688,33 +659,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setAgentModel: (value: string) => {
     if (isBrowser) localStorage.setItem("agentModel", value);
-    if (!value) {
-      useSettingsStore.setState({ agentModel: value });
-      return;
-    }
-    const mode = inferenceModeForProvider(useSettingsStore.getState().agentProvider);
-    if (isBrowser) {
-      localStorage.setItem("agentInferenceMode", mode);
-      localStorage.setItem("cloudAgentMode", "byok");
-    }
-    useSettingsStore.setState({
-      agentModel: value,
-      agentInferenceMode: mode,
-      cloudAgentMode: "byok",
-    });
+    useSettingsStore.setState({ agentModel: value });
   },
   setAgentProvider: (value: string) => {
-    const mode = inferenceModeForProvider(value);
-    if (isBrowser) {
-      localStorage.setItem("agentProvider", value);
-      localStorage.setItem("agentInferenceMode", mode);
-      localStorage.setItem("cloudAgentMode", "byok");
-    }
-    useSettingsStore.setState({
-      agentProvider: value,
-      agentInferenceMode: mode,
-      cloudAgentMode: "byok",
-    });
+    if (isBrowser) localStorage.setItem("agentProvider", value);
+    useSettingsStore.setState({ agentProvider: value });
   },
   setAgentKey: (key: string) => {
     if (!isBrowser) {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1343,24 +1343,6 @@ declare global {
       }) => Promise<{ success: boolean }>;
       getMD5Hash: (text: string) => Promise<string>;
 
-      // Meeting chain transcription (BaseTen)
-      meetingTranscribeChain?: (
-        blobUrl: string,
-        opts?: {
-          skipCleanup?: boolean;
-          agentName?: string;
-          customDictionary?: string[];
-        }
-      ) => Promise<{
-        success: boolean;
-        text?: string;
-        rawText?: string;
-        cleanedText?: string;
-        processingDurationSec?: number;
-        speedupFactor?: number;
-        error?: string;
-      }>;
-
       // Meeting transcription (streaming, dual-channel)
       meetingTranscriptionPrepare?: (options: {
         provider?: string;


### PR DESCRIPTION
## Summary

Fixes cloud transcription silently failing on long audio (> ~5 min / > 4 MB) with Vercel's opaque `FUNCTION_PAYLOAD_TOO_LARGE`, plus a couple of unrelated UX fixes for the limit banner and settings inference-mode selector.

## What changed

**Cloud transcription — chunking everywhere it was missing**

All three cloud paths (`cloud-transcribe` for dictation, `retry-transcription` for retries, `transcribe-audio-file-cloud` for file uploads) were hitting `/api/transcribe` inline. File upload had chunking but gated at 25 MB — a full dead zone between 4.5–25 MB. Dictation and retry had no chunking at all.

- New `chunkedCloudTranscribe` helper in `ipcHandlers.js`: accepts either a buffer or file path, splits via existing ffmpeg `splitAudioFile`, parallel-posts chunks (concurrency 5, ~3.75 MB segments), tracks per-chunk failure codes, joins text, cleans up tmp + chunk dir in `finally`.
- New `interpretTranscribeResponse` helper — single source of truth for HTTP status → error-code mapping (401/503/429/422/non-200). Used by the helper and both inline callers.
- `CLOUD_INLINE_LIMIT = 4 MB` threshold; below it, requests still take the fast single-POST path — zero added latency for short dictations.
- Chunked dictation returns the same field set as inline (`sttProcessingMs`, `sttWordCount`, `audioDurationMs` now correctly summed across chunks; state fields like `wordsUsed`/`plan` from the last completed chunk).

**Upload UX: NO_SPEECH_DETECTED**

Previously a ringtone / silence / music file returned a generic `NoTranscriptGeneratedError` from the AI SDK, which surfaced as `Invalid JSON response: ...` in the UI. Now:
- API ([openwhispr-api#main](https://github.com/OpenWhispr/openwhispr-api)): `transcribe.ts` catches `NoTranscriptGeneratedError.isInstance(error)` and returns `422 { code: "NO_SPEECH_DETECTED" }`.
- Client: inline + chunked paths map this to `code: "NO_SPEECH_DETECTED"`. Chunked path only propagates it if *every* chunk uniformly failed with that code — mixed audio with some silent sections still gets partial text.
- UI: `UploadAudioView` renders a localized `notes.upload.noSpeechDetected` message. Translations added for all 10 supported locales with contextually correct terms for "speech" in each language.

**Remove dormant blob upload scaffolding**

`/api/upload-audio`, `/api/delete-audio`, the `meeting-transcribe-chain` IPC handler, `meetingTranscribeChain` preload entry + TS type, and `@vercel/blob` dep on both sides — all removed. Zero live callers confirmed by grep across `openwhispr/src`. Dropped ~78 packages from the client bundle.

**Sidebar limit-banner**

`ControlPanelSidebar` limit banner now routes to the plans & billing settings page instead of a dead-end modal.

**Inference mode selector**

`ReasoningModelSelector`: model/provider setters no longer override the user's inference-mode selection (local vs cloud).

## Technical notes

- Inline path preserved unchanged for files < 4 MB — no regression risk for short recordings.
- Streaming transcription (Deepgram/AssemblyAI websocket) is the default and untouched; this only fixes the non-streaming + fallback + retry + file-upload paths.
- All IPC channel names, return shapes, and progress event payloads preserved. Verified via `grep -r` and typecheck.
- Net diff: +285/-415 across 20 files. Most negative lines are the dormant blob scaffolding + deduplicated chunk logic.

## Paired with

- `openwhispr-api@main`: two commits with matching API changes (422 response + blob endpoint removal).