### PR TITLE
fix(security): prevent key loss when keychain backend becomes unavailable

### DIFF
--- a/src/helpers/secretCrypto.js
+++ b/src/helpers/secretCrypto.js
@@ -1,5 +1,7 @@
 const crypto = require("crypto");
-const { safeStorage } = require("electron");
+const fs = require("fs");
+const path = require("path");
+const { app, safeStorage } = require("electron");
 const debugLogger = require("./debugLogger");
 
 const SERVICE = "OpenWhispr";
@@ -8,9 +10,42 @@ const ALGO = "aes-256-gcm";
 const IV_LEN = 12;
 const TAG_LEN = 16;
 const KEY_LEN = 32;
+const BACKUP_FILE = "master-key-backup.enc";
 
 let mode = null;
 let masterKey = null;
+
+function _backupPath() {
+  return path.join(app.getPath("userData"), "secure-keys", BACKUP_FILE);
+}
+
+function _saveMasterKeyBackup() {
+  if (!masterKey || !safeStorage.isEncryptionAvailable()) return;
+  try {
+    const dir = path.dirname(_backupPath());
+    fs.mkdirSync(dir, { recursive: true });
+    const encrypted = safeStorage.encryptString(masterKey.toString("base64"));
+    const tmp = _backupPath() + ".tmp";
+    fs.writeFileSync(tmp, encrypted, { mode: 0o600 });
+    fs.renameSync(tmp, _backupPath());
+  } catch (error) {
+    debugLogger.warn("failed to save master key backup", { error: error?.message }, "secretCrypto");
+  }
+}
+
+function _loadMasterKeyBackup() {
+  if (!safeStorage.isEncryptionAvailable()) return false;
+  try {
+    const buf = fs.readFileSync(_backupPath());
+    const b64 = safeStorage.decryptString(buf);
+    const key = Buffer.from(b64, "base64");
+    if (key.length !== KEY_LEN) return false;
+    masterKey = key;
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function _initKeychain() {
   let Entry;
@@ -35,6 +70,7 @@ function _initKeychain() {
       masterKey = crypto.randomBytes(KEY_LEN);
       entry.setPassword(masterKey.toString("base64"));
     }
+    _saveMasterKeyBackup();
     return true;
   } catch (error) {
     debugLogger.warn(
@@ -50,6 +86,11 @@ function _ensureInit() {
   if (mode) return;
   if (_initKeychain()) {
     mode = "keychain";
+    return;
+  }
+  if (_loadMasterKeyBackup()) {
+    mode = "keychain";
+    debugLogger.info("recovered master key from safeStorage backup", {}, "secretCrypto");
     return;
   }
   mode = safeStorage.isEncryptionAvailable() ? "safeStorage" : "unavailable";

--- a/src/helpers/secretCrypto.js
+++ b/src/helpers/secretCrypto.js
@@ -21,13 +21,13 @@ function _backupPath() {
 
 function _saveMasterKeyBackup() {
   if (!masterKey || !safeStorage.isEncryptionAvailable()) return;
+  const target = _backupPath();
   try {
-    const dir = path.dirname(_backupPath());
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(path.dirname(target), { recursive: true });
     const encrypted = safeStorage.encryptString(masterKey.toString("base64"));
-    const tmp = _backupPath() + ".tmp";
+    const tmp = target + ".tmp";
     fs.writeFileSync(tmp, encrypted, { mode: 0o600 });
-    fs.renameSync(tmp, _backupPath());
+    fs.renameSync(tmp, target);
   } catch (error) {
     debugLogger.warn("failed to save master key backup", { error: error?.message }, "secretCrypto");
   }


### PR DESCRIPTION
## Summary

`secretCrypto.js` stores the AES-256-GCM master key exclusively in the OS keychain via `@napi-rs/keyring`. If the native module fails to load on a subsequent launch (binding issues documented in [keyring-node#93](https://github.com/Brooooooklyn/keyring-node/issues/93), breaking changes in [keyring-node#81](https://github.com/Brooooooklyn/keyring-node/issues/81)), `decrypt()` skips the keychain path entirely and tries `safeStorage.decryptString()` on AES-256-GCM blobs, which throws. All encrypted secrets become unrecoverable.

This adds a safeStorage-encrypted backup of the master key written once when the keychain initializes. If `@napi-rs/keyring` fails on a future launch, the backup recovers the master key so existing blobs can still be decrypted.

safeStorage never touches actual secrets directly, only the master key backup.

## Changes

- src/helpers/secretCrypto.js: add `_saveMasterKeyBackup()` (called after keychain init), `_loadMasterKeyBackup()` (tried when keychain fails), and a new recovery step in `_ensureInit()` between keychain and pure safeStorage fallback