### PR TITLE
fix(macos): cancel Fn push-to-talk on intervening keypress

### DIFF
--- a/main.js
+++ b/main.js
@@ -893,6 +893,28 @@ async function startApp() {
       windowManager.handleMacPushModifierUp("fn");
     });
 
+    globeKeyManager.on("globe-interrupted", () => {
+      const currentHotkey = hotkeyManager.getCurrentHotkey && hotkeyManager.getCurrentHotkey();
+      if (!isGlobeLikeHotkey(currentHotkey)) return;
+      if (!isLiveWindow(windowManager.mainWindow)) return;
+      if (windowManager.getActivationMode() !== "push") return;
+
+      debugLogger?.debug("[Globe] globe-interrupted received", {
+        wasRecording: globeKeyIsRecording,
+        hadPendingStart: globeKeyDownTime !== 0,
+      });
+
+      // Cancel any pending deferred recording start (within MIN_HOLD_DURATION_MS).
+      globeKeyDownTime = 0;
+
+      if (globeKeyIsRecording) {
+        globeKeyIsRecording = false;
+        // Engage cooldown so the next Fn press isn't treated as a re-trigger.
+        globeLastStopTime = Date.now();
+        windowManager.mainWindow.webContents.send("cancel-hotkey-pressed");
+      }
+    });
+
     globeKeyManager.on("modifier-up", (modifier) => {
       if (windowManager?.handleMacPushModifierUp) {
         windowManager.handleMacPushModifierUp(modifier);

--- a/main.js
+++ b/main.js
@@ -24,6 +24,7 @@ const {
   dialog,
   ipcMain,
   session,
+  shell,
   systemPreferences,
 } = require("electron");
 const path = require("path");
@@ -811,8 +812,21 @@ async function startApp() {
     let globeKeyDownTime = 0;
     let globeKeyIsRecording = false;
     let globeLastStopTime = 0;
-    const MIN_HOLD_DURATION_MS = 150;
+    let pushHoldDurationMs = environmentManager.getPushHoldDurationMs();
+    let inputMonitoringGranted = false;
+    let inputMonitoringResetNoticeSent = false;
+    ipcMain.handle("get-input-monitoring-status", () => inputMonitoringGranted);
     const POST_STOP_COOLDOWN_MS = 300;
+    const PUSH_HOLD_MIN_MS = 100;
+    const PUSH_HOLD_MAX_MS = 1500;
+
+    ipcMain.on("push-hold-duration-changed", (_event, value) => {
+      const num = Number(value);
+      if (!Number.isFinite(num)) return;
+      const clamped = Math.max(PUSH_HOLD_MIN_MS, Math.min(PUSH_HOLD_MAX_MS, Math.round(num)));
+      pushHoldDurationMs = clamped;
+      environmentManager.savePushHoldDurationMs(clamped);
+    });
 
     globeKeyManager.on("globe-down", async () => {
       const currentHotkey = hotkeyManager.getCurrentHotkey && hotkeyManager.getCurrentHotkey();
@@ -850,7 +864,7 @@ async function startApp() {
                 debugLogger?.debug("[Globe] Starting dictation (push hold)");
                 windowManager.sendStartDictation();
               }
-            }, MIN_HOLD_DURATION_MS);
+            }, pushHoldDurationMs);
           } else {
             windowManager.sendToggleDictation();
           }
@@ -893,6 +907,50 @@ async function startApp() {
       windowManager.handleMacPushModifierUp("fn");
     });
 
