### PR TITLE
feat(auth): switch desktop to Authorization: Bearer + safeStorage

### DIFF
--- a/main.js
+++ b/main.js
@@ -471,9 +471,6 @@ app.on("open-url", (event, url) => {
   }
 });
 
-// Mirror the channel-aware URL resolution used by ipcHandlers.js getAuthUrl()
-// and the renderer's AUTH_URL: env wins, then runtime-env.json baked in by
-// Vite, then fall back to the production host.
 function resolveAuthUrl() {
   const fs = require("fs");
   const envPath = path.join(__dirname, "src", "dist", "runtime-env.json");
@@ -495,9 +492,8 @@ function getOauthCookieName() {
     : "openwhispr.session_token";
 }
 
-// Older website builds send `?token=` as the signed cookie value rather than
-// the raw session.token the bearer plugin expects. Trade the signed value
-// for the raw token via Better Auth's get-session endpoint.
+// Older website builds send the signed cookie value as `?token=`; trade it
+// for the raw session.token the bearer plugin expects.
 async function exchangeSignedTokenForRawBearer(signedToken) {
   try {
     const res = await fetch(`${resolveAuthUrl()}/api/auth/get-session`, {
@@ -584,8 +580,6 @@ async function handleOAuthDeepLink(deepLinkUrl) {
       void applySessionTokenAndRefresh(bearerToken);
       return;
     }
-    // Older website builds only send `?token=` carrying the signed cookie value;
-    // exchange it for a raw session.token before storing.
     const signedToken = parsed.searchParams.get("token");
     if (!signedToken) return;
     const rawToken = await exchangeSignedTokenForRawBearer(signedToken);
@@ -653,8 +647,7 @@ function startAuthBridgeServer() {
       return;
     }
 
-    let token =
-      requestUrl.searchParams.get("bearer_token") || requestUrl.searchParams.get("token");
+    let token = requestUrl.searchParams.get("bearer_token") || requestUrl.searchParams.get("token");
     if (!token && req.method === "POST") {
       try {
         const body = await parseJsonBody(req);

--- a/main.js
+++ b/main.js
@@ -471,27 +471,53 @@ app.on("open-url", (event, url) => {
   }
 });
 
-// Inject the Better Auth session cookie into Electron's session, then reload
-// the control panel so the renderer's authClient picks up the new session.
+// One-time bridge for users upgrading from a build that injected the session
+// cookie into Electron's jar: exchange the existing cookie for a raw bearer
+// token, store it, and remove the cookie. Non-fatal — failures fall through
+// to the normal sign-in flow.
+async function migrateCookieToBearerToken() {
+  const tokenStore = require("./src/helpers/tokenStore");
+  if (tokenStore.get()) return;
+
+  const cookieName =
+    process.env.NODE_ENV === "production"
+      ? "__Secure-openwhispr.session_token"
+      : "openwhispr.session_token";
+  const authUrl = "https://auth.openwhispr.com";
+
+  try {
+    const cookies = await session.defaultSession.cookies.get({ url: authUrl, name: cookieName });
+    if (!cookies.length) return;
+
+    const res = await fetch(`${authUrl}/api/auth/get-session`, {
+      headers: { Cookie: `${cookieName}=${cookies[0].value}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    const token = data?.session?.token;
+    if (!token) return;
+
+    tokenStore.set(token);
+    await session.defaultSession.cookies.remove(authUrl, cookieName);
+    if (debugLogger) debugLogger.debug("Migrated cookie to bearer token");
+  } catch (err) {
+    if (debugLogger) {
+      debugLogger.warn("Cookie→bearer token migration failed (non-fatal)", {
+        error: err?.message,
+      });
+    }
+  }
+}
+
+// Persist the bearer token and reload the control panel so the renderer's
+// authClient sends `Authorization: Bearer <token>` on its next request.
 async function applySessionTokenAndRefresh(token) {
   if (!token) return;
   if (!isLiveWindow(windowManager?.controlPanelWindow)) return;
 
-  try {
-    await session.defaultSession.cookies.set({
-      url: "https://auth.openwhispr.com",
-      name: "__Secure-openwhispr.session_token",
-      value: token,
-      domain: ".openwhispr.com",
-      path: "/",
-      secure: true,
-      httpOnly: true,
-      sameSite: "lax",
-    });
-  } catch (err) {
-    if (debugLogger) debugLogger.error("Failed to set OAuth session cookie:", err);
-    return;
-  }
+  const tokenStore = require("./src/helpers/tokenStore");
+  tokenStore.set(token);
 
   const appUrl = DevServerManager.getAppUrl(true);
   if (appUrl) {
@@ -504,7 +530,7 @@ async function applySessionTokenAndRefresh(token) {
   }
 
   if (debugLogger) {
-    debugLogger.debug("Applied OAuth session cookie and reloaded control panel", {
+    debugLogger.debug("Applied bearer token and reloaded control panel", {
       appChannel: APP_CHANNEL,
       oauthProtocol: OAUTH_PROTOCOL,
     });
@@ -637,6 +663,8 @@ async function startApp() {
     debugLogger.error("CLI bridge failed to start", { error: err.message });
     cliBridge = null;
   });
+
+  await migrateCookieToBearerToken();
 
   // Electron's file:// renderer sends Origin: null, which Better Auth's
   // trustedOrigins check rejects. Spoof Origin to the request's own URL so

--- a/main.js
+++ b/main.js
@@ -483,7 +483,23 @@ async function migrateCookieToBearerToken() {
     process.env.NODE_ENV === "production"
       ? "__Secure-openwhispr.session_token"
       : "openwhispr.session_token";
-  const authUrl = "https://auth.openwhispr.com";
+
+  // Mirror the channel-aware URL resolution used by ipcHandlers.js getAuthUrl()
+  // and the renderer's AUTH_URL: env wins, then runtime-env.json baked in by
+  // Vite, then fall back to the production host.
+  const runtimeEnv = (() => {
+    const fs = require("fs");
+    const envPath = path.join(__dirname, "src", "dist", "runtime-env.json");
+    try {
+      if (fs.existsSync(envPath)) return JSON.parse(fs.readFileSync(envPath, "utf8"));
+    } catch {}
+    return {};
+  })();
+  const authUrl =
+    process.env.AUTH_URL ||
+    process.env.VITE_AUTH_URL ||
+    runtimeEnv.VITE_AUTH_URL ||
+    "https://auth.openwhispr.com";
 
   try {
     const cookies = await session.defaultSession.cookies.get({ url: authUrl, name: cookieName });

--- a/main.js
+++ b/main.js
@@ -463,13 +463,59 @@ app.on("open-url", (event, url) => {
     return;
   }
 
-  handleOAuthDeepLink(url);
+  void handleOAuthDeepLink(url);
 
   if (windowManager && isLiveWindow(windowManager.controlPanelWindow)) {
     windowManager.controlPanelWindow.show();
     windowManager.controlPanelWindow.focus();
   }
 });
+
+// Mirror the channel-aware URL resolution used by ipcHandlers.js getAuthUrl()
+// and the renderer's AUTH_URL: env wins, then runtime-env.json baked in by
+// Vite, then fall back to the production host.
+function resolveAuthUrl() {
+  const fs = require("fs");
+  const envPath = path.join(__dirname, "src", "dist", "runtime-env.json");
+  let runtimeEnv = {};
+  try {
+    if (fs.existsSync(envPath)) runtimeEnv = JSON.parse(fs.readFileSync(envPath, "utf8"));
+  } catch {}
+  return (
+    process.env.AUTH_URL ||
+    process.env.VITE_AUTH_URL ||
+    runtimeEnv.VITE_AUTH_URL ||
+    "https://auth.openwhispr.com"
+  );
+}
+
+function getOauthCookieName() {
+  return process.env.NODE_ENV === "production"
+    ? "__Secure-openwhispr.session_token"
+    : "openwhispr.session_token";
+}
+
+// Older website builds send `?token=` as the signed cookie value rather than
+// the raw session.token the bearer plugin expects. Trade the signed value
+// for the raw token via Better Auth's get-session endpoint.
+async function exchangeSignedTokenForRawBearer(signedToken) {
+  try {
+    const res = await fetch(`${resolveAuthUrl()}/api/auth/get-session`, {
+      headers: { Cookie: `${getOauthCookieName()}=${signedToken}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.session?.token || null;
+  } catch (err) {
+    if (debugLogger) {
+      debugLogger.warn("Signed-token bearer exchange failed (non-fatal)", {
+        error: err?.message,
+      });
+    }
+    return null;
+  }
+}
 
 // One-time bridge for users upgrading from a build that injected the session
 // cookie into Electron's jar: exchange the existing cookie for a raw bearer
@@ -479,42 +525,17 @@ async function migrateCookieToBearerToken() {
   const tokenStore = require("./src/helpers/tokenStore");
   if (tokenStore.get()) return;
 
-  const cookieName =
-    process.env.NODE_ENV === "production"
-      ? "__Secure-openwhispr.session_token"
-      : "openwhispr.session_token";
-
-  // Mirror the channel-aware URL resolution used by ipcHandlers.js getAuthUrl()
-  // and the renderer's AUTH_URL: env wins, then runtime-env.json baked in by
-  // Vite, then fall back to the production host.
-  const runtimeEnv = (() => {
-    const fs = require("fs");
-    const envPath = path.join(__dirname, "src", "dist", "runtime-env.json");
-    try {
-      if (fs.existsSync(envPath)) return JSON.parse(fs.readFileSync(envPath, "utf8"));
-    } catch {}
-    return {};
-  })();
-  const authUrl =
-    process.env.AUTH_URL ||
-    process.env.VITE_AUTH_URL ||
-    runtimeEnv.VITE_AUTH_URL ||
-    "https://auth.openwhispr.com";
+  const cookieName = getOauthCookieName();
+  const authUrl = resolveAuthUrl();
 
   try {
     const cookies = await session.defaultSession.cookies.get({ url: authUrl, name: cookieName });
     if (!cookies.length) return;
 
-    const res = await fetch(`${authUrl}/api/auth/get-session`, {
-      headers: { Cookie: `${cookieName}=${cookies[0].value}` },
-      signal: AbortSignal.timeout(5000),
-    });
-    if (!res.ok) return;
-    const data = await res.json();
-    const token = data?.session?.token;
-    if (!token) return;
+    const rawToken = await exchangeSignedTokenForRawBearer(cookies[0].value);
+    if (!rawToken) return;
 
-    tokenStore.set(token);
+    tokenStore.set(rawToken);
     await session.defaultSession.cookies.remove(authUrl, cookieName);
     if (debugLogger) debugLogger.debug("Migrated cookie to bearer token");
   } catch (err) {
@@ -555,12 +576,20 @@ async function applySessionTokenAndRefresh(token) {
   windowManager.controlPanelWindow.focus();
 }
 
-function handleOAuthDeepLink(deepLinkUrl) {
+async function handleOAuthDeepLink(deepLinkUrl) {
   try {
     const parsed = new URL(deepLinkUrl);
-    const token = parsed.searchParams.get("token");
-    if (!token) return;
-    void applySessionTokenAndRefresh(token);
+    const bearerToken = parsed.searchParams.get("bearer_token");
+    if (bearerToken) {
+      void applySessionTokenAndRefresh(bearerToken);
+      return;
+    }
+    // Older website builds only send `?token=` carrying the signed cookie value;
+    // exchange it for a raw session.token before storing.
+    const signedToken = parsed.searchParams.get("token");
+    if (!signedToken) return;
+    const rawToken = await exchangeSignedTokenForRawBearer(signedToken);
+    if (rawToken) void applySessionTokenAndRefresh(rawToken);
   } catch (err) {
     if (debugLogger) debugLogger.error("Failed to handle OAuth deep link:", err);
   }
@@ -624,11 +653,12 @@ function startAuthBridgeServer() {
       return;
     }
 
-    let token = requestUrl.searchParams.get("token");
+    let token =
+      requestUrl.searchParams.get("bearer_token") || requestUrl.searchParams.get("token");
     if (!token && req.method === "POST") {
       try {
         const body = await parseJsonBody(req);
-        token = body?.token || null;
+        token = body?.bearer_token || body?.token || null;
       } catch (error) {
         res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
         res.end(error.message || "Invalid request");
@@ -1344,7 +1374,7 @@ if (gotSingleInstanceLock) {
       if (url.includes("upgrade-success")) {
         handleUpgradeDeepLink();
       } else {
-        handleOAuthDeepLink(url);
+        void handleOAuthDeepLink(url);
       }
     }
   });

--- a/preload.js
+++ b/preload.js
@@ -466,6 +466,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   resumeMediaPlayback: () => ipcRenderer.invoke("resume-media-playback"),
   openWhisperModelsFolder: () => ipcRenderer.invoke("open-whisper-models-folder"),
   authClearSession: () => ipcRenderer.invoke("auth-clear-session"),
+  authGetToken: () => ipcRenderer.invoke("auth-get-token"),
+  authSetToken: (token) => ipcRenderer.invoke("auth-set-token", token),
+  authClearToken: () => ipcRenderer.invoke("auth-clear-token"),
 
   // OpenWhispr Cloud API
   cloudHealthCheck: () => ipcRenderer.invoke("cloud-health-check"),

--- a/preload.js
+++ b/preload.js
@@ -467,7 +467,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   authClearSession: () => ipcRenderer.invoke("auth-clear-session"),
   authGetToken: () => ipcRenderer.invoke("auth-get-token"),
   authSetToken: (token) => ipcRenderer.invoke("auth-set-token", token),
-  authClearToken: () => ipcRenderer.invoke("auth-clear-token"),
 
   // OpenWhispr Cloud API
   cloudHealthCheck: () => ipcRenderer.invoke("cloud-health-check"),

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -136,7 +136,7 @@ class EnvironmentManager {
       if (error.code === "ENOENT") return;
       debugLogger.error(
         "Failed to decrypt secret — user must re-enter",
-        { key: envVarName, error: error.message },
+        { key: envVarName, code: error.code, error: error.message },
         "environment"
       );
     }
@@ -203,10 +203,7 @@ class EnvironmentManager {
       return;
     }
 
-    // Sentinel before .env rewrite: if the rewrite fails, next launch loads
-    // stale plaintext but encrypted values overwrite it on _loadAllSecrets,
-    // and the next saveAllKeysToEnvFile cleans the .env. Reverse order risks
-    // stripping plaintext for secrets that haven't been encrypted yet.
+    // Write sentinel before stripping plaintext from .env so a crash mid-rewrite is recoverable.
     await fsPromises.writeFile(this._getMigrationSentinelPath(), "");
     const envPath = path.join(app.getPath("userData"), ".env");
     if (fs.existsSync(envPath)) await this._writeEnvFileAtomic(envPath);
@@ -240,8 +237,6 @@ class EnvironmentManager {
 
   _saveKey(envVarName, key) {
     if (SECRET_KEY_SET.has(envVarName) && this._encryptionAvailable()) {
-      // _saveSecretKey updates process.env before its first await, so
-      // in-process reads see the new value while the encrypted write lands.
       this._saveSecretKey(envVarName, key).catch((error) => {
         debugLogger.error(
           "Failed to persist encrypted secret",

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3293,9 +3293,16 @@ class IPCHandlers {
 
     ipcMain.handle("auth-get-token", () => tokenStore.get());
     ipcMain.handle("auth-set-token", (_event, token) => {
-      if (typeof token === "string" && token) tokenStore.set(token);
+      if (typeof token === "string" && token) {
+        tokenStore.set(token);
+      } else {
+        // Surface silent rotation-to-empty so we can spot regressions where the
+        // renderer thinks it's persisting a token but the value never lands.
+        debugLogger.debug("auth-set-token ignored: empty or non-string token", {
+          type: typeof token,
+        });
+      }
     });
-    ipcMain.handle("auth-clear-token", () => tokenStore.clear());
 
     // In production, VITE_* env vars aren't available in the main process because
     // Vite only inlines them into the renderer bundle at build time. Load the

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6,6 +6,7 @@ const http = require("http");
 const https = require("https");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
+const tokenStore = require("./tokenStore");
 const { classifyAndLog } = require("./networkErrors");
 const GnomeShortcutManager = require("./gnomeShortcut");
 const HyprlandShortcutManager = require("./hyprlandShortcut");
@@ -165,7 +166,7 @@ async function chunkedCloudTranscribe({
   buffer = null,
   filePath = null,
   apiUrl,
-  cookieHeader,
+  authHeader,
   multipartFields = {},
   onProgress,
   concurrencyLimit = CLOUD_CHUNK_CONCURRENCY,
@@ -208,7 +209,7 @@ async function chunkedCloudTranscribe({
         multipartFields
       );
       const url = new URL(`${apiUrl}/api/transcribe`);
-      const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
+      const data = await postMultipart(url, body, boundary, authHeader);
 
       results[index] = interpretTranscribeResponse(data);
       completedCount++;
@@ -3280,13 +3281,9 @@ class IPCHandlers {
       });
     });
 
-    // Auth: clear all session cookies for sign-out.
-    // This clears every cookie in the renderer session rather than targeting
-    // individual auth cookies, which is acceptable because the app only sets
-    // cookies for Better Auth. Avoids CSRF/Origin header issues that occur when
-    // the renderer tries to call the server-side sign-out endpoint directly.
     ipcMain.handle("auth-clear-session", async (event) => {
       try {
+        tokenStore.clear();
         const win = BrowserWindow.fromWebContents(event.sender);
         if (win) {
           await win.webContents.session.clearStorageData({ storages: ["cookies"] });
@@ -3297,6 +3294,12 @@ class IPCHandlers {
         return { success: false, error: error.message };
       }
     });
+
+    ipcMain.handle("auth-get-token", () => tokenStore.get());
+    ipcMain.handle("auth-set-token", (_event, token) => {
+      if (typeof token === "string" && token) tokenStore.set(token);
+    });
+    ipcMain.handle("auth-clear-token", () => tokenStore.clear());
 
     // In production, VITE_* env vars aren't available in the main process because
     // Vite only inlines them into the renderer bundle at build time. Load the
@@ -3374,9 +3377,22 @@ class IPCHandlers {
       return getSessionCookiesFromWindow(win);
     };
 
-    // Honors system proxy via Electron's net stack. useSessionCookies:false
-    // because we set the Cookie header manually from getSessionCookies() —
-    // letting Electron also attach session cookies risks duplicates.
+    // Bearer auth is preferred. Cookie fallback covers the brief window before
+    // main.js's startup migration bridge runs (or if it failed for this user).
+    const getAuthHeaderFromWindow = async (win) => {
+      const token = tokenStore.get();
+      if (token) return { Authorization: `Bearer ${token}` };
+      const cookieHeader = win ? await getSessionCookiesFromWindow(win) : "";
+      return cookieHeader ? { Cookie: cookieHeader } : {};
+    };
+
+    const getAuthHeader = async (event) => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      return getAuthHeaderFromWindow(win);
+    };
+
+    // Honors system proxy via Electron's net stack. useSessionCookies:false so
+    // Electron doesn't auto-attach jar cookies on top of our explicit headers.
     const proxyFetch = (url, init = {}) => net.fetch(url, { ...init, useSessionCookies: false });
 
     ipcMain.handle("cloud-transcribe", async (event, audioBuffer, opts = {}) => {
@@ -3384,8 +3400,8 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const audioData = Buffer.from(audioBuffer);
         // Reused for the local SQLite row so SyncService upserts the existing
@@ -3408,7 +3424,7 @@ class IPCHandlers {
           const { text, responses, lastResponse } = await chunkedCloudTranscribe({
             buffer: audioData,
             apiUrl,
-            cookieHeader,
+            authHeader,
             multipartFields,
           });
           const sum = (field) => responses.reduce((s, r) => s + (r?.[field] || 0), 0);
@@ -3436,7 +3452,7 @@ class IPCHandlers {
           multipartFields
         );
         const url = new URL(`${apiUrl}/api/transcribe`);
-        const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
+        const data = await postMultipart(url, body, boundary, authHeader);
 
         debugLogger.debug(
           "Cloud transcribe response",
@@ -3517,8 +3533,8 @@ class IPCHandlers {
         } else if (settings?.cloudTranscriptionMode === "openwhispr") {
           const win = BrowserWindow.fromWebContents(event.sender);
           if (win) {
-            const cookieHeader = await getSessionCookiesFromWindow(win);
-            if (cookieHeader) {
+            const authHeader = await getAuthHeaderFromWindow(win);
+            if (Object.keys(authHeader).length) {
               const apiUrl = getApiUrl();
               if (apiUrl) {
                 const multipartFields = {
@@ -3530,7 +3546,7 @@ class IPCHandlers {
                   const { text } = await chunkedCloudTranscribe({
                     buffer,
                     apiUrl,
-                    cookieHeader,
+                    authHeader,
                     multipartFields,
                   });
                   result = { text, source: "openwhispr", model: "cloud" };
@@ -3542,9 +3558,7 @@ class IPCHandlers {
                     multipartFields
                   );
                   const url = new URL(`${apiUrl}/api/transcribe`);
-                  const data = await postMultipart(url, body, boundary, {
-                    Cookie: cookieHeader,
-                  });
+                  const data = await postMultipart(url, body, boundary, authHeader);
                   const responseData = interpretTranscribeResponse(data);
                   result = {
                     text: responseData.text,
@@ -4041,14 +4055,14 @@ class IPCHandlers {
       const postServerToken = async (path, body = {}) => {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
         const url = `${apiUrl}${path}`;
         let response;
         try {
           response = await proxyFetch(url, {
             method: "POST",
-            headers: { "Content-Type": "application/json", Cookie: cookieHeader },
+            headers: { "Content-Type": "application/json", ...authHeader },
             body: JSON.stringify(body),
           });
         } catch (err) {
@@ -5536,8 +5550,8 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         debugLogger.debug(
           "Cloud reason request",
@@ -5553,7 +5567,7 @@ class IPCHandlers {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Cookie: cookieHeader,
+            ...authHeader,
           },
           body: JSON.stringify({
             text,
@@ -5622,14 +5636,14 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/agent/stream`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Cookie: cookieHeader,
+            ...authHeader,
           },
           body: JSON.stringify({
             messages,
@@ -5715,8 +5729,8 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         debugLogger.debug("Agent web search request", { query, numResults }, "cloud-api");
 
@@ -5724,7 +5738,7 @@ class IPCHandlers {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Cookie: cookieHeader,
+            ...authHeader,
           },
           body: JSON.stringify({ query, numResults }),
         });
@@ -5758,14 +5772,14 @@ class IPCHandlers {
           const apiUrl = getApiUrl();
           if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-          const cookieHeader = await getSessionCookies(event);
-          if (!cookieHeader) throw new Error("No session cookies available");
+          const authHeader = await getAuthHeader(event);
+          if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
           const response = await proxyFetch(`${apiUrl}/api/streaming-usage`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Cookie: cookieHeader,
+              ...authHeader,
             },
             body: JSON.stringify({
               text,
@@ -5809,11 +5823,11 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/usage`, {
-          headers: { Cookie: cookieHeader },
+          headers: authHeader,
         });
 
         if (!response.ok) {
@@ -5839,10 +5853,10 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
-        const headers = { Cookie: cookieHeader };
+        const headers = { ...authHeader };
         const fetchOpts = { method: "POST", headers };
         if (body) {
           headers["Content-Type"] = "application/json";
@@ -5883,12 +5897,12 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/stripe/switch-plan`, {
           method: "POST",
-          headers: { Cookie: cookieHeader, "Content-Type": "application/json" },
+          headers: { ...authHeader, "Content-Type": "application/json" },
           body: JSON.stringify(opts),
         });
 
@@ -5915,12 +5929,12 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/stripe/preview-switch`, {
           method: "POST",
-          headers: { Cookie: cookieHeader, "Content-Type": "application/json" },
+          headers: { ...authHeader, "Content-Type": "application/json" },
           body: JSON.stringify(opts),
         });
 
@@ -5947,11 +5961,11 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const method = (opts.method || "GET").toUpperCase();
-        const headers = { Cookie: cookieHeader };
+        const headers = { ...authHeader };
         const fetchOpts = { method, headers };
 
         if (opts.body !== undefined) {
@@ -5990,11 +6004,11 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/stt-config`, {
-          headers: { Cookie: cookieHeader },
+          headers: authHeader,
         });
 
         if (!response.ok) {
@@ -6020,11 +6034,11 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const response = await proxyFetch(`${apiUrl}/api/note-recording-config`, {
-          headers: { Cookie: cookieHeader },
+          headers: authHeader,
         });
 
         if (!response.ok) {
@@ -6047,8 +6061,8 @@ class IPCHandlers {
         const apiUrl = getApiUrl();
         if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
         const multipartFields = {
           source: "file_upload",
@@ -6068,7 +6082,7 @@ class IPCHandlers {
           const { text, warning } = await chunkedCloudTranscribe({
             filePath,
             apiUrl,
-            cookieHeader,
+            authHeader,
             multipartFields,
             onProgress: (payload) => event.sender.send("upload-transcription-progress", payload),
           });
@@ -6087,7 +6101,7 @@ class IPCHandlers {
           multipartFields
         );
         const url = new URL(`${apiUrl}/api/transcribe`);
-        const data = await postMultipart(url, body, boundary, { Cookie: cookieHeader });
+        const data = await postMultipart(url, body, boundary, authHeader);
         const result = interpretTranscribeResponse(data);
 
         return { success: true, text: result.text };
@@ -6163,14 +6177,14 @@ class IPCHandlers {
           throw new Error("OpenWhispr API URL not configured");
         }
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) {
-          throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) {
+          throw new Error("Not authenticated");
         }
 
         const response = await proxyFetch(`${apiUrl}/api/referrals/stats`, {
           headers: {
-            Cookie: cookieHeader,
+            ...authHeader,
           },
         });
 
@@ -6199,15 +6213,15 @@ class IPCHandlers {
           throw new Error("OpenWhispr API URL not configured");
         }
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) {
-          throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) {
+          throw new Error("Not authenticated");
         }
 
         const response = await proxyFetch(`${apiUrl}/api/referrals/invite`, {
           method: "POST",
           headers: {
-            Cookie: cookieHeader,
+            ...authHeader,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ email }),
@@ -6237,14 +6251,14 @@ class IPCHandlers {
           throw new Error("OpenWhispr API URL not configured");
         }
 
-        const cookieHeader = await getSessionCookies(event);
-        if (!cookieHeader) {
-          throw new Error("No session cookies available");
+        const authHeader = await getAuthHeader(event);
+        if (!Object.keys(authHeader).length) {
+          throw new Error("Not authenticated");
         }
 
         const response = await proxyFetch(`${apiUrl}/api/referrals/invites`, {
           headers: {
-            Cookie: cookieHeader,
+            ...authHeader,
           },
         });
 
@@ -6427,15 +6441,15 @@ class IPCHandlers {
         throw new Error("OpenWhispr API URL not configured");
       }
 
-      const cookieHeader = await getSessionCookies(event);
-      if (!cookieHeader) {
-        throw new Error("No session cookies available");
+      const authHeader = await getAuthHeader(event);
+      if (!Object.keys(authHeader).length) {
+        throw new Error("Not authenticated");
       }
 
       const tokenResponse = await proxyFetch(`${apiUrl}/api/streaming-token`, {
         method: "POST",
         headers: {
-          Cookie: cookieHeader,
+          ...authHeader,
         },
       });
 
@@ -6630,12 +6644,12 @@ class IPCHandlers {
       const win = BrowserWindow.fromId(windowId);
       if (!win || win.isDestroyed()) throw new Error("Window not available for token refresh");
 
-      const cookieHeader = await getSessionCookiesFromWindow(win);
-      if (!cookieHeader) throw new Error("No session cookies available");
+      const authHeader = await getAuthHeaderFromWindow(win);
+      if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
 
       const tokenResponse = await proxyFetch(`${apiUrl}/api/deepgram-streaming-token`, {
         method: "POST",
-        headers: { Cookie: cookieHeader },
+        headers: authHeader,
       });
 
       if (!tokenResponse.ok) {
@@ -6658,15 +6672,15 @@ class IPCHandlers {
         throw new Error("OpenWhispr API URL not configured");
       }
 
-      const cookieHeader = await getSessionCookies(event);
-      if (!cookieHeader) {
-        throw new Error("No session cookies available");
+      const authHeader = await getAuthHeader(event);
+      if (!Object.keys(authHeader).length) {
+        throw new Error("Not authenticated");
       }
 
       const tokenResponse = await proxyFetch(`${apiUrl}/api/deepgram-streaming-token`, {
         method: "POST",
         headers: {
-          Cookie: cookieHeader,
+          ...authHeader,
         },
       });
 

--- a/src/helpers/tokenStore.js
+++ b/src/helpers/tokenStore.js
@@ -1,0 +1,49 @@
+const { safeStorage, app } = require("electron");
+const fs = require("fs");
+const path = require("path");
+const debugLogger = require("./debugLogger");
+
+const tokenFile = () => path.join(app.getPath("userData"), "auth-token.bin");
+
+let cached = null;
+
+function get() {
+  if (cached !== null) return cached || null;
+  try {
+    const file = tokenFile();
+    if (!fs.existsSync(file)) return (cached = "");
+    const buf = fs.readFileSync(file);
+    cached = safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(buf)
+      : buf.toString("utf8");
+    return cached || null;
+  } catch (err) {
+    debugLogger.error("tokenStore.get failed", { error: err?.message });
+    cached = "";
+    return null;
+  }
+}
+
+function set(token) {
+  try {
+    const file = tokenFile();
+    const data = safeStorage.isEncryptionAvailable()
+      ? safeStorage.encryptString(token)
+      : Buffer.from(token, "utf8");
+    fs.writeFileSync(file, data, { mode: 0o600 });
+    cached = token;
+  } catch (err) {
+    debugLogger.error("tokenStore.set failed", { error: err?.message });
+  }
+}
+
+function clear() {
+  cached = "";
+  try {
+    fs.rmSync(tokenFile(), { force: true });
+  } catch (err) {
+    debugLogger.error("tokenStore.clear failed", { error: err?.message });
+  }
+}
+
+module.exports = { get, set, clear };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,7 +6,15 @@ export const AUTH_URL = import.meta.env.VITE_AUTH_URL || "https://auth.openwhisp
 export const authClient = createAuthClient({
   baseURL: AUTH_URL,
   fetchOptions: {
+    auth: {
+      type: "Bearer",
+      token: async () => (await window.electronAPI?.authGetToken?.()) ?? "",
+    },
     headers: { "x-openwhispr-source": "desktop" },
+    onSuccess: async (ctx: { response: Response }) => {
+      const newToken = ctx.response.headers.get("set-auth-token");
+      if (newToken) await window.electronAPI?.authSetToken?.(newToken);
+    },
   },
 });
 
@@ -121,10 +129,10 @@ export async function deleteAccount(): Promise<{ error?: Error }> {
 
 export async function signOut(): Promise<void> {
   try {
+    await authClient.signOut();
     if (window.electronAPI?.authClearSession) {
       await window.electronAPI.authClearSession();
     }
-    await authClient.signOut();
     markSignedOutState();
   } catch {
     markSignedOutState();

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -560,7 +560,13 @@ function debouncedSaveSecret(provider: SecretProvider, key: string) {
     const save = api?.[SECRET_IPC_SAVERS[provider]] as
       | ((k: string) => Promise<unknown>)
       | undefined;
-    void save?.(key);
+    save?.(key)?.catch((err) => {
+      logger.warn(
+        "Failed to persist secret to safeStorage",
+        { provider, error: (err as Error).message },
+        "settings"
+      );
+    });
   }, 250);
 }
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -956,6 +956,9 @@ declare global {
 
       // Auth
       authClearSession?: () => Promise<void>;
+      authGetToken?: () => Promise<string | null>;
+      authSetToken?: (token: string) => Promise<void>;
+      authClearToken?: () => Promise<void>;
 
       // OpenWhispr Cloud API
       cloudTranscribe?: (

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -957,7 +957,6 @@ declare global {
       authClearSession?: () => Promise<void>;
       authGetToken?: () => Promise<string | null>;
       authSetToken?: (token: string) => Promise<void>;
-      authClearToken?: () => Promise<void>;
 
       // OpenWhispr Cloud API
       cloudTranscribe?: (


### PR DESCRIPTION
## Summary

Phase B of the bearer migration. Replaces the cookie-injection workaround in `main.js` with Better Auth's official bearer plugin pattern: tokens live in `safeStorage` (OS keychain), every API call sends `Authorization: Bearer …`. Removes 80+ lines of fragile glue, including the cookie format coupling that caused the recent Google sign-in bug.

## What changed

- **New `src/helpers/tokenStore.js`** — `get/set/clear` over `safeStorage` with plaintext `0600` fallback when OS encryption isn't available (Linux without keyring).
- **Renderer `authClient`** — `fetchOptions.auth: { type: "Bearer", token: () => electronAPI.authGetToken() }` plus `onSuccess` capturing rotated `set-auth-token` headers on every session refresh.
- **`ipcHandlers.js`** — paired `getAuthHeader(event)` / `getAuthHeaderFromWindow(win)` helpers prefer bearer, fall back to cookies during the migration window. `chunkedCloudTranscribe` takes a generic `authHeader` object. 21 cloud-bound call sites updated mechanically. Three new IPC channels: `auth-get-token` / `auth-set-token` / `auth-clear-token`.
- **`main.js`** — `applySessionTokenAndRefresh` writes to `tokenStore` instead of the cookie jar. New `migrateCookieToBearerToken` runs once on startup with a 5s timeout: if a Better Auth cookie is in the jar, exchange it for the raw token and remove the cookie. Failures are non-fatal. Origin spoof retained because the renderer's `authClient` still hits `auth.openwhispr.com` directly.
- **`signOut`** — now calls `authClient.signOut()` BEFORE clearing the local token, so the server session row actually gets invalidated instead of leaving a zombie.

## Migration story (zero forced sign-out)

Existing 1.7.x desktops carry a valid signed cookie. On first launch after this update, the migration bridge silently exchanges it for a raw token and stores it in safeStorage. Users never see a sign-in screen.

1.6.10 Neon Auth users are untouched — the cookie name doesn't match, migration exits early, and the server's existing `fetchNeonAuthSession` fallback (`openwhispr-api/lib/auth.ts:71`) handles their requests as before.

## Refactor verification

```
grep -c "Cookie: cookieHeader" src/helpers/ipcHandlers.js          # 1 (legitimate, in getAuthHeaderFromWindow fallback)
grep -c "getSessionCookies(event)" src/helpers/ipcHandlers.js       # 0
grep -c "getSessionCookiesFromWindow" src/helpers/ipcHandlers.js    # 3 (definition + 2 fallback uses inside helpers)
grep -c "cookieHeader," src/helpers/ipcHandlers.js                  # 0 (no stale chunkedCloudTranscribe callers)
```

All pass.

## Test plan

- [ ] **Existing 1.7.x user upgrades** — cookie in jar, no token in safeStorage → on first launch, migration bridge runs, `auth-token.bin` appears in userData, cookie removed from jar, control panel loads signed in.
- [ ] **Fresh sign-in** (Google/Microsoft/Apple) — deep link `openwhispr://auth/callback?token=…` fires, token written to safeStorage, control panel shows authenticated state. Verify cloud-transcribe call sends `Authorization: Bearer …` in API logs.
- [ ] **Sign-out** — server session row deleted (check Neon DB); `auth-token.bin` removed; renderer shows sign-in.
- [ ] **Session expiry** — manually delete the session row server-side; next API call returns 401; renderer shows sign-in (no infinite retry loop).
- [ ] **Linux without keyring** — `safeStorage.isEncryptionAvailable()` false → token written as plaintext with `0600` perms; warn logged.
- [ ] **1.6.10 Neon Auth user** — they don't update; `validateSession` fallback at `lib/auth.ts:71` handles them as before.
- [ ] **Migration bridge timeout** — simulate slow network; bridge gives up after 5s; user falls through to sign-in screen with no startup hang.

## Depends on

- openwhispr-api#feat/bearer-auth-plugin must be deployed first.
- openwhispr-website#feat/bearer-desktop-callback should ship at the same time as this Electron release.

## Followups (Phase D, after this build is widely adopted)

- Delete `/api/desktop-handoff` endpoint.
- Drop `getSessionCookiesFromWindow` and the cookie fallback in `getAuthHeaderFromWindow`.
- Reconsider deleting the Origin spoof in `main.js` once we verify Better Auth skips origin checks on bearer-authed paths.