### PR TITLE
fix(realtime): dedup duplicate transcription completions by item_id

### DIFF
--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -26,6 +26,10 @@ class OpenAIRealtimeStreaming {
     this.coldStartBuffer = [];
     this.coldStartBufferSize = 0;
     this.speechStartedAt = null;
+    // Tracks transcription-completed item_ids we've already pushed onto
+    // completedSegments so server re-emissions of the same event don't
+    // duplicate text in the final transcript (#770).
+    this.seenItemIds = new Set();
   }
 
   getFullTranscript() {
@@ -50,6 +54,7 @@ class OpenAIRealtimeStreaming {
     this.coldStartBuffer = [];
     this.coldStartBufferSize = 0;
     this.speechStartedAt = null;
+    this.seenItemIds = new Set();
 
     const url = "wss://api.openai.com/v1/realtime?intent=transcription";
     debugLogger.debug("OpenAI Realtime connecting", { model: this.model });
@@ -183,6 +188,17 @@ class OpenAIRealtimeStreaming {
         }
 
         case "conversation.item.input_audio_transcription.completed": {
+          // Server occasionally re-emits the same completion event for one
+          // conversation item, which would otherwise multiply text in the
+          // final transcript (#770). Dedup by item_id; when the field is
+          // missing fall through to the existing single-fire behaviour.
+          const itemId = typeof event.item_id === "string" ? event.item_id : undefined;
+          if (itemId && this.seenItemIds.has(itemId)) {
+            debugLogger.debug("OpenAI Realtime duplicate completion ignored", { itemId });
+            break;
+          }
+          if (itemId) this.seenItemIds.add(itemId);
+
           const transcript = (event.transcript || "").trim();
           if (transcript) {
             this.completedSegments.push(transcript);


### PR DESCRIPTION
Closes #770.

## Why

Users hit ~10% rate of identical-text 3–4× repetition with `gpt-4o-mini-transcribe`. Identical-verbatim repetition (not internal stutter) points to protocol-layer duplication: the server occasionally re-emits the same `conversation.item.input_audio_transcription.completed` event for one conversation item, and `openaiRealtimeStreaming.js:185–200` pushes each event's transcript onto `completedSegments` and emits the running joined text.

Another production OpenAI Realtime client ([daintreehq/daintree](https://github.com/daintreehq/daintree/blob/main/electron/services/VoiceTranscriptionService.ts)) explicitly dedups by `item_id` and documents the same server behaviour.

## What

Track a `Set` of seen `item_id`s per session. On a completion event with an `item_id` we've already processed, log at debug level and skip the push + `onFinalTranscript` emit. Reset the Set on each `connect()` so it can't grow across sessions.

Falls back to current single-fire behaviour when `item_id` is absent on the event — purely additive, no regression risk.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched file
- [ ] Manual: dictate 10+ short clips with `gpt-4o-mini-transcribe`, cleanup disabled, watch debug logs for "OpenAI Realtime duplicate completion ignored" entries — their presence confirms the dedup is firing.
- [ ] @kunal118 to verify against their original repro.

## Files

1 file, +16 / −0.

## Honest framing

**Mitigation, not proven elimination.** I can't reproduce locally (intermittent, no Realtime API key). Confidence breakdown:

- ~85% chance this catches the dominant root cause (server re-emission of `.completed` events; daintree's precedent strongly supports this hypothesis).
- ~60% chance this catches *all* duplicates. Residual mechanism, if any, is likely renderer-side listener accumulation in `audioManager.js` (`provider.onFinal` listeners not cleaned up between sessions) — separate small fix if reports persist after this lands.
- ~5% regression risk (additive guard; legitimate consecutive turns get unique item_ids; safe fallback when item_id absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)