+    globeKeyManager.on("input-monitoring-status", (granted) => {
+      inputMonitoringGranted = !!granted;
+      const previouslyGranted = environmentManager.getLastInputMonitoringGranted();
+      environmentManager.saveLastInputMonitoringGranted(inputMonitoringGranted);
+
+      // Notify renderer of current state
+      const wins = [windowManager?.mainWindow, windowManager?.controlPanelWindow];
+      for (const w of wins) {
+        if (isLiveWindow(w) && w.webContents && !w.webContents.isDestroyed()) {
+          w.webContents.send("input-monitoring-status-changed", inputMonitoringGranted);
+        }
+      }
+
+      // If permission was previously granted but is now denied (e.g. after an
+      // app update reset TCC), show a one-shot non-blocking native dialog.
+      if (
+        !inputMonitoringResetNoticeSent &&
+        previouslyGranted === true &&
+        inputMonitoringGranted === false
+      ) {
+        inputMonitoringResetNoticeSent = true;
+        dialog
+          .showMessageBox({
+            type: "info",
+            title: "Input Monitoring permission reset",
+            message: "Input Monitoring permission for OpenWhispr was reset.",
+            detail:
+              "This permission is optional — only needed when using the Globe key with Hold-to-Talk to cancel recording on other key presses. Re-grant it in System Settings if you want this behavior.",
+            buttons: ["Open Settings", "Not Now"],
+            defaultId: 0,
+            cancelId: 1,
+            noLink: true,
+          })
+          .then((result) => {
+            if (result.response === 0) {
+              shell.openExternal(
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+              );
+            }
+          })
+          .catch(() => {});
+      }
+    });
+
     globeKeyManager.on("globe-interrupted", () => {
       const currentHotkey = hotkeyManager.getCurrentHotkey && hotkeyManager.getCurrentHotkey();
       if (!isGlobeLikeHotkey(currentHotkey)) return;
@@ -904,7 +962,6 @@ async function startApp() {
         hadPendingStart: globeKeyDownTime !== 0,
       });
 
-      // Cancel any pending deferred recording start (within MIN_HOLD_DURATION_MS).
       globeKeyDownTime = 0;
 
       if (globeKeyIsRecording) {
@@ -952,7 +1009,7 @@ async function startApp() {
             rightModIsRecording = true;
             windowManager.sendStartDictation();
           }
-        }, MIN_HOLD_DURATION_MS);
+        }, pushHoldDurationMs);
       } else {
         windowManager.sendToggleDictation();
       }

--- a/main.js
+++ b/main.js
@@ -968,7 +968,12 @@ async function startApp() {
         globeKeyIsRecording = false;
         // Engage cooldown so the next Fn press isn't treated as a re-trigger.
         globeLastStopTime = Date.now();
-        windowManager.mainWindow.webContents.send("cancel-hotkey-pressed");
+        // Cancels in the renderer and resets meeting-detection state.
+        windowManager.sendCancelDictation();
+      } else {
+        // Pre-threshold: recording never started, but the panel was already
+        // shown on globe-down — hide it so it doesn't linger.
+        windowManager.hideDictationPanel();
       }
     });
 

--- a/preload.js
+++ b/preload.js
@@ -457,6 +457,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
   openMicrophoneSettings: () => ipcRenderer.invoke("open-microphone-settings"),
   openSoundInputSettings: () => ipcRenderer.invoke("open-sound-input-settings"),
   openAccessibilitySettings: () => ipcRenderer.invoke("open-accessibility-settings"),
+  openInputMonitoringSettings: () => ipcRenderer.invoke("open-input-monitoring-settings"),
+  getInputMonitoringStatus: () => ipcRenderer.invoke("get-input-monitoring-status"),
+  onInputMonitoringStatusChanged: (cb) => {
+    const handler = (_event, granted) => cb(granted);
+    ipcRenderer.on("input-monitoring-status-changed", handler);
+    return () => ipcRenderer.removeListener("input-monitoring-status-changed", handler);
+  },
+  onInputMonitoringPermissionReset: (cb) => {
+    const handler = () => cb();
+    ipcRenderer.on("input-monitoring-permission-reset", handler);
+    return () => ipcRenderer.removeListener("input-monitoring-permission-reset", handler);
+  },
   openSystemAudioSettings: () => ipcRenderer.invoke("open-system-audio-settings"),
   toggleMediaPlayback: () => ipcRenderer.invoke("toggle-media-playback"),
   pauseMediaPlayback: () => ipcRenderer.invoke("pause-media-playback"),
@@ -648,6 +660,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   notifyActivationModeChanged: (mode) => ipcRenderer.send("activation-mode-changed", mode),
   notifyHotkeyChanged: (hotkey) => ipcRenderer.send("hotkey-changed", hotkey),
   registerMeetingHotkey: (hotkey) => ipcRenderer.invoke("register-meeting-hotkey", hotkey),
+
+  // Push-to-talk hold duration (ms before recording starts)
+  notifyPushHoldDurationChanged: (value) =>
+    ipcRenderer.send("push-hold-duration-changed", value),
 
   // Floating icon auto-hide
   notifyFloatingIconAutoHideChanged: (enabled) =>

