### PR TITLE
feat(auth): Sign in with Apple on macOS

### DIFF
--- a/src/components/AuthenticationStep.tsx
+++ b/src/components/AuthenticationStep.tsx
@@ -56,7 +56,12 @@ const MicrosoftIcon = ({ className }: { className?: string }) => (
 );
 
 const AppleIcon = ({ className }: { className?: string }) => (
-  <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
     <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
   </svg>
 );

--- a/src/components/AuthenticationStep.tsx
+++ b/src/components/AuthenticationStep.tsx
@@ -14,6 +14,7 @@ import { Input } from "./ui/input";
 import { AlertCircle, ArrowRight, Check, Loader2, ChevronLeft } from "lucide-react";
 import logoIcon from "../assets/icon.png";
 import logger from "../utils/logger";
+import { getCachedPlatform } from "../utils/platform";
 import ForgotPasswordView from "./ForgotPasswordView";
 
 interface AuthenticationStepProps {
@@ -54,6 +55,12 @@ const MicrosoftIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+const AppleIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+  </svg>
+);
+
 export default function AuthenticationStep({
   onContinueWithoutAccount,
   onAuthComplete,
@@ -71,6 +78,7 @@ export default function AuthenticationStep({
   const [error, setError] = useState<string | null>(null);
   const [forgotPasswordOpen, setForgotPasswordOpen] = useState(false);
   const [oauthProtocolRegistered, setOauthProtocolRegistered] = useState(true);
+  const isMacOS = getCachedPlatform() === "darwin";
 
   const needsVerificationRef = useRef(false);
 
@@ -464,6 +472,31 @@ export default function AuthenticationStep({
           {t("auth.welcomeSubtitle")}
         </p>
       </div>
+
+      {isMacOS && (
+        <Button
+          type="button"
+          variant="social"
+          onClick={() => handleSocialSignIn("apple")}
+          disabled={isSocialLoading !== null || isCheckingEmail || !oauthProtocolRegistered}
+          title={!oauthProtocolRegistered ? t("auth.social.protocolUnavailable") : undefined}
+          className="w-full h-9"
+        >
+          {isSocialLoading === "apple" ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+              <span className="text-sm font-medium text-muted-foreground">
+                {t("auth.social.completeInBrowser")}
+              </span>
+            </>
+          ) : (
+            <>
+              <AppleIcon className="w-4 h-4" />
+              <span className="text-sm font-medium">{t("auth.social.continueWithApple")}</span>
+            </>
+          )}
+        </Button>
+      )}
 
       <Button
         type="button"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,7 +10,7 @@ export const authClient = createAuthClient({
   },
 });
 
-export type SocialProvider = "google" | "microsoft";
+export type SocialProvider = "google" | "microsoft" | "apple";
 
 const LAST_SIGN_IN_STORAGE_KEY = "openwhispr:lastSignInTime";
 const GRACE_PERIOD_MS = 60_000;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "Anmeldung im Browser abschließen",
+      "continueWithApple": "Weiter mit Apple",
       "continueWithGoogle": "Weiter mit Google",
       "continueWithMicrosoft": "Weiter mit Microsoft",
       "protocolUnavailable": "Browser-Anmeldung nicht verfügbar — registrieren Sie das openwhispr://-Protokoll in den Standardanwendungs-Einstellungen Ihres Systems erneut."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "Complete sign-in in your browser",
+      "continueWithApple": "Continue with Apple",
       "continueWithGoogle": "Continue with Google",
       "continueWithMicrosoft": "Continue with Microsoft",
       "protocolUnavailable": "Browser sign-in unavailable — re-register the openwhispr:// protocol in your system's Default Apps settings."

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "Completa el inicio de sesión en tu navegador",
+      "continueWithApple": "Continuar con Apple",
       "continueWithGoogle": "Continuar con Google",
       "continueWithMicrosoft": "Continuar con Microsoft",
       "protocolUnavailable": "Inicio de sesión por navegador no disponible — vuelve a registrar el protocolo openwhispr:// en los ajustes de Aplicaciones predeterminadas del sistema."

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "Terminez la connexion dans votre navigateur",
+      "continueWithApple": "Continuer avec Apple",
       "continueWithGoogle": "Continuer avec Google",
       "continueWithMicrosoft": "Continuer avec Microsoft",
       "protocolUnavailable": "Connexion par navigateur indisponible — réenregistrez le protocole openwhispr:// dans les paramètres Applications par défaut du système."

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -615,6 +615,7 @@
     },
     "social": {
       "completeInBrowser": "Completa l'accesso nel browser",
+      "continueWithApple": "Continua con Apple",
       "continueWithGoogle": "Continua con Google",
       "continueWithMicrosoft": "Continua con Microsoft",
       "protocolUnavailable": "Accesso dal browser non disponibile — registra di nuovo il protocollo openwhispr:// nelle impostazioni Applicazioni predefinite del sistema."

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -615,6 +615,7 @@
     },
     "social": {
       "completeInBrowser": "ブラウザでサインインを完了してください",
+      "continueWithApple": "Apple で続ける",
       "continueWithGoogle": "Google で続ける",
       "continueWithMicrosoft": "Microsoft で続ける",
       "protocolUnavailable": "ブラウザでのサインインを利用できません — システムの「既定のアプリ」設定で openwhispr:// プロトコルを再登録してください。"

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -587,6 +587,7 @@
     },
     "social": {
       "completeInBrowser": "Conclua o login no navegador",
+      "continueWithApple": "Continuar com a Apple",
       "continueWithGoogle": "Continuar com o Google",
       "continueWithMicrosoft": "Continuar com a Microsoft",
       "protocolUnavailable": "Login pelo navegador indisponível — registre novamente o protocolo openwhispr:// nas configurações de Aplicativos Padrão do sistema."

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "Завершите вход в браузере",
+      "continueWithApple": "Продолжить с Apple",
       "continueWithGoogle": "Продолжить с Google",
       "continueWithMicrosoft": "Продолжить с Microsoft",
       "protocolUnavailable": "Вход через браузер недоступен — повторно зарегистрируйте протокол openwhispr:// в системных настройках приложений по умолчанию."

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "在浏览器中完成登录",
+      "continueWithApple": "使用 Apple 继续",
       "continueWithGoogle": "使用 Google 继续",
       "continueWithMicrosoft": "使用 Microsoft 继续",
       "protocolUnavailable": "无法通过浏览器登录 — 请在系统的“默认应用”设置中重新注册 openwhispr:// 协议。"

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -614,6 +614,7 @@
     },
     "social": {
       "completeInBrowser": "請在瀏覽器中完成登入",
+      "continueWithApple": "使用 Apple 繼續",
       "continueWithGoogle": "使用 Google 繼續",
       "continueWithMicrosoft": "使用 Microsoft 繼續",
       "protocolUnavailable": "無法透過瀏覽器登入 — 請在系統的「預設應用程式」設定中重新註冊 openwhispr:// 協定。"


### PR DESCRIPTION
## Summary

- Adds a **Sign in with Apple** button to the desktop auth UI, rendered only on macOS (`getCachedPlatform() === "darwin"`).
- Apple is already wired into Better Auth on the API side ([openwhispr-api/lib/better-auth.ts:126-130](https://github.com/OpenWhispr/openwhispr-api/blob/main/lib/better-auth.ts#L126-L130)); the desktop OAuth deep-link flow (`openwhispr://`) is provider-agnostic, so this is a UI-only change — no IPC, preload, or backend work needed.
- Reuses the existing `<Button variant="social">` glassmorphism for visual consistency with Google/Microsoft.
- Translations added across all 10 supported locales.

## Implementation

- `SocialProvider` widened with `"apple"` ([src/lib/auth.ts](https://github.com/OpenWhispr/openwhispr/blob/feat/sign-in-with-apple/src/lib/auth.ts))
- `AuthenticationStep.tsx`: new `AppleIcon`, conditional Apple button rendered first (per Apple HIG ordering), shares `handleSocialSignIn` and the `oauthProtocolRegistered` gating
- `auth.social.continueWithApple` key in `de`, `en`, `es`, `fr`, `it`, `ja`, `pt`, `ru`, `zh-CN`, `zh-TW`

## Test plan

- [ ] Open the Control Panel sign-in screen on macOS — Apple button appears above Google
- [ ] Click "Continue with Apple" — browser opens to Apple's OAuth flow with `openwhispr://` callback
- [ ] Complete OAuth — deep-link returns to app, session is established
- [ ] Verify Windows/Linux builds **do not** show the Apple button
- [ ] Loading state shows "Complete sign-in in your browser" while Apple OAuth is in flight
- [ ] Disabled when `oauthProtocolRegistered` is false (same as Google/Microsoft)
- [ ] Switch UI language — translations render correctly