### PR TITLE
fix: improve live transcription preview for non-English and limit to streaming-capable models

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -352,7 +352,7 @@ function TranscriptionSection({
       {transcriptionMode === "local" && (
         <>
           {renderTranscriptionPicker("local")}
-          {renderPreviewToggle()}
+          {localTranscriptionProvider === "nvidia" && renderPreviewToggle()}
         </>
       )}
 

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -423,7 +423,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         parakeetModel,
         preferredLanguage,
       } = getSettings();
-      if (showTranscriptionPreview && useLocalWhisper) {
+      if (showTranscriptionPreview && useLocalWhisper && localTranscriptionProvider === "nvidia") {
         try {
           this._previewAudioContext = new AudioContext({ sampleRate: 16000 });
           this._previewSource = this._previewAudioContext.createMediaStreamSource(micStream);

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -421,6 +421,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         localTranscriptionProvider,
         whisperModel,
         parakeetModel,
+        preferredLanguage,
       } = getSettings();
       if (showTranscriptionPreview && useLocalWhisper) {
         try {
@@ -439,7 +440,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
           const provider = localTranscriptionProvider === "nvidia" ? "nvidia" : "whisper";
           const model = provider === "nvidia" ? parakeetModel : whisperModel;
-          window.electronAPI?.startDictationPreview?.({ provider, model });
+          window.electronAPI?.startDictationPreview?.({ provider, model, language: preferredLanguage });
         } catch (e) {
           logger.warn("Preview worklet setup failed", { error: e.message }, "audio");
         }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -4865,6 +4865,7 @@ class IPCHandlers {
     let dictationPreviewTranscribing = false;
     let dictationPreviewProvider = null;
     let dictationPreviewModel = null;
+    let dictationPreviewLanguage = "auto";
     let dictationPreviewSessionActive = false;
     let dictationPreviewChunkCount = 0;
 
@@ -4881,6 +4882,7 @@ class IPCHandlers {
       dictationPreviewTranscribing = false;
       dictationPreviewProvider = null;
       dictationPreviewModel = null;
+      dictationPreviewLanguage = "auto";
     };
 
     const transcribeDictationPreviewChunk = async () => {
@@ -4912,10 +4914,12 @@ class IPCHandlers {
         if (dictationPreviewProvider === "nvidia") {
           result = await this.parakeetManager.transcribeLocalParakeet(wav, {
             model: dictationPreviewModel,
+            language: dictationPreviewLanguage,
           });
         } else {
           result = await this.whisperManager.transcribeLocalWhisper(wav, {
             model: dictationPreviewModel,
+            language: dictationPreviewLanguage,
           });
         }
 
@@ -5466,12 +5470,13 @@ class IPCHandlers {
       return { success: true, text: result.text || "" };
     });
 
-    ipcMain.handle("start-dictation-preview", async (_event, { provider, model }) => {
+    ipcMain.handle("start-dictation-preview", async (_event, { provider, model, language }) => {
       resetDictationPreviewState();
       dictationPreviewMode = true;
       dictationPreviewSessionActive = true;
       dictationPreviewProvider = provider;
       dictationPreviewModel = model;
+      dictationPreviewLanguage = language || "auto";
       dictationPreviewChunkCount = 0;
       this.windowManager.showTranscriptionPreview("");
       dictationPreviewTimer = setInterval(() => transcribeDictationPreviewChunk(), 1500);


### PR DESCRIPTION
## Summary

Two issues with the live transcription preview: it never passed the user's preferred language to local models, producing gibberish on non-English dictation; and the toggle was shown for whisper.cpp which can't keep up with real-time chunk processing.

## Changes

- src/helpers/ipcHandlers.js, src/helpers/audioManager.js: pass preferredLanguage through IPC to Parakeet/whisper preview chunks
- src/components/SettingsPage.tsx, src/helpers/audioManager.js: hide preview toggle and skip activation when the local provider isn't NVIDIA/Parakeet