### PR TITLE
fix(desktop): remove boot-time BYOK auto-default that overrode subscribed users

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { API_ENDPOINTS } from "../config/constants";
 import i18n, { normalizeUiLanguage } from "../i18n";
-import { hasStoredByokKey } from "../utils/byokDetection";
 import { ensureAgentNameInDictionary } from "../utils/agentName";
 import { useStreamingProvidersStore } from "./streamingProvidersStore";
 import logger from "../utils/logger";
@@ -1643,11 +1642,6 @@ export async function initializeSettings(): Promise<void> {
         azureApiKey: azureApiKey || "",
         vertexApiKey: vertexApiKey || "",
       });
-
-      // hasStoredByokKey reads from Zustand, so this default must run after hydration.
-      if (!localStorage.getItem("cloudTranscriptionMode") && hasStoredByokKey()) {
-        useSettingsStore.setState({ cloudTranscriptionMode: "byok" });
-      }
 
       for (const key of STALE_SECRET_LOCALSTORAGE_KEYS) {
         localStorage.removeItem(key);

--- a/src/utils/byokDetection.ts
+++ b/src/utils/byokDetection.ts
@@ -1,6 +1,0 @@
-import { useSettingsStore } from "../stores/settingsStore";
-
-export const hasStoredByokKey = () => {
-  const s = useSettingsStore.getState();
-  return !!(s.openaiApiKey || s.groqApiKey || s.mistralApiKey || s.customTranscriptionApiKey);
-};


### PR DESCRIPTION
## Summary

A one-shot migration in `initializeSettings` auto-switched `cloudTranscriptionMode` to `"byok"` whenever any BYOK key existed in storage. Two problems:

1. **Re-fired every boot.** It called `useSettingsStore.setState(...)` directly instead of the persisting setter, so `cloudTranscriptionMode` was never written to `localStorage`. The check `!localStorage.getItem(...)` was true on every cold boot, silently overriding the user's UI selection.
2. **"Has any key" is the wrong signal.** Modern users set keys via the Settings UI and pick a mode at the same moment — a stored OpenAI/Groq/Mistral key from a previous trial doesn't imply transcription intent (those keys are dual-use; users may keep them around purely for cleanup or the agent). Subscribed users in particular got routed to `api.openai.com` every launch and saw "Daily limit reached" — which was actually OpenAI returning `insufficient_quota` on the user's expired trial key.

## Fix

Drop the migration entirely. The store default (`"openwhispr"`) stands. Users who want BYOK transcription pick it explicitly in Settings — same as every other setting in the app. Removes the now-unused `byokDetection` helper.

## Who's affected

- **Modern users with an explicit mode set** — unchanged (the migration's `!localStorage.getItem(...)` short-circuit already excluded them).
- **Subscribed users silently flipped to BYOK by the bug** — unbroken on next launch; they land on the default OpenWhispr Cloud mode.
- **Edge case: legacy user with a keychain key but no `cloudTranscriptionMode` in localStorage** — lands on OpenWhispr Cloud by default. If they want BYOK, they click it in Settings once.

## Test plan

- [ ] Fresh install, never opened Settings → mode is `openwhispr`
- [ ] Existing user already on `byok` (mode in localStorage) → unchanged
- [ ] Subscribed user reinstalls with leftover OpenAI key in keychain → stays on OpenWhispr Cloud (no silent flip)
- [ ] No other references to `byokDetection` / `hasStoredByokKey` left in the codebase