### PR TITLE
fix(transcription): pass preferredLanguage through retry, meetings, and dictation preview

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -464,6 +464,7 @@ export default function ControlPanel() {
           cloudTranscriptionBaseUrl: s.cloudTranscriptionBaseUrl,
           parakeetModel: s.parakeetModel,
           whisperModel: s.whisperModel,
+          preferredLanguage: s.preferredLanguage,
           transcriptionMode: s.transcriptionMode,
           remoteTranscriptionType: s.remoteTranscriptionType,
           remoteTranscriptionUrl: s.remoteTranscriptionUrl,

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -4,7 +4,7 @@ import logger from "../utils/logger";
 import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/auth";
-import { getBaseLanguageCode, validateLanguageForModel } from "../utils/languageSupport";
+import { getBaseLanguageCode } from "../utils/languageSupport";
 import {
   createLocalSpeechGateState,
   getLocalSpeechGateDecision,
@@ -439,7 +439,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
           const provider = localTranscriptionProvider === "nvidia" ? "nvidia" : "whisper";
           const model = provider === "nvidia" ? parakeetModel : whisperModel;
-          window.electronAPI?.startDictationPreview?.({ provider, model });
+          const language = getBaseLanguageCode(getSettings().preferredLanguage);
+          window.electronAPI?.startDictationPreview?.({ provider, model, language });
         } catch (e) {
           logger.warn("Preview worklet setup failed", { error: e.message }, "audio");
         }
@@ -743,11 +744,6 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     try {
       const arrayBuffer = await audioBlob.arrayBuffer();
-      const language = validateLanguageForModel(getSettings().preferredLanguage, model);
-      const options = { model };
-      if (language) {
-        options.language = language;
-      }
 
       logger.debug(
         "Parakeet transcription starting",
@@ -760,7 +756,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       );
 
       const transcriptionStart = performance.now();
-      const result = await window.electronAPI.transcribeLocalParakeet(arrayBuffer, options);
+      const result = await window.electronAPI.transcribeLocalParakeet(arrayBuffer, { model });
       timings.transcriptionProcessingDurationMs = Math.round(
         performance.now() - transcriptionStart
       );

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3529,6 +3529,11 @@ class IPCHandlers {
       if (!buffer) return { success: false, error: "Audio file not found" };
       try {
         let result;
+        const preferredLanguage = settings?.preferredLanguage;
+        const language =
+          preferredLanguage && preferredLanguage !== "auto"
+            ? preferredLanguage.split("-")[0]
+            : undefined;
 
         if (settings?.useLocalWhisper) {
           if (settings.localTranscriptionProvider === "nvidia") {
@@ -3538,6 +3543,7 @@ class IPCHandlers {
           } else if (this.whisperManager?.serverManager?.isAvailable?.()) {
             result = await this.whisperManager.transcribeLocalWhisper(buffer, {
               model: settings.whisperModel,
+              language,
             });
           }
         } else if (settings?.cloudTranscriptionMode === "openwhispr") {
@@ -3548,6 +3554,7 @@ class IPCHandlers {
               const apiUrl = getApiUrl();
               if (apiUrl) {
                 const multipartFields = {
+                  language,
                   clientType: "desktop",
                   appVersion: app.getVersion(),
                   sessionId: this.sessionId,
@@ -3609,6 +3616,7 @@ class IPCHandlers {
           const formData = new FormData();
           formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
           formData.append("model", model);
+          if (language) formData.append("language", language);
           const headers = {};
           if (provider === "mistral") {
             headers["x-api-key"] = apiKey;
@@ -4287,6 +4295,7 @@ class IPCHandlers {
     let meetingLocalTranscript = "";
     let meetingLocalProvider = null;
     let meetingLocalModel = null;
+    let meetingLocalLanguage = null;
     let meetingLocalTranscribing = false;
     let meetingPendingMicChunks = [];
     let meetingPendingMicFinals = [];
@@ -4681,6 +4690,7 @@ class IPCHandlers {
         } else {
           result = await this.whisperManager.transcribeLocalWhisper(wav, {
             model: meetingLocalModel,
+            language: meetingLocalLanguage,
           });
         }
 
@@ -4851,6 +4861,7 @@ class IPCHandlers {
       meetingLocalTranscript = "";
       meetingLocalProvider = null;
       meetingLocalModel = null;
+      meetingLocalLanguage = null;
       meetingLocalTranscribing = false;
       meetingPendingMicChunks = [];
       resetPendingMicFinals();
@@ -4865,6 +4876,7 @@ class IPCHandlers {
     let dictationPreviewTranscribing = false;
     let dictationPreviewProvider = null;
     let dictationPreviewModel = null;
+    let dictationPreviewLanguage = null;
     let dictationPreviewSessionActive = false;
     let dictationPreviewChunkCount = 0;
 
@@ -4881,6 +4893,7 @@ class IPCHandlers {
       dictationPreviewTranscribing = false;
       dictationPreviewProvider = null;
       dictationPreviewModel = null;
+      dictationPreviewLanguage = null;
     };
 
     const transcribeDictationPreviewChunk = async () => {
@@ -4916,6 +4929,7 @@ class IPCHandlers {
         } else {
           result = await this.whisperManager.transcribeLocalWhisper(wav, {
             model: dictationPreviewModel,
+            language: dictationPreviewLanguage,
           });
         }
 
@@ -5154,6 +5168,7 @@ class IPCHandlers {
           meetingLocalMode = true;
           meetingLocalProvider = options.localProvider || "whisper";
           meetingLocalModel = options.localModel || null;
+          meetingLocalLanguage = options.language || null;
           meetingLocalWin = BrowserWindow.fromWebContents(event.sender);
           meetingLocalBuffers = { mic: [], system: [] };
           meetingLocalTranscript = "";
@@ -5466,12 +5481,13 @@ class IPCHandlers {
       return { success: true, text: result.text || "" };
     });
 
-    ipcMain.handle("start-dictation-preview", async (_event, { provider, model }) => {
+    ipcMain.handle("start-dictation-preview", async (_event, { provider, model, language }) => {
       resetDictationPreviewState();
       dictationPreviewMode = true;
       dictationPreviewSessionActive = true;
       dictationPreviewProvider = provider;
       dictationPreviewModel = model;
+      dictationPreviewLanguage = language || null;
       dictationPreviewChunkCount = 0;
       this.windowManager.showTranscriptionPreview("");
       dictationPreviewTimer = setInterval(() => transcribeDictationPreviewChunk(), 1500);

--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -226,8 +226,7 @@ class ParakeetManager {
     });
 
     const startTime = Date.now();
-    const language = options.language || "auto";
-    const result = await this.serverManager.transcribe(audioBuffer, { modelName: model, language });
+    const result = await this.serverManager.transcribe(audioBuffer, { modelName: model });
     const elapsed = Date.now() - startTime;
 
     debugLogger.logSTTPipeline("transcribeLocalParakeet - completed", {

--- a/src/helpers/parakeetServer.js
+++ b/src/helpers/parakeetServer.js
@@ -83,7 +83,7 @@ class ParakeetServerManager {
   }
 
   async transcribe(audioBuffer, options = {}) {
-    const { modelName = "parakeet-tdt-0.6b-v3", language = "auto" } = options;
+    const { modelName = "parakeet-tdt-0.6b-v3" } = options;
 
     const modelDir = path.join(this.getModelsDir(), modelName);
     if (!this.isModelDownloaded(modelName)) {
@@ -92,7 +92,6 @@ class ParakeetServerManager {
 
     debugLogger.debug("Parakeet transcription request", {
       modelName,
-      language,
       audioSize: audioBuffer?.length || 0,
       isWavFormat: isWavFormat(audioBuffer),
     });
@@ -109,7 +108,7 @@ class ParakeetServerManager {
       const rms = computeFloat32RMS(samples);
       debugLogger.debug("Parakeet audio analysis", { durationSeconds, rms });
       if (rms < SILENCE_RMS_THRESHOLD) {
-        return { text: "", elapsed: 0, language };
+        return { text: "", elapsed: 0 };
       }
 
       if (samples.length <= MAX_SEGMENT_BYTES) {
@@ -121,7 +120,7 @@ class ParakeetServerManager {
             samplesBytes: samples.length,
           });
         }
-        return { ...result, language };
+        return result;
       }
 
       debugLogger.debug("Parakeet segmenting long audio", {
@@ -147,7 +146,7 @@ class ParakeetServerManager {
         }
       }
 
-      return { text: texts.join(" "), elapsed: totalElapsed, language };
+      return { text: texts.join(" "), elapsed: totalElapsed };
     } finally {
       this._cleanupFiles(filesToCleanup);
     }

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { getSettings, selectResolvedMeetingTranscription } from "./settingsStore";
 import { useStreamingProvidersStore } from "./streamingProvidersStore";
 import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
+import { getBaseLanguageCode } from "../utils/languageSupport";
 import type { SystemAudioAccessResult, SystemAudioStrategy } from "../types/electron";
 import {
   DEFAULT_SYSTEM_AUDIO_ACCESS,
@@ -109,6 +110,7 @@ const isSegmentWithinIdentificationWindow = (
 const getMeetingTranscriptionOptions = () => {
   const state = getSettings();
   const resolved = selectResolvedMeetingTranscription(state);
+  const language = getBaseLanguageCode(state.preferredLanguage);
 
   if (resolved.useLocalWhisper) {
     return {
@@ -118,6 +120,7 @@ const getMeetingTranscriptionOptions = () => {
         resolved.localTranscriptionProvider === "nvidia"
           ? resolved.parakeetModel || "parakeet-tdt-0.6b-v3"
           : resolved.whisperModel || "base",
+      language,
     };
   }
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -422,6 +422,7 @@ declare global {
           cloudTranscriptionBaseUrl?: string;
           parakeetModel: string;
           whisperModel: string;
+          preferredLanguage?: string;
           transcriptionMode?: InferenceMode;
           remoteTranscriptionType?: SelfHostedType;
           remoteTranscriptionUrl?: string;
@@ -644,7 +645,7 @@ declare global {
       // Parakeet operations (NVIDIA via sherpa-onnx)
       transcribeLocalParakeet: (
         audioBlob: ArrayBuffer,
-        options?: { model?: string; language?: string }
+        options?: { model?: string }
       ) => Promise<ParakeetTranscriptionResult>;
       checkParakeetInstallation: () => Promise<ParakeetCheckResult>;
       downloadParakeetModel: (modelName: string) => Promise<ParakeetModelResult>;
@@ -1623,6 +1624,7 @@ declare global {
       startDictationPreview?: (opts: {
         provider: string;
         model: string;
+        language?: string;
       }) => Promise<{ success: boolean }>;
       stopDictationPreview?: (opts?: { showCleanup?: boolean }) => Promise<{ success: boolean }>;
       dismissDictationPreview?: () => Promise<{ success: boolean }>;

--- a/src/utils/languageSupport.ts
+++ b/src/utils/languageSupport.ts
@@ -1,6 +1,6 @@
 import registry from "../config/languageRegistry.json";
 
-function buildLanguageSet(key: "whisper" | "parakeet" | "assemblyai"): Set<string> {
+function buildLanguageSet(key: "whisper" | "assemblyai"): Set<string> {
   const set = new Set<string>();
   for (const lang of registry.languages) {
     if (lang[key]) {
@@ -13,13 +13,7 @@ function buildLanguageSet(key: "whisper" | "parakeet" | "assemblyai"): Set<strin
 }
 
 const WHISPER_LANGUAGES = buildLanguageSet("whisper");
-const PARAKEET_LANGUAGES = buildLanguageSet("parakeet");
 const ASSEMBLYAI_UNIVERSAL3_PRO_LANGUAGES = buildLanguageSet("assemblyai");
-
-const MODEL_LANGUAGE_MAP: Record<string, Set<string>> = {
-  "parakeet-tdt-0.6b-v3": PARAKEET_LANGUAGES,
-  "parakeet-unified-en-0.6b": new Set(["en"]),
-};
 
 const LANGUAGE_INSTRUCTIONS: Record<string, string> = Object.fromEntries(
   registry.languages
@@ -35,19 +29,6 @@ export function getBaseLanguageCode(language: string | null | undefined): string
   return language.split("-")[0];
 }
 
-export function validateLanguageForModel(
-  language: string | null | undefined,
-  modelId: string
-): string | undefined {
-  const baseCode = getBaseLanguageCode(language);
-  if (!baseCode) return undefined;
-
-  const supportedSet = MODEL_LANGUAGE_MAP[modelId];
-  if (!supportedSet) return baseCode;
-
-  return supportedSet.has(baseCode) ? baseCode : undefined;
-}
-
 export function getLanguageInstruction(language: string | undefined): string {
   if (!language) return "";
   return LANGUAGE_INSTRUCTIONS[language] || buildGenericInstruction(language);
@@ -58,4 +39,4 @@ function buildGenericInstruction(langCode: string): string {
   return template.replace("{{code}}", langCode);
 }
 
-export { WHISPER_LANGUAGES, PARAKEET_LANGUAGES, ASSEMBLYAI_UNIVERSAL3_PRO_LANGUAGES };
+export { WHISPER_LANGUAGES, ASSEMBLYAI_UNIVERSAL3_PRO_LANGUAGES };


### PR DESCRIPTION
## Summary

- `preferredLanguage` was honored on the main dictation flow for whisper.cpp / OpenAI / OpenWhispr cloud, but silently dropped on three other paths — leaving non-English users with auto-detect (which misfires on short utterances).
- Threads language through every dropping site: `retry-transcription` (whisper, OpenWhispr cloud, BYOK OpenAI/Groq/Mistral), local meeting chunk transcription, and dictation preview overlay chunks.
- Removes dead Parakeet language plumbing. Sherpa-onnx never accepted a language argument; `validateLanguageForModel`, `MODEL_LANGUAGE_MAP`, and `PARAKEET_LANGUAGES` were misleading and unused. Parakeet's multilingual TDT v3 auto-detects; the user-facing language lever for Parakeet is model selection (multilingual vs en-only variant), and that remains untouched.

## Files changed

| File | Change |
|---|---|
| `src/helpers/ipcHandlers.js` | retry-transcription resolves language once and forwards to all branches; meeting + preview gain `meetingLocalLanguage`/`dictationPreviewLanguage` closures with proper reset; `start-dictation-preview` accepts `language` |
| `src/components/ControlPanel.tsx` | retry-transcription payload now includes `preferredLanguage` (otherwise main-side resolution would always see undefined) |
| `src/stores/meetingRecordingStore.ts` | `getMeetingTranscriptionOptions()` includes resolved language for local meetings |
| `src/helpers/audioManager.js` | dictation preview start passes `language`; dead Parakeet language block deleted |
| `src/types/electron.ts` | `startDictationPreview` accepts `language?`; `retryTranscription` accepts `preferredLanguage?`; `transcribeLocalParakeet` no longer advertises stale `language?` |
| `src/helpers/parakeet.js`, `src/helpers/parakeetServer.js` | dead language plumbing removed (5 sites) |
| `src/utils/languageSupport.ts` | `validateLanguageForModel`, `MODEL_LANGUAGE_MAP`, `PARAKEET_LANGUAGES` removed |

Net diff: +35/-38 across 8 files. No new IPC channels, no settings migration, no breaking changes — payloads only gained optional fields.

## Behavior

- Default users (`preferredLanguage = "auto"`): zero behavior change.
- Users with a specific language set (e.g. `es`, `es-MX`): retry, local meetings, and dictation preview now respect it instead of falling back to auto-detect.
- Parakeet users: no functional change (it was already auto-detect-only).

## Test plan

Set `preferredLanguage` to `es` and verify each path:

- [ ] Local whisper retry → whisper-server form-data shows `language=es`
- [ ] Local parakeet retry → transcribes; no language in logs
- [ ] OpenWhispr cloud retry → multipart includes `language=es`
- [ ] BYOK retry (OpenAI / Groq / Mistral) → form-data includes `language=es`
- [ ] Local meeting (whisper) → per-chunk debug log shows `language: "es"`
- [ ] Local meeting (parakeet) → transcribes; no language in logs
- [ ] Dictation preview (whisper) → preview chunks log `language: "es"`
- [ ] `npm run quality-check` clean (typecheck + lint + format)
- [ ] `grep -rn validateLanguageForModel src` returns nothing