### PR TITLE
feat(transcribe): generate clientTranscriptionId for cloud sync dedup

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1376,6 +1376,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       limitReached: result.limitReached,
       wordsUsed: result.wordsUsed,
       wordsRemaining: result.wordsRemaining,
+      clientTranscriptionId: result.clientTranscriptionId,
     };
   }
 
@@ -1909,7 +1910,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  async saveTranscription(text, rawText = null) {
+  async saveTranscription(text, rawText = null, { clientTranscriptionId } = {}) {
     if (!getSettings().dataRetentionEnabled) {
       logger.debug("Skipping transcription save — data retention disabled", {}, "audio");
       this.lastAudioBlob = null;
@@ -1918,7 +1919,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     try {
-      const result = await window.electronAPI.saveTranscription(text, rawText);
+      const result = await window.electronAPI.saveTranscription(
+        text,
+        rawText,
+        clientTranscriptionId ? { clientTranscriptionId } : undefined
+      );
       if (result?.id) syncService.debouncedPush("transcription", result.id);
 
       // Save audio if we have a captured blob and the transcription was saved successfully

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1919,11 +1919,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     try {
-      const result = await window.electronAPI.saveTranscription(
-        text,
-        rawText,
-        clientTranscriptionId ? { clientTranscriptionId } : undefined
-      );
+      const result = await window.electronAPI.saveTranscription(text, rawText, {
+        clientTranscriptionId,
+      });
       if (result?.id) syncService.debouncedPush("transcription", result.id);
 
       // Save audio if we have a captured blob and the transcription was saved successfully

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -552,18 +552,24 @@ class DatabaseManager {
       status = "completed",
       errorMessage = null,
       errorCode = null,
-      clientTranscriptionId = null,
+      clientTranscriptionId = randomUUID(),
     } = {}
   ) {
     try {
       if (!this.db) {
         throw new Error("Database not initialized");
       }
-      const txId = clientTranscriptionId || randomUUID();
       const stmt = this.db.prepare(
         "INSERT INTO transcriptions (text, raw_text, status, error_message, error_code, client_transcription_id) VALUES (?, ?, ?, ?, ?, ?)"
       );
-      const result = stmt.run(text, rawText, status, errorMessage, errorCode, txId);
+      const result = stmt.run(
+        text,
+        rawText,
+        status,
+        errorMessage,
+        errorCode,
+        clientTranscriptionId
+      );
 
       const fetchStmt = this.db.prepare("SELECT * FROM transcriptions WHERE id = ?");
       const transcription = fetchStmt.get(result.lastInsertRowid);

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -548,24 +548,22 @@ class DatabaseManager {
   saveTranscription(
     text,
     rawText = null,
-    { status = "completed", errorMessage = null, errorCode = null } = {}
+    {
+      status = "completed",
+      errorMessage = null,
+      errorCode = null,
+      clientTranscriptionId = null,
+    } = {}
   ) {
     try {
       if (!this.db) {
         throw new Error("Database not initialized");
       }
-      const clientTranscriptionId = randomUUID();
+      const txId = clientTranscriptionId || randomUUID();
       const stmt = this.db.prepare(
         "INSERT INTO transcriptions (text, raw_text, status, error_message, error_code, client_transcription_id) VALUES (?, ?, ?, ?, ?, ?)"
       );
-      const result = stmt.run(
-        text,
-        rawText,
-        status,
-        errorMessage,
-        errorCode,
-        clientTranscriptionId
-      );
+      const result = stmt.run(text, rawText, status, errorMessage, errorCode, txId);
 
       const fetchStmt = this.db.prepare("SELECT * FROM transcriptions WHERE id = ?");
       const transcription = fetchStmt.get(result.lastInsertRowid);

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3379,6 +3379,9 @@ class IPCHandlers {
         if (!cookieHeader) throw new Error("No session cookies available");
 
         const audioData = Buffer.from(audioBuffer);
+        // Reused for the local SQLite row so SyncService upserts the existing
+        // cloud row (filling in text) instead of creating a duplicate.
+        const clientTranscriptionId = crypto.randomUUID();
         const multipartFields = {
           language: opts.language,
           prompt: opts.prompt,
@@ -3387,6 +3390,7 @@ class IPCHandlers {
           appVersion: app.getVersion(),
           clientVersion: app.getVersion(),
           sessionId: this.sessionId,
+          clientTranscriptionId,
         };
 
         debugLogger.debug("Cloud transcribe request", { audioSize: audioData.length }, "cloud-api");
@@ -3402,6 +3406,7 @@ class IPCHandlers {
           return {
             success: true,
             text,
+            clientTranscriptionId,
             wordsUsed: lastResponse?.wordsUsed,
             wordsRemaining: lastResponse?.wordsRemaining,
             plan: lastResponse?.plan,
@@ -3434,6 +3439,7 @@ class IPCHandlers {
         return {
           success: true,
           text: result.text,
+          clientTranscriptionId,
           wordsUsed: result.wordsUsed,
           wordsRemaining: result.wordsRemaining,
           plan: result.plan,

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -158,7 +158,9 @@ export const useAudioRecording = (toast, options = {}) => {
             await navigator.clipboard.writeText(result.text);
           }
 
-          audioManagerRef.current.saveTranscription(result.text, result.rawText ?? result.text);
+          audioManagerRef.current.saveTranscription(result.text, result.rawText ?? result.text, {
+            clientTranscriptionId: result.clientTranscriptionId,
+          });
 
           if (result.source === "openai" && getSettings().useLocalWhisper) {
             toast({

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -389,6 +389,7 @@ declare global {
           status?: TranscriptionStatus;
           errorMessage?: string | null;
           errorCode?: TranscriptionErrorCode;
+          clientTranscriptionId?: string;
         }
       ) => Promise<{ id: number; success: boolean; transcription?: TranscriptionItem }>;
       getTranscriptions: (limit?: number) => Promise<TranscriptionItem[]>;
@@ -963,6 +964,7 @@ declare global {
       ) => Promise<{
         success: boolean;
         text?: string;
+        clientTranscriptionId?: string;
         wordsUsed?: number;
         wordsRemaining?: number;
         limitReached?: boolean;


### PR DESCRIPTION
## Summary

Pairs with OpenWhispr/openwhispr-api#52. The desktop now generates a UUID before each `/api/transcribe` call and reuses the same UUID for the local SQLite row. `SyncService` then upserts the existing cloud row (filling in text) instead of creating a duplicate.

This pairs with the API-side privacy gate to deliver:
- **Privacy**: cloud transcript text is no longer stored server-side by default. Path A (`/api/transcribe`) writes metadata only; path B (`/api/transcriptions/create`) is the only path that persists text and is already gated by `cloudBackupEnabled`.
- **Dedup**: cloud-STT users with sync enabled now get one `transcriptions` row per dictation instead of two, which fixes a `word_count` double-count for billing/referrals.

## Changes

- `src/helpers/ipcHandlers.js` — `cloud-transcribe` IPC: generate `clientTranscriptionId` via `crypto.randomUUID()`, send in multipart, return in response (both inline and chunked branches)
- `src/helpers/database.js` — `saveTranscription` accepts optional `clientTranscriptionId`, falls back to generated UUID when not provided
- `src/helpers/audioManager.js` — return `clientTranscriptionId` from `cloudTranscribe()`; thread it through to `saveTranscription()`
- `src/hooks/useAudioRecording.js` — pass `clientTranscriptionId` through to `saveTranscription`
- `src/types/electron.ts` — type updates for the new field on `cloudTranscribe` response and `saveTranscription` opts

## Backwards compatibility

- API contract is additive: old API servers ignore the new multipart field
- Other transcribe paths (`retry-transcription`, `transcribe-audio-file-cloud`) are unchanged — they keep working with `client_transcription_id = NULL`. The privacy fix still applies because that's enforced server-side in `recordTranscription`.

## Test plan

- [ ] Cloud STT dictation with cloud backup OFF — confirm response includes `clientTranscriptionId`, local SQLite row uses it, no cloud sync push
- [ ] Cloud STT dictation with cloud backup ON — confirm sync upserts the same cloud row (no duplicate)
- [ ] Local whisper / Parakeet dictation — unaffected, generates its own UUID via existing fallback
- [ ] Verify `npm run typecheck` passes