### PR TITLE
chore(eslint): pin react-hooks to proven rules only

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,10 @@ module.exports = [
     rules: {
       ...js.configs.recommended.rules,
       // Relaxed rules - catch syntax errors but don't be too strict
-      "no-unused-vars": ["warn", { varsIgnorePattern: "^_", argsIgnorePattern: "^_|^event|^err|^error" }],
+      "no-unused-vars": [
+        "warn",
+        { varsIgnorePattern: "^_", argsIgnorePattern: "^_|^event|^err|^error" },
+      ],
       "no-console": "off",
       "no-empty": ["error", { allowEmptyCatch: true }],
       "no-constant-condition": ["error", { checkLoops: false }],

--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -27,7 +27,8 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      ...reactHooks.configs.recommended.rules,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
       "no-unused-vars": [
         "warn",
         { varsIgnorePattern: "^[A-Z_]", argsIgnorePattern: "^_|^event|^err|^error" },
@@ -62,7 +63,8 @@ export default [
       "@typescript-eslint": tseslint.plugin,
     },
     rules: {
-      ...reactHooks.configs.recommended.rules,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
       "no-undef": "off",
       "no-unused-vars": "off",
       "no-console": "off",


### PR DESCRIPTION
## Summary
- eslint-plugin-react-hooks@7.1.0 expanded its \`recommended\` preset to include React Compiler enforcement rules (\`set-state-in-effect\`, \`refs\`, \`immutability\`, etc.) at error level, which broke lint on \`main\` after #623 landed.
- Pin to the two battle-tested rules (\`rules-of-hooks\` error, \`exhaustive-deps\` warn) — the subset the preset shipped with in 7.0.x.
- Adopting the new Compiler-era rules requires a codebase-wide hooks cleanup (57 errors across 22 files); better to do that incrementally, not in a dep bump.
- Also includes prettier 3.8.3 reflow on \`eslint.config.js\` (from #620).

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npm run format:check\` passes
- [ ] CI green