### PR TITLE
fix(auth): initiate desktop OAuth from browser, not renderer

### DIFF
--- a/main.js
+++ b/main.js
@@ -392,6 +392,7 @@ function initializeCoreManagers() {
     meetingAecManager,
     getTrayManager: () => trayManager,
     oauthProtocolRegistered: protocolRegistered,
+    oauthProtocol: OAUTH_PROTOCOL,
   });
 }
 
@@ -774,8 +775,7 @@ async function startApp() {
 
   // TODO: drop legacy REASONING_PROVIDER / LOCAL_REASONING_MODEL fallbacks after 2 releases.
   const cleanupProvider = process.env.CLEANUP_PROVIDER || process.env.REASONING_PROVIDER;
-  const cleanupLocalModel =
-    process.env.LOCAL_CLEANUP_MODEL || process.env.LOCAL_REASONING_MODEL;
+  const cleanupLocalModel = process.env.LOCAL_CLEANUP_MODEL || process.env.LOCAL_REASONING_MODEL;
   if (cleanupProvider === "local" && cleanupLocalModel) {
     const modelManager = require("./src/helpers/modelManagerBridge").default;
     modelManager.prewarmServer(cleanupLocalModel).catch((err) => {

--- a/preload.js
+++ b/preload.js
@@ -306,6 +306,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getAppVersion: () => ipcRenderer.invoke("get-app-version"),
   getPostMigrationState: () => ipcRenderer.invoke("get-post-migration-state"),
   getOAuthProtocolRegistered: () => ipcRenderer.invoke("get-oauth-protocol-registered"),
+  getOAuthProtocol: () => ipcRenderer.invoke("get-oauth-protocol"),
   markBundleMigrated: () => ipcRenderer.invoke("mark-bundle-migrated"),
   markBundleMigrationDismissed: () => ipcRenderer.invoke("mark-bundle-migration-dismissed"),
   getUpdateStatus: () => ipcRenderer.invoke("get-update-status"),

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -298,6 +298,7 @@ class IPCHandlers {
     this.linuxPortalAudioManager = managers.linuxPortalAudioManager;
     this.meetingAecManager = managers.meetingAecManager;
     this.oauthProtocolRegistered = managers.oauthProtocolRegistered === true;
+    this.oauthProtocol = managers.oauthProtocol || "openwhispr";
     this.sessionId = crypto.randomUUID();
     this.assemblyAiStreaming = null;
     this.deepgramStreaming = null;
@@ -6386,6 +6387,8 @@ class IPCHandlers {
     }));
 
     ipcMain.handle("get-oauth-protocol-registered", () => this.oauthProtocolRegistered);
+
+    ipcMain.handle("get-oauth-protocol", () => this.oauthProtocol);
 
     ipcMain.handle("mark-bundle-migrated", () => {
       postMigrationDetector.markBundleMigrated();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,6 @@
 import { createAuthClient } from "better-auth/react";
 import { OPENWHISPR_API_URL } from "../config/constants";
 import { openExternalLink } from "../utils/externalLinks";
-import logger from "../utils/logger";
 
 export const AUTH_URL = import.meta.env.VITE_AUTH_URL || "https://auth.openwhispr.com";
 export const authClient = createAuthClient({
@@ -161,57 +160,21 @@ export async function withSessionRefresh<T>(operation: () => Promise<T>): Promis
   }
 }
 
-function getElectronOAuthCallbackURL(): string {
-  const configuredUrl = (import.meta.env.VITE_OPENWHISPR_OAUTH_CALLBACK_URL || "").trim();
-  if (configuredUrl) return configuredUrl;
-
-  if (window.location.protocol !== "file:") return `${window.location.origin}/?panel=true`;
-
-  const port = import.meta.env.VITE_DEV_SERVER_PORT || "5183";
-  return `http://localhost:${port}/?panel=true`;
-}
+const DESKTOP_OAUTH_CALLBACK_URL = "https://openwhispr.com/auth/desktop-callback";
 
 export async function signInWithSocial(provider: SocialProvider): Promise<{ error?: Error }> {
-  // State enforced server-side by Better Auth.
   try {
     const isElectron = Boolean((window as any).electronAPI);
 
     if (isElectron) {
-      const callbackURL = getElectronOAuthCallbackURL();
-
-      const response = await fetch(`${AUTH_URL}/api/auth/sign-in/social`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-openwhispr-source": "desktop",
-        },
-        credentials: "include",
-        body: JSON.stringify({
-          provider,
-          callbackURL,
-          newUserCallbackURL: callbackURL,
-          disableRedirect: true,
-        }),
-      });
-
-      const text = await response.text();
-
-      if (!response.ok) {
-        logger.error(`Social sign-in failed: ${response.status}`, text.slice(0, 200), "auth");
-        return { error: new Error("Failed to initiate sign-in") };
-      }
-
-      let data: { url?: string };
-      try {
-        data = JSON.parse(text);
-      } catch {
-        logger.error("Non-JSON response from auth server", text.slice(0, 200), "auth");
-        return { error: new Error("Unexpected response from auth server") };
-      }
-
-      if (!data.url) return { error: new Error("Failed to get OAuth URL") };
-
-      openExternalLink(data.url);
+      // OAuth must be initiated from the user's browser, not the renderer:
+      // the state cookie Better Auth sets has to land in the same cookie jar
+      // that handles the /api/auth/callback/* round-trip. The shim endpoint
+      // does the POST server-side and 302s with the cookies attached.
+      const protocol = (await window.electronAPI?.getOAuthProtocol?.()) || "openwhispr";
+      const url = new URL(`${AUTH_URL}/api/desktop-signin/${provider}`);
+      url.searchParams.set("callbackURL", `${DESKTOP_OAUTH_CALLBACK_URL}?protocol=${protocol}`);
+      openExternalLink(url.toString());
       return {};
     }
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -772,6 +772,7 @@ declare global {
       getAppVersion: () => Promise<AppVersionResult>;
       getPostMigrationState: () => Promise<{ justMigrated: boolean }>;
       getOAuthProtocolRegistered: () => Promise<boolean>;
+      getOAuthProtocol: () => Promise<string>;
       markBundleMigrated: () => Promise<void>;
       markBundleMigrationDismissed: () => Promise<void>;
       getUpdateStatus: () => Promise<UpdateStatusResult>;


### PR DESCRIPTION
## Summary

Fixes the \`state_mismatch\` error on every desktop OAuth attempt (Google, Microsoft, and the upcoming Apple).

**Root cause:** the renderer-side \`fetch\` to \`/api/auth/sign-in/social\` made Better Auth set the OAuth state cookie on Electron's renderer cookie jar. Then \`openExternalLink\` opened the provider URL in the user's external browser, which had no state cookie → callback fails.

**Fix:** the renderer now opens a single GET URL pointing at a new shim endpoint on the auth server (companion PR below). The shim does the POST server-side, so cookies land in the same browser session that completes the OAuth round-trip. Net **-32 LOC** on this side — the bug fix simplifies the code.

## Companion PR

- **openwhispr-api/pull/50** — \`/api/desktop-signin/[provider]\` GET shim. **Must merge first.**

## Changes

- \`src/lib/auth.ts\`: replace renderer fetch + \`disableRedirect: true\` flow with a single \`openExternalLink(...)\` to the shim. Delete \`getElectronOAuthCallbackURL\`. Drop unused \`logger\` import.
- \`main.js\` / \`src/helpers/ipcHandlers.js\` / \`preload.js\` / \`src/types/electron.ts\`: plumb \`OAUTH_PROTOCOL\` through IPC so the desktop-callback page knows which channel-specific deep link to fire (\`openwhispr\`, \`openwhispr-dev\`, \`openwhispr-staging\`). Mirrors the existing \`oauthProtocolRegistered\` plumbing.
- Callback URL is now \`https://openwhispr.com/auth/desktop-callback\` (the existing page) instead of unreachable \`localhost:5183/file://\` URLs.

## End-to-end after the fix

1. User clicks Google/Microsoft → desktop opens \`auth.openwhispr.com/api/desktop-signin/google?callbackURL=...&protocol=...\` in browser
2. Server initiates OAuth → state cookie set on user's browser → 302 to provider
3. User authorizes → provider 302s to \`/api/auth/callback/google\` → state cookie present → ✅ session set on \`.openwhispr.com\`
4. Better Auth 302s to \`openwhispr.com/auth/desktop-callback\` → page reads session via shared cookie → fires \`openwhispr://auth/callback?token=...\`
5. Electron's existing protocol handler at [main.js:501](main.js#L501) catches → applies token

## Backward compatibility (verified)

- ✅ **1.6.10 users (Neon Auth)**: untouched — different auth system entirely. The desktop-callback page still handles their \`?neon_auth_session_verifier=...\` param.
- ✅ **1.7.0 existing sessions**: stay signed in — no session validation/storage changes.
- ✅ **Mobile / web**: not affected — they don't use the new shim.

## Test plan

- [ ] Wait for companion API PR to deploy
- [ ] Run desktop dev build → click Google → completes sign-in
- [ ] Same for Microsoft
- [ ] Verify on staging build: \`openwhispr-staging://\` deep link fires
- [ ] Existing signed-in user: stays signed in after pulling the change
- [ ] After Apple PR (#691) rebases on this: Apple sign-in works on macOS