### PR TITLE
fix(hooks): address real react-hooks rule violations

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -103,8 +103,20 @@ export default function ControlPanel() {
   } = useDialogs();
 
   useEffect(() => {
-    loadTranscriptions();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    (async () => {
+      try {
+        setIsLoading(true);
+        await initializeTranscriptions();
+      } catch {
+        showAlertDialog({
+          title: t("controlPanel.history.couldNotLoadTitle"),
+          description: t("controlPanel.history.couldNotLoadDescription"),
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [showAlertDialog, t]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -282,20 +294,6 @@ export default function ControlPanel() {
     setIsMeetingMode(false);
     window.electronAPI?.restoreFromMeetingMode?.();
   }, []);
-
-  const loadTranscriptions = async () => {
-    try {
-      setIsLoading(true);
-      await initializeTranscriptions();
-    } catch (error) {
-      showAlertDialog({
-        title: t("controlPanel.history.couldNotLoadTitle"),
-        description: t("controlPanel.history.couldNotLoadDescription"),
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const copyToClipboard = useCallback(
     async (text: string) => {

--- a/src/components/notes/ActionManagerDialog.tsx
+++ b/src/components/notes/ActionManagerDialog.tsx
@@ -25,6 +25,13 @@ export default function ActionManagerDialog({ open, onOpenChange }: ActionManage
   const [isCreating, setIsCreating] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
+  const resetForm = () => {
+    setName("");
+    setDescription("");
+    setPrompt("");
+    setEditingId(null);
+  };
+
   useEffect(() => {
     if (open) {
       initializeActions();
@@ -46,13 +53,6 @@ export default function ActionManagerDialog({ open, onOpenChange }: ActionManage
       setPrompt(first.prompt);
     }
   }, [open, actions, selectedId, isCreating]);
-
-  const resetForm = () => {
-    setName("");
-    setDescription("");
-    setPrompt("");
-    setEditingId(null);
-  };
 
   const handleSelectAction = (action: ActionItem) => {
     setSelectedId(action.id);

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -96,10 +96,17 @@ export default function PersonalNotesView({
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const enhancedSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const activeNoteRef = useRef<number | null>(null);
+  const [lastSyncedNoteId, setLastSyncedNoteId] = useState<number | null>(null);
   const localContentRef = useRef(localContent);
-  localContentRef.current = localContent;
   const localTitleRef = useRef(localTitle);
-  localTitleRef.current = localTitle;
+  useEffect(() => {
+    localContentRef.current = localContent;
+    localTitleRef.current = localTitle;
+  });
+  const setActiveNoteId = (id: number | null) => {
+    activeNoteRef.current = id;
+    setLastSyncedNoteId(id);
+  };
   const { toast } = useToast();
   const isCloudMode = useSettingsStore(selectIsCloudReasoningMode);
   const effectiveModelId = useSettingsStore((s) => s.reasoningModel);
@@ -126,6 +133,11 @@ export default function PersonalNotesView({
     lockSpeaker,
   } = useMeetingTranscription();
   const recordingNoteIdRef = useRef<number | null>(null);
+  const [recordingNoteId, setRecordingNoteId] = useState<number | null>(null);
+  const setActiveRecordingNoteId = (id: number | null) => {
+    recordingNoteIdRef.current = id;
+    setRecordingNoteId(id);
+  };
 
   const {
     folders,
@@ -169,7 +181,7 @@ export default function PersonalNotesView({
   }, [activeNote?.calendar_event_id]);
 
   const startRecording = useCallback(async () => {
-    recordingNoteIdRef.current = activeNoteRef.current;
+    setActiveRecordingNoteId(activeNoteRef.current);
     const note = notes.find((n) => n.id === activeNoteRef.current);
     const seedSegments = note?.transcript ? parseTranscriptSegments(note.transcript) : [];
     await startTranscription({ seedSegments, noteId: activeNoteRef.current });
@@ -196,7 +208,7 @@ export default function PersonalNotesView({
           clearTimeout(enhancedSaveTimeoutRef.current);
           enhancedSaveTimeoutRef.current = null;
         }
-        activeNoteRef.current = activeNote.id;
+        setActiveNoteId(activeNote.id);
         setLocalTitle(activeNote.title);
         setLocalContent(activeNote.content);
         setLocalEnhancedContent(activeNote.enhanced_content ?? null);
@@ -217,7 +229,7 @@ export default function PersonalNotesView({
           clearTimeout(enhancedSaveTimeoutRef.current);
           enhancedSaveTimeoutRef.current = null;
         }
-        activeNoteRef.current = null;
+        setActiveNoteId(null);
         setLocalTitle("");
         setLocalContent("");
         setLocalEnhancedContent(null);
@@ -475,7 +487,7 @@ export default function PersonalNotesView({
 
   useEffect(() => {
     if (!meetingRecordingRequest || activeNoteId !== meetingRecordingRequest.noteId) return;
-    recordingNoteIdRef.current = meetingRecordingRequest.noteId;
+    setActiveRecordingNoteId(meetingRecordingRequest.noteId);
     const note = notes.find((n) => n.id === meetingRecordingRequest.noteId);
     const seedSegments = note?.transcript ? parseTranscriptSegments(note.transcript) : [];
     startTranscription({ seedSegments, noteId: meetingRecordingRequest.noteId });
@@ -505,7 +517,7 @@ export default function PersonalNotesView({
       if (noteId && transcript) {
         window.electronAPI.updateNote(noteId, { transcript });
       }
-      recordingNoteIdRef.current = null;
+      setActiveRecordingNoteId(null);
     }
     prevTranscribingRef.current = isTranscribing;
   }, [isTranscribing, realtimeTranscript, realtimeSegments]);
@@ -524,8 +536,8 @@ export default function PersonalNotesView({
     return () => clearInterval(interval);
   }, [isTranscribing, realtimeSegments]);
 
-  const isLocalSynced = activeNoteRef.current === activeNote?.id;
-  const isActiveNoteRecording = isTranscribing && recordingNoteIdRef.current === activeNote?.id;
+  const isLocalSynced = lastSyncedNoteId === activeNote?.id;
+  const isActiveNoteRecording = isTranscribing && recordingNoteId === activeNote?.id;
   const editorNote = activeNote
     ? {
         ...activeNote,

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -96,16 +96,16 @@ export default function PersonalNotesView({
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const enhancedSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const activeNoteRef = useRef<number | null>(null);
-  const [lastSyncedNoteId, setLastSyncedNoteId] = useState<number | null>(null);
+  const [syncedNoteId, setSyncedNoteIdState] = useState<number | null>(null);
   const localContentRef = useRef(localContent);
   const localTitleRef = useRef(localTitle);
   useEffect(() => {
     localContentRef.current = localContent;
     localTitleRef.current = localTitle;
-  });
-  const setActiveNoteId = (id: number | null) => {
+  }, [localContent, localTitle]);
+  const markNoteAsSynced = (id: number | null) => {
     activeNoteRef.current = id;
-    setLastSyncedNoteId(id);
+    setSyncedNoteIdState(id);
   };
   const { toast } = useToast();
   const isCloudMode = useSettingsStore(selectIsCloudReasoningMode);
@@ -208,7 +208,7 @@ export default function PersonalNotesView({
           clearTimeout(enhancedSaveTimeoutRef.current);
           enhancedSaveTimeoutRef.current = null;
         }
-        setActiveNoteId(activeNote.id);
+        markNoteAsSynced(activeNote.id);
         setLocalTitle(activeNote.title);
         setLocalContent(activeNote.content);
         setLocalEnhancedContent(activeNote.enhanced_content ?? null);
@@ -229,7 +229,7 @@ export default function PersonalNotesView({
           clearTimeout(enhancedSaveTimeoutRef.current);
           enhancedSaveTimeoutRef.current = null;
         }
-        setActiveNoteId(null);
+        markNoteAsSynced(null);
         setLocalTitle("");
         setLocalContent("");
         setLocalEnhancedContent(null);
@@ -536,7 +536,7 @@ export default function PersonalNotesView({
     return () => clearInterval(interval);
   }, [isTranscribing, realtimeSegments]);
 
-  const isLocalSynced = lastSyncedNoteId === activeNote?.id;
+  const isLocalSynced = syncedNoteId === activeNote?.id;
   const isActiveNoteRecording = isTranscribing && recordingNoteId === activeNote?.id;
   const editorNote = activeNote
     ? {


### PR DESCRIPTION
## Summary
Targets only the react-hooks violations that represent **actual bugs or anti-patterns**, not the aspirational React-Compiler-era rules. After this lands, the codebase could adopt the full react-hooks 7.1.x recommended preset incrementally without a mass cleanup.

### Changes

- **PersonalNotesView.tsx** — 26 \`react-hooks/refs\` violations
  - Moved render-body ref writes (\`localContentRef.current = localContent\`, \`localTitleRef.current = localTitle\`) into a \`useEffect\`.
  - Mirrored \`activeNoteRef\` and \`recordingNoteIdRef\` as parallel state (\`lastSyncedNoteId\`, \`recordingNoteId\`) so render-time reads for \`isLocalSynced\` / \`isActiveNoteRecording\` no longer access \`ref.current\` during render. Refs remain for effect/callback closure access (no stale-capture regressions in the 30s save-interval, debounced save handlers, or start/stop transcription paths).

- **ControlPanel.tsx** — 1 \`react-hooks/immutability\` (TDZ) violation
  - Inlined \`loadTranscriptions\` into its sole caller (the mount effect). The previous const-arrow declaration below the effect was accessed before declaration, which the rule correctly flagged. No functional change.

- **ActionManagerDialog.tsx** — 1 \`react-hooks/immutability\` (TDZ) violation
  - Hoisted \`resetForm\` above its first \`useEffect\` usage. Same TDZ fix; no functional change.

### Deliberately out of scope

- \`react-hooks/set-state-in-effect\` (28 occurrences) — the \`useEffect(() => fetchX(), [])\` "load on mount" pattern. Works today; the rule pushes toward Suspense/data-lib migration, which is a separate effort.
- \`react-hooks/preserve-manual-memoization\` (1) — React Compiler hint; not adopting the Compiler.
- \`react-hooks/incompatible-library\` (1) — TanStack Virtual's \`useVirtualizer\` can't be safely memoized by React Compiler. Not applicable (we don't use the Compiler).

## Test plan
- [x] \`npm run lint\` clean (modified files pass the pinned rules set on main)
- [x] \`npm run format:check\` clean
- [x] \`npm run typecheck\` — only pre-existing \`tsconfig.json(20,5): TS5101\` (\`baseUrl\` deprecation, unrelated to this PR)
- [ ] Manual QA: note switching saves pending edits, external note updates resync when idle, meeting mode recording flow (start/stop/interval save) still attributes transcripts to the correct note