### PR TITLE
docs: add Arch linux ydotool installation guide in "Wayland Paste Setup" settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -2629,6 +2629,7 @@ export default function SettingsPage({
                           cmds: [
                             { label: "Ubuntu / Pop!_OS / Debian", cmd: "sudo apt install ydotool" },
                             { label: "Fedora", cmd: "sudo dnf install ydotool" },
+                            { label: "Arch Linux", cmd: "sudo pacman -S ydotool" },
                             { label: "openSUSE", cmd: "sudo zypper install ydotool" },
                           ],
                         },
@@ -2665,6 +2666,7 @@ export default function SettingsPage({
                               cmd: "sudo apt install ydotoold",
                             },
                             { label: "Fedora", cmd: "# Already included in the ydotool package" },
+                            { label: "Arch Linux", cmd: "# Included in the ydotool package" },
                           ],
                         },
                       ],
@@ -2869,13 +2871,23 @@ EOF`,
                             {
                               cmd: "systemctl --user enable ydotoold && systemctl --user start ydotoold",
                             },
+                            {
+                              label: "Arch Linux (service is named ydotool.service)",
+                              cmd: "systemctl --user enable --now ydotool.service",
+                            },
                           ],
                         },
                         {
                           title: t("settingsPage.general.waylandPaste.guide.daemon.step2Title", {
                             defaultValue: "Verify it's running",
                           }),
-                          cmds: [{ cmd: "systemctl --user status ydotoold" }],
+                          cmds: [
+                            { cmd: "systemctl --user status ydotoold" },
+                            {
+                              label: "Arch Linux",
+                              cmd: "systemctl --user status ydotool.service",
+                            },
+                          ],
                         },
                       ],
                     },

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1600,7 +1600,7 @@ class ClipboardManager {
 
     if (ydotoolExists && !ydotoolDaemonRunning) {
       errorMsg +=
-        "\n\nNote: ydotool is installed but the ydotoold daemon is not running. Start it with: sudo systemctl enable --now ydotool";
+        "\n\nNote: ydotool is installed but the ydotoold daemon is not running. Start it with: systemctl --user enable --now ydotoold";
     }
 
     const err = new Error(errorMsg + failureSummary);

--- a/src/helpers/ensureYdotool.js
+++ b/src/helpers/ensureYdotool.js
@@ -136,7 +136,7 @@ async function ensureYdotool() {
   }
   if (!hasYdotoold) {
     missing.push(
-      "- ydotoold (daemon) is not installed. On Ubuntu/Pop!_OS: sudo apt install ydotoold"
+      "- ydotoold (daemon) is not installed. On Ubuntu/Pop!_OS: sudo apt install ydotoold. On Arch: included in the ydotool package."
     );
   }
   if (!hasUinput) {


### PR DESCRIPTION
Add `ydotool` installation guides for Arch Linux.

closes #796 