### PR TITLE
fix(transcription): honor self-hosted URL in STT endpoint resolution

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1769,15 +1769,18 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const s = getSettings();
     const currentProvider = s.cloudTranscriptionProvider || "openai";
     const currentBaseUrl = s.cloudTranscriptionBaseUrl || "";
+    const transcriptionMode = s.transcriptionMode || "";
+    const remoteUrl = (s.remoteTranscriptionUrl || "").trim();
 
-    // Only use custom URL when provider is explicitly "custom"
-    const isCustomEndpoint = currentProvider === "custom";
+    const isSelfHosted = transcriptionMode === "self-hosted" && remoteUrl.length > 0;
+    const isCustomEndpoint = isSelfHosted || currentProvider === "custom";
 
-    // Invalidate cache if provider or base URL changed
     if (
       this.cachedTranscriptionEndpoint &&
       (this.cachedEndpointProvider !== currentProvider ||
-        this.cachedEndpointBaseUrl !== currentBaseUrl)
+        this.cachedEndpointBaseUrl !== currentBaseUrl ||
+        this.cachedEndpointMode !== transcriptionMode ||
+        this.cachedEndpointRemoteUrl !== remoteUrl)
     ) {
       logger.debug(
         "STT endpoint cache invalidated",
@@ -1786,6 +1789,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           newProvider: currentProvider,
           previousBaseUrl: this.cachedEndpointBaseUrl,
           newBaseUrl: currentBaseUrl,
+          previousMode: this.cachedEndpointMode,
+          newMode: transcriptionMode,
+          previousRemoteUrl: this.cachedEndpointRemoteUrl,
+          newRemoteUrl: remoteUrl,
         },
         "transcription"
       );
@@ -1797,9 +1804,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     try {
-      // Use custom URL only when provider is "custom", otherwise use provider-specific defaults
       let base;
-      if (isCustomEndpoint) {
+      if (isSelfHosted) {
+        base = remoteUrl;
+      } else if (currentProvider === "custom") {
         base = currentBaseUrl.trim() || API_ENDPOINTS.TRANSCRIPTION_BASE;
       } else if (currentProvider === "groq") {
         base = API_ENDPOINTS.GROQ_BASE;
@@ -1816,8 +1824,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         "STT endpoint resolution",
         {
           provider: currentProvider,
+          mode: transcriptionMode,
+          isSelfHosted,
           isCustomEndpoint,
           rawBaseUrl: currentBaseUrl,
+          remoteUrl,
           normalizedBase,
           defaultBase: API_ENDPOINTS.TRANSCRIPTION_BASE,
         },
@@ -1828,6 +1839,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         this.cachedTranscriptionEndpoint = endpoint;
         this.cachedEndpointProvider = currentProvider;
         this.cachedEndpointBaseUrl = currentBaseUrl;
+        this.cachedEndpointMode = transcriptionMode;
+        this.cachedEndpointRemoteUrl = remoteUrl;
 
         logger.debug(
           "STT endpoint resolved",
@@ -1885,6 +1898,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.cachedTranscriptionEndpoint = API_ENDPOINTS.TRANSCRIPTION;
       this.cachedEndpointProvider = currentProvider;
       this.cachedEndpointBaseUrl = currentBaseUrl;
+      this.cachedEndpointMode = transcriptionMode;
+      this.cachedEndpointRemoteUrl = remoteUrl;
       return API_ENDPOINTS.TRANSCRIPTION;
     }
   }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -192,11 +192,7 @@ function migrateProviderSettings() {
     localStorage.setItem("remoteTranscriptionType", "openai-compatible");
     const legacyBaseUrl = localStorage.getItem("cloudTranscriptionBaseUrl");
     const existingRemoteUrl = localStorage.getItem("remoteTranscriptionUrl");
-    if (
-      !existingRemoteUrl &&
-      legacyBaseUrl &&
-      legacyBaseUrl !== API_ENDPOINTS.TRANSCRIPTION_BASE
-    ) {
+    if (!existingRemoteUrl && legacyBaseUrl && legacyBaseUrl !== API_ENDPOINTS.TRANSCRIPTION_BASE) {
       localStorage.setItem("remoteTranscriptionUrl", legacyBaseUrl);
     }
   }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -190,6 +190,15 @@ function migrateProviderSettings() {
 
   if (provider === "custom" && cloudMode === "byok") {
     localStorage.setItem("remoteTranscriptionType", "openai-compatible");
+    const legacyBaseUrl = localStorage.getItem("cloudTranscriptionBaseUrl");
+    const existingRemoteUrl = localStorage.getItem("remoteTranscriptionUrl");
+    if (
+      !existingRemoteUrl &&
+      legacyBaseUrl &&
+      legacyBaseUrl !== API_ENDPOINTS.TRANSCRIPTION_BASE
+    ) {
+      localStorage.setItem("remoteTranscriptionUrl", legacyBaseUrl);
+    }
   }
 
   const reasoningMode = localStorage.getItem("cloudReasoningMode");


### PR DESCRIPTION
## Summary

Fixes #750 — when the user picks "Self-hosted server" mode and enters a custom server URL, the app was silently sending transcription requests to `https://api.openai.com/v1/audio/transcriptions` and returning 401.

## Root cause

`getTranscriptionEndpoint()` in `audioManager.js` only read `cloudTranscriptionBaseUrl` (which defaults to the OpenAI URL). The self-hosted UI writes the user's URL to a different setting — `remoteTranscriptionUrl` — which the resolver never consulted.

## Changes

- `audioManager.js`: when `transcriptionMode === "self-hosted"` and `remoteTranscriptionUrl` is set, use that URL as the base. Cache key now includes mode and remote URL so live edits take effect without a restart.
- `settingsStore.ts`: in the one-shot `migrateProviderSettings()` step, copy `cloudTranscriptionBaseUrl` → `remoteTranscriptionUrl` for users upgrading from the legacy "custom" cloud provider, so they don't have to re-enter their server URL.

Existing `openwhispr` / `providers` / `local` modes and the named cloud providers (OpenAI / Groq / Mistral) all fall through to the unchanged path. HTTPS guard already allows private hosts (127.0.0.1, RFC1918, .local), so local whisper.cpp servers over HTTP work.

## Test plan

- [ ] Pick Settings → Transcription → Self-hosted server, enter `http://127.0.0.1:8080`, dictate — request hits the local server (verify in `whisper-server` logs)
- [ ] Edit the URL while the app is open; next dictation uses the new URL without restart
- [ ] Fresh install with OpenWhispr Cloud / BYOK providers / Local — unchanged behavior
- [ ] Upgrade path from 1.6.x with `cloudTranscriptionProvider=custom` + a configured base URL: URL appears in self-hosted UI after upgrade