--- a/resources/macos-globe-listener.swift
+++ b/resources/macos-globe-listener.swift
@@ -1,5 +1,7 @@
 import Cocoa
+import CoreGraphics
 import Darwin
+import IOKit.hid
 
 var fnIsDown = false
 var fnInterruptedThisCycle = false
@@ -63,22 +65,76 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
     exit(1)
 }
 
-let keyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown, handler: { _ in
+// Proactively request Input Monitoring permission so the user sees the TCC
+// prompt (or the app appears in System Settings → Privacy & Security → Input
+// Monitoring) instead of the listener silently no-op'ing.
+_ = IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+
+// CGEventTap delivers global keyDown reliably (NSEvent global keyDown monitor
+// is gated by Input Monitoring TCC and silently no-ops without it).
+let keyDownTapCallback: CGEventTapCallBack = { _, _, event, _ in
     if fnIsDown && !fnInterruptedThisCycle {
         fnInterruptedThisCycle = true
         emit("FN_INTERRUPTED")
     }
-})
-if keyDownMonitor == nil {
-    FileHandle.standardError.write("Failed to create keyDown monitor — Fn interrupt detection disabled\n".data(using: .utf8)!)
+    return Unmanaged.passUnretained(event)
 }
+
+let keyDownEventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
+
+var keyDownTapRef: CFMachPort? = nil
+var keyDownRunLoopSource: CFRunLoopSource? = nil
+var inputMonitoringGranted = false
+
+func tryAttachKeyDownTap() -> Bool {
+    let tap = CGEvent.tapCreate(
+        tap: .cghidEventTap,
+        place: .headInsertEventTap,
+        options: .listenOnly,
+        eventsOfInterest: keyDownEventMask,
+        callback: keyDownTapCallback,
+        userInfo: nil
+    )
+    guard let tap = tap else { return false }
+    let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+    if let source = source {
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        keyDownTapRef = tap
+        keyDownRunLoopSource = source
+        return true
+    }
+    return false
+}
+
+if tryAttachKeyDownTap() {
+    inputMonitoringGranted = true
+    emit("INPUT_MONITORING:granted")
+} else {
+    FileHandle.standardError.write("Failed to create keyDown event tap — Fn interrupt detection disabled (grant Input Monitoring permission)\n".data(using: .utf8)!)
+    emit("INPUT_MONITORING:denied")
+}
+
+// Re-probe periodically so a newly-granted permission is picked up without
+// requiring an app restart. Stops probing once granted.
+let probeTimer = Timer(timeInterval: 3.0, repeats: true) { _ in
+    if inputMonitoringGranted { return }
+    if tryAttachKeyDownTap() {
+        inputMonitoringGranted = true
+        emit("INPUT_MONITORING:granted")
+    }
+}
+RunLoop.main.add(probeTimer, forMode: .common)
 
 let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
 signal(SIGTERM, SIG_IGN)
 signalSource.setEventHandler {
     NSEvent.removeMonitor(monitor)
-    if let keyMonitor = keyDownMonitor {
-        NSEvent.removeMonitor(keyMonitor)
+    if let tap = keyDownTapRef {
+        CGEvent.tapEnable(tap: tap, enable: false)
+    }
+    if let source = keyDownRunLoopSource {
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
     }
     exit(0)
 }

--- a/resources/macos-globe-listener.swift
+++ b/resources/macos-globe-listener.swift
@@ -2,6 +2,7 @@ import Cocoa
 import Darwin
 
 var fnIsDown = false
+var fnInterruptedThisCycle = false
 var lastModifierFlags: NSEvent.ModifierFlags = []
 
 let rightModifiers: [(UInt16, NSEvent.ModifierFlags, String)] = [
@@ -31,9 +32,11 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
 
     if containsFn && !fnIsDown {
         fnIsDown = true
+        fnInterruptedThisCycle = false
         emit("FN_DOWN")
     } else if !containsFn && fnIsDown {
         fnIsDown = false
+        fnInterruptedThisCycle = false
         emit("FN_UP")
     }
 
@@ -60,10 +63,23 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
     exit(1)
 }
 
+let keyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown, handler: { _ in
+    if fnIsDown && !fnInterruptedThisCycle {
+        fnInterruptedThisCycle = true
+        emit("FN_INTERRUPTED")
+    }
+})
+if keyDownMonitor == nil {
+    FileHandle.standardError.write("Failed to create keyDown monitor — Fn interrupt detection disabled\n".data(using: .utf8)!)
+}
+
 let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
 signal(SIGTERM, SIG_IGN)
 signalSource.setEventHandler {
     NSEvent.removeMonitor(monitor)
+    if let keyMonitor = keyDownMonitor {
+        NSEvent.removeMonitor(keyMonitor)
+    }
     exit(0)
 }
 signalSource.resume()

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -7,6 +7,9 @@ import {
   RefreshCw,
   Download,
   Mic,
+  Keyboard,
+  Minus,
+  Plus,
   Shield,
   FolderOpen,
   LogOut,
@@ -71,7 +74,7 @@ import { useHotkeyRegistration } from "../hooks/useHotkeyRegistration";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { validateHotkeyForSlot } from "../utils/hotkeyValidation";
 import { getPlatform, getCachedPlatform } from "../utils/platform";
-import { formatHotkeyLabel } from "../utils/hotkeys";
+import { formatHotkeyLabel, isGlobeLikeHotkey } from "../utils/hotkeys";
 import { ActivationModeSelector } from "./ui/ActivationModeSelector";
 import LinuxPttSetupInfo from "./ui/LinuxPttSetupInfo";
 import { Toggle } from "./ui/toggle";
@@ -792,6 +795,8 @@ export default function SettingsPage({
     dictationKey,
     activationMode,
     setActivationMode,
+    pushHoldDurationMs,
+    setPushHoldDurationMs,
     preferBuiltInMic,
     selectedMicDeviceId,
     setPreferBuiltInMic,
@@ -906,6 +911,17 @@ export default function SettingsPage({
   const { checkWhisperInstallation } = useWhisper();
   const permissionsHook = usePermissions(showAlertDialog);
   const systemAudio = useSystemAudioPermission();
+  const [inputMonitoringGranted, setInputMonitoringGranted] = useState(false);
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    window.electronAPI?.getInputMonitoringStatus?.().then((granted) => {
+      setInputMonitoringGranted(!!granted);
+    });
+    unsubscribe = window.electronAPI?.onInputMonitoringStatusChanged?.((granted) => {
+      setInputMonitoringGranted(!!granted);
+    });
+    return () => unsubscribe?.();
+  }, []);
   useClipboard(showAlertDialog);
   const { agentName, setAgentName } = useAgentName();
   const [agentNameInput, setAgentNameInput] = useState(agentName);
@@ -3123,6 +3139,74 @@ EOF`,
                     {getCachedPlatform() === "linux" && activationMode === "push" && (
                       <LinuxPttSetupInfo isAvailable={linuxPttAvailable} />
                     )}
+                    {getCachedPlatform() === "darwin" &&
+                      activationMode === "push" &&
+                      isGlobeLikeHotkey(dictationKey) &&
+                      !inputMonitoringGranted && (
+                        <div className="mt-3 rounded-md border border-warning/30 bg-warning/5 p-2.5 text-xs">
+                          <p className="font-medium text-foreground/90">
+                            {t("settingsPage.general.hotkey.inputMonitoringHint", {
+                              defaultValue:
+                                "Grant Input Monitoring (optional) to cancel recording when you press another key while holding Globe.",
+                            })}
+                          </p>
+                          <button
+                            type="button"
+                            onClick={async () => {
+                              await window.electronAPI?.openInputMonitoringSettings?.();
+                            }}
+                            className="mt-1.5 text-[11px] font-medium text-primary hover:underline"
+                          >
+                            {t("settingsPage.permissions.openSettings", {
+                              defaultValue: "Open Settings",
+                            })}
+                          </button>
+                        </div>
+                      )}
+                    {activationMode === "push" && (
+                      <div className="mt-3 flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="text-xs font-medium text-foreground/80">
+                            {t("settingsPage.general.hotkey.pushHoldDuration", {
+                              defaultValue: "Hold duration before recording",
+                            })}
+                          </p>
+                          <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                            {t("settingsPage.general.hotkey.pushHoldDurationHint", {
+                              defaultValue:
+                                "How long to hold the hotkey before recording starts. Higher values reduce accidental recordings when using the key for other shortcuts.",
+                            })}
+                          </p>
+                        </div>
+                        <div className="shrink-0 flex items-center gap-1">
+                          <button
+                            type="button"
+                            aria-label="Decrease"
+                            onClick={() => setPushHoldDurationMs(pushHoldDurationMs - 50)}
+                            disabled={pushHoldDurationMs <= 100}
+                            className="h-7 w-7 inline-flex items-center justify-center rounded border border-border/70 bg-surface-1/80 text-foreground shadow-sm backdrop-blur-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200"
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <div
+                            className="h-7 min-w-[3.5rem] inline-flex items-center justify-center rounded border border-border/70 bg-surface-1/60 px-2 text-xs font-medium text-foreground tabular-nums select-none"
+                            aria-live="polite"
+                          >
+                            {pushHoldDurationMs}
+                          </div>
+                          <button
+                            type="button"
+                            aria-label="Increase"
+                            onClick={() => setPushHoldDurationMs(pushHoldDurationMs + 50)}
+                            disabled={pushHoldDurationMs >= 1500}
+                            className="h-7 w-7 inline-flex items-center justify-center rounded border border-border/70 bg-surface-1/80 text-foreground shadow-sm backdrop-blur-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200"
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                          <span className="ml-1 text-[11px] text-muted-foreground/70">ms</span>
+                        </div>
+                      </div>
+                    )}
                   </SettingsPanelRow>
                 )}
               </SettingsPanel>
@@ -3582,6 +3666,26 @@ EOF`,
                         granted={permissionsHook.accessibilityPermissionGranted}
                         onRequest={permissionsHook.requestAccessibilityPermission}
                         buttonText={t("settingsPage.permissions.grantAccess")}
+                      />
+                    )}
+                    {platform === "darwin" && (
+                      <PermissionCard
+                        icon={Keyboard}
+                        title={t("settingsPage.permissions.inputMonitoringTitle", {
+                          defaultValue: "Input Monitoring",
+                        })}
+                        description={t("settingsPage.permissions.inputMonitoringDescription", {
+                          defaultValue:
+                            "Optional. Needed only when using the Globe key with Hold-to-Talk to cancel recording on other key presses.",
+                        })}
+                        granted={inputMonitoringGranted}
+                        onRequest={async () => {
+                          await window.electronAPI?.openInputMonitoringSettings?.();
+                        }}
+                        buttonText={t("settingsPage.permissions.openSettings", {
+                          defaultValue: "Open Settings",
+                        })}
+                        badge={t("settingsPage.permissions.optional")}
                       />
                     )}
                     {canManageSystemAudioInApp(systemAudio) && (

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -44,6 +44,8 @@ const PERSISTED_KEYS = [
   "VERTEX_PROJECT",
   "VERTEX_LOCATION",
   "VERTEX_API_KEY",
+  "PUSH_HOLD_DURATION_MS",
+  "LAST_INPUT_MONITORING_GRANTED",
 ];
 
 class EnvironmentManager {
@@ -274,6 +276,32 @@ class EnvironmentManager {
   saveActivationMode(mode) {
     const validMode = mode === "push" ? "push" : "tap";
     const result = this._saveKey("ACTIVATION_MODE", validMode);
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getLastInputMonitoringGranted() {
+    const v = this._getKey("LAST_INPUT_MONITORING_GRANTED");
+    if (v === "true") return true;
+    if (v === "false") return false;
+    return null;
+  }
+
+  saveLastInputMonitoringGranted(granted) {
+    const result = this._saveKey("LAST_INPUT_MONITORING_GRANTED", String(!!granted));
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getPushHoldDurationMs() {
+    const raw = this._getKey("PUSH_HOLD_DURATION_MS");
+    const parsed = parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) return 150;
+    return Math.max(100, Math.min(1500, parsed));
+  }
+
+  savePushHoldDurationMs(ms) {
+    const result = this._saveKey("PUSH_HOLD_DURATION_MS", String(ms));
     this.saveAllKeysToEnvFile().catch(() => {});
     return result;
   }

--- a/src/helpers/globeKeyManager.js
+++ b/src/helpers/globeKeyManager.js
@@ -102,6 +102,10 @@ class GlobeKeyManager extends EventEmitter {
             this.emit("globe-up");
           } else if (line === "FN_INTERRUPTED") {
             this.emit("globe-interrupted");
+          } else if (line === "INPUT_MONITORING:granted") {
+            this.emit("input-monitoring-status", true);
+          } else if (line === "INPUT_MONITORING:denied") {
+            this.emit("input-monitoring-status", false);
           } else if (line.startsWith("RIGHT_MOD_DOWN:")) {
             const modifier = line.replace("RIGHT_MOD_DOWN:", "").trim();
             if (modifier) {

--- a/src/helpers/globeKeyManager.js
+++ b/src/helpers/globeKeyManager.js
@@ -100,6 +100,8 @@ class GlobeKeyManager extends EventEmitter {
             this.emit("globe-down");
           } else if (line === "FN_UP") {
             this.emit("globe-up");
+          } else if (line === "FN_INTERRUPTED") {
+            this.emit("globe-interrupted");
           } else if (line.startsWith("RIGHT_MOD_DOWN:")) {
             const modifier = line.replace("RIGHT_MOD_DOWN:", "").trim();
             if (modifier) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3025,6 +3025,8 @@ class IPCHandlers {
           "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
         systemAudio:
           "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+        inputMonitoring:
+          "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
       },
       win32: {
         microphone: "ms-settings:privacy-microphone",
@@ -3065,6 +3067,9 @@ class IPCHandlers {
     ipcMain.handle("open-sound-input-settings", () => openSystemSettings("sound"));
     ipcMain.handle("open-accessibility-settings", () => openSystemSettings("accessibility"));
     ipcMain.handle("open-system-audio-settings", () => openSystemSettings("systemAudio"));
+    ipcMain.handle("open-input-monitoring-settings", () =>
+      openSystemSettings("inputMonitoring")
+    );
 
     ipcMain.handle("toggle-media-playback", () => {
       const mediaPlayer = require("./mediaPlayer");

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -467,6 +467,17 @@ class WindowManager {
     }
   }
 
+  sendCancelDictation() {
+    if (this.hotkeyManager.isInListeningMode()) {
+      return;
+    }
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send("cancel-hotkey-pressed");
+      this._isDictatingToggle = false;
+      this.meetingDetectionEngine?.setUserRecording(false);
+    }
+  }
+
   getActivationMode() {
     return this._cachedActivationMode;
   }

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import AudioManager from "../helpers/audioManager";
 import logger from "../utils/logger";
-import { playStartCue, playStopCue } from "../utils/dictationCues";
+import { playStartCue, playStopCue, playCancelCue } from "../utils/dictationCues";
 import { getSettings } from "../stores/settingsStore";
 import { getRecordingErrorTitle } from "../utils/recordingErrors";
 import { isAccessibilitySkipped } from "../utils/permissions";
@@ -254,6 +254,7 @@ export const useAudioRecording = (toast, options = {}) => {
 
   const cancelRecording = useCallback(async () => {
     if (audioManagerRef.current) {
+      void playCancelCue();
       window.electronAPI?.unregisterCancelHotkey?.();
       const state = audioManagerRef.current.getState();
       if (getSettings().pauseMediaOnDictation) {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -41,6 +41,7 @@ export interface HotkeySettings {
   dictationKey: string;
   meetingKey: string;
   activationMode: "tap" | "push";
+  pushHoldDurationMs: number;
 }
 
 export interface MicrophoneSettings {
@@ -247,6 +248,8 @@ function useSettingsInternal() {
     setTheme: store.setTheme,
     activationMode: store.activationMode,
     setActivationMode: store.setActivationMode,
+    pushHoldDurationMs: store.pushHoldDurationMs,
+    setPushHoldDurationMs: store.setPushHoldDurationMs,
     audioCuesEnabled: store.audioCuesEnabled,
     setAudioCuesEnabled: store.setAudioCuesEnabled,
     pauseMediaOnDictation: store.pauseMediaOnDictation,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1356,6 +1356,8 @@
       },
       "hotkey": {
         "activationMode": "Activation Mode",
+        "pushHoldDuration": "Hold duration before recording",
+        "pushHoldDurationHint": "How long to hold the hotkey before recording starts. Higher values reduce accidental recordings when using the key for other shortcuts.",
         "description": "The key combination that starts and stops voice dictation",
         "resetToDefault": "Reset to {{hotkey}}",
         "title": "Dictation Hotkey",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -121,7 +121,7 @@ const BOOLEAN_SETTINGS = new Set([
 
 const ARRAY_SETTINGS = new Set(["customDictionary", "gcalAccounts"]);
 
-const NUMERIC_SETTINGS = new Set(["audioRetentionDays"]);
+const NUMERIC_SETTINGS = new Set(["audioRetentionDays", "pushHoldDurationMs"]);
 
 const LANGUAGE_MIGRATIONS: Record<string, string> = { zh: "zh-CN" };
 
@@ -234,6 +234,7 @@ export interface SettingsState
   isSignedIn: boolean;
   audioCuesEnabled: boolean;
   pauseMediaOnDictation: boolean;
+  pushHoldDurationMs: number;
   floatingIconAutoHide: boolean;
   startMinimized: boolean;
   gcalAccounts: GoogleCalendarAccount[];
@@ -376,6 +377,7 @@ export interface SettingsState
   setDataRetentionEnabled: (value: boolean) => void;
   setAudioCuesEnabled: (value: boolean) => void;
   setPauseMediaOnDictation: (value: boolean) => void;
+  setPushHoldDurationMs: (ms: number) => void;
   setFloatingIconAutoHide: (enabled: boolean) => void;
   setStartMinimized: (enabled: boolean) => void;
   setGcalAccounts: (accounts: GoogleCalendarAccount[]) => void;
@@ -513,6 +515,14 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   activationMode: (readString("activationMode", "tap") === "push" ? "push" : "tap") as
     | "tap"
     | "push",
+  pushHoldDurationMs: (() => {
+    if (!isBrowser) return 150;
+    const stored = localStorage.getItem("pushHoldDurationMs");
+    if (stored === null) return 150;
+    const parsed = parseInt(stored, 10);
+    if (!Number.isFinite(parsed)) return 150;
+    return Math.max(100, Math.min(1500, parsed));
+  })(),
 
   preferBuiltInMic: readBoolean("preferBuiltInMic", true),
   selectedMicDeviceId: readString("selectedMicDeviceId", ""),
@@ -928,6 +938,16 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
   setAudioCuesEnabled: createBooleanSetter("audioCuesEnabled"),
   setPauseMediaOnDictation: createBooleanSetter("pauseMediaOnDictation"),
+
+  setPushHoldDurationMs: (ms: number) => {
+    const clamped = Math.max(100, Math.min(1500, Math.round(ms)));
+    if (get().pushHoldDurationMs === clamped) return;
+    if (isBrowser) localStorage.setItem("pushHoldDurationMs", String(clamped));
+    set({ pushHoldDurationMs: clamped });
+    if (isBrowser) {
+      window.electronAPI?.notifyPushHoldDurationChanged?.(clamped);
+    }
+  },
 
   setFloatingIconAutoHide: (enabled: boolean) => {
     if (get().floatingIconAutoHide === enabled) return;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -928,6 +928,10 @@ declare global {
       openMicrophoneSettings?: () => Promise<{ success: boolean; error?: string }>;
       openSoundInputSettings?: () => Promise<{ success: boolean; error?: string }>;
       openAccessibilitySettings?: () => Promise<{ success: boolean; error?: string }>;
+      openInputMonitoringSettings?: () => Promise<{ success: boolean; error?: string }>;
+      getInputMonitoringStatus?: () => Promise<boolean>;
+      onInputMonitoringStatusChanged?: (cb: (granted: boolean) => void) => () => void;
+      onInputMonitoringPermissionReset?: (cb: () => void) => () => void;
       openSystemAudioSettings?: () => Promise<{ success: boolean; error?: string }>;
       toggleMediaPlayback?: () => Promise<boolean>;
       pauseMediaPlayback?: () => Promise<boolean>;

--- a/src/utils/dictationCues.js
+++ b/src/utils/dictationCues.js
@@ -3,6 +3,8 @@ import { getSettings } from "../stores/settingsStore";
 
 const START_NOTES = [523.25, 659.25];
 const STOP_NOTES = [587.33, 440];
+// Distinct three-note descending pattern so cancel is audibly different from stop
+const CANCEL_NOTES = [440, 349.23, 261.63];
 const NOTE_DURATION_SECONDS = 0.09;
 const NOTE_GAP_SECONDS = 0.025;
 const NOTE_ATTACK_SECONDS = 0.015;
@@ -97,3 +99,5 @@ const playCue = async (notes) => {
 export const playStartCue = () => playCue(START_NOTES);
 
 export const playStopCue = () => playCue(STOP_NOTES);
+
+export const playCancelCue = () => playCue(CANCEL_NOTES);


### PR DESCRIPTION
## Summary

Fixes #684. On macOS, when the Globe/Fn key is configured as the push-to-talk hotkey, holding Fn and pressing an Fn-mapped navigation key (Fn+Arrow → Home/End/PgUp/PgDn, Fn+Backspace → Forward Delete) used to keep the recording running, because the native listener only watched modifier flag changes and never observed key-down events.

This change makes the listener notice that Fn is being used as a navigation modifier rather than for dictation, and cancels the in-flight recording (no partial transcription, no paste). It also addresses the surrounding UX: the previously hardcoded 150 ms hold threshold is now configurable, and Input Monitoring permission state is surfaced in the UI so users understand when the cancel-on-keypress feature is active.

## Changes

### Cancel-on-keypress (#684)

- `resources/macos-globe-listener.swift` — added a `CGEventTap` (`.cghidEventTap`, `listenOnly`) for global keyDown events. The first key-down within a given Fn-hold cycle emits `FN_INTERRUPTED`. Flag resets on FN_DOWN/FN_UP so the next hold gets a fresh signal.
- `src/helpers/globeKeyManager.js` — parses `FN_INTERRUPTED` and emits `globe-interrupted`.
- `main.js` — handles `globe-interrupted`. Gates on Fn hotkey + push-to-talk mode. Zeroes the pending deferred-start so the hold-duration setTimeout no-ops, and if recording is in flight, sends the existing `cancel-hotkey-pressed` IPC (the same channel used for Esc cancel from #290). Engages cooldown so the next Fn press isn't treated as a re-trigger.
- Distinct **cancel audio cue** (descending three-note pattern) so users get audible feedback that the cancel happened.

### "Hold duration before recording" setting

The previously hardcoded 150 ms hold threshold is now a configurable setting. Default 150 ms, range 100–1500 ms in 50 ms steps. Visible in **Settings → Dictation Hotkey** when "Hold to speak" is selected. Persisted to `.env` (added to `PERSISTED_KEYS`) so it survives app restarts.

### Input Monitoring permission UX

`CGEventTap` for keyDown is gated by macOS Input Monitoring TCC (separate from Accessibility), so the cancel-on-keypress only works once the user grants this permission. Surface this clearly:

- New **Input Monitoring** card in **Settings → Permissions** (Optional badge), with live granted/denied state. The listener probes every 3 seconds while denied so a newly granted permission is picked up without an app restart.
- Inline warning under the Activation Mode selector when **macOS + Globe hotkey + Hold-to-Talk + IM not granted**, with a deep-link to System Settings.
- Listener calls `IOHIDRequestAccess(.listenEvent)` at startup so the TCC prompt fires on first launch instead of silently failing.
- **TCC reset detection across app updates**: state is persisted (`LAST_INPUT_MONITORING_GRANTED` in `.env`); if previously granted but now denied, a one-shot native dialog informs the user with Open Settings / Not Now.
- Messaging emphasizes the permission is **optional**, only needed for the Globe + Hold-to-Talk cancel flow.

## Design decisions

- **Cancel trigger:** any key-down while Fn is held (not just nav keys). Robust against macOS "Use F1, F2, etc. as standard function keys" toggle and similar key-mapping variations.
- **Cancel action:** discard the recording. Reuses the existing Esc cancel path so renderer logic is unchanged.
- **Scope (mode):** push-to-talk only. Tap mode is unaffected by design — users want to keep navigating while dictating in tap mode.
- **Scope (modifier):** Fn (Globe) only. Right-side modifier hotkeys deferred — bug class is unique to Fn because of the OS-level Fn-mapped nav keys.

## Test plan

- [x] `npm run lint` clean
- [x] Native binary rebuilt via `node scripts/build-globe-listener.js`
- [x] Hotkey = Globe, mode = Push: hold Fn → speak → release → transcript pasted (regression check)
- [x] Hold Fn (>hold-duration), press Right Arrow (End) → recording cancelled, distinct cancel cue plays, no paste
- [x] Hold Fn briefly (<hold-duration), press Backspace → no recording starts at all
- [x] Tap mode: Fn-tap → Right Arrow → recording continues normally (out of scope unchanged)
- [x] Hotkey = backtick: Fn+Arrow has no effect on dictation
- [x] Hold-duration setting persists across app restarts; range is enforced
- [x] Input Monitoring card flips to "granted" within ~3 s of toggling permission on, without app restart
- [x] TCC reset detection: revoke after grant + restart → native "permission was reset" dialog appears