### PR TITLE
fix(reasoning): suppress Qwen thinking on local streaming chat-agent path

### DIFF
--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -20,6 +20,7 @@ function suppressThinking(requestBody: Record<string, unknown>, providerKey: str
   } else {
     requestBody.reasoning_effort = "none";
   }
+  requestBody.chat_template_kwargs = { enable_thinking: false };
 }
 
 export function applyThinkingSuppression(


### PR DESCRIPTION
Closes the streaming-path half of #783.

## Why

#752 patched the **note-formatting** path so local Qwen3.x stops exhausting its token budget inside `<think>` and returning empty `content`. The **streaming chat-agent** path hits the same llama.cpp endpoint but goes through `applyThinkingSuppression()` instead of `llamaServer.inference()`'s request builder — and the suppression helper only sends `think: false` (Ollama-native) and `reasoning_effort: "none"` (OpenAI-compat). Neither is honored by llama.cpp's `--jinja` chat template, so users running the chat agent against a local Qwen still see empty responses.

Verified in [`thinkingSuppression.ts:17-23`](src/services/ai/thinkingSuppression.ts#L17-L23) (the path) and [`ReasoningService.ts:352-357`](src/services/ReasoningService.ts#L352-L357) + [`:404`](src/services/ReasoningService.ts#L404) (the streaming entry).

## What

One line in `suppressThinking()`: also set `chat_template_kwargs: { enable_thinking: false }`.

## Why universal, not provider-targeted

`chat_template_kwargs.enable_thinking` is the cross-server standard for Qwen3.x thinking suppression — llama.cpp, vLLM, SGLang, and LM Studio all read it (per Qwen's own docs and each server's docs). Unknown-field-ignore semantics are documented for Groq, OpenAI-compat, and Ollama, so adding the flag universally does not regress any of the other 7 providers that route through this helper. Matches the precedent #752 set on the note-formatting path, where all three flags are sent side-by-side.

The targeted alternative ("only add for `local`/`lan-ollama`") would add provider-branching for no functional benefit and would re-open the trap whenever a new provider wraps llama.cpp.

## Scope

- Streaming chat-agent against local Qwen: fixed.
- Note-formatting: unchanged (already fixed by #752).
- Groq / OpenAI / Anthropic / Gemini / Enterprise / OpenWhispr: unchanged (those don't run through `suppressThinking()` or ignore the extra field).
- Defensive "don't persist empty `enhanced_content`" guard from #783's comment thread: **out of scope** — latent (root cause already patched by #752 + this PR), separate concern, separate PR if/when we want belt-and-suspenders.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched file
- [ ] Manual: chat agent set to Local → Qwen3.5; send a message; verify non-empty streamed response (was empty before this patch).
- [ ] Manual regression: Groq cleanup with a thinking-capable model still suppresses thinking via `reasoning_effort`.
- [ ] Manual regression: LAN cleanup in Ollama mode still sends `think: false`; LAN cleanup in OpenAI-compat mode still sends `reasoning_effort: "none"`.