### PR TITLE
fix: accept OpenAI-compat URLs with or without /v1 suffix (LAN + custom cloud)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -37,8 +37,11 @@ export const buildApiUrl = (base: string, path: string): string => {
   return `${normalizedBase}${normalizedPath}`;
 };
 
-export const ensureV1Suffix = (base: string): string =>
-  base.endsWith("/v1") ? base : buildApiUrl(base, "/v1");
+export const ensureV1Suffix = (base: string): string => {
+  if (!base) return base;
+  const normalized = normalizeBaseUrl(base) || base;
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+};
 
 const env = (typeof import.meta !== "undefined" && (import.meta as any).env) || {};
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -37,6 +37,9 @@ export const buildApiUrl = (base: string, path: string): string => {
   return `${normalizedBase}${normalizedPath}`;
 };
 
+export const ensureV1Suffix = (base: string): string =>
+  base.endsWith("/v1") ? base : buildApiUrl(base, "/v1");
+
 const env = (typeof import.meta !== "undefined" && (import.meta as any).env) || {};
 
 const computeBaseUrl = (candidates: Array<string | undefined>, fallback: string): string => {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -7,7 +7,13 @@ import {
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy } from "../utils/retry";
-import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, normalizeBaseUrl } from "../config/constants";
+import {
+  API_ENDPOINTS,
+  TOKEN_LIMITS,
+  buildApiUrl,
+  ensureV1Suffix,
+  normalizeBaseUrl,
+} from "../config/constants";
 import logger from "../utils/logger";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
 import { streamText, stepCountIs } from "ai";
