### PR TITLE
fix(chat): persist first user message when creating a new conversation

### DIFF
--- a/src/components/chat/useChatPersistence.ts
+++ b/src/components/chat/useChatPersistence.ts
@@ -32,6 +32,7 @@ export function useChatPersistence(options: UseChatPersistenceOptions = {}): Cha
     async (title: string, noteId?: number | null): Promise<number> => {
       const conv = await window.electronAPI?.createAgentConversation?.(title, noteId ?? undefined);
       const id = conv?.id ?? 0;
+      conversationIdRef.current = id;
       setConversationId(id);
       options.onConversationCreated?.(id, title);
       return id;
@@ -42,6 +43,7 @@ export function useChatPersistence(options: UseChatPersistenceOptions = {}): Cha
   const loadConversation = useCallback(async (id: number) => {
     const conv = await window.electronAPI?.getAgentConversation?.(id);
     if (!conv) return;
+    conversationIdRef.current = id;
     setConversationId(id);
     const loaded: Message[] = conv.messages.map((m) => {
       const parsed = m.metadata ? tryParseMetadata(m.metadata) : undefined;
@@ -76,6 +78,7 @@ export function useChatPersistence(options: UseChatPersistenceOptions = {}): Cha
 
   const handleNewChat = useCallback(() => {
     setMessages([]);
+    conversationIdRef.current = null;
     setConversationId(null);
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes the bug where the first prompt in a chat session disappears when switching to another conversation and switching back. The root cause is a race condition in `useChatPersistence`: `conversationIdRef` was updated only via a `useEffect` (post-render), so `saveUserMessage` called immediately after `createConversation` read a stale `null` ref and silently skipped the database write.

## Changes

- `src/components/chat/useChatPersistence.ts` -- update `conversationIdRef.current` synchronously in `createConversation`, `loadConversation`, and `handleNewChat`, so the ref is always current before any downstream save call. The `useEffect` sync remains as a redundant safety net.

Closes #649