### PR TITLE
fix(media): make macos-media-remote work on macOS 15.4+

### DIFF
--- a/resources/macos-media-remote.swift
+++ b/resources/macos-media-remote.swift
@@ -1,69 +1,114 @@
+import CoreFoundation
 import Foundation
 
-// MediaRemote.framework command constants
 let kMRPlay: UInt32 = 0
 let kMRPause: UInt32 = 1
-let kMRTogglePlayPause: UInt32 = 2
 
-// C function type aliases from MediaRemote.framework
-typealias MRMediaRemoteSendCommandType = @convention(c) (UInt32, Optional<AnyObject>) -> Bool
-typealias MRMediaRemoteGetNowPlayingApplicationIsPlayingType = @convention(c) (DispatchQueue, @escaping (Bool) -> Void) -> Void
+typealias MRSendCommand = @convention(c) (UInt32, Optional<AnyObject>) -> Bool
+typealias MRRegister = @convention(c) (DispatchQueue) -> Void
+typealias MRGetIsPlaying = @convention(c) (DispatchQueue, @escaping (Bool) -> Void) -> Void
+typealias MRGetInfo = @convention(c) (DispatchQueue, @escaping ([AnyHashable: Any]?) -> Void) -> Void
 
-func loadMediaRemote() -> (send: MRMediaRemoteSendCommandType, isPlaying: MRMediaRemoteGetNowPlayingApplicationIsPlayingType)? {
+struct MediaRemote {
+    let send: MRSendCommand
+    let register: MRRegister?
+    let isPlaying: MRGetIsPlaying
+    let nowPlayingInfo: MRGetInfo
+}
+
+func loadMediaRemote() -> MediaRemote? {
     let frameworkPath = "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote"
     guard let handle = dlopen(frameworkPath, RTLD_NOW) else { return nil }
 
     guard let sendPtr = dlsym(handle, "MRMediaRemoteSendCommand"),
-          let isPlayingPtr = dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying") else {
+          let isPlayingPtr = dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying"),
+          let infoPtr = dlsym(handle, "MRMediaRemoteGetNowPlayingInfo") else {
         return nil
     }
 
-    let send = unsafeBitCast(sendPtr, to: MRMediaRemoteSendCommandType.self)
-    let isPlaying = unsafeBitCast(isPlayingPtr, to: MRMediaRemoteGetNowPlayingApplicationIsPlayingType.self)
-    return (send: send, isPlaying: isPlaying)
+    let registerPtr = dlsym(handle, "MRMediaRemoteRegisterForNowPlayingNotifications")
+    let register = registerPtr.flatMap { unsafeBitCast($0, to: MRRegister.self) }
+
+    return MediaRemote(
+        send: unsafeBitCast(sendPtr, to: MRSendCommand.self),
+        register: register,
+        isPlaying: unsafeBitCast(isPlayingPtr, to: MRGetIsPlaying.self),
+        nowPlayingInfo: unsafeBitCast(infoPtr, to: MRGetInfo.self)
+    )
 }
 
-func checkIsPlaying(_ isPlayingFn: MRMediaRemoteGetNowPlayingApplicationIsPlayingType) -> Bool {
-    let semaphore = DispatchSemaphore(value: 0)
-    var playing = false
-    isPlayingFn(DispatchQueue.main) { result in
-        playing = result
-        semaphore.signal()
+// macOS 15.4+ regression: legacy MediaRemote callbacks return empty even when
+// a session is active. Fall back to MRNowPlayingController via runtime lookup.
+func controllerApplicationIsPlaying() -> Bool? {
+    guard let cls = NSClassFromString("MRNowPlayingController") as? NSObject.Type else {
+        return nil
     }
-    _ = semaphore.wait(timeout: .now() + 2)
-    return playing
+    let sharedSel = NSSelectorFromString("sharedNowPlayingController")
+    guard cls.responds(to: sharedSel),
+          let shared = cls.perform(sharedSel)?.takeUnretainedValue() as? NSObject else {
+        return nil
+    }
+    let playingSel = NSSelectorFromString("applicationIsPlaying")
+    guard shared.responds(to: playingSel),
+          let value = shared.perform(playingSel)?.takeUnretainedValue() as? NSNumber else {
+        return nil
+    }
+    return value.boolValue
+}
+
+func emit(_ message: String, exitCode: Int32) -> Never {
+    print(message)
+    exit(exitCode)
 }
 
 guard let mr = loadMediaRemote() else {
-    print("ERROR")
-    exit(1)
+    emit("ERROR", exitCode: 1)
 }
 
 let args = CommandLine.arguments
 let command = args.count > 1 ? args[1] : ""
 
+// Required on macOS 13+ for the now-playing daemon to wire up before any
+// subsequent get-callbacks fire. Harmless on older systems where it's absent.
+mr.register?(DispatchQueue.main)
+
 switch command {
-case "--is-playing":
-    let playing = checkIsPlaying(mr.isPlaying)
-    print(playing ? "PLAYING" : "NOT_PLAYING")
-    exit(playing ? 0 : 1)
-
-case "--pause":
-    let playing = checkIsPlaying(mr.isPlaying)
-    if !playing {
-        print("NOT_PLAYING")
-        exit(1)
-    }
-    let ok = mr.send(kMRPause, nil)
-    print(ok ? "OK" : "FAIL")
-    exit(ok ? 0 : 1)
-
 case "--play":
     let ok = mr.send(kMRPlay, nil)
-    print(ok ? "OK" : "FAIL")
-    exit(ok ? 0 : 1)
-
+    emit(ok ? "OK" : "FAIL", exitCode: ok ? 0 : 1)
+case "--is-playing", "--pause":
+    break
 default:
-    print("Usage: macos-media-remote --is-playing|--pause|--play")
-    exit(1)
+    emit("Usage: macos-media-remote --is-playing|--pause|--play", exitCode: 1)
 }
+
+DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+    emit("NOT_PLAYING", exitCode: 1)
+}
+
+func resolveIsPlaying(_ done: @escaping (Bool) -> Void) {
+    mr.nowPlayingInfo(DispatchQueue.main) { info in
+        if !(info?.isEmpty ?? true) {
+            mr.isPlaying(DispatchQueue.main) { done($0) }
+            return
+        }
+        done(controllerApplicationIsPlaying() ?? false)
+    }
+}
+
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+    resolveIsPlaying { playing in
+        switch command {
+        case "--is-playing":
+            emit(playing ? "PLAYING" : "NOT_PLAYING", exitCode: playing ? 0 : 1)
+        case "--pause":
+            if !playing { emit("NOT_PLAYING", exitCode: 1) }
+            let ok = mr.send(kMRPause, nil)
+            emit(ok ? "OK" : "FAIL", exitCode: ok ? 0 : 1)
+        default:
+            emit("Usage: macos-media-remote --is-playing|--pause|--play", exitCode: 1)
+        }
+    }
+}
+
+CFRunLoopRun()

--- a/resources/macos-media-remote.swift
+++ b/resources/macos-media-remote.swift
@@ -3,57 +3,37 @@ import Foundation
 
 let kMRPlay: UInt32 = 0
 let kMRPause: UInt32 = 1
+let usage = "Usage: macos-media-remote --is-playing|--pause|--play"
+let playbackRateKey = "kMRMediaRemoteNowPlayingInfoPlaybackRate"
 
 typealias MRSendCommand = @convention(c) (UInt32, Optional<AnyObject>) -> Bool
 typealias MRRegister = @convention(c) (DispatchQueue) -> Void
-typealias MRGetIsPlaying = @convention(c) (DispatchQueue, @escaping (Bool) -> Void) -> Void
-typealias MRGetInfo = @convention(c) (DispatchQueue, @escaping ([AnyHashable: Any]?) -> Void) -> Void
+// The get-callback is an Objective-C block, not a C function pointer;
+// @convention(c) here would silently misroute the callback.
+typealias MRGetInfo = @convention(c) (
+    DispatchQueue, @escaping @convention(block) ([AnyHashable: Any]?) -> Void
+) -> Void
 
 struct MediaRemote {
     let send: MRSendCommand
     let register: MRRegister?
-    let isPlaying: MRGetIsPlaying
-    let nowPlayingInfo: MRGetInfo
+    let getInfo: MRGetInfo
 }
 
 func loadMediaRemote() -> MediaRemote? {
-    let frameworkPath = "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote"
-    guard let handle = dlopen(frameworkPath, RTLD_NOW) else { return nil }
-
-    guard let sendPtr = dlsym(handle, "MRMediaRemoteSendCommand"),
-          let isPlayingPtr = dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying"),
-          let infoPtr = dlsym(handle, "MRMediaRemoteGetNowPlayingInfo") else {
+    let url = URL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")
+    guard let bundle = CFBundleCreate(kCFAllocatorDefault, url as CFURL),
+          let sendPtr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteSendCommand" as CFString),
+          let infoPtr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteGetNowPlayingInfo" as CFString) else {
         return nil
     }
-
-    let registerPtr = dlsym(handle, "MRMediaRemoteRegisterForNowPlayingNotifications")
-    let register = registerPtr.flatMap { unsafeBitCast($0, to: MRRegister.self) }
-
+    let regPtr = CFBundleGetFunctionPointerForName(
+        bundle, "MRMediaRemoteRegisterForNowPlayingNotifications" as CFString)
     return MediaRemote(
         send: unsafeBitCast(sendPtr, to: MRSendCommand.self),
-        register: register,
-        isPlaying: unsafeBitCast(isPlayingPtr, to: MRGetIsPlaying.self),
-        nowPlayingInfo: unsafeBitCast(infoPtr, to: MRGetInfo.self)
+        register: regPtr.map { unsafeBitCast($0, to: MRRegister.self) },
+        getInfo: unsafeBitCast(infoPtr, to: MRGetInfo.self)
     )
-}
-
-// macOS 15.4+ regression: legacy MediaRemote callbacks return empty even when
-// a session is active. Fall back to MRNowPlayingController via runtime lookup.
-func controllerApplicationIsPlaying() -> Bool? {
-    guard let cls = NSClassFromString("MRNowPlayingController") as? NSObject.Type else {
-        return nil
-    }
-    let sharedSel = NSSelectorFromString("sharedNowPlayingController")
-    guard cls.responds(to: sharedSel),
-          let shared = cls.perform(sharedSel)?.takeUnretainedValue() as? NSObject else {
-        return nil
-    }
-    let playingSel = NSSelectorFromString("applicationIsPlaying")
-    guard shared.responds(to: playingSel),
-          let value = shared.perform(playingSel)?.takeUnretainedValue() as? NSNumber else {
-        return nil
-    }
-    return value.boolValue
 }
 
 func emit(_ message: String, exitCode: Int32) -> Never {
@@ -61,43 +41,47 @@ func emit(_ message: String, exitCode: Int32) -> Never {
     exit(exitCode)
 }
 
+let args = CommandLine.arguments
+let command = args.count > 1 ? args[1] : ""
+
+switch command {
+case "--play", "--is-playing", "--pause":
+    break
+default:
+    emit(usage, exitCode: 1)
+}
+
+// macOS 15.4 closed the now-playing daemon to unprivileged Mach-O processes;
+// both reads and sends silently no-op. Emit UNKNOWN so the consumer falls
+// back to its media-key path.
+let v = ProcessInfo.processInfo.operatingSystemVersion
+if v.majorVersion > 15 || (v.majorVersion == 15 && v.minorVersion >= 4) {
+    emit("UNKNOWN", exitCode: 1)
+}
+
 guard let mr = loadMediaRemote() else {
     emit("ERROR", exitCode: 1)
 }
 
-let args = CommandLine.arguments
-let command = args.count > 1 ? args[1] : ""
-
-// Required on macOS 13+ for the now-playing daemon to wire up before any
-// subsequent get-callbacks fire. Harmless on older systems where it's absent.
+// macOS 13+ requires this before any subsequent get-callback fires.
 mr.register?(DispatchQueue.main)
 
-switch command {
-case "--play":
+if command == "--play" {
     let ok = mr.send(kMRPlay, nil)
     emit(ok ? "OK" : "FAIL", exitCode: ok ? 0 : 1)
-case "--is-playing", "--pause":
-    break
-default:
-    emit("Usage: macos-media-remote --is-playing|--pause|--play", exitCode: 1)
 }
 
 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
     emit("NOT_PLAYING", exitCode: 1)
 }
 
-func resolveIsPlaying(_ done: @escaping (Bool) -> Void) {
-    mr.nowPlayingInfo(DispatchQueue.main) { info in
-        if !(info?.isEmpty ?? true) {
-            mr.isPlaying(DispatchQueue.main) { done($0) }
-            return
-        }
-        done(controllerApplicationIsPlaying() ?? false)
-    }
-}
-
 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-    resolveIsPlaying { playing in
+    mr.getInfo(DispatchQueue.main) { info in
+        guard let info = info, !info.isEmpty else {
+            emit("NOT_PLAYING", exitCode: 1)
+        }
+        let rate = (info[playbackRateKey] as? NSNumber)?.doubleValue ?? 0
+        let playing = rate > 0
         switch command {
         case "--is-playing":
             emit(playing ? "PLAYING" : "NOT_PLAYING", exitCode: playing ? 0 : 1)
@@ -106,7 +90,7 @@ DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             let ok = mr.send(kMRPause, nil)
             emit(ok ? "OK" : "FAIL", exitCode: ok ? 0 : 1)
         default:
-            emit("Usage: macos-media-remote --is-playing|--pause|--play", exitCode: 1)
+            emit(usage, exitCode: 1)
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the binary shipped in #700 always returning `NOT_PLAYING` for users on macOS 26.4.x, breaking media-pause-on-dictation. Two independent root causes:

- **Wrong callback ABI.** `MRMediaRemoteGetNowPlayingInfo` takes an Objective-C *block*, not a C function pointer. The original `@convention(c)` typealias passed a wrong-ABI pointer and the framework never invoked our callback — combined with a `DispatchSemaphore.wait` deadlock on the main thread, the binary returned `NOT_PLAYING` regardless of state on **every** macOS version.

- **macOS 15.4+ daemon closure.** Apple closed the now-playing daemon to unprivileged Mach-O processes in 15.4: both `MRMediaRemoteGet*` and `MRMediaRemoteSendCommand` silently no-op for us. The wider ecosystem (e.g. `nowplaying-cli`) works around this by shelling out to a `/usr/bin/perl` helper — that vendoring is the long-term fix tracked separately.

## Approach

Single-file change to `resources/macos-media-remote.swift`:

- Rewrite against the canonical CFBundle + `CFRunLoopRun()` pattern with daemon registration (required on macOS 13+).
- Declare the get-callback `@escaping @convention(block) ([AnyHashable: Any]?) -> Void` so the framework can actually call back.
- On macOS 15.4+, short-circuit all commands to a new `UNKNOWN` stdout value (exit 1) — `mediaPlayer.js`'s existing fallback chain already treats any non-`NOT_PLAYING` exit-1 result as a trigger to fall through to its osascript media-key path, restoring pre-#700 behavior on affected systems with **no consumer changes**.
- Pre-15.4 path uses playback-rate read for state — same CLI contract (`PLAYING` / `NOT_PLAYING` / `OK` / `FAIL` / `ERROR`).

## Test plan

- [x] `npm run compile:media-remote` succeeds (arm64)
- [x] `--is-playing`, `--pause`, `--play` return `UNKNOWN` exit 1 on macOS 26.4.1 in <15ms
- [x] Bogus arg returns usage exit 1
- [x] `npm run quality-check` (eslint + prettier + tsc) passes
- [x] End-to-end pause/resume verified against live YouTube playback (rate `1 → 0 → 1` round-trip)
- [ ] CI builds the binary into the packaged `.app` bundle
- [ ] Verify on macOS 15.4 / 15.5 / 14.x / 13.x
- [ ] Verify in a notarized packaged build that osascript media-key fallback runs (requires Accessibility permission, which OpenWhispr already needs for paste)

## Bundles

Closes #508 (same root cause). Companion to the larger plan in `Plans/macos-media-pause-post-15-4-fix.md`, which adds vendored `mediaremote-adapter` for proper macOS 15.4+ state detection.