### PR TITLE
fix(tls): trust OS CA store for Node-side TLS; keep realtime WS on OpenAI only

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,12 +34,13 @@ require("dotenv").config({ path: path.join(__dirname, ".env") });
 // Extend Node's TLS trust with the OS store so ws and https.get see corporate
 // CAs that Chromium already trusts.
 try {
+  const currentCAs = tls.getCACertificates();
   const systemCAs = tls.getCACertificates("system");
   if (systemCAs?.length) {
-    tls.setDefaultCACertificates([...tls.rootCertificates, ...systemCAs]);
+    tls.setDefaultCACertificates([...currentCAs, ...systemCAs]);
   }
 } catch (err) {
-  require("./src/helpers/debugLogger").warn("System CA merge failed; using bundled CA list", {
+  require("./src/helpers/debugLogger").warn("System CA merge failed; using existing CA list", {
     error: err?.message,
   });
 }

--- a/main.js
+++ b/main.js
@@ -28,7 +28,29 @@ const {
 } = require("electron");
 const path = require("path");
 const http = require("http");
+const tls = require("tls");
 require("dotenv").config({ path: path.join(__dirname, ".env") });
+
+// Trust the OS certificate store for all Node-side TLS (ws, https.get, etc.).
+// Chromium's network stack already honors the system keychain, but Node uses a
+// bundled CA list — so corporate MITM proxies break realtime WS and HF
+// downloads while the renderer's fetch works. Merging is strictly additive:
+// nothing that validated before stops validating.
+try {
+  if (
+    typeof tls.getCACertificates === "function" &&
+    typeof tls.setDefaultCACertificates === "function"
+  ) {
+    const systemCAs = tls.getCACertificates("system");
+    if (Array.isArray(systemCAs) && systemCAs.length > 0) {
+      tls.setDefaultCACertificates([...tls.rootCertificates, ...systemCAs]);
+    }
+  }
+} catch (err) {
+  require("./src/helpers/debugLogger").warn("System CA merge failed; using bundled CA list", {
+    error: err?.message,
+  });
+}
 
 const VALID_CHANNELS = new Set(["development", "staging", "production"]);
 const DEFAULT_OAUTH_PROTOCOL_BY_CHANNEL = {

--- a/main.js
+++ b/main.js
@@ -31,20 +31,12 @@ const http = require("http");
 const tls = require("tls");
 require("dotenv").config({ path: path.join(__dirname, ".env") });
 
-// Trust the OS certificate store for all Node-side TLS (ws, https.get, etc.).
-// Chromium's network stack already honors the system keychain, but Node uses a
-// bundled CA list — so corporate MITM proxies break realtime WS and HF
-// downloads while the renderer's fetch works. Merging is strictly additive:
-// nothing that validated before stops validating.
+// Extend Node's TLS trust with the OS store so ws and https.get see corporate
+// CAs that Chromium already trusts.
 try {
-  if (
-    typeof tls.getCACertificates === "function" &&
-    typeof tls.setDefaultCACertificates === "function"
-  ) {
-    const systemCAs = tls.getCACertificates("system");
-    if (Array.isArray(systemCAs) && systemCAs.length > 0) {
-      tls.setDefaultCACertificates([...tls.rootCertificates, ...systemCAs]);
-    }
+  const systemCAs = tls.getCACertificates("system");
+  if (systemCAs?.length) {
+    tls.setDefaultCACertificates([...tls.rootCertificates, ...systemCAs]);
   }
 } catch (err) {
   require("./src/helpers/debugLogger").warn("System CA merge failed; using bundled CA list", {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1964,11 +1964,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     if (REALTIME_MODELS.has(s.cloudTranscriptionModel)) {
-      // Realtime WebSocket is OpenAI-only; non-OpenAI providers (custom, groq,
-      // mistral) don't speak the realtime protocol and must fall through to
-      // the HTTP path.
-      const provider = s.cloudTranscriptionProvider || "openai";
-      if (provider !== "openai") return false;
+      // Realtime WS is OpenAI-only — other providers fall through to HTTP.
+      if ((s.cloudTranscriptionProvider || "openai") !== "openai") return false;
       if (s.cloudTranscriptionMode === "byok") return !!s.openaiApiKey;
       if (s.cloudTranscriptionMode === "openwhispr") return !!(isSignedInOverride ?? s.isSignedIn);
       return false;

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1964,6 +1964,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     if (REALTIME_MODELS.has(s.cloudTranscriptionModel)) {
+      // Realtime WebSocket is OpenAI-only; non-OpenAI providers (custom, groq,
+      // mistral) don't speak the realtime protocol and must fall through to
+      // the HTTP path.
+      const provider = s.cloudTranscriptionProvider || "openai";
+      if (provider !== "openai") return false;
       if (s.cloudTranscriptionMode === "byok") return !!s.openaiApiKey;
       if (s.cloudTranscriptionMode === "openwhispr") return !!(isSignedInOverride ?? s.isSignedIn);
       return false;


### PR DESCRIPTION
## Summary

Fixes three symptoms a user reported on a corporate MITM network:

1. **GPT-4o Transcribe / Mini Transcribe** failing with `self signed certificate in certificate chain`.
2. **Custom provider** pointed at `https://api.openai.com/v1` with `gpt-4o-transcribe` → same error.
3. **Whisper model downloads** from HuggingFace silently hanging (while Parakeet from GitHub downloads fine, and `whisper-1` via the renderer works).

All three share one root cause: Chromium's network stack trusts the OS keychain, but Node-side code (the \`ws\` realtime WebSocket in the main process, and \`https.get()\` in the model downloader) uses Node's bundled CA list — which does not contain the corporate root CA.

## Fix

**main.js** — one-shot at startup, merge the OS trust store into Node's TLS default so every subsequent \`ws\` / \`https.get()\` / \`fetch\` inside Node picks it up without any call-site changes:

\`\`\`js
try {
  const systemCAs = tls.getCACertificates("system");
  if (systemCAs?.length) {
    tls.setDefaultCACertificates([...tls.rootCertificates, ...systemCAs]);
  }
} catch (err) { ... }
\`\`\`

Strictly additive — a cert that validated before still validates. Uses documented Node 22.15+ / Electron 41 APIs. Try/catch degrades gracefully if ever unavailable.

**audioManager.js** — secondary bug surfaced during investigation: even when a user selects the Custom provider with \`gpt-4o-transcribe\`, the renderer still routed to the hardcoded OpenAI realtime WebSocket. Added a one-line provider gate mirroring the existing gate in \`shouldStreamTranscription()\` so non-OpenAI providers fall through to the existing HTTP path.

Total diff vs main: **16 lines added, 0 deleted**, across 2 files. No new deps, no IPC/settings changes.

## Why no breaking changes

- Default \`cloudTranscriptionProvider\` is \`"openai"\` → provider gate is a no-op for the overwhelming majority of users.
- \`tls.setDefaultCACertificates([...rootCertificates, ...systemCAs])\` is a superset — never reduces trust.
- Try/catch fallback keeps current behavior if the Node TLS API is ever unavailable.
- No IPC, preload, settings, or dependency changes — existing installs upgrade cleanly.

## Test plan

- [ ] Standard home network: confirm \`gpt-4o-mini-transcribe\`, \`whisper-1\`, and Whisper/Parakeet model downloads still work.
- [ ] Corporate / MITM network: install self-signed root CA in keychain; confirm realtime streaming connects and HuggingFace downloads complete.
- [ ] Remove the root CA and confirm we fail again (proves we're using system trust, not accepting anything).
- [ ] macOS / Windows / Linux smoke test — \`tls.getCACertificates("system")\` handles all three natively.
- [ ] Custom provider + \`gpt-4o-transcribe\`: confirm it now falls through to the HTTP path instead of hitting the broken WebSocket.