### PR TITLE
fix(qdrant): set cwd to STORAGE_DIR so packaged app doesn't crash on startup

### DIFF
--- a/src/helpers/qdrantManager.js
+++ b/src/helpers/qdrantManager.js
@@ -88,6 +88,7 @@ class QdrantManager {
     });
 
     this.process = spawn(binaryPath, ["--config-path", configPath], {
+      cwd: STORAGE_DIR,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
     });


### PR DESCRIPTION
## Summary

- One-line fix: pass `cwd: STORAGE_DIR` to the qdrant `spawn()` call in [src/helpers/qdrantManager.js](src/helpers/qdrantManager.js)
- Stops qdrant from panicking at startup in packaged builds (observed in 1.6.10 logs)
- Restores local semantic search via the agent's `search_notes` tool

## What was happening

In packaged builds, qdrant was spawned with its cwd inside `/Applications/OpenWhispr.app/Contents/Resources/bin/` (read-only). It writes two stray paths relative to cwd at startup that bypass the explicit `storage_path` in `config.yaml`:

- `./snapshots/tmp` — snapshot temp dir
- `.qdrant-initialized` — init marker file

Both writes failed with `ReadOnlyFilesystem`, qdrant panicked and exited with code 101, and local semantic search silently fell through to the FTS5 keyword fallback (per the documented search chain).

## Why `cwd: STORAGE_DIR` is the right fix

- `STORAGE_DIR` (`~/.cache/openwhispr/qdrant-data/`) is already created via `fs.mkdirSync(STORAGE_DIR, { recursive: true })` immediately before the spawn — no new I/O, no new code paths
- Captures *both* stray writes at once (and any future relative writes if qdrant adds them)
- Alternatives considered and rejected:
  - `--snapshots-path` CLI flag → only fixes one of the two failing paths
  - `snapshots_path` in config.yaml → same, partial coverage

## Cross-platform

`STORAGE_DIR` uses `os.homedir()` — works on macOS, Linux, Windows. Dev mode was unaffected because cwd was already the writable repo root.

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- Prettier ✓ (no changes)
- Manual test once merged + packaged: log should show qdrant reaching `INFO qdrant::tonic: Qdrant gRPC listening on …` instead of the ReadOnlyFilesystem panic