### PR TITLE
fix(notes): update folder selection when moving notes between folders

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -61,6 +61,7 @@ import {
   initializeNotes,
   setActiveNoteId,
   setActiveFolderId,
+  removeNote,
 } from "../../stores/noteStore";
 import { useMeetingTranscription } from "../../hooks/useMeetingTranscription";
 import { useNotesOnboarding } from "../../hooks/useNotesOnboarding";
@@ -407,11 +408,15 @@ export default function PersonalNotesView({
   const handleMoveToFolder = useCallback(
     async (noteId: number, folderId: number) => {
       await window.electronAPI.updateNote(noteId, { folder_id: folderId });
-      // Don't re-filter notes — the IPC onNoteUpdated listener updates the note
-      // in the store, and we stay on the current note. Folder counts refresh below.
+      if (noteId === activeNoteId) {
+        // Follow the moved note — switching active folder re-loads notes and preserves activeNoteId.
+        setActiveFolderId(folderId);
+      } else {
+        removeNote(noteId);
+      }
       loadFolders();
     },
-    [loadFolders]
+    [activeNoteId, loadFolders]
   );
 
   const { dragState, noteDragHandlers, folderDropHandlers } = useNoteDragAndDrop({

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -409,7 +409,6 @@ export default function PersonalNotesView({
     async (noteId: number, folderId: number) => {
       await window.electronAPI.updateNote(noteId, { folder_id: folderId });
       if (noteId === activeNoteId) {
-        // Follow the moved note — switching active folder re-loads notes and preserves activeNoteId.
         setActiveFolderId(folderId);
       } else {
         removeNote(noteId);


### PR DESCRIPTION
## Summary
- Fix bug where drag-and-dropping a note into a different folder didn't update the sidebar selection — previously required a page refresh.
- If the moved note is the active note, `activeFolderId` now follows it (the folder-change effect in `useFolderManagement` re-loads notes and preserves `activeNoteId`, so the editor stays on the same note while the sidebar selection moves to the destination folder).
- Otherwise, the note is removed from the current folder's list since it no longer belongs there.
- Same logic applies uniformly to all three move paths: drag-drop, the editor metadata-row folder picker, and the list-item context menu.

## Test plan
- [ ] Drag a note (the currently active one) into a different folder → editor stays on the note, sidebar selection moves to the destination folder.
- [ ] Drag a non-active note into a different folder → it disappears from the current folder's list; sidebar stays on current folder.
- [ ] Move the active note via the metadata-row folder picker → editor stays on note, sidebar follows.
- [ ] Move a note via the list-item context menu → behaves per the two cases above.
- [ ] Folder counts in the sidebar refresh after each move.