### PR TITLE
fix(streaming): attach NO_API code when OpenWhispr API URL is unconfigured

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -4064,7 +4064,11 @@ class IPCHandlers {
     const fetchRealtimeToken = async (event, options, { streams } = {}) => {
       const postServerToken = async (path, body = {}) => {
         const apiUrl = getApiUrl();
-        if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
+        if (!apiUrl) {
+          const err = new Error("OpenWhispr API URL not configured");
+          err.code = "NO_API";
+          throw err;
+        }
         const authHeader = await getAuthHeader(event);
         if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
         const url = `${apiUrl}${path}`;


### PR DESCRIPTION
## Summary

- `postServerToken` threw a plain `Error` (no `.code`) when `getApiUrl()` returned falsy
- `startStreamingRecording` only recognises `code === "NO_API"` as the signal to fall back to batch recording
- Without the code, the error propagated as an unhandled crash instead of triggering the graceful fallback

## Fix

Attach `err.code = "NO_API"` to the error thrown in `postServerToken` when the OpenWhispr API URL is not configured. This lets the existing fallback in `audioManager.js` catch it and call `startRecording()` (batch mode) instead of hard-erroring.

## Who is affected

Any user running from source in a dev environment (without `VITE_OPENWHISPR_API_URL` set) while signed in to an OpenWhispr account. The streaming path is triggered because `isSignedIn` is true, but the API URL isn't available, causing a crash instead of a graceful fallback to batch recording.

## Test plan

- [ ] Run `npm run dev` without `VITE_OPENWHISPR_API_URL` configured while signed in
- [ ] Press record — should fall back to batch recording (look for `"Streaming API not configured, falling back to regular recording"` in logs) instead of erroring
- [ ] Verify normal signed-in cloud streaming still works when `VITE_OPENWHISPR_API_URL` is set

🤖 Generated with [Claude Code](https://claude.ai/claude-code)