### PR TITLE
docs(readme): acknowledge Hugging Face as model hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ We welcome contributions. Fork the repo, create a feature branch, and open a pul
 - **[whisper.cpp](https://github.com/ggerganov/whisper.cpp)** — high-performance C++ implementation for local processing
 - **[NVIDIA Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)** — fast multilingual ASR model
 - **[sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx)** — cross-platform ONNX runtime for Parakeet inference
+- **[Hugging Face](https://huggingface.co/)** — model hub hosting Whisper, Parakeet, and embedding model weights
 - **[llama.cpp](https://github.com/ggerganov/llama.cpp)** — local LLM inference for AI text processing
 - **[Electron](https://www.electronjs.org/)** — cross-platform desktop framework
 - **[React](https://react.dev/)** — UI component library


### PR DESCRIPTION
## Summary

Adds Hugging Face to the README acknowledgments section. They host the model weights for Whisper (GGML), NVIDIA Parakeet (INT8 ONNX), and the all-MiniLM-L6-v2 embedding model — all of which are auto-downloaded by the desktop app.

Placed in the model/runtime cluster, after sherpa-onnx and before llama.cpp, to match the existing flow of the list.

## Test plan

- [ ] Render the README on GitHub and verify the new line appears in the right place