@@ -347,7 +353,7 @@ class ReasoningService extends BaseReasoningService {
 
     if (isLanCleanup) {
       const rawUrl = lanOverride || settings.cleanupRemoteUrl.trim();
-      const baseUrl = normalizeBaseUrl(rawUrl) || rawUrl;
+      const baseUrl = ensureV1Suffix(normalizeBaseUrl(rawUrl) || rawUrl);
       endpoint = buildApiUrl(baseUrl, "/chat/completions");
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
@@ -559,10 +565,7 @@ class ReasoningService extends BaseReasoningService {
 
     if (isLanCleanup) {
       const rawUrl = lanOverride || settings.cleanupRemoteUrl.trim();
-      baseURL = normalizeBaseUrl(rawUrl) || rawUrl;
-      if (!baseURL.endsWith("/v1")) {
-        baseURL = buildApiUrl(baseURL, "/v1");
-      }
+      baseURL = ensureV1Suffix(normalizeBaseUrl(rawUrl) || rawUrl);
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
       if (!serverResult.success || !serverResult.port) {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -7,13 +7,7 @@ import {
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy } from "../utils/retry";
-import {
-  API_ENDPOINTS,
-  TOKEN_LIMITS,
-  buildApiUrl,
-  ensureV1Suffix,
-  normalizeBaseUrl,
-} from "../config/constants";
+import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, ensureV1Suffix } from "../config/constants";
 import logger from "../utils/logger";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
 import { streamText, stepCountIs } from "ai";
@@ -353,7 +347,7 @@ class ReasoningService extends BaseReasoningService {
 
     if (isLanCleanup) {
       const rawUrl = lanOverride || settings.cleanupRemoteUrl.trim();
-      const baseUrl = ensureV1Suffix(normalizeBaseUrl(rawUrl) || rawUrl);
+      const baseUrl = ensureV1Suffix(rawUrl);
       endpoint = buildApiUrl(baseUrl, "/chat/completions");
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
@@ -565,7 +559,7 @@ class ReasoningService extends BaseReasoningService {
 
     if (isLanCleanup) {
       const rawUrl = lanOverride || settings.cleanupRemoteUrl.trim();
-      baseURL = ensureV1Suffix(normalizeBaseUrl(rawUrl) || rawUrl);
+      baseURL = ensureV1Suffix(rawUrl);
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
       if (!serverResult.success || !serverResult.port) {

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -1,5 +1,5 @@
 import type { InferenceProvider } from "./types";
-import { buildApiUrl, ensureV1Suffix, normalizeBaseUrl } from "../../../config/constants";
+import { buildApiUrl, ensureV1Suffix } from "../../../config/constants";
 import { getSettings } from "../../../stores/settingsStore";
 import logger from "../../../utils/logger";
 
@@ -10,7 +10,7 @@ export const lanProvider: InferenceProvider = {
     logger.logReasoning("LAN_START", { url: lanUrl, agentName, model });
 
     try {
-      const baseUrl = ensureV1Suffix(normalizeBaseUrl(lanUrl) || lanUrl);
+      const baseUrl = ensureV1Suffix(lanUrl);
       const endpoint = buildApiUrl(baseUrl, "/chat/completions");
       const apiKey = config.customApiKey?.trim() || getSettings().cleanupCustomApiKey?.trim() || "";
       const resolvedModel = model?.trim() || "default";

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -1,5 +1,5 @@
 import type { InferenceProvider } from "./types";
-import { buildApiUrl, normalizeBaseUrl } from "../../../config/constants";
+import { buildApiUrl, ensureV1Suffix, normalizeBaseUrl } from "../../../config/constants";
 import { getSettings } from "../../../stores/settingsStore";
 import logger from "../../../utils/logger";
 
@@ -10,7 +10,7 @@ export const lanProvider: InferenceProvider = {
     logger.logReasoning("LAN_START", { url: lanUrl, agentName, model });
 
     try {
-      const baseUrl = normalizeBaseUrl(lanUrl) || lanUrl;
+      const baseUrl = ensureV1Suffix(normalizeBaseUrl(lanUrl) || lanUrl);
       const endpoint = buildApiUrl(baseUrl, "/chat/completions");
       const apiKey = config.customApiKey?.trim() || getSettings().cleanupCustomApiKey?.trim() || "";
       const resolvedModel = model?.trim() || "default";

--- a/src/services/ai/openaiBase.ts
+++ b/src/services/ai/openaiBase.ts
@@ -1,4 +1,4 @@
-import { API_ENDPOINTS, normalizeBaseUrl } from "../../config/constants";
+import { API_ENDPOINTS, ensureV1Suffix } from "../../config/constants";
 import { getSettings } from "../../stores/settingsStore";
 import { isSecureEndpoint } from "../../utils/urlUtils";
 import logger from "../../utils/logger";
@@ -36,7 +36,7 @@ export function getConfiguredOpenAIBase(): string {
       return API_ENDPOINTS.OPENAI_BASE;
     }
 
-    const normalized = normalizeBaseUrl(trimmed) || API_ENDPOINTS.OPENAI_BASE;
+    const normalized = ensureV1Suffix(trimmed) || API_ENDPOINTS.OPENAI_BASE;
 
     logger.logReasoning("CUSTOM_CLEANUP_ENDPOINT_CHECK", {
       hasCustomUrl: true,


### PR DESCRIPTION
## Summary

Follow-up to #720. Makes the user-supplied OpenAI-compat URL surface uniformly forgiving: any shape the user types now resolves to a valid endpoint.

**What works after this PR:**
- \`http://localhost:11434/v1\` (matches the placeholder)
- \`http://localhost:11434\` (no \`/v1\`)
- \`http://localhost:11434/v1/chat/completions\` (full path — normalize strips it)
- Same for cloud OpenAI-compat services (Together, Anyscale, OpenRouter, etc.)

Before this PR, only the first form worked after #720 fixed the LAN path. URLs without \`/v1\` 404'd both for LAN (Ollama) and for the custom cloud cleanup provider.

## Changes

- **New helper:** \`ensureV1Suffix(base)\` in [constants.ts](src/config/constants.ts) — normalizes input and ensures a \`/v1\` suffix in one operation
- **LAN paths:** [lan.ts:13](src/services/ai/inferenceProviders/lan.ts#L13), [ReasoningService.ts:350](src/services/ReasoningService.ts#L350) (direct fetch), [ReasoningService.ts:562](src/services/ReasoningService.ts#L562) (SDK path) — replaces inline \`endsWith(\"/v1\")\` check
- **Custom cloud provider:** [openaiBase.ts:39](src/services/ai/openaiBase.ts#L39) — same fix for \`getConfiguredOpenAIBase()\` so users plugging in OpenAI-compat cloud services without \`/v1\` also work

## Test plan

- [ ] LAN: set endpoint to \`http://localhost:11434/v1\` with Ollama — Prompt Studio test succeeds
- [ ] LAN: set endpoint to \`http://localhost:11434\` (no \`/v1\`) — Prompt Studio test succeeds
- [ ] LAN: verify reasoning/agent scope works for both shapes (SDK path)
- [ ] Custom cloud: set cleanup base URL to a Together/OpenRouter-style URL without \`/v1\` — works
- [ ] Custom cloud: same URL with \`/v1\` — works identically (no regression)
- [ ] LM Studio / vLLM still work with \`/v1\`-suffixed URLs