### PR TITLE
fix(media): resume playback on no-audio-detected event

### DIFF
--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -232,6 +232,9 @@ export const useAudioRecording = (toast, options = {}) => {
     });
 
     const handleNoAudioDetected = () => {
+      if (getSettings().pauseMediaOnDictation) {
+        window.electronAPI?.resumeMediaPlayback?.();
+      }
       toast({
         title: t("hooks.audioRecording.noAudio.title"),
         description: t("hooks.audioRecording.noAudio.description"),


### PR DESCRIPTION
  ## Summary

When Whisper returns an empty transcription, the pipeline emits a `no-audio-detected`IPC event directly to the renderer rather than routing through the normal `onTranscriptionComplete` or `onError` callbacks in `audioManager`. Because of this, the `handleNoAudioDetected` handler in `useAudioRecording.js` was the only recording exit path that did not call `resumeMediaPlayback()`, leaving media paused after a failed dictation attempt.

  The three existing resume call sites all follow the same pattern:

  ```js
  if (getSettings().pauseMediaOnDictation) {
    window.electronAPI?.resumeMediaPlayback?.();
  }
  ```

  This PR adds the same to `handleNoAudioDetected`, making it consistent with `onError`, `onTranscriptionComplete`, and `cancelRecording`.

  ## Changes

  - **`src/hooks/useAudioRecording.js`** — added `resumeMediaPlayback()` call to `handleNoAudioDetected` before the toast, matching the pattern used in all other recording exit paths

  ## Test plan

  - [ ] Start dictation with "Pause media on dictation" enabled, say nothing — media resumes after the "No audio detected" toast appears
  - [ ] Start dictation and speak normally — media still resumes on successful transcription
  - [ ] Start dictation and cancel — media still resumes on cancel
  - [ ] Start dictation with "Pause media on dictation" disabled — no resume call is made, behavior unchanged