### PR TITLE
fix(lan-provider): remove duplicate /v1 prefix in chat completions URL

### DIFF
--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -348,7 +348,7 @@ class ReasoningService extends BaseReasoningService {
     if (isLanCleanup) {
       const rawUrl = lanOverride || settings.cleanupRemoteUrl.trim();
       const baseUrl = normalizeBaseUrl(rawUrl) || rawUrl;
-      endpoint = buildApiUrl(baseUrl, "/v1/chat/completions");
+      endpoint = buildApiUrl(baseUrl, "/chat/completions");
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
       if (!serverResult.success || !serverResult.port) {

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -11,7 +11,7 @@ export const lanProvider: InferenceProvider = {
 
     try {
       const baseUrl = normalizeBaseUrl(lanUrl) || lanUrl;
-      const endpoint = buildApiUrl(baseUrl, "/v1/chat/completions");
+      const endpoint = buildApiUrl(baseUrl, "/chat/completions");
       const apiKey = config.customApiKey?.trim() || getSettings().cleanupCustomApiKey?.trim() || "";
       const resolvedModel = model?.trim() || "default";
       return await ctx.callChatCompletionsApi(


### PR DESCRIPTION
## Summary

`normalizeBaseUrl` preserves the `/v1` suffix in user-configured endpoints (e.g. `http://localhost:11434/v1`). Two call sites were then appending `/v1/chat/completions`, producing `…/v1/v1/chat/completions` → 404.

Fixed in both affected files:
- `src/services/ai/inferenceProviders/lan.ts`
- `src/services/ReasoningService.ts`

Note: there are two valid approaches — remove `/v1` from the endpoint placeholder/instructions, or remove the `/v1` from the appended path (this PR). Went with the latter to keep the endpoint format consistent with what users expect from OpenAI-compatible servers.

All other `buildApiUrl` call sites were audited and are unaffected.

## Test plan
- [ ] Set LAN endpoint to `http://localhost:11434/v1` with an Ollama model selected
- [ ] Prompt Studio test (Dictation Cleanup) — should return a valid response instead of 404
- [ ] Verify LAN provider also works for reasoning/agent scope
- [ ] Verify other LAN-compatible servers (LM Studio, vLLM) still work with `/v1`-suffixed URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)