### PR TITLE
fix(linux): resolve symlink in launcher wrapper

### DIFF
--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -176,7 +176,7 @@ function wrapLinuxBinary(context) {
 # OpenWhispr launcher
 # User flags: ~/.config/${binaryName}-flags.conf (one per line, # = comment)
 
-HERE="\${BASH_SOURCE%/*}"
+HERE="$(dirname "$(readlink -f "\${BASH_SOURCE[0]}")")"
 FLAGS=()
 
 # Wayland: forces XWayland (overlay positioning requires X11)


### PR DESCRIPTION
## Summary

The Linux launcher wrapper generated by afterPack.js used `${BASH_SOURCE%/*}` to find the companion binary. When package managers (deb/rpm) install a symlink at `/usr/bin/open-whispr` pointing to `/opt/OpenWhispr/open-whispr`, that expansion resolves to `/usr/bin/` instead of the actual install directory, so `open-whispr-app` is never found.

Replaced with `readlink -f` which follows the symlink chain before extracting the directory.

## Changes

- scripts/afterPack.js: use `readlink -f` + `dirname` instead of `${BASH_SOURCE%/*}` in the generated wrapper script