### PR TITLE
fix(reasoning): stop sending Ollama-only `think` field to Groq

### DIFF
--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -1,22 +1,30 @@
 import type { ReasoningConfig } from "../BaseReasoningService";
 import { getCloudModel, getLocalModel } from "../../models/ModelRegistry";
 
-// Sends both `reasoning_effort` (OpenAI/Groq dialect) and `think` (Ollama
-// dialect); servers ignore unknown fields. Skips known non-thinking models
-// to avoid suppressing reasoning on models like gpt-5 where the user toggle
-// is hidden but the default value still applies.
+// Groq strictly validates request bodies and rejects unknown fields like
+// `think` ("property 'think' is unsupported"). Only Ollama-dialect providers
+// accept `think`; OpenAI-compatible providers use `reasoning_effort`.
+const OLLAMA_DIALECT_PROVIDERS = new Set(["local", "lan"]);
+
+function suppressThinking(requestBody: Record<string, unknown>, providerKey: string): void {
+  if (OLLAMA_DIALECT_PROVIDERS.has(providerKey)) {
+    requestBody.think = false;
+  } else {
+    requestBody.reasoning_effort = "none";
+  }
+}
+
 export function applyThinkingSuppression(
   requestBody: Record<string, unknown>,
   model: string,
   provider: string,
   config: ReasoningConfig
 ): void {
+  const providerKey = provider.toLowerCase();
   const cloudModel = getCloudModel(model);
-  const curatedGroqSuppress = !!cloudModel?.disableThinking && provider.toLowerCase() === "groq";
 
-  if (curatedGroqSuppress) {
-    requestBody.reasoning_effort = "none";
-    requestBody.think = false;
+  if (cloudModel?.disableThinking && providerKey === "groq") {
+    suppressThinking(requestBody, providerKey);
     return;
   }
 
@@ -26,6 +34,5 @@ export function applyThinkingSuppression(
   const knownModel = cloudModel || localModel;
   if (knownModel && !knownModel.supportsThinking) return;
 
-  requestBody.reasoning_effort = "none";
-  requestBody.think = false;
+  suppressThinking(requestBody, providerKey);
 }

--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -1,13 +1,21 @@
 import type { ReasoningConfig } from "../BaseReasoningService";
 import { getCloudModel, getLocalModel } from "../../models/ModelRegistry";
 
-// Groq strictly validates request bodies and rejects unknown fields like
-// `think` ("property 'think' is unsupported"). Only Ollama-dialect providers
-// accept `think`; OpenAI-compatible providers use `reasoning_effort`.
-const OLLAMA_DIALECT_PROVIDERS = new Set(["local", "lan"]);
+// Strict OpenAI-compatible servers (Groq, LM Studio, vLLM, LocalAI) reject
+// unknown fields like `think` with "property 'think' is unsupported". Only
+// Ollama-native servers accept `think`; everyone else uses `reasoning_effort`.
+// The `lan` provider defaults to Ollama dialect, but legacy users who
+// configured Self-Hosted as "openai-compatible" still route through `lan`
+// — honor that flag so their backend doesn't reject the request.
+function usesOllamaDialect(providerKey: string): boolean {
+  if (providerKey === "local") return true;
+  if (providerKey !== "lan") return false;
+  if (typeof window === "undefined") return true;
+  return window.localStorage?.getItem("remoteReasoningType") !== "openai-compatible";
+}
 
 function suppressThinking(requestBody: Record<string, unknown>, providerKey: string): void {
-  if (OLLAMA_DIALECT_PROVIDERS.has(providerKey)) {
+  if (usesOllamaDialect(providerKey)) {
     requestBody.think = false;
   } else {
     requestBody.reasoning_effort = "none";


### PR DESCRIPTION
## Summary

Groq's API rejects requests that contain unknown body fields. The reasoning request builder was sending both `reasoning_effort: "none"` (OpenAI/Groq dialect) and `think: false` (Ollama dialect) to every chat-completions provider on the assumption that "servers ignore unknown fields." Groq does not — it returns `property 'think' is unsupported`.

Symptoms: after updating, the Prompt Studio test button (and any reasoning call) fails on Groq with `Test failed: property 'think' is unsupported`. Disabling the new thinking-mode toggle didn't help because `groq/qwen/qwen3-32b` has `disableThinking: true` in the model registry, triggering a curated suppression branch *before* the user toggle is consulted.

## Change

`src/services/ai/thinkingSuppression.ts` — route both the curated and user-toggle branches through a shared `suppressThinking()` helper that picks the dialect by provider:
- Ollama-style providers (`local`, `lan`) → `think: false`
- All other (OpenAI-compatible) providers → `reasoning_effort: "none"`

## Test plan

- [ ] Open Prompt Studio with the Groq provider and `qwen/qwen3-32b` selected → Test button succeeds (was previously failing)
- [ ] Same with the user thinking-mode toggle off → still succeeds
- [ ] Same with toggle on → succeeds (no suppression sent)
- [ ] Local/Ollama provider with toggle off → request body still contains `think: false`, no `reasoning_effort` regression
- [ ] OpenAI provider with a non-thinking model → unchanged behavior
- [ ] Agent dictation/cleanup flow against Groq → no regression

## Out of scope

While auditing for similar quirks I noticed two latent issues in the non-streaming `callChatCompletionsApi` path (`ReasoningService.ts:153-168`): `temperature` and `max_tokens` are set unconditionally rather than gated by `getOpenAiApiConfig(model)` the way the streaming path does. Not actively broken because no Groq-served model currently rejects either, but worth a follow-up if Groq ever fronts a GPT-5/o-series model. Filed mentally; not changed here to keep this PR minimal.