### PR TITLE
docs(changelog): plain-English 1.7.0 + lockfile refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ A big release: new sign-in options, smoother meeting recording, faster cross-dev
 - **Per-scope language model setup**: pick different providers and models for dictation cleanup, the agent, note formatting, and chat. An empty agent setting links back to your cleanup model with one click.
 - **Switching agent mode** between Cloud and Local no longer leaves stale provider state behind.
 - **More reliable ONNX inference** (speaker embeddings, semantic search): long meetings no longer crash the app from a memory allocation failure deep in the speaker model.
+- **Local helpers shut down cleanly on Quit.** Local Whisper, Parakeet, llama-server, Qdrant, and the diarization helper now stop properly when you Quit. If a previous session ever leaves one stuck, the app catches and cleans it up on the next launch — so dictation and transcription work right away without manual cleanup.
 
 ### Sync
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,60 +9,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.0] - 2026-04-30
 
-### Added
+A big release: new sign-in options, smoother meeting recording, faster cross-device sync, a more configurable AI setup, and the long-planned move to our new legal entity (Gizmo Labs Inc.) on macOS and Windows.
 
-- **Self-Hosted Authentication via Better Auth**: Replaced the Neon Auth integration with a self-hosted [Better Auth](https://better-auth.com) deployment at `auth.openwhispr.com`. Sessions, OAuth, and account state now live entirely on OpenWhispr infrastructure — no third-party vendor lock-in, and the custom Electron OAuth bridge dance (protocol-handler interception, `neon_auth_session_verifier` cookie shuffling, in-browser "redirecting to app" splash) is gone. Configurable via `VITE_AUTH_URL` for self-hosters
-- **Microsoft Sign-In**: Sign in with a Microsoft account alongside Google and email/password, via Better Auth's OAuth provider
-- **Bundle ID Migration to Gizmo Labs** (macOS/Windows): App identifier renamed from `com.herotools.openwispr` to `com.gizmolabs.openwhispr` to align with the new legal entity (Gizmo Labs Inc.) and fix the long-standing typo. Existing notes, settings, API keys, and downloaded models carry over automatically on first launch (userData path is keyed by `productName`, not bundle ID). Auto-update from 1.6.x cannot reach this release — Squirrel.Mac enforces `CFBundleIdentifier` matching and the Team ID change in Gizmo Labs signing already broke the cryptographic update chain. Users must manually re-download from openwhispr.com/download
-- **Post-Migration Onboarding** (macOS): One-time modal walks returning users through re-granting Microphone, Accessibility, and System Audio after the bundle rename. Detected via a sentinel file (`.bundle-migrated`) in userData; reuses the existing `PermissionsSection` and live-polling hooks. Fresh installs write the sentinel during onboarding completion so the modal never fires for new users. False-positive guard requires both the SQLite DB and `userData/.env` to exist; "Remind Me Later" now persists for 24h
-- **Interoperable Cloud Streaming Providers**: Meeting recording now supports AssemblyAI Universal-3 Pro, Deepgram, and OpenAI Realtime as interchangeable cloud streaming backends. Provider availability is server-authoritative via the `NOTE_RECORDING_PROVIDERS` env var on the API; desktop picks the active provider from the catalog returned by `/api/note-recording-config`
-- **Acoustic VAD Gate for Meeting Mic**: Drops system-dominant microphone chunks using RMS/peak thresholds against a rolling reference window, preventing cross-language hallucinations from speaker bleed into the mic
-- **Peak Escape**: Soft exception to the VAD gate when the mic peak spikes cleanly over the system-speaking window, so the user's voice onset is never clipped mid-syllable
-- **Cross-Device Delete Propagation** (#646): Deletes now propagate across devices through the sync pipeline for all object types
-- **Folder Cascade Delete with Confirmation** (`dbe1b6a`): Deleting a folder shows a confirmation dialog with the affected note count, removes its notes locally in a single SQLite transaction, and propagates to other devices (server cascades child notes server-side)
-- **Per-Scope LLM Configuration** (#677): Split the single reasoning model into four independent scopes — `dictationCleanup`, `dictationAgent`, `noteFormatting`, `chatIntelligence` — each with its own provider, model, mode, and key. New provider registry in `src/services/ai/inferenceProviders/` (OpenAI, Anthropic, Gemini, Groq, LAN, Local, Enterprise, OpenWhispr). Empty `dictationAgent` shows an inline "Use cleanup model" link to copy the cleanup config in one click. Existing single-model setups migrate via versioned `_promptsMigrated` / `_llmScopeKeysMigrated` markers
-- **Local HTTP Bridge for Unified CLI** (#676): Loopback HTTP server on ports 8200–8219 with bearer-token auth (token at `~/.openwhispr/cli-bridge.json`, 0o600 on Unix, 127.0.0.1-only). The `openwhispr` CLI now talks to a running desktop app for note/folder/transcription CRUD before falling back to the cloud API
-- **Windows Text Pattern Fallback** (#665): `windows-text-monitor` now tries UIA `TextPattern` when `ValuePattern` is unavailable, restoring rich-edit support in RichEdit, Monaco, WinUI, Qt, and Electron-hosted text controls
+### Sign in your way
 
-### Changed
+- **Sign in with Microsoft** — new on this release, alongside Google and email/password.
+- **Sign in with Apple** on macOS — native Apple ID flow.
+- **Self-hosted authentication.** Sign-in now runs entirely on OpenWhispr infrastructure (we replaced Neon Auth with [Better Auth](https://better-auth.com) at `auth.openwhispr.com`). No third-party vendor lock-in. Self-hosters can point at their own server via `VITE_AUTH_URL`.
+- **Forgot password** opens a browser tab to `openwhispr.com/reset-password` instead of an in-app form, matching how every other reset flow works on the web.
+- **Sign-in buttons disable with a tooltip** when the OS hasn't registered the `openwhispr://` callback handler, so OAuth never gets stuck without a return path.
 
-- **macOS Code-Signing Identity** (#639): Switched to Gizmo Labs Inc. (Team ID `T832773L2J`). Notarization and hardened runtime unchanged
-- **Forgot-Password Flow Centralized on Website**: Password reset now opens `openwhispr.com/reset-password` in the browser instead of an in-app reset view. Email links land on the website where the form lives, matching how every other reset flow works. The desktop's `ResetPasswordView` and its 20-key `resetPassword.*` i18n block (× 10 languages) were removed
-- **Meeting Streaming Provider Authority**: Removed the desktop-side streaming provider UI picker. The authoritative list lives on the API; the desktop renders whichever providers are enabled server-side
-- **Echo Cancellation Pipeline**: AEC3 config now disables OS-level `echoCancellation` (it was double-processing) and enables the built-in high-pass filter plus `kModerate` noise suppression, giving a noticeably cleaner mic path before the VAD gate
-- **VAD Thresholds Tuned Against Measured Leak**: RMS ceiling `0.018`, peak ceiling `0.07`, lookback `500ms` — calibrated from real session traces where user speech consistently exceeded both thresholds and bleed consistently sat below
-- **Network — Proxy-Aware Fetches and Actionable Connectivity Errors** (#687): Node-side fetches now honor the system proxy. Network failures surface auth-host / DNS / port-443 / TLS-cert hints to the user instead of a generic "Network error"
-- **Node TLS Trusts OS CA Store** (#657): Corporate TLS-interception with an OS-trusted root no longer breaks Node-side fetches. OpenAI realtime WebSocket is intentionally exempt (its TLS goes through Chromium and was never affected)
+### Meeting recording
 
-### Fixed
+- **Three interchangeable streaming providers**: OpenAI Realtime, AssemblyAI Universal-3 Pro, and Deepgram. Which providers are available is set on the OpenWhispr server, so there's no desktop-side toggle to keep in sync.
+- **Cleaner mic capture.** A new acoustic gate prevents system audio from leaking into your mic during meetings. Speech onsets are protected so your voice isn't clipped at the start of a sentence.
+- **Better echo cancellation** with built-in noise suppression in the same pass.
+- **Speaker labels capped to attendee count** — no more phantom "Speaker 3+" labels in 1-on-1s and small groups.
+- **Live diarization** stays scoped to the current note's attendees instead of pulling in profiles from unrelated meetings.
+- **Stable AssemblyAI / Deepgram turns**: fixed a crash on turn-end and a frame-size mismatch with AssemblyAI v3.
+- **Fewer dropped turns**: speech-start timestamps now flow through the echo-leak detector for AssemblyAI and Deepgram (was OpenAI-only).
 
-- **AssemblyAI v3 Frame Size**: Buffer audio to meet the v3 minimum 50ms frame requirement (was hitting "Input Duration Error: 45.0 ms")
-- **AssemblyAI / Deepgram `completedSegments`**: The echo-leak detector crashed on turn-end for non-OpenAI providers because `completedSegments` only existed on the OpenAI client; exposed it on AssemblyAI and Deepgram as well
-- **Streaming Token Plumbing**: Streaming client factory now passes both `apiKey` and `token` fields (OpenAI expects `apiKey`, AssemblyAI/Deepgram expect `token`)
-- **Note-Recording Config Over IPC**: Moved the `/api/note-recording-config` fetch from the renderer into the main process so Neon Auth session cookies are attached (was returning 401)
-- **Speech-Start Timestamp to Echo-Leak Detector**: AssemblyAI and Deepgram turns now pass their speech-start wall-clock time to the detector, eliminating `missing_start` drops on legitimate turns
-- **Drop Flagged-Bleed Mic Segments on Holdback Expiry**: When the echo-leak detector flags a mic turn as bleed, the segment is now dropped rather than flushed once the holdback window closes; correlation `>= 0.70` alone is sufficient evidence (in addition to the prior three-condition check)
-- **Speaker Label Cap**: UI speaker labels are now strictly capped at `expectedCount` (interpreted as the number of other attendees besides the user), preventing phantom `Speaker 3+` labels in 1-on-1 and small-group sessions
-- **Live Speaker Profile Matching Scoped to Note Attendees**: Live diarization no longer pulls in profiles from unrelated notes when identifying attendees
-- **Sync — Preserve Client `updated_at` on Note Push**: Server was overwriting `updated_at` on every push, causing spurious sync loops and stale-merge conflicts
-- **Sync — Folder Create / Rename Propagates to Cloud** (`2c1c521`): Folder name changes and creates now sync; previously only updates were pushed
-- **Sync — Push Transcriptions on Save** (`a06b76c`): Transcriptions sync to cloud immediately on save instead of waiting for the next app launch
-- **Sync — Folder Pull Compares Against `local.updated_at`** (`5bf449a`): Was comparing against `local.created_at`, allowing older cloud copies to overwrite locally renamed folders. Adds an `updated_at` column to the local `folders` table with an idempotent ALTER TABLE migration that backfills from `created_at`
-- **Settings — Cleanup-Mode Selectors Require Explicit Mode** (`5bf449a`): `selectIsCloudCleanupMode` and `selectIsCloudChatAgentMode` now require BOTH the scope mode AND the cloud-mode field to be `openwhispr`, so a stale `cleanupCloudMode` value can't silently route BYOK / local users through the cloud
-- **Auth — Better Auth Cookie Name Match** (`5bf449a`): Corrected the desktop's injected session cookie to `__Secure-openwhispr.session_token` to match what the auth server emits. The legacy `__Secure-neon-auth.*` name no longer applies; OAuth sessions now resume cleanly
-- **Auth — Social Sign-In Gated on Protocol Registration** (`5bf449a`): Google + Microsoft sign-in buttons disable with a tooltip when `app.setAsDefaultProtocolClient()` reports failure, preventing OAuth-without-return-path on locked-down systems with stale `openwhispr://` handlers
-- **Chat Intelligence Stale Provider on Mode Switch** (#647): Switching Agent Mode from Cloud Providers to Local left the previous cloud provider cached, routing chat to the stale provider and erroring with "API key not configured" despite a local model being selected; mode changes now clear `agentProvider`/`agentModel` when incompatible with the new mode
-- **Chat — First Message Persisted on Conversation Create** (#662): The first user message is now written to SQLite the moment the conversation row is created, eliminating the race that left the opening message orphaned if the renderer was closed too quickly
-- **Notes — Folder Selection on Move** (#678): When the active note is moved between folders, selection follows it. Non-active notes are removed from the source folder list immediately
-- **Correction Learner — Unicode Tokenization** (#666): Switched from ASCII `\w+` to Unicode property escapes (`\p{L}\p{N}_`), restoring auto-learn for Cyrillic, CJK, Arabic, Devanagari, and other non-Latin scripts
-- **Qdrant — cwd Set to STORAGE_DIR** (#640): Spawn cwd is now the writable Qdrant data dir; relative writes no longer hit the read-only macOS app bundle
+### AI configuration
+
+- **Per-scope language model setup**: pick different providers and models for dictation cleanup, the agent, note formatting, and chat. An empty agent setting links back to your cleanup model with one click.
+- **Switching agent mode** between Cloud and Local no longer leaves stale provider state behind.
+- **More reliable ONNX inference** (speaker embeddings, semantic search): long meetings no longer crash the app from a memory allocation failure deep in the speaker model.
+
+### Sync
+
+- **Cross-device delete** propagates to other signed-in devices for all object types.
+- **Folder cascade delete** with a confirmation dialog showing how many notes will be removed.
+- **Folders sync immediately** on rename and create (was previously only on update).
+- **Transcriptions sync on save** instead of waiting for the next app launch.
+- **Folder pull** no longer overwrites a freshly-renamed folder with a stale cloud copy.
+- **Server stops overwriting `updated_at`** on every note push, eliminating spurious sync loops.
+
+### CLI
+
+- **Local HTTP bridge** for the `openwhispr` CLI: when the desktop is running, CLI commands hit it directly for note/folder/transcription operations and only fall back to the cloud API if the desktop is closed. Bearer-token auth, 127.0.0.1-only.
+
+### Network
+
+- **Proxy-aware fetches**: Node-side requests now honor the system proxy.
+- **Trusts your OS CA store**: corporate TLS interception with a trusted root no longer breaks Node-side requests.
+- **Helpful error messages**: connectivity failures explain whether it's an auth-host issue, DNS, port 443, or a TLS certificate, instead of a generic "Network error".
+
+### Other notable improvements
+
+- **Auto-learn corrections** now works for Cyrillic, CJK, Arabic, Devanagari, and other non-Latin scripts.
+- **Windows text-field detection** falls back to UIA `TextPattern` when `ValuePattern` isn't available — restoring rich-edit support in apps like RichEdit, Monaco, Qt, and Electron-hosted controls.
+- **Chat — first message saved** the moment the conversation is created, eliminating a race that could orphan it.
+- **Note move** keeps the active note selected and removes the source-folder entry immediately.
+- **Local semantic search (Qdrant)** writes to the user data directory, not the read-only app bundle.
+
+### macOS / Windows: bundle identifier change
+
+The app's bundle ID changed from `com.herotools.openwispr` to `com.gizmolabs.openwhispr` to match our new legal entity (Gizmo Labs Inc.) and fix the long-standing typo. Your notes, settings, API keys, and downloaded models carry over automatically on first launch.
+
+**Auto-update from 1.6.x cannot reach this release.** Please download the new build manually from [openwhispr.com/download](https://openwhispr.com/download).
+
+A one-time onboarding modal walks you through re-granting Microphone, Accessibility, and System Audio permissions on macOS.
 
 ### Upgrade notes
 
-- Manual download required for 1.6.x users; auto-update is intentionally broken across the bundle ID change.
-- You will be signed out and need to sign in again on first launch (Better Auth swap).
-- macOS users will be prompted to re-grant microphone access in-app and re-grant accessibility + screen-recording in System Settings.
-- Self-hosters: rename `VITE_NEON_AUTH_URL` → `VITE_AUTH_URL` in your build env; rename `REASONING_MODEL`/`REASONING_PROVIDER`/etc. → `CLEANUP_MODEL`/`CLEANUP_PROVIDER`; rename `AGENT_KEY` → `CHAT_AGENT_KEY` (the desktop reads both for two releases).
+- 1.6.x users: download manually from [openwhispr.com/download](https://openwhispr.com/download).
+- You'll be signed out and need to sign in again.
+- macOS: re-grant Microphone in-app and Accessibility + Screen Recording in System Settings.
+- Self-hosters: rename `VITE_NEON_AUTH_URL` → `VITE_AUTH_URL`; rename the legacy reasoning-model env vars (e.g. `REASONING_MODEL` → `CLEANUP_MODEL`); rename `AGENT_KEY` → `CHAT_AGENT_KEY`. Both old and new names work for two releases.
 
 ## [1.6.10] - 2026-04-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4118,6 +4118,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",


### PR DESCRIPTION
## Summary

- Rewrites the 1.7.0 changelog entry as feature-forward plain English ("Sign in with Microsoft", "Sign in with Apple on macOS", "Three interchangeable streaming providers") instead of the engineering-heavy version that was there.
- Adds the items that were missing: Apple Sign-In (#691), the OAuth-from-browser fix (#692), the ONNX inference isolation (#693).
- Regenerates `package-lock.json` on Node 24 to align with the pinned `.nvmrc` and CI.

## Test plan

- [ ] Skim the new 1.7.0 section as a non-engineer — "do I know what shipped?"
- [ ] `npm ci` works locally on Node 24