### PR TITLE
build(mac): migrate Apple signing to Gizmo Labs Inc.

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -131,7 +131,7 @@
     "hardenedRuntime": true,
     "entitlements": "resources/mac/entitlements.mac.plist",
     "entitlementsInherit": "resources/mac/entitlements.mac.plist",
-    "identity": "HeroTools Inc. (9R85XFMH59)",
+    "identity": "Gizmo Labs Inc. (T832773L2J)",
     "notarize": true,
     "extraResources": [
       {


### PR DESCRIPTION
## Summary
- Switches the macOS codesign identity from **HeroTools Inc. (9R85XFMH59)** → **Gizmo Labs Inc. (T832773L2J)** in [electron-builder.json:134](electron-builder.json#L134).
- Aligns macOS signing with the existing Windows Azure Trusted Signing setup (already on Gizmo Labs).
- Bundle ID `com.herotools.openwispr` is **preserved** — changing the bundle ID would reset user permissions (Microphone, Accessibility, Globe-key), orphan user data, and break electron-updater across the rename. A dedicated future release can handle the rename with proper migration.

## Why
Consolidating all code-signing under one legal entity (Gizmo Labs Inc.) ahead of the old HeroTools Apple Developer Program enrollment lapsing.

## Validation
Local end-to-end build + notarization on this branch succeeded:

- ✅ `codesign -dvvv` → `TeamIdentifier=T832773L2J`, chain: Developer ID Application → Developer ID CA → Apple Root CA
- ✅ `spctl -a -vvv -t install` → `source=Notarized Developer ID`, `accepted`
- ✅ `xcrun stapler validate` → `The validate action worked!`

Apple's first-submission manual review (standard fraud check for a new Team ID) cleared after ~2h — future notarizations will be back to the normal 5–30 min window.

## Before merging — rotate the 6 GitHub secrets
| Secret | New value |
|---|---|
| `APPLE_CERTIFICATE_BASE64` | new Gizmo Labs `.p12` (base64) |
| `APPLE_CERTIFICATE_PASSWORD` | `.p12` export password |
| `APPLE_API_KEY_BASE64` | new `.p8` (base64) |
| `APPLE_API_KEY_ID` | `9VZ97YPS48` |
| `APPLE_API_ISSUER` | `23cfad7a-5171-4968-bae3-ba116dfed869` |
| `APPLE_TEAM_ID` | `T832773L2J` |

Merging without rotating will break macOS CI signing (the old HeroTools cert would no longer match this identity).

## Post-merge
- Trigger **Build and Notarize** workflow on `main` to confirm CI signing succeeds end-to-end.
- Keep the old HeroTools `.p12` / API key saved offline for ~30 days as a rollback cushion.