### PR TITLE
feat(transcription): add OpenRouter as a first-class STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,9 @@ GROQ_API_KEY=your_groq_api_key_here
 # Get your API key from: https://console.mistral.ai/api-keys
 MISTRAL_API_KEY=your_mistral_api_key_here
 
+# OpenRouter API Configuration (optional - for transcription via OpenRouter)
+# Get your API key from: https://openrouter.ai/keys
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
 # Optional: Debug mode
 OPENWHISPR_LOG_LEVEL=debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OpenRouter STT**: Added OpenRouter as a first-class cloud transcription provider, sitting alongside OpenAI, Groq, Mistral, and Custom in the Speech-to-Text tab. OpenRouter's transcription endpoint takes a JSON body with base64-encoded audio in `input_audio.data` (not OpenAI-style multipart), so the request builder switches wire format when this provider is selected. Free-text model field accepts any OpenRouter STT model id (e.g. `google/chirp-3`). Closes #769.
+
 ## [1.7.0] - 2026-04-30
 
 A big release: new sign-in options, smoother meeting recording, faster cross-device sync, a more configurable AI setup, and the long-planned move to our new legal entity (Gizmo Labs Inc.) on macOS and Windows.

--- a/preload.js
+++ b/preload.js
@@ -358,6 +358,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveMistralKey: (key) => ipcRenderer.invoke("save-mistral-key", key),
   proxyMistralTranscription: (data) => ipcRenderer.invoke("proxy-mistral-transcription", data),
 
+  // OpenRouter API
+  getOpenRouterKey: () => ipcRenderer.invoke("get-openrouter-key"),
+  saveOpenRouterKey: (key) => ipcRenderer.invoke("save-openrouter-key", key),
+
   // Custom endpoint API keys
   getCustomTranscriptionKey: () => ipcRenderer.invoke("get-custom-transcription-key"),
   saveCustomTranscriptionKey: (key) => ipcRenderer.invoke("save-custom-transcription-key", key),

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -85,6 +85,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    openrouterApiKey,
     dictationKey,
     activationMode,
     setActivationMode,
@@ -700,6 +701,8 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
             return groqApiKey.trim().length > 0;
           } else if (cloudTranscriptionProvider === "mistral") {
             return mistralApiKey.trim().length > 0;
+          } else if (cloudTranscriptionProvider === "openrouter") {
+            return openrouterApiKey.trim().length > 0;
           } else if (cloudTranscriptionProvider === "custom") {
             // Custom can work without API key for local endpoints
             return true;

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -202,6 +202,7 @@ const CLOUD_PROVIDER_TABS = [
   { id: "openai", name: "OpenAI" },
   { id: "groq", name: "Groq" },
   { id: "mistral", name: "Mistral" },
+  { id: "openrouter", name: "OpenRouter" },
   { id: "custom", name: "Custom" },
 ];
 
@@ -273,6 +274,8 @@ export default function TranscriptionModelPicker({
   const setGroqApiKey = useSettingsStore((s) => s.setGroqApiKey);
   const mistralApiKey = useSettingsStore((s) => s.mistralApiKey);
   const setMistralApiKey = useSettingsStore((s) => s.setMistralApiKey);
+  const openrouterApiKey = useSettingsStore((s) => s.openrouterApiKey);
+  const setOpenRouterApiKey = useSettingsStore((s) => s.setOpenRouterApiKey);
   const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
   const setCustomTranscriptionApiKey = useSettingsStore((s) => s.setCustomTranscriptionApiKey);
   const effectiveLocal = mode === "local" ? true : mode === "cloud" ? false : useLocalWhisper;
@@ -534,6 +537,12 @@ export default function TranscriptionModelPicker({
 
       if (providerId === "custom") {
         onCloudModelSelect("whisper-1");
+        return;
+      }
+
+      if (providerId === "openrouter") {
+        if (provider) setCloudTranscriptionBaseUrl?.(provider.baseUrl);
+        onCloudModelSelect("");
         return;
       }
 
@@ -855,6 +864,54 @@ export default function TranscriptionModelPicker({
                     placeholder="whisper-1"
                     className="h-8 text-sm"
                   />
+                </div>
+              </div>
+            ) : selectedCloudProvider === "openrouter" ? (
+              <div className="space-y-2">
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <label className="text-xs font-medium text-foreground">
+                      {t("common.apiKey")}
+                    </label>
+                    <button
+                      type="button"
+                      onClick={createExternalLinkHandler("https://openrouter.ai/keys")}
+                      className="text-xs text-primary/70 hover:text-primary transition-colors cursor-pointer"
+                    >
+                      {t("transcription.getKey")}
+                    </button>
+                  </div>
+                  <ApiKeyInput
+                    apiKey={openrouterApiKey}
+                    setApiKey={setOpenRouterApiKey}
+                    label=""
+                    helpText=""
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="block text-xs font-medium text-foreground">
+                    {t("common.model")}
+                  </label>
+                  <Input
+                    value={selectedCloudModel}
+                    onChange={(e) => onCloudModelSelect(e.target.value)}
+                    placeholder="google/chirp-3"
+                    className="h-8 text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Browse models at{" "}
+                    <button
+                      type="button"
+                      onClick={createExternalLinkHandler(
+                        "https://openrouter.ai/models?modality=audio-%3Etext"
+                      )}
+                      className="text-primary hover:underline cursor-pointer"
+                    >
+                      openrouter.ai/models
+                    </button>
+                    .
+                  </p>
                 </div>
               </div>
             ) : (

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -117,6 +117,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    openrouterApiKey,
     customTranscriptionApiKey,
     updateTranscriptionSettings,
   } = useSettings();
@@ -199,7 +200,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
                 ? groqApiKey
                 : cloudTranscriptionProvider === "mistral"
                   ? mistralApiKey
-                  : customTranscriptionApiKey;
+                  : cloudTranscriptionProvider === "openrouter"
+                    ? openrouterApiKey
+                    : customTranscriptionApiKey;
           if (!cancelled) setProviderReady(!!key);
         }
         return;
@@ -231,6 +234,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    openrouterApiKey,
     customTranscriptionApiKey,
   ]);
 
@@ -256,6 +260,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         return groqApiKey;
       case "mistral":
         return mistralApiKey;
+      case "openrouter":
+        return openrouterApiKey;
       case "custom":
         return customTranscriptionApiKey || "";
       default:

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -76,6 +76,7 @@ export const API_ENDPOINTS = {
   GEMINI: "https://generativelanguage.googleapis.com/v1beta",
   GROQ_BASE: "https://api.groq.com/openai/v1",
   MISTRAL_BASE: "https://api.mistral.ai/v1",
+  OPENROUTER_BASE: "https://openrouter.ai/api/v1",
   TRANSCRIPTION_BASE: DEFAULT_TRANSCRIPTION_BASE,
   TRANSCRIPTION: buildApiUrl(DEFAULT_TRANSCRIPTION_BASE, "/audio/transcriptions"),
 } as const;

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -55,12 +55,23 @@ const PLACEHOLDER_KEYS = {
   openai: "your_openai_api_key_here",
   groq: "your_groq_api_key_here",
   mistral: "your_mistral_api_key_here",
+  openrouter: "your_openrouter_api_key_here",
 };
 
 const isValidApiKey = (key, provider = "openai") => {
   if (!key || key.trim() === "") return false;
   const placeholder = PLACEHOLDER_KEYS[provider] || PLACEHOLDER_KEYS.openai;
   return key !== placeholder;
+};
+
+// Chunked to avoid `String.fromCharCode(...largeArray)` stack overflow on multi-MB clips.
+const bytesToBase64 = (bytes) => {
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
 };
 
 const STREAMING_PROVIDERS = {
@@ -882,6 +893,18 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         err.code = "API_KEY_MISSING";
         throw err;
       }
+    } else if (provider === "openrouter") {
+      apiKey = s.openrouterApiKey;
+      if (!isValidApiKey(apiKey, "openrouter")) {
+        apiKey = await window.electronAPI.getOpenRouterKey?.();
+      }
+      if (!isValidApiKey(apiKey, "openrouter")) {
+        const err = new Error(
+          "OpenRouter API key not found. Please set your API key in the Control Panel."
+        );
+        err.code = "API_KEY_MISSING";
+        throw err;
+      }
     } else {
       // Default to OpenAI
       // Prefer store value (user-entered via UI) over main process (.env)
@@ -1483,7 +1506,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         provider === "custom" ||
         (!endpoint.includes("api.openai.com") &&
           !endpoint.includes("api.groq.com") &&
-          !endpoint.includes("api.mistral.ai"));
+          !endpoint.includes("api.mistral.ai") &&
+          !endpoint.includes("openrouter.ai"));
 
       const apiCallStart = performance.now();
 
@@ -1539,18 +1563,44 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         headers.Authorization = `Bearer ${apiKey}`;
       }
 
+      // OpenRouter's transcription API is JSON-only with base64 audio in `input_audio.data`,
+      // not multipart/form-data. See https://openrouter.ai/docs/api/api-reference/transcriptions.
+      const isOpenRouter = provider === "openrouter";
+      let requestBody;
+      if (isOpenRouter) {
+        const audioBuffer = await optimizedAudio.arrayBuffer();
+        const base64Audio = bytesToBase64(new Uint8Array(audioBuffer));
+        const orFormat = extension === "mp4" ? "m4a" : extension;
+        const orBody = {
+          model,
+          input_audio: { data: base64Audio, format: orFormat },
+        };
+        if (language && language !== "auto") {
+          orBody.language = language;
+        }
+        headers["Content-Type"] = "application/json";
+        requestBody = JSON.stringify(orBody);
+      } else {
+        requestBody = formData;
+      }
+
       logger.debug(
         "STT request details",
         {
           endpoint,
           method: "POST",
           hasAuthHeader: !!apiKey,
-          formDataFields: [
-            "file",
-            "model",
-            language && language !== "auto" ? "language" : null,
-            shouldStream ? "stream" : null,
-          ].filter(Boolean),
+          bodyFormat: isOpenRouter ? "json" : "multipart",
+          fields: isOpenRouter
+            ? ["model", "input_audio", language && language !== "auto" ? "language" : null].filter(
+                Boolean
+              )
+            : [
+                "file",
+                "model",
+                language && language !== "auto" ? "language" : null,
+                shouldStream ? "stream" : null,
+              ].filter(Boolean),
         },
         "transcription"
       );
@@ -1558,7 +1608,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       const response = await fetch(endpoint, {
         method: "POST",
         headers,
-        body: formData,
+        body: requestBody,
       });
 
       const responseContentType = response.headers.get("content-type") || "";
@@ -1737,6 +1787,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       if (provider === "custom") {
         return trimmedModel || "whisper-1";
       }
+      // OpenRouter: free-text model id (e.g. "google/chirp-3")
+      if (provider === "openrouter") {
+        return trimmedModel || "";
+      }
 
       // Validate model matches provider to handle settings migration
       if (trimmedModel) {
@@ -1805,6 +1859,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         base = API_ENDPOINTS.GROQ_BASE;
       } else if (currentProvider === "mistral") {
         base = API_ENDPOINTS.MISTRAL_BASE;
+      } else if (currentProvider === "openrouter") {
+        base = API_ENDPOINTS.OPENROUTER_BASE;
       } else {
         // OpenAI or other standard providers
         base = API_ENDPOINTS.TRANSCRIPTION_BASE;

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -12,6 +12,7 @@ const SECRET_KEYS = [
   "GEMINI_API_KEY",
   "GROQ_API_KEY",
   "MISTRAL_API_KEY",
+  "OPENROUTER_API_KEY",
   "ASSEMBLYAI_API_KEY",
   "DEEPGRAM_API_KEY",
   "CUSTOM_TRANSCRIPTION_API_KEY",
@@ -293,6 +294,14 @@ class EnvironmentManager {
 
   saveMistralKey(key) {
     return this._saveKey("MISTRAL_API_KEY", key);
+  }
+
+  getOpenRouterKey() {
+    return this._getKey("OPENROUTER_API_KEY");
+  }
+
+  saveOpenRouterKey(key) {
+    return this._saveKey("OPENROUTER_API_KEY", key);
   }
 
   getAssemblyAIKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -505,7 +505,7 @@ class IPCHandlers {
 
   _resolveByokModel(provider, configuredModel) {
     const trimmed = (configuredModel || "").trim();
-    if (provider === "custom") return trimmed || "whisper-1";
+    if (provider === "custom" || provider === "openrouter") return trimmed || "whisper-1";
     if (trimmed) {
       const isGroq = trimmed.startsWith("whisper-large-v3");
       const isOpenAI = trimmed.startsWith("gpt-4o") || trimmed === "whisper-1";
@@ -2483,6 +2483,14 @@ class IPCHandlers {
       return this.environmentManager.saveMistralKey(key);
     });
 
+    ipcMain.handle("get-openrouter-key", async () => {
+      return this.environmentManager.getOpenRouterKey();
+    });
+
+    ipcMain.handle("save-openrouter-key", async (event, key) => {
+      return this.environmentManager.saveOpenRouterKey(key);
+    });
+
     ipcMain.handle(
       "proxy-mistral-transcription",
       async (event, { audioBuffer, model, language, contextBias }) => {
@@ -3650,6 +3658,9 @@ class IPCHandlers {
           } else if (provider === "mistral") {
             apiKey = this.environmentManager.getMistralKey();
             endpoint = MISTRAL_TRANSCRIPTION_URL;
+          } else if (provider === "openrouter") {
+            apiKey = this.environmentManager.getOpenRouterKey();
+            endpoint = "https://openrouter.ai/api/v1/audio/transcriptions";
           } else if (provider === "custom") {
             apiKey = this.environmentManager.getCustomTranscriptionKey();
             const base = (settings?.cloudTranscriptionBaseUrl || "").trim();
@@ -3666,18 +3677,38 @@ class IPCHandlers {
             throw new Error(`${provider} API key not configured`);
           }
 
-          const formData = new FormData();
-          formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
-          formData.append("model", model);
-          if (language) formData.append("language", language);
-          const headers = {};
-          if (provider === "mistral") {
-            headers["x-api-key"] = apiKey;
-          } else if (apiKey) {
-            headers.Authorization = `Bearer ${apiKey}`;
+          let response;
+          if (provider === "openrouter") {
+            const body = {
+              model,
+              input_audio: {
+                data: Buffer.from(buffer).toString("base64"),
+                format: "webm",
+              },
+            };
+            if (language) body.language = language;
+            response = await proxyFetch(endpoint, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${apiKey}`,
+              },
+              body: JSON.stringify(body),
+            });
+          } else {
+            const formData = new FormData();
+            formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
+            formData.append("model", model);
+            if (language) formData.append("language", language);
+            const headers = {};
+            if (provider === "mistral") {
+              headers["x-api-key"] = apiKey;
+            } else if (apiKey) {
+              headers.Authorization = `Bearer ${apiKey}`;
+            }
+            response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
           }
 
-          const response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
           if (!response.ok) {
             const errorText = await response.text();
             throw new Error(`${provider} API Error: ${response.status} ${errorText}`);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -56,6 +56,7 @@ export interface ApiKeySettings {
   geminiApiKey: string;
   groqApiKey: string;
   mistralApiKey: string;
+  openrouterApiKey: string;
   customTranscriptionApiKey: string;
   cleanupCustomApiKey: string;
 }
@@ -215,6 +216,7 @@ function useSettingsInternal() {
     geminiApiKey: store.geminiApiKey,
     groqApiKey: store.groqApiKey,
     mistralApiKey: store.mistralApiKey,
+    openrouterApiKey: store.openrouterApiKey,
     dictationKey: store.dictationKey,
     meetingKey: store.meetingKey,
     meetingHotkeyLayoutMode: store.meetingHotkeyLayoutMode,
@@ -250,6 +252,7 @@ function useSettingsInternal() {
     setGeminiApiKey: store.setGeminiApiKey,
     setGroqApiKey: store.setGroqApiKey,
     setMistralApiKey: store.setMistralApiKey,
+    setOpenRouterApiKey: store.setOpenRouterApiKey,
     customTranscriptionApiKey: store.customTranscriptionApiKey,
     setCustomTranscriptionApiKey: store.setCustomTranscriptionApiKey,
     cleanupCustomApiKey: store.cleanupCustomApiKey,

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -191,6 +191,12 @@
           "descriptionKey": "models.descriptions.transcription.mistral_voxtral_mini_latest"
         }
       ]
+    },
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "models": []
     }
   ],
   "cloudProviders": [

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -479,6 +479,7 @@ export interface SettingsState
   setGeminiApiKey: (key: string) => void;
   setGroqApiKey: (key: string) => void;
   setMistralApiKey: (key: string) => void;
+  setOpenRouterApiKey: (key: string) => void;
   setCustomTranscriptionApiKey: (key: string) => void;
   setCleanupCustomApiKey: (key: string) => void;
 
@@ -600,6 +601,7 @@ const SECRET_IPC_SAVERS = {
   gemini: "saveGeminiKey",
   groq: "saveGroqKey",
   mistral: "saveMistralKey",
+  openrouter: "saveOpenRouterKey",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
   bedrockAccessKeyId: "saveBedrockAccessKeyId",
@@ -637,6 +639,7 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
   "geminiApiKey",
   "groqApiKey",
   "mistralApiKey",
+  "openrouterApiKey",
   "customTranscriptionApiKey",
   "customReasoningApiKey",
   "cleanupCustomApiKey",
@@ -704,6 +707,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   geminiApiKey: "",
   groqApiKey: "",
   mistralApiKey: "",
+  openrouterApiKey: "",
   customTranscriptionApiKey: "",
   cleanupCustomApiKey: "",
 
@@ -1048,6 +1052,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ mistralApiKey: key });
     debouncedSaveSecret("mistral", key);
     invalidateApiKeyCaches("mistral");
+  },
+  setOpenRouterApiKey: (key: string) => {
+    set({ openrouterApiKey: key });
+    debouncedSaveSecret("openrouter", key);
+    invalidateApiKeyCaches();
   },
   setCustomTranscriptionApiKey: (key: string) => {
     set({ customTranscriptionApiKey: key });
@@ -1413,6 +1422,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (keys.geminiApiKey !== undefined) s.setGeminiApiKey(keys.geminiApiKey);
     if (keys.groqApiKey !== undefined) s.setGroqApiKey(keys.groqApiKey);
     if (keys.mistralApiKey !== undefined) s.setMistralApiKey(keys.mistralApiKey);
+    if (keys.openrouterApiKey !== undefined) s.setOpenRouterApiKey(keys.openrouterApiKey);
     if (keys.customTranscriptionApiKey !== undefined)
       s.setCustomTranscriptionApiKey(keys.customTranscriptionApiKey);
     if (keys.cleanupCustomApiKey !== undefined) s.setCleanupCustomApiKey(keys.cleanupCustomApiKey);
@@ -1607,6 +1617,7 @@ export async function initializeSettings(): Promise<void> {
         gemini,
         groq,
         mistral,
+        openrouter,
         customTx,
         customRx,
         bedrockAccessKeyId,
@@ -1620,6 +1631,7 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getGeminiKey?.(),
         window.electronAPI.getGroqKey?.(),
         window.electronAPI.getMistralKey?.(),
+        window.electronAPI.getOpenRouterKey?.(),
         window.electronAPI.getCustomTranscriptionKey?.(),
         window.electronAPI.getCleanupCustomKey?.(),
         window.electronAPI.getBedrockAccessKeyId?.(),
@@ -1635,6 +1647,7 @@ export async function initializeSettings(): Promise<void> {
         geminiApiKey: gemini || "",
         groqApiKey: groq || "",
         mistralApiKey: mistral || "",
+        openrouterApiKey: openrouter || "",
         customTranscriptionApiKey: customTx || "",
         cleanupCustomApiKey: customRx || "",
         bedrockAccessKeyId: bedrockAccessKeyId || "",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -975,6 +975,10 @@ declare global {
         contextBias?: string[];
       }) => Promise<{ text: string }>;
 
+      // OpenRouter API key management
+      getOpenRouterKey: () => Promise<string | null>;
+      saveOpenRouterKey: (key: string) => Promise<void>;
+
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;
       saveCustomTranscriptionKey?: (key: string) => Promise<void>;

--- a/src/utils/byokDetection.ts
+++ b/src/utils/byokDetection.ts
@@ -2,5 +2,11 @@ import { useSettingsStore } from "../stores/settingsStore";
 
 export const hasStoredByokKey = () => {
   const s = useSettingsStore.getState();
-  return !!(s.openaiApiKey || s.groqApiKey || s.mistralApiKey || s.customTranscriptionApiKey);
+  return !!(
+    s.openaiApiKey ||
+    s.groqApiKey ||
+    s.mistralApiKey ||
+    s.openrouterApiKey ||
+    s.customTranscriptionApiKey
+  );
 };


### PR DESCRIPTION
Closes #769.

## Why

OpenRouter's `POST /api/v1/audio/transcriptions` isn't wire-compatible with OpenAI's despite sharing the URL. Per [their docs](https://openrouter.ai/docs/api/api-reference/transcriptions/create-audio-transcriptions), the endpoint takes `Content-Type: application/json` with base64 audio in `input_audio.data` and a `format` discriminator — not OpenAI-style `multipart/form-data` with a `file` field. The existing "Custom" provider always builds multipart, so OpenRouter fails with the misleading `"No number after minus sign in JSON at position 1"` when it tries to JSON-parse the form bytes.

## What

Add OpenRouter as a first-class cloud STT provider, mirroring the precedent set by #227 (Mistral) when its wire contract diverged.

- New **OpenRouter** tab in Speech-to-Text → Cloud Providers with API key input and a free-text model field (OpenRouter exposes hundreds of model IDs like `google/chirp-3`)
- JSON request body with base64-encoded audio. Chunked encoding (32 KB) so larger clips don't blow the stack on `String.fromCharCode(...largeArray)`
- Bearer auth via dedicated `OPENROUTER_API_KEY` in `SECRET_KEYS` — inherits at-rest encryption from #629 / #704
- Retry-transcription path in the main process updated for parity, so failed transcriptions can be retried against OpenRouter
- Falls back to the existing multipart path for every other provider — nothing else changes

## Alternatives considered

- **A. Hostname-detect OpenRouter and switch encoding inline.** Cheapest, but the codebase doesn't sniff hostnames for dispatch anywhere — would be a one-off pattern.
- **C. "Wire format" toggle inside the Custom tab** (multipart vs JSON). Generic, but adds a knob most users won't understand.
- **D. Capability probe** mirroring `detectServerType` in `openai.ts:79`. Elegant in theory, but there's no clean handshake — you'd be inferring from error shape.

Chose B because the codebase precedent is "if the wire contract is materially different, it's its own provider": Mistral (#227), and the currently-open #634 (Smallest AI), #635 (Gladia), #418 (Soniox) continuing that pattern.

## Provider-tab growth (flag, not blocker)

With OpenRouter + #634 + #635 + #418 all queued, the cloud STT tab list grows from 4 → 8. Worth a call on whether you want to land a refactor (e.g. "More providers…" overflow, grouping by category, or revisiting capability-probing) before more providers ship. Happy to defer either way; I went with the established precedent.

## Files

15 files, +228 / −21. No new dependencies. Same architectural shape as #227.

## Test plan

- [x] `npm run typecheck` clean on all modified files
- [x] `npm run lint` clean on all modified files
- [ ] Manual: configure OpenRouter tab with key + model `google/chirp-3`, record clip, verify success — **not done by me; I don't have a Chirp-3 key.** @VVincentt and @raabot on #769 have offered to verify against their real OpenRouter setups
- [ ] Manual regression: same flow with OpenAI / Groq / Mistral / Custom — must still go through the multipart branch unchanged
- [ ] Retry-transcription against OpenRouter (main-process path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)