### PR TITLE
fix(ci): compile macos-media-remote binary in release and build workflows

### DIFF
--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -225,8 +225,14 @@ jobs:
           path: resources/bin
           key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift', 'scripts/build-media-remote.js', 'resources/macos-media-remote.swift') }}
 
+      - name: Compile macos-globe-listener binary
+        run: npm run compile:globe -- --arch ${{ matrix.arch }}
+
+      - name: Compile macos-fast-paste binary
+        run: npm run compile:fast-paste -- --arch ${{ matrix.arch }}
+
       - name: Compile macos-media-remote binary
-        run: node scripts/build-media-remote.js --arch ${{ matrix.arch }}
+        run: npm run compile:media-remote -- --arch ${{ matrix.arch }}
 
       - name: Download whisper.cpp binaries
         run: node scripts/download-whisper-cpp.js --current --platform darwin --arch ${{ matrix.arch }}
@@ -303,6 +309,13 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Verify packaged macOS native binaries
+        run: |
+          APP_PATH=$(ls -d dist/mac*/OpenWhispr.app | head -n1)
+          for bin in macos-audio-tap macos-globe-listener macos-fast-paste macos-mic-listener macos-text-monitor macos-media-remote; do
+            test -x "$APP_PATH/Contents/Resources/bin/$bin" || { echo "Missing in bundle: $bin"; exit 1; }
+          done
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -223,7 +223,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: resources/bin
-          key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift') }}
+          key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift', 'scripts/build-media-remote.js', 'resources/macos-media-remote.swift') }}
+
+      - name: Compile macos-media-remote binary
+        run: node scripts/build-media-remote.js --arch ${{ matrix.arch }}
 
       - name: Download whisper.cpp binaries
         run: node scripts/download-whisper-cpp.js --current --platform darwin --arch ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,8 +210,14 @@ jobs:
           path: resources/bin
           key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift', 'scripts/build-media-remote.js', 'resources/macos-media-remote.swift') }}
 
+      - name: Compile macos-globe-listener binary
+        run: npm run compile:globe -- --arch ${{ matrix.arch }}
+
+      - name: Compile macos-fast-paste binary
+        run: npm run compile:fast-paste -- --arch ${{ matrix.arch }}
+
       - name: Compile macos-media-remote binary
-        run: node scripts/build-media-remote.js --arch ${{ matrix.arch }}
+        run: npm run compile:media-remote -- --arch ${{ matrix.arch }}
 
       - name: Download whisper.cpp binaries
         run: node scripts/download-whisper-cpp.js --current --platform darwin --arch ${{ matrix.arch }}
@@ -287,6 +293,13 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Verify packaged macOS native binaries
+        run: |
+          APP_PATH=$(ls -d dist/mac*/OpenWhispr.app | head -n1)
+          for bin in macos-audio-tap macos-globe-listener macos-fast-paste macos-mic-listener macos-text-monitor macos-media-remote; do
+            test -x "$APP_PATH/Contents/Resources/bin/$bin" || { echo "Missing in bundle: $bin"; exit 1; }
+          done
 
       - name: Upload arch-specific update metadata
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: resources/bin
-          key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift') }}
+          key: macos-${{ matrix.arch }}-bin-${{ hashFiles('scripts/download-*.js', 'scripts/build-globe-listener.js', 'resources/macos-globe-listener.swift', 'scripts/build-macos-fast-paste.js', 'resources/macos-fast-paste.swift', 'scripts/build-media-remote.js', 'resources/macos-media-remote.swift') }}
+
+      - name: Compile macos-media-remote binary
+        run: node scripts/build-media-remote.js --arch ${{ matrix.arch }}
 
       - name: Download whisper.cpp binaries
         run: node scripts/download-whisper-cpp.js --current --platform darwin --arch ${{ matrix.arch }}


### PR DESCRIPTION
Fixes #632.

  ### Summary

  The "Pause media on dictation" feature is broken on macOS. `electron-builder.json` lists `resources/bin/macos-media-remote` under extraResources (added in #487), but the binary is never produced during CI, so the packager finds nothing and silently skips it. Every macOS release ships without it.

  Root cause: `scripts/build-media-remote.js` (the Swift compile step for macos-media-remote) has no corresponding step in either `release.yml` or `build-and-notarize.yml`. In addition, the two other Swift binaries compiled from source (macos-globe-listener, macos-fast-paste) are both represented in the native binaries cache key but `macos-media-remote.swift` and `scripts/build-media-remote.js` are not.

  The result is visible in debug logs on every dictation activation:
`  [DEBUG][media] MediaRemote unavailable, falling back to osascript {}`
  And confirmed by inspecting the installed app bundle — macos-media-remote is absent from `OpenWhispr.app/Contents/Resources/bin/` on v1.6.10.

  ### Changes

  Both `release.yml` and `build-and-notarize.yml` receive the same two changes in their build-macos job:

  1. New compile step (inserted after cache restore, before the download steps):
  - name: Compile macos-media-remote binary
    run: `node scripts/build-media-remote.js --arch ${{ matrix.arch }}`

  2. Cache key updated to include the Swift source files:
  `'scripts/build-media-remote.js', 'resources/macos-media-remote.swift'`
  This ensures the cache invalidates correctly when the source changes, matching the pattern already used for macos-globe-listener and macos-fast-paste.

###   Test plan

  - Successful CI run produces resources/bin/macos-media-remote in the build artifacts for both x64 and arm64
  - macos-media-remote is present inside the packaged .app bundle under Contents/Resources/bin/
  - Debug log no longer shows MediaRemote unavailable on dictation activation
  - Spotify (and other players) pause when dictation starts and resume when it completes
  - Linux and Windows build jobs are unaffected