### PR TITLE
fix(llama): unload model from VRAM after idle timeout

### DIFF
--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -17,6 +17,7 @@ const HEALTH_CHECK_INTERVAL_MS = 5000;
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const STARTUP_POLL_INTERVAL_MS = 500;
 const HEALTH_CHECK_FAILURE_THRESHOLD = 3;
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 class LlamaServerManager {
   constructor() {
@@ -29,6 +30,7 @@ class LlamaServerManager {
     this.healthCheckFailures = 0;
     this.cachedServerBinaryPaths = null;
     this.activeBackend = null;
+    this.idleTimer = null;
   }
 
   getServerBinaryPaths() {
@@ -163,6 +165,7 @@ class LlamaServerManager {
     }
 
     this.startHealthCheck();
+    this.resetIdleTimer();
     debugLogger.info("llama-server started successfully", {
       port: this.port,
       model: path.basename(modelPath),
@@ -415,10 +418,30 @@ class LlamaServerManager {
     }
   }
 
+  resetIdleTimer() {
+    this.clearIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      debugLogger.info("llama-server idle timeout reached, stopping to free VRAM", {
+        timeoutMs: IDLE_TIMEOUT_MS,
+        model: this.modelPath ? path.basename(this.modelPath) : null,
+      });
+      this.stop();
+    }, IDLE_TIMEOUT_MS);
+  }
+
+  clearIdleTimer() {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
   async inference(messages, options = {}) {
     if (!this.ready || !this.process) {
       throw new Error("llama-server is not running");
     }
+
+    this.clearIdleTimer();
 
     const body = JSON.stringify({
       messages,
@@ -479,10 +502,11 @@ class LlamaServerManager {
 
       req.write(body);
       req.end();
-    });
+    }).finally(() => this.resetIdleTimer());
   }
 
   async stop() {
+    this.clearIdleTimer();
     this.stopHealthCheck();
 
     if (!this.process) {


### PR DESCRIPTION
## Summary

The local llama-server process stayed running indefinitely after the last inference, keeping the model loaded in VRAM until the user quit the app. Added a 5-minute idle timeout that stops the server when no requests come in, freeing VRAM. The server restarts transparently on the next inference request.

## Changes

- src/helpers/llamaServer.js: added idle timer that fires after 5 minutes of inactivity, calling `stop()` to release the process. Timer is cleared during active inference and reset after each completed request (success or failure). Cleared on explicit `stop()` to prevent double-stop.

Closes #653