### PR TITLE
fix(ci): unbreak Dependabot Windows builds and macOS icon fallback

### DIFF
--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -178,7 +178,7 @@ jobs:
           echo "GOOGLE_CALENDAR_CLIENT_SECRET=${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}" >> .env
 
       - name: Build and Sign Application
-        run: npm run build:win -- --publish never
+        run: npm run build:win -- --publish never ${{ github.actor == 'dependabot[bot]' && '--config.win.azureSignOptions=null' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           VITE_NEON_AUTH_URL: ${{ vars.VITE_NEON_AUTH_URL }}

--- a/scripts/compile-macos-icon.js
+++ b/scripts/compile-macos-icon.js
@@ -59,7 +59,12 @@ try {
 
   const producedCar = path.join(tmpDir, "Assets.car");
   if (!fs.existsSync(producedCar)) {
-    throw new Error("actool did not produce Assets.car");
+    console.warn(
+      "compile-macos-icon: actool ran but did not emit Assets.car " +
+        "(likely a partial Xcode install on the runner). " +
+        "Falling back to icon.icns; no Liquid Glass on macOS 26+."
+    );
+    return;
   }
 
   fs.copyFileSync(producedCar, OUTPUT_CAR);


### PR DESCRIPTION
## Summary
Two unrelated CI papercuts surfaced during the eslint-10 merge train, fixed in one PR:

- **Windows / Dependabot signing** — Azure Trusted Signing creds aren't exposed to bot PRs (by GitHub design), so every Dependabot PR failed the Windows build at \`Unable to find valid azure env field AZURE_TENANT_ID\`. Pass \`--config.win.azureSignOptions=null\` only when \`github.actor == 'dependabot[bot]'\`, letting the packaging step complete unsigned on bot PRs. Normal PRs and pushes to main sign unchanged.
- **macOS \`actool\` fallback** — \`scripts/compile-macos-icon.js\` claims in its top comment to fall back to \`icon.icns\` on runners without full Xcode, but line 62 hard-threw on that exact condition (actool runs, emits \`plist.plist\`, no \`Assets.car\`). Warn and return instead, matching the script's stated intent. Release builds on machines with full Xcode still produce \`Assets.car\` normally.

## Test plan
- [ ] CI green (modulo signing step on this PR's Windows build, which is now what we want)
- [ ] Next Dependabot PR after merge completes Windows/macOS checks