### PR TITLE
fix(desktop): probe wildcard address in port availability check

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -21,13 +21,19 @@ function getBridgeFilePath() {
 
 function isPortAvailable(port) {
   return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close();
-      resolve(true);
+    const probe = net.createServer();
+    probe.once("error", () => resolve(false));
+    probe.once("listening", () => {
+      probe.close(() => {
+        const loopback = net.createServer();
+        loopback.once("error", () => resolve(false));
+        loopback.once("listening", () => {
+          loopback.close(() => resolve(true));
+        });
+        loopback.listen(port, HOST);
+      });
     });
-    server.listen(port, HOST);
+    probe.listen(port, "0.0.0.0");
   });
 }
 

--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -1,10 +1,10 @@
 const http = require("http");
-const net = require("net");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
+const { isPortAvailable } = require("../utils/serverUtils");
 
 const PORT_RANGE_START = 8200;
 const PORT_RANGE_END = 8219;
@@ -17,24 +17,6 @@ const NO_CONTENT = Symbol("CliBridge.NoContent");
 
 function getBridgeFilePath() {
   return path.join(os.homedir(), ".openwhispr", "cli-bridge.json");
-}
-
-function isPortAvailable(port) {
-  return new Promise((resolve) => {
-    const probe = net.createServer();
-    probe.once("error", () => resolve(false));
-    probe.once("listening", () => {
-      probe.close(() => {
-        const loopback = net.createServer();
-        loopback.once("error", () => resolve(false));
-        loopback.once("listening", () => {
-          loopback.close(() => resolve(true));
-        });
-        loopback.listen(port, HOST);
-      });
-    });
-    probe.listen(port, "0.0.0.0");
-  });
 }
 
 async function findAvailablePort() {

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -104,13 +104,19 @@ class LlamaServerManager {
 
   isPortAvailable(port) {
     return new Promise((resolve) => {
-      const server = net.createServer();
-      server.once("error", () => resolve(false));
-      server.once("listening", () => {
-        server.close();
-        resolve(true);
+      const probe = net.createServer();
+      probe.once("error", () => resolve(false));
+      probe.once("listening", () => {
+        probe.close(() => {
+          const loopback = net.createServer();
+          loopback.once("error", () => resolve(false));
+          loopback.once("listening", () => {
+            loopback.close(() => resolve(true));
+          });
+          loopback.listen(port, "127.0.0.1");
+        });
       });
-      server.listen(port, "127.0.0.1");
+      probe.listen(port, "0.0.0.0");
     });
   }
 

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -1,10 +1,10 @@
 const { spawn } = require("child_process");
 const fs = require("fs");
-const net = require("net");
 const path = require("path");
 const http = require("http");
 const debugLogger = require("./debugLogger");
 const { killProcess } = require("../utils/process");
+const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
@@ -97,27 +97,9 @@ class LlamaServerManager {
 
   async findAvailablePort() {
     for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
-      if (await this.isPortAvailable(port)) return port;
+      if (await isPortAvailable(port)) return port;
     }
     throw new Error(`No available ports in range ${PORT_RANGE_START}-${PORT_RANGE_END}`);
-  }
-
-  isPortAvailable(port) {
-    return new Promise((resolve) => {
-      const probe = net.createServer();
-      probe.once("error", () => resolve(false));
-      probe.once("listening", () => {
-        probe.close(() => {
-          const loopback = net.createServer();
-          loopback.once("error", () => resolve(false));
-          loopback.once("listening", () => {
-            loopback.close(() => resolve(true));
-          });
-          loopback.listen(port, "127.0.0.1");
-        });
-      });
-      probe.listen(port, "0.0.0.0");
-    });
   }
 
   async start(modelPath, options = {}) {

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -280,13 +280,19 @@ class WhisperServerManager extends EventEmitter {
 
   isPortAvailable(port) {
     return new Promise((resolve) => {
-      const server = net.createServer();
-      server.once("error", () => resolve(false));
-      server.once("listening", () => {
-        server.close();
-        resolve(true);
+      const probe = net.createServer();
+      probe.once("error", () => resolve(false));
+      probe.once("listening", () => {
+        probe.close(() => {
+          const loopback = net.createServer();
+          loopback.once("error", () => resolve(false));
+          loopback.once("listening", () => {
+            loopback.close(() => resolve(true));
+          });
+          loopback.listen(port, "127.0.0.1");
+        });
       });
-      server.listen(port, "127.0.0.1");
+      probe.listen(port, "0.0.0.0");
     });
   }
 

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -1,12 +1,12 @@
 const { spawn } = require("child_process");
 const EventEmitter = require("events");
 const fs = require("fs");
-const net = require("net");
 const path = require("path");
 const http = require("http");
 const { app } = require("electron");
 const debugLogger = require("./debugLogger");
 const { killProcess } = require("../utils/process");
+const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { convertToWav } = require("./ffmpegUtils");
 const sidecarPidFile = require("./sidecarPidFile");
@@ -273,27 +273,9 @@ class WhisperServerManager extends EventEmitter {
 
   async findAvailablePort() {
     for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
-      if (await this.isPortAvailable(port)) return port;
+      if (await isPortAvailable(port)) return port;
     }
     throw new Error(`No available ports in range ${PORT_RANGE_START}-${PORT_RANGE_END}`);
-  }
-
-  isPortAvailable(port) {
-    return new Promise((resolve) => {
-      const probe = net.createServer();
-      probe.once("error", () => resolve(false));
-      probe.once("listening", () => {
-        probe.close(() => {
-          const loopback = net.createServer();
-          loopback.once("error", () => resolve(false));
-          loopback.once("listening", () => {
-            loopback.close(() => resolve(true));
-          });
-          loopback.listen(port, "127.0.0.1");
-        });
-      });
-      probe.listen(port, "0.0.0.0");
-    });
   }
 
   async start(modelPath, options = {}) {

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -7,13 +7,19 @@ const GRACEFUL_STOP_TIMEOUT_MS = 5000;
 
 function isPortAvailable(port) {
   return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once("error", () => resolve(false));
-    server.once("listening", () => {
-      server.close();
-      resolve(true);
+    const probe = net.createServer();
+    probe.once("error", () => resolve(false));
+    probe.once("listening", () => {
+      probe.close(() => {
+        const loopback = net.createServer();
+        loopback.once("error", () => resolve(false));
+        loopback.once("listening", () => {
+          loopback.close(() => resolve(true));
+        });
+        loopback.listen(port, "127.0.0.1");
+      });
     });
-    server.listen(port, "127.0.0.1");
+    probe.listen(port, "0.0.0.0");
   });
 }
 

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -5,22 +5,17 @@ const { killProcessGroup } = require("./process");
 
 const GRACEFUL_STOP_TIMEOUT_MS = 5000;
 
-function isPortAvailable(port) {
+function tryBind(port, host) {
   return new Promise((resolve) => {
-    const probe = net.createServer();
-    probe.once("error", () => resolve(false));
-    probe.once("listening", () => {
-      probe.close(() => {
-        const loopback = net.createServer();
-        loopback.once("error", () => resolve(false));
-        loopback.once("listening", () => {
-          loopback.close(() => resolve(true));
-        });
-        loopback.listen(port, "127.0.0.1");
-      });
-    });
-    probe.listen(port, "0.0.0.0");
+    const s = net.createServer();
+    s.once("error", () => resolve(false));
+    s.once("listening", () => s.close(() => resolve(true)));
+    s.listen(port, host);
   });
+}
+
+async function isPortAvailable(port) {
+  return (await tryBind(port, "0.0.0.0")) && (await tryBind(port, "::")) && (await tryBind(port, "127.0.0.1"));
 }
 
 async function findAvailablePort(rangeStart, rangeEnd) {


### PR DESCRIPTION
## Summary

On Windows, `isPortAvailable()` only tested binding to `127.0.0.1`, which succeeds even when another app (like Duplicati) already holds `0.0.0.0` on the same port. OpenWhispr would bind `127.0.0.1:8200` and steal loopback traffic from the other app.

The fix adds a `0.0.0.0` wildcard probe before the existing `127.0.0.1` check. A port is considered available only if both binds succeed. The probes run sequentially (close the wildcard before testing loopback) to avoid self-conflict. On Linux/macOS, the extra check is redundant but harmless since the kernel already prevents wildcard/loopback coexistence for listening sockets.

## Changes

- src/utils/serverUtils.js: double-bind probe in shared `isPortAvailable()`
- src/helpers/cliBridge.js: same fix in standalone copy
- src/helpers/llamaServer.js: same fix in standalone copy
- src/helpers/whisperServer.js: same fix in standalone copy

Fixes #748