### PR TITLE
Fix adding non-ASCII languages to dictionary

### DIFF
--- a/src/utils/correctionLearner.js
+++ b/src/utils/correctionLearner.js
@@ -28,7 +28,7 @@ function editDistance(a, b) {
 function tokenize(text) {
   return text
     .split(/\s+/)
-    .map((w) => w.replace(/^[^\w]+|[^\w]+$/g, ""))
+    .map((w) => w.replace(/^[^\p{L}\p{N}_]+|[^\p{L}\p{N}_]+$/gu, ""))
     .filter((w) => w.length > 0);
 }
 


### PR DESCRIPTION
## What

One-line change in `src/utils/correctionLearner.js`. The tokenizer used in auto-learn now treats every Unicode letter and digit as a word character, so edits to Russian/Chinese/Arabic/etc. transcriptions actually produce correction candidates instead of silently dropping them.

## Why

`tokenize()` strips leading/trailing non-word characters via `/^[^\w]+|[^\w]+$/g`. In JavaScript, without the `/u` flag, `\w` is `[A-Za-z0-9_]`. On a word like `продиктовано`, every character hits `[^\w]`, both anchors fire, and the whole string is replaced with `""`. The `.filter(w => w.length > 0)` then drops it. `findSubstitutions` receives empty arrays and `extractCorrections` returns `[]`.

Net effect: `custom_dictionary` never accumulated entries from non-ASCII languages. Observed live on Russian dictation — edits were visible in renderer logs but `[AutoLearn] Corrections result` had `corrections: []` every time. English worked fine and acted as a control.

## Fix

```diff
 function tokenize(text) {
   return text
     .split(/\s+/)
-    .map((w) => w.replace(/^[^\w]+|[^\w]+$/g, ""))
+    .map((w) => w.replace(/^[^\p{L}\p{N}_]+|[^\p{L}\p{N}_]+$/gu, ""))
     .filter((w) => w.length > 0);
 }
```

`\p{L}` matches any Unicode letter, `\p{N}` any digit. `_` is preserved to keep behavior aligned with the original `\w`. The `/u` flag is required for Unicode property escapes. Node 18+ and Electron's V8 support this natively.

## Before / after

```js
tokenize("Голосовой ввод в поле. Это сообщение было продиктовано.")
// before: []  (all Cyrillic words dropped)
// after:  ["Голосовой","ввод","в","поле","Это","сообщение","было","продиктовано"]

extractCorrections(
  "Голосовой ввод в поле. Это сообщение было продиктовано.",
  "Голосовой ввод в поле. Это сообщение было продиктован.",
  []
)
// before: []
// after:  ["продиктован"]

extractCorrections(
  "learning from english correction is not broken",
  "learning from english correction is not broke",
  []
)
// before: ["broke"]
// after:  ["broke"]   (English unchanged)
```

## Scope

Affects every non-ASCII language (Russian, Ukrainian, Bulgarian, Greek, Arabic, Hebrew, Chinese, Japanese, Korean, Thai, Vietnamese, etc.). Platform-agnostic — same JS runs on macOS, Windows, Linux.

## Testing

Manual end-to-end on Windows x64:

- Dictate Russian into a text field, edit one word, observe `[AutoLearn] Corrections result { corrections: ["<word>"], dictSize: N }` in `debug-*.log` (previously always `corrections: []` for Russian)
- Confirm row appears in `custom_dictionary` SQLite table
- English dictation still produces the same results as before

## Risk

Minimal — the only new behavior is that previously-dropped non-ASCII tokens now survive tokenization. Downstream logic already handles arbitrary strings (lowercasing via `String.prototype.toLowerCase`, Levenshtein over JS strings, etc.). No schema or API changes.