### PR TITLE
fix: decouple agent toggle from text cleanup toggle

### DIFF
--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -19,77 +19,7 @@ function getPromptBundle(uiLanguage?: string): PromptBundle {
   };
 }
 
-function levenshteinDistance(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-  if (m === 0) return n;
-  if (n === 0) return m;
-
-  let prev = Array.from({ length: n + 1 }, (_, i) => i);
-  let curr = new Array<number>(n + 1);
-
-  for (let i = 1; i <= m; i++) {
-    curr[0] = i;
-    for (let j = 1; j <= n; j++) {
-      curr[j] =
-        a[i - 1] === b[j - 1] ? prev[j - 1] : 1 + Math.min(prev[j - 1], prev[j], curr[j - 1]);
-    }
-    [prev, curr] = [curr, prev];
-  }
-
-  return prev[n];
-}
-
-function maxEditsForLength(len: number): number {
-  if (len <= 4) return 0;
-  if (len <= 6) return 1;
-  return 2;
-}
-
-function detectAgentName(transcript: string, agentName: string): boolean {
-  const name = agentName.trim();
-  if (!name || name.length < 2) return false;
-
-  // Layer 1: Exact word-boundary match
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (new RegExp(`\\b${escaped}\\b`, "i").test(transcript)) return true;
-
-  // Layer 2: Space-normalized exact match (STT splitting compound names)
-  const nameLower = name.toLowerCase().replace(/\s+/g, "");
-  const words = transcript
-    .split(/\s+/)
-    .map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase())
-    .filter(Boolean);
-
-  for (let i = 0; i < words.length - 1; i++) {
-    if (words[i] + words[i + 1] === nameLower) return true;
-  }
-
-  // Layer 3: Fuzzy Levenshtein match (STT mishearings)
-  const maxEdits = maxEditsForLength(nameLower.length);
-  if (maxEdits === 0) return false;
-
-  for (const word of words) {
-    if (
-      Math.abs(word.length - nameLower.length) <= maxEdits &&
-      levenshteinDistance(word, nameLower) <= maxEdits
-    ) {
-      return true;
-    }
-  }
-
-  for (let i = 0; i < words.length - 1; i++) {
-    const combined = words[i] + words[i + 1];
-    if (
-      Math.abs(combined.length - nameLower.length) <= maxEdits &&
-      levenshteinDistance(combined, nameLower) <= maxEdits
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-}
+export { detectAgentName } from "../utils/agentNameDetection";
 
 export function getSystemPrompt(
   agentName: string | null,

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -15,6 +15,7 @@ import {
   getEffectiveReasoningModel,
   isCloudReasoningMode,
 } from "../stores/settingsStore";
+import { shouldProcessTranscription } from "./transcriptionDecision";
 import { syncService } from "../services/SyncService.js";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
@@ -93,6 +94,7 @@ class AudioManager {
     this.recordingStartTime = null;
     this.reasoningAvailabilityCache = { value: false, expiresAt: 0 };
     this.cachedReasoningPreference = null;
+    this.cachedAgentPreference = null;
     this.isStreaming = false;
     this.streamingAudioContext = null;
     this.streamingSource = null;
@@ -917,12 +919,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       return false;
     }
 
-    const useReasoning = getSettings().useReasoningModel;
+    const settings = getSettings();
+    const useReasoning = settings.useReasoningModel;
+    const agentEnabled = settings.agentEnabled;
     const now = Date.now();
     const cacheValid =
       this.reasoningAvailabilityCache &&
       now < this.reasoningAvailabilityCache.expiresAt &&
-      this.cachedReasoningPreference === useReasoning;
+      this.cachedReasoningPreference === useReasoning &&
+      this.cachedAgentPreference === agentEnabled;
 
     if (cacheValid) {
       return this.reasoningAvailabilityCache.value;
@@ -930,14 +935,16 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     logger.logReasoning("REASONING_STORAGE_CHECK", {
       useReasoning,
+      agentEnabled,
     });
 
-    if (!useReasoning) {
+    if (!useReasoning && !agentEnabled) {
       this.reasoningAvailabilityCache = {
         value: false,
         expiresAt: now + REASONING_CACHE_TTL,
       };
       this.cachedReasoningPreference = useReasoning;
+      this.cachedAgentPreference = agentEnabled;
       return false;
     }
 
@@ -947,6 +954,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         expiresAt: now + REASONING_CACHE_TTL,
       };
       this.cachedReasoningPreference = useReasoning;
+      this.cachedAgentPreference = agentEnabled;
       return true;
     }
 
@@ -956,7 +964,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       logger.logReasoning("REASONING_AVAILABILITY", {
         isAvailable,
         reasoningEnabled: useReasoning,
-        finalDecision: useReasoning && isAvailable,
+        agentEnabled,
+        finalDecision: (useReasoning || agentEnabled) && isAvailable,
       });
 
       this.reasoningAvailabilityCache = {
@@ -964,6 +973,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         expiresAt: now + REASONING_CACHE_TTL,
       };
       this.cachedReasoningPreference = useReasoning;
+      this.cachedAgentPreference = agentEnabled;
 
       return isAvailable;
     } catch (error) {
@@ -977,6 +987,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         expiresAt: now + REASONING_CACHE_TTL,
       };
       this.cachedReasoningPreference = useReasoning;
+      this.cachedAgentPreference = agentEnabled;
       return false;
     }
   }
@@ -1009,7 +1020,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     const reasoningModel = getEffectiveReasoningModel();
     const isCloud = isCloudReasoningMode();
-    const reasoningProvider = getSettings().reasoningProvider || "auto";
+    const settings = getSettings();
+    const reasoningProvider = settings.reasoningProvider || "auto";
     const agentName =
       typeof window !== "undefined" && window.localStorage
         ? localStorage.getItem("agentName") || null
@@ -1028,9 +1040,31 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       reasoningModel,
       reasoningProvider,
       agentName,
+      agentEnabled: settings.agentEnabled,
+      useReasoningModel: settings.useReasoningModel,
     });
 
     if (useReasoning) {
+      const decision = shouldProcessTranscription({
+        useReasoningModel: settings.useReasoningModel,
+        agentEnabled: settings.agentEnabled,
+        agentName,
+        transcript: normalizedText,
+      });
+
+      if (decision === "skip") {
+        logger.logReasoning("AGENT_ONLY_NOT_ADDRESSED", {
+          source,
+          reason: "Agent enabled without text cleanup, but transcript does not address agent",
+          agentName,
+        });
+        return normalizedText;
+      }
+
+      if (decision === "agent-only") {
+        logger.logReasoning("AGENT_ONLY_DETECTED", { source, agentName });
+      }
+
       try {
         logger.logReasoning("SENDING_TO_REASONING", {
           preparedTextLength: normalizedText.length,
@@ -1240,7 +1274,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const opts = {};
     if (language) opts.language = language;
     const reasoningMode = settings.cloudReasoningMode || "openwhispr";
-    if (settings.useReasoningModel && !this.skipReasoning && reasoningMode === "openwhispr") {
+    if ((settings.useReasoningModel || settings.agentEnabled) && !this.skipReasoning && reasoningMode === "openwhispr") {
       opts.sendLogs = "false";
     }
 
@@ -1260,15 +1294,27 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     });
     timings.transcriptionProcessingDurationMs = Math.round(performance.now() - transcriptionStart);
 
-    // Process with reasoning if enabled
+    // Process with reasoning if enabled (text cleanup or agent-only)
     const rawText = result.text;
     let processedText = result.text;
-    if (settings.useReasoningModel && processedText && !this.skipReasoning) {
+    if ((settings.useReasoningModel || settings.agentEnabled) && processedText && !this.skipReasoning) {
       const reasoningStart = performance.now();
       const agentName = localStorage.getItem("agentName") || null;
       const cloudReasoningMode = settings.cloudReasoningMode || "openwhispr";
 
-      if (cloudReasoningMode === "openwhispr") {
+      const decision = shouldProcessTranscription({
+        useReasoningModel: settings.useReasoningModel,
+        agentEnabled: settings.agentEnabled,
+        agentName,
+        transcript: processedText,
+      });
+
+      if (decision === "skip") {
+        logger.logReasoning("CLOUD_AGENT_ONLY_NOT_ADDRESSED", {
+          reason: "Agent enabled without text cleanup, but transcript does not address agent",
+          agentName,
+        });
+      } else if (cloudReasoningMode === "openwhispr") {
         const reasonResult = await withSessionRefresh(async () => {
           const res = await window.electronAPI.cloudReason(processedText, {
             agentName,
@@ -2425,74 +2471,88 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const streamingSttWordCount = finalText ? finalText.split(/\s+/).filter(Boolean).length : 0;
 
     let usedCloudReasoning = false;
-    if (stSettings.useReasoningModel && finalText && !this.skipReasoning) {
+    if ((stSettings.useReasoningModel || stSettings.agentEnabled) && finalText && !this.skipReasoning) {
       const reasoningStart = performance.now();
       const agentName = localStorage.getItem("agentName") || null;
       const cloudReasoningMode = stSettings.cloudReasoningMode || "openwhispr";
 
-      try {
-        if (cloudReasoningMode === "openwhispr") {
-          const reasonResult = await withSessionRefresh(async () => {
-            const res = await window.electronAPI.cloudReason(finalText, {
-              agentName,
-              customDictionary: stSettings.customDictionary,
-              customPrompt: this.getCustomPrompt(),
-              language: stSettings.preferredLanguage || "auto",
-              locale: stSettings.uiLanguage || "en",
-              sttProvider: this.getStreamingProviderName(),
-              sttModel: streamingSttModel,
-              sttProcessingMs: streamingSttProcessingMs,
-              sttWordCount: streamingSttWordCount,
-              sttLanguage: streamingSttLanguage,
-              audioDurationMs: durationSeconds ? Math.round(durationSeconds * 1000) : undefined,
-              audioSizeBytes: streamingAudioBytesSent || undefined,
-              audioFormat: "linear16",
+      const decision = shouldProcessTranscription({
+        useReasoningModel: stSettings.useReasoningModel,
+        agentEnabled: stSettings.agentEnabled,
+        agentName,
+        transcript: finalText,
+      });
+
+      if (decision === "skip") {
+        logger.logReasoning("STREAMING_AGENT_ONLY_NOT_ADDRESSED", {
+          reason: "Agent enabled without text cleanup, but transcript does not address agent",
+          agentName,
+        });
+      } else {
+        try {
+          if (cloudReasoningMode === "openwhispr") {
+            const reasonResult = await withSessionRefresh(async () => {
+              const res = await window.electronAPI.cloudReason(finalText, {
+                agentName,
+                customDictionary: stSettings.customDictionary,
+                customPrompt: this.getCustomPrompt(),
+                language: stSettings.preferredLanguage || "auto",
+                locale: stSettings.uiLanguage || "en",
+                sttProvider: this.getStreamingProviderName(),
+                sttModel: streamingSttModel,
+                sttProcessingMs: streamingSttProcessingMs,
+                sttWordCount: streamingSttWordCount,
+                sttLanguage: streamingSttLanguage,
+                audioDurationMs: durationSeconds ? Math.round(durationSeconds * 1000) : undefined,
+                audioSizeBytes: streamingAudioBytesSent || undefined,
+                audioFormat: "linear16",
+              });
+              if (!res.success) {
+                const err = new Error(res.error || "Cloud reasoning failed");
+                err.code = res.code;
+                throw err;
+              }
+              return res;
             });
-            if (!res.success) {
-              const err = new Error(res.error || "Cloud reasoning failed");
-              err.code = res.code;
-              throw err;
-            }
-            return res;
-          });
 
-          if (reasonResult.success && reasonResult.text) {
-            finalText = reasonResult.text;
-          }
-          usedCloudReasoning = true;
-
-          logger.info(
-            "Streaming reasoning complete",
-            {
-              reasoningDurationMs: Math.round(performance.now() - reasoningStart),
-              model: reasonResult.model,
-            },
-            "streaming"
-          );
-        } else {
-          const effectiveModel = getEffectiveReasoningModel();
-          if (effectiveModel) {
-            const result = await this.processWithReasoningModel(
-              finalText,
-              effectiveModel,
-              agentName
-            );
-            if (result) {
-              finalText = result;
+            if (reasonResult.success && reasonResult.text) {
+              finalText = reasonResult.text;
             }
+            usedCloudReasoning = true;
+
             logger.info(
-              "Streaming BYOK reasoning complete",
-              { reasoningDurationMs: Math.round(performance.now() - reasoningStart) },
+              "Streaming reasoning complete",
+              {
+                reasoningDurationMs: Math.round(performance.now() - reasoningStart),
+                model: reasonResult.model,
+              },
               "streaming"
             );
+          } else {
+            const effectiveModel = getEffectiveReasoningModel();
+            if (effectiveModel) {
+              const result = await this.processWithReasoningModel(
+                finalText,
+                effectiveModel,
+                agentName
+              );
+              if (result) {
+                finalText = result;
+              }
+              logger.info(
+                "Streaming BYOK reasoning complete",
+                { reasoningDurationMs: Math.round(performance.now() - reasoningStart) },
+                "streaming"
+              );
+            }
           }
+        } catch (reasonError) {
+          logger.error(
+            "Streaming reasoning failed, using raw text",
+            { error: reasonError.message },
+            "streaming"
+          );
         }
-      } catch (reasonError) {
-        logger.error(
-          "Streaming reasoning failed, using raw text",
-          { error: reasonError.message },
-          "streaming"
-        );
       }
     }
 

--- a/src/helpers/transcriptionDecision.js
+++ b/src/helpers/transcriptionDecision.js
@@ -1,0 +1,29 @@
+import { detectAgentName } from "../utils/agentNameDetection.js";
+
+/**
+ * Decides whether a transcription should be processed through the LLM,
+ * based on the current toggle states and transcript content.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.useReasoningModel - "Text Cleanup" toggle
+ * @param {boolean} opts.agentEnabled      - "AI Agent" toggle
+ * @param {string|null} opts.agentName     - configured agent name (nullable)
+ * @param {string} opts.transcript         - the transcribed text
+ * @returns {"process"|"agent-only"|"skip"}
+ */
+export function shouldProcessTranscription({
+  useReasoningModel,
+  agentEnabled,
+  agentName,
+  transcript,
+}) {
+  // Both off: nothing to do
+  if (!useReasoningModel && !agentEnabled) return "skip";
+
+  // Cleanup on: always process (prompt selection handles agent detection)
+  if (useReasoningModel) return "process";
+
+  // Agent-only (cleanup off, agent on): process only when addressed
+  if (!agentName || !detectAgentName(transcript, agentName)) return "skip";
+  return "agent-only";
+}

--- a/src/utils/agentNameDetection.js
+++ b/src/utils/agentNameDetection.js
@@ -1,0 +1,88 @@
+/**
+ * Agent name detection for transcribed speech.
+ *
+ * Standalone module with zero imports so it can be tested
+ * outside the Vite/Electron bundler context.
+ */
+
+function levenshteinDistance(a, b) {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let curr = new Array(n + 1);
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      curr[j] =
+        a[i - 1] === b[j - 1] ? prev[j - 1] : 1 + Math.min(prev[j - 1], prev[j], curr[j - 1]);
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  return prev[n];
+}
+
+function maxEditsForLength(len) {
+  if (len <= 4) return 0;
+  if (len <= 6) return 1;
+  return 2;
+}
+
+/**
+ * Detects whether the agent's name appears in a transcript, using three
+ * layers: exact word-boundary match, space-normalized match (for STT
+ * splitting compound names), and fuzzy Levenshtein match (for STT
+ * mishearings).
+ *
+ * @param {string} transcript
+ * @param {string} agentName
+ * @returns {boolean}
+ */
+export function detectAgentName(transcript, agentName) {
+  const name = agentName.trim();
+  if (!name || name.length < 2) return false;
+
+  // Layer 1: Exact word-boundary match
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (new RegExp(`\\b${escaped}\\b`, "i").test(transcript)) return true;
+
+  // Layer 2: Space-normalized exact match (STT splitting compound names)
+  const nameLower = name.toLowerCase().replace(/\s+/g, "");
+  const words = transcript
+    .split(/\s+/)
+    .map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase())
+    .filter(Boolean);
+
+  for (let i = 0; i < words.length - 1; i++) {
+    if (words[i] + words[i + 1] === nameLower) return true;
+  }
+
+  // Layer 3: Fuzzy Levenshtein match (STT mishearings)
+  const maxEdits = maxEditsForLength(nameLower.length);
+  if (maxEdits === 0) return false;
+
+  for (const word of words) {
+    if (
+      Math.abs(word.length - nameLower.length) <= maxEdits &&
+      levenshteinDistance(word, nameLower) <= maxEdits
+    ) {
+      return true;
+    }
+  }
+
+  for (let i = 0; i < words.length - 1; i++) {
+    const combined = words[i] + words[i + 1];
+    if (
+      Math.abs(combined.length - nameLower.length) <= maxEdits &&
+      levenshteinDistance(combined, nameLower) <= maxEdits
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/helpers/transcriptionDecision.test.js
+++ b/test/helpers/transcriptionDecision.test.js
@@ -1,0 +1,202 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// --- shouldProcessTranscription ---
+
+test("both toggles off: skip", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: false,
+      agentName: "Jarvis",
+      transcript: "Hey Jarvis, what time is it",
+    }),
+    "skip"
+  );
+});
+
+test("cleanup on, agent off: process all text", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: true,
+      agentEnabled: false,
+      agentName: "Jarvis",
+      transcript: "I need to buy groceries",
+    }),
+    "process"
+  );
+});
+
+test("cleanup on, agent on: process all text (prompt handles agent detection)", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: true,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "I need to buy groceries",
+    }),
+    "process"
+  );
+});
+
+test("cleanup on, agent on, name in transcript: still process (not agent-only)", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: true,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "Hey Jarvis, what time is it",
+    }),
+    "process"
+  );
+});
+
+test("agent on, cleanup off, name detected: agent-only", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "Hey Jarvis, what time is it",
+    }),
+    "agent-only"
+  );
+});
+
+test("agent on, cleanup off, name absent: skip", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "I need to buy groceries",
+    }),
+    "skip"
+  );
+});
+
+test("agent on, cleanup off, agentName null: skip", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: null,
+      transcript: "Hey Jarvis, do something",
+    }),
+    "skip"
+  );
+});
+
+test("agent on, cleanup off, agentName empty string: skip", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "",
+      transcript: "Hey Jarvis, do something",
+    }),
+    "skip"
+  );
+});
+
+test("agent on, cleanup off, single-char agentName: skip (too short for detection)", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "J",
+      transcript: "Hey J, do something",
+    }),
+    "skip"
+  );
+});
+
+test("agent on, cleanup off, fuzzy match within Levenshtein distance: agent-only", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  // "Jarvis" (6 chars) allows maxEdits=1, so "Jarvs" should match
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "Hey Jarvs, set a timer",
+    }),
+    "agent-only"
+  );
+});
+
+test("agent on, cleanup off, case-insensitive exact match: agent-only", async () => {
+  const { shouldProcessTranscription } = await import(
+    "../../src/helpers/transcriptionDecision.js"
+  );
+  assert.equal(
+    shouldProcessTranscription({
+      useReasoningModel: false,
+      agentEnabled: true,
+      agentName: "Jarvis",
+      transcript: "hey jarvis, tell me a joke",
+    }),
+    "agent-only"
+  );
+});
+
+// --- detectAgentName edge cases ---
+
+test("detectAgentName: compound name split by STT", async () => {
+  const { detectAgentName } = await import("../../src/utils/agentNameDetection.js");
+  // STT splits "SkyNet" into "sky net"
+  assert.equal(detectAgentName("hey sky net do something", "SkyNet"), true);
+});
+
+test("detectAgentName: name shorter than 2 chars returns false", async () => {
+  const { detectAgentName } = await import("../../src/utils/agentNameDetection.js");
+  assert.equal(detectAgentName("hey A do something", "A"), false);
+});
+
+test("detectAgentName: empty transcript returns false", async () => {
+  const { detectAgentName } = await import("../../src/utils/agentNameDetection.js");
+  assert.equal(detectAgentName("", "Jarvis"), false);
+});
+
+test("detectAgentName: short name (4 chars) requires exact match, no fuzzy", async () => {
+  const { detectAgentName } = await import("../../src/utils/agentNameDetection.js");
+  // "Nova" (4 chars) → maxEdits=0, so "Nava" should NOT match
+  assert.equal(detectAgentName("hey Nava, do something", "Nova"), false);
+});
+
+test("detectAgentName: name with special regex chars does not crash", async () => {
+  const { detectAgentName } = await import("../../src/utils/agentNameDetection.js");
+  // Agent named "C++" shouldn't throw from unescaped regex.
+  // Won't match because \b word boundaries don't fire around non-word chars,
+  // but the important thing is no exception from the unescaped regex.
+  assert.doesNotThrow(() => detectAgentName("tell C++ to compile", "C++"));
+});


### PR DESCRIPTION
## Summary

The agent toggle had no effect unless text cleanup was also on. All three transcription paths checked only the cleanup flag before calling the LLM, so the agent never fired on its own. Now the two settings work independently. With cleanup off and agent on, text goes to the LLM only when the transcript contains the agent's name.

Fixes #644

## Changes

- `src/utils/agentNameDetection.js` -- pulled `detectAgentName` and its helpers out of `prompts.ts` into a zero-import module that runs in plain Node without the Vite/Electron bundle
- `src/config/prompts.ts` -- re-exports from the new module, no change for existing callers
- `src/helpers/transcriptionDecision.js` -- pure function that takes the two toggle states and the transcript, returns `"process"`, `"agent-only"`, or `"skip"`
- `src/helpers/audioManager.js` -- `isReasoningAvailable()` checks both toggles; local, cloud, and streaming paths call `shouldProcessTranscription()` instead of inline conditionals
- `test/helpers/transcriptionDecision.test.js` -- 16 tests covering every toggle combo plus edge cases (null/empty/short names, fuzzy matching, STT name splitting, regex-special characters)