### PR TITLE
fix(notes): route Generate Notes through Note Formatting scope

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -46,7 +46,11 @@ import ActionPicker from "./ActionPicker";
 import ActionManagerDialog from "./ActionManagerDialog";
 import AddNotesToFolderDialog from "./AddNotesToFolderDialog";
 import { useActionProcessing } from "../../hooks/useActionProcessing";
-import { useSettingsStore, selectIsCloudCleanupMode } from "../../stores/settingsStore";
+import {
+  useSettingsStore,
+  selectIsCloudNoteFormattingMode,
+  selectResolvedNoteFormatting,
+} from "../../stores/settingsStore";
 import { useFolderManagement } from "../../hooks/useFolderManagement";
 import { useNoteDragAndDrop } from "../../hooks/useNoteDragAndDrop";
 import { cn } from "../lib/utils";
@@ -131,8 +135,8 @@ export default function PersonalNotesView({
     setSyncedNoteIdState(id);
   };
   const { toast } = useToast();
-  const isCloudMode = useSettingsStore(selectIsCloudCleanupMode);
-  const effectiveModelId = useSettingsStore((s) => s.cleanupModel);
+  const isCloudMode = useSettingsStore(selectIsCloudNoteFormattingMode);
+  const effectiveModelId = useSettingsStore((s) => selectResolvedNoteFormatting(s).model);
   const noteFilesEnabled = useSettingsStore((s) => s.noteFilesEnabled);
   const fileManagerName = navigator.platform.startsWith("Mac")
     ? "Finder"

--- a/src/stores/actionProcessingStore.ts
+++ b/src/stores/actionProcessingStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import reasoningService from "../services/ReasoningService";
-import { getEffectiveCleanupModel, getSettings } from "./settingsStore";
+import { getSettings } from "./settingsStore";
 import { appendDictionarySuffix } from "../config/prompts";
 import { generateNoteTitle } from "../utils/generateTitle";
 import type { ActionItem } from "../types/electron";
@@ -109,7 +109,7 @@ export function runBackgroundAction(
 ): void {
   if (processingFlags.get(noteId)) return;
 
-  const modelId = getEffectiveCleanupModel() || options.modelId;
+  const modelId = options.modelId;
   if (!modelId && !options.isCloudMode) {
     pushErrorEvent({ noteId, message: labels.noModel });
     return;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1442,6 +1442,11 @@ export const selectIsCloudChatAgentMode = (state: SettingsState) =>
   state.chatAgentMode === "openwhispr" &&
   state.chatAgentCloudMode === "openwhispr";
 
+export const selectIsCloudNoteFormattingMode = (state: SettingsState) => {
+  const cfg = selectResolvedNoteFormatting(state);
+  return state.isSignedIn && cfg.mode === "openwhispr" && cfg.cloudMode === "openwhispr";
+};
+
 export interface ResolvedMeetingTranscription {
   useLocalWhisper: boolean;
   whisperModel: string;


### PR DESCRIPTION
Closes #784.

## Why

Note Formatting has its own settings tab in the UI (`Settings → Language Models → Note Formatting`) but two reads in the runtime path were hardcoded to the Dictation Cleanup scope, so the per-scope selectors silently did nothing.

## What

- `PersonalNotesView.tsx:135` now resolves `effectiveModelId` and `isCloudMode` from the note-formatting scope via `selectResolvedNoteFormatting` and a new `selectIsCloudNoteFormattingMode`.
- `actionProcessingStore.ts:112` no longer overrides with `getEffectiveCleanupModel()` — trusts caller's `options.modelId`.
- New `selectIsCloudNoteFormattingMode` selector in `settingsStore.ts`, mirroring `selectIsCloudCleanupMode` / `selectIsCloudChatAgentMode`.

Backwards-compatible by design: `selectResolvedLLMConfig` already has `fallbackScope: "dictationCleanup"`, so users who never touched Note Formatting settings continue to use their cleanup model/mode unchanged. Users who explicitly set a different Note Formatting model — today silently ignored — now get it respected. The runtime swap in `modelManagerBridge.runInference:362` handles the actual model swap on the sidecar.

Builds on #752 (already in `main`) which fixed the Qwen reasoning trap. Together they close the user-visible Note Formatting failure end-to-end.

## Out of scope (deliberate)

- **Startup pre-warm** in `main.js:893–911` still only pre-warms cleanup + dictation-agent models. First Note Formatting call after launch carries sidecar-swap latency when models differ. Functional, not optimal. Follow-up.
- **`getModelProvider()` scope-awareness**: still reads `cleanupProvider` for cloud-vs-local branching. Narrow edge case (mixing BYOK cleanup with OpenWhispr-cloud note formatting). Separate fix.
- **Streaming `applyThinkingSuppression`** doesn't send `chat_template_kwargs.enable_thinking: false` for local Qwen (flagged in #783's comment). Different code path, same root cause as #783. Separate issue.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched files
- [ ] Manual: with Cleanup → Local Qwen and Note Formatting → Local Gemma (per @chris-ari's repro), click Generate Notes; verify sidecar respawns with Gemma weights and notes are non-empty.
- [ ] Manual regression: user who never touches Note Formatting settings sees identical behaviour to before (fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)