### PR TITLE
fix: sync custom prompts across windows without restart

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1662,6 +1662,15 @@ export async function initializeSettings(): Promise<void> {
     if (!event.key || event.storageArea !== localStorage || event.newValue === null) return;
 
     const { key, newValue } = event;
+
+    if (key.startsWith("customPrompt.")) {
+      const kind = key.slice("customPrompt.".length);
+      useSettingsStore.setState((s) => ({
+        customPrompts: { ...s.customPrompts, [kind]: newValue || "" },
+      }));
+      return;
+    }
+
     const state = useSettingsStore.getState();
     if (!(key in state) || typeof (state as unknown as Record<string, unknown>)[key] === "function")
       return;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1664,9 +1664,10 @@ export async function initializeSettings(): Promise<void> {
     const { key, newValue } = event;
 
     if (key.startsWith("customPrompt.")) {
-      const kind = key.slice("customPrompt.".length);
+      const kind = key.slice("customPrompt.".length) as PromptKind;
+      if (!PROMPT_KIND_LIST.includes(kind)) return;
       useSettingsStore.setState((s) => ({
-        customPrompts: { ...s.customPrompts, [kind]: newValue || "" },
+        customPrompts: { ...s.customPrompts, [kind]: newValue },
       }));
       return;
     }


### PR DESCRIPTION
## Summary

Custom prompts (dictation cleanup, voice agent, etc.) changed in the Control Panel never propagated to the Main Window until a full app restart. The storage event listener in settingsStore skipped `customPrompt.*` keys because they use dot-notation in localStorage but don't exist as top-level keys in the Zustand state, so the generic sync handler bailed out early.

## Changes

- src/stores/settingsStore.ts: intercept `customPrompt.*` storage events before the generic key-in-state check and update the `customPrompts` object in the store