### PR TITLE
fix: bugginess in notes view state management

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -122,10 +122,14 @@ export default function PersonalNotesView({
   const [syncedNoteId, setSyncedNoteIdState] = useState<number | null>(null);
   const localContentRef = useRef(localContent);
   const localTitleRef = useRef(localTitle);
+  const localEnhancedContentRef = useRef(localEnhancedContent);
   useEffect(() => {
     localContentRef.current = localContent;
     localTitleRef.current = localTitle;
   }, [localContent, localTitle]);
+  useEffect(() => {
+    localEnhancedContentRef.current = localEnhancedContent;
+  }, [localEnhancedContent]);
   const markNoteAsSynced = (id: number | null) => {
     activeNoteRef.current = id;
     setSyncedNoteIdState(id);
@@ -233,55 +237,72 @@ export default function PersonalNotesView({
   }, []);
 
   useEffect(() => {
-    const syncNote = async () => {
-      if (activeNote && activeNote.id !== activeNoteRef.current) {
-        if (saveTimeoutRef.current) {
-          clearTimeout(saveTimeoutRef.current);
-          saveTimeoutRef.current = null;
-          if (activeNoteRef.current) {
-            await window.electronAPI.updateNote(activeNoteRef.current, {
-              title: localTitleRef.current,
-              content: localContentRef.current,
-            });
-          }
-        }
-        if (enhancedSaveTimeoutRef.current) {
-          clearTimeout(enhancedSaveTimeoutRef.current);
-          enhancedSaveTimeoutRef.current = null;
-        }
-        markNoteAsSynced(activeNote.id);
-        setLocalTitle(activeNote.title);
-        setLocalContent(activeNote.content);
+    if (activeNote && activeNote.id !== activeNoteRef.current) {
+      // --- Switching notes ---
+      // 1. Capture old note state before anything changes
+      const oldNoteId = activeNoteRef.current;
+      const oldTitle = localTitleRef.current;
+      const oldContent = localContentRef.current;
+      const hadPendingSave = !!saveTimeoutRef.current;
+
+      // 2. Clear all pending timers
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+      if (enhancedSaveTimeoutRef.current) {
+        clearTimeout(enhancedSaveTimeoutRef.current);
+        enhancedSaveTimeoutRef.current = null;
+      }
+
+      // 3. Switch to new note IMMEDIATELY (no await, eliminates race window)
+      markNoteAsSynced(activeNote.id);
+      setLocalTitle(activeNote.title);
+      setLocalContent(activeNote.content);
+      setLocalEnhancedContent(activeNote.enhanced_content ?? null);
+      // Also update refs directly so callbacks are correct before next render
+      localTitleRef.current = activeNote.title;
+      localContentRef.current = activeNote.content;
+
+      // 4. Flush old note data fire-and-forget (uses captured values, not refs)
+      if (hadPendingSave && oldNoteId) {
+        window.electronAPI
+          .updateNote(oldNoteId, { title: oldTitle, content: oldContent })
+          .catch((err: unknown) => {
+            logger.warn(
+              "Failed to flush note on switch",
+              { error: (err as Error).message },
+              "notes"
+            );
+          });
+      }
+    } else if (activeNote && activeNote.id === activeNoteRef.current && !saveTimeoutRef.current) {
+      // External update (e.g. AI chat tool) — resync only when no user save is pending
+      if (activeNote.title !== localTitleRef.current) setLocalTitle(activeNote.title);
+      if (activeNote.content !== localContentRef.current) setLocalContent(activeNote.content);
+      if ((activeNote.enhanced_content ?? null) !== localEnhancedContentRef.current) {
         setLocalEnhancedContent(activeNote.enhanced_content ?? null);
-      } else if (activeNote && activeNote.id === activeNoteRef.current && !saveTimeoutRef.current) {
-        // External update (e.g. AI chat tool) — resync only when no user save is pending
-        if (activeNote.title !== localTitleRef.current) setLocalTitle(activeNote.title);
-        if (activeNote.content !== localContentRef.current) setLocalContent(activeNote.content);
-        if ((activeNote.enhanced_content ?? null) !== localEnhancedContent) {
-          setLocalEnhancedContent(activeNote.enhanced_content ?? null);
-        }
       }
-      if (!activeNote) {
-        if (saveTimeoutRef.current) {
-          clearTimeout(saveTimeoutRef.current);
-          saveTimeoutRef.current = null;
-        }
-        if (enhancedSaveTimeoutRef.current) {
-          clearTimeout(enhancedSaveTimeoutRef.current);
-          enhancedSaveTimeoutRef.current = null;
-        }
-        markNoteAsSynced(null);
-        setLocalTitle("");
-        setLocalContent("");
-        setLocalEnhancedContent(null);
+    } else if (!activeNote) {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
       }
-    };
-    syncNote();
-  }, [activeNote, localEnhancedContent]);
+      if (enhancedSaveTimeoutRef.current) {
+        clearTimeout(enhancedSaveTimeoutRef.current);
+        enhancedSaveTimeoutRef.current = null;
+      }
+      markNoteAsSynced(null);
+      setLocalTitle("");
+      setLocalContent("");
+      setLocalEnhancedContent(null);
+    }
+  }, [activeNote]);
 
   const debouncedSave = useCallback((noteId: number, title: string, content: string) => {
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     saveTimeoutRef.current = setTimeout(async () => {
+      saveTimeoutRef.current = null;
       setIsSaving(true);
       try {
         await window.electronAPI.updateNote(noteId, { title, content });
@@ -324,6 +345,7 @@ export default function PersonalNotesView({
     const noteId = activeNoteRef.current;
     if (enhancedSaveTimeoutRef.current) clearTimeout(enhancedSaveTimeoutRef.current);
     enhancedSaveTimeoutRef.current = setTimeout(async () => {
+      enhancedSaveTimeoutRef.current = null;
       setIsSaving(true);
       try {
         await window.electronAPI.updateNote(noteId, { enhanced_content: content });
@@ -896,6 +918,7 @@ export default function PersonalNotesView({
         {editorNote ? (
           <>
             <NoteEditor
+              key={editorNote.id}
               note={editorNote}
               onTitleChange={handleTitleChange}
               onContentChange={handleContentChange}
@@ -943,8 +966,10 @@ export default function PersonalNotesView({
               actionPicker={
                 <ActionPicker
                   onRunAction={(action) => {
-                    const rawTranscript = realtimeTranscript || activeNote?.transcript;
-                    const hasNotes = !!localContent.trim();
+                    if (!editorNote) return;
+                    const rawTranscript = realtimeTranscript || editorNote.transcript;
+                    const noteContent = editorNote.content;
+                    const hasNotes = !!noteContent.trim();
                     if (!hasNotes && !rawTranscript) return;
 
                     let formattedTranscript = "";
@@ -966,12 +991,12 @@ export default function PersonalNotesView({
                     }
 
                     const parts = [
-                      hasNotes ? localContent : "",
+                      hasNotes ? noteContent : "",
                       formattedTranscript ? `## Meeting Transcript\n${formattedTranscript}` : "",
                     ]
                       .filter(Boolean)
                       .join("\n\n");
-                    runAction(action, parts, makeContentHash(localContentRef.current), {
+                    runAction(action, parts, makeContentHash(noteContent), {
                       isCloudMode,
                       modelId: effectiveModelId,
                       isMeetingNote,
@@ -979,7 +1004,9 @@ export default function PersonalNotesView({
                   }}
                   onManageActions={() => setShowActionManager(true)}
                   disabled={
-                    (!localContent.trim() && !realtimeTranscript && !activeNote?.transcript) ||
+                    (!editorNote?.content?.trim() &&
+                      !realtimeTranscript &&
+                      !activeNote?.transcript) ||
                     actionProcessingState === "processing"
                   }
                 />


### PR DESCRIPTION
### Summary
Fixes multiple state management bugs in the Notes view that caused note content, titles, and AI-generated enhancements to bleed between notes during switching.
### Problem
Users reported three symptoms:
- Note content colliding between notes
- AI summarizations/actions applied to the wrong note
- Note titles bleeding to another note
### Root causes identified
All traced to `PersonalNotesView.tsx`'s local state management:
1. **`saveTimeoutRef` never cleared after debounced save fired** — the stale timer ID permanently blocked external updates (AI titles, enhanced content, chat tool edits) from syncing to local state. When the user eventually switched notes, the flush overwrote AI-generated changes with stale local values.
2. **Async race window during note switching** — the `syncNote` effect used `await` to flush the old note's data before updating `activeNoteRef` and local state. During that gap, the component had already rendered the new note's content, but all refs (`activeNoteRef`, `localTitleRef`, `localContentRef`) still pointed to the old note. Any user input during this window saved to the wrong note ID.
3. **`onRunAction` read stale `localContent`** — the action picker callback read `localContent` directly instead of `editorNote.content`. On the first render after a note switch (before `syncNote` updated local state), this held the previous note's content. Clicking an action during this window sent the old note's content to AI processing but saved the result to the new note's ID.
4. **No `key` on `NoteEditor`** — React reused the same component instance across note switches, carrying over the TipTap editor, title DOM, and internal hook state. The title `contentEditable` div was synced via `requestAnimationFrame`, leaving a 1-frame window where old state was interactive.
5. **`localEnhancedContent` in `syncNote` deps** — caused unnecessary effect re-runs that amplified the stale-ref issues.
### Fixes
| # | Fix | Lines |
|---|-----|-------|
| 1 | Clear `saveTimeoutRef.current = null` / `enhancedSaveTimeoutRef.current = null` at the start of each debounced save callback so external updates are no longer permanently blocked | 305, 348 |
| 2 | Rewrite `syncNote` to be fully synchronous: capture old values, switch state + refs immediately, then flush old data fire-and-forget | 239-300 |
| 3 | `onRunAction` reads from `editorNote.content` / `editorNote.transcript` (which has the `isLocalSynced` fallback) instead of raw `localContent` | 968-999, 1007 |
| 4 | Add `key={editorNote.id}` to `<NoteEditor>` so React fully remounts on note switch | 921 |
| 5 | Replace `localEnhancedContent` state dep with `localEnhancedContentRef` in the sync effect; dep array reduced to `[activeNote]` | 125, 130-132, 283, 300 |
### Verification
- [x] `tsc --noEmit`: 0 errors
- [x] `npm run lint`: 0 errors (3 pre-existing warnings in unrelated files)
- [x] `npm run format`: clean
- [x] No new UI strings — no i18n changes needed