### PR TITLE
fix(meeting): fall back to mic-only when native system audio tap fails

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5211,12 +5211,12 @@ class IPCHandlers {
           }
           await startMeetingAec(systemAudioMode);
           await startLiveSpeakerIdentification(win, systemAudioMode);
-          systemAudioStrategy = await startMeetingSystemAudio(
+          ({ systemAudioMode, systemAudioStrategy } = await startMeetingSystemAudio(
             event,
             systemAudioMode,
             systemAudioStrategy,
             "during warm-start reuse"
-          );
+          ));
           return {
             success: true,
             systemAudioMode,
@@ -5241,12 +5241,12 @@ class IPCHandlers {
             transcribeAllLocalBuffers();
           }, 5000);
 
-          systemAudioStrategy = await startMeetingSystemAudio(
+          ({ systemAudioMode, systemAudioStrategy } = await startMeetingSystemAudio(
             event,
             systemAudioMode,
             systemAudioStrategy,
             "in local meeting mode"
-          );
+          ));
 
           debugLogger.debug("Meeting transcription started in local mode", {
             provider: meetingLocalProvider,
@@ -5270,12 +5270,12 @@ class IPCHandlers {
         const realtimeWin = BrowserWindow.fromWebContents(event.sender);
         await startLiveSpeakerIdentification(realtimeWin, systemAudioMode);
         await startMeetingAec(systemAudioMode);
-        systemAudioStrategy = await startMeetingSystemAudio(
+        ({ systemAudioMode, systemAudioStrategy } = await startMeetingSystemAudio(
           event,
           systemAudioMode,
           systemAudioStrategy,
           "in realtime mode"
-        );
+        ));
         return {
           success: true,
           systemAudioMode,
@@ -5387,24 +5387,44 @@ class IPCHandlers {
       context
     ) => {
       if (systemAudioMode === "native") {
-        await startNativeMeetingSystemAudio(event);
-        return systemAudioStrategy;
+        try {
+          await startNativeMeetingSystemAudio(event);
+          return { systemAudioMode, systemAudioStrategy };
+        } catch (error) {
+          debugLogger.warn(
+            `Native system audio tap failed ${context}, falling back to mic-only`,
+            { error: error.message },
+            "meeting"
+          );
+          if (this._meetingSystemStreaming?.isConnected) {
+            await this._meetingSystemStreaming.disconnect().catch((disconnectError) => {
+              debugLogger.debug(
+                "System streaming disconnect during native fallback failed",
+                { error: disconnectError.message },
+                "meeting"
+              );
+            });
+          }
+          this._meetingSystemStreaming = null;
+          await stopLiveSpeakerIdentification().catch(() => {});
+          return { systemAudioMode: "unsupported", systemAudioStrategy: "unsupported" };
+        }
       }
 
       if (systemAudioStrategy !== "portal-helper") {
-        return systemAudioStrategy;
+        return { systemAudioMode, systemAudioStrategy };
       }
 
       try {
         await startLinuxMeetingSystemAudio(event);
-        return systemAudioStrategy;
+        return { systemAudioMode, systemAudioStrategy };
       } catch (error) {
         debugLogger.warn(
           `Linux portal helper failed ${context}, falling back to browser portal`,
           { error: error.message },
           "meeting"
         );
-        return "browser-portal";
+        return { systemAudioMode, systemAudioStrategy: "browser-portal" };
       }
     };
 


### PR DESCRIPTION
## Summary

- Catches `audioTapManager.start()` failures in `startMeetingSystemAudio` and downgrades to mic-only instead of aborting the whole meeting recording session.
- Disconnects the orphaned system streaming client and stops live speaker ID (which requires the native tap) on fallback.
- Mirrors the existing Linux portal-helper fallback pattern; helper now returns `{ systemAudioMode, systemAudioStrategy }` so call sites propagate the downgraded mode.

## Why

Issue #744: on Intel Macs (e.g. i9 + AMD GPU) the macOS Core Audio process tap intermittently fails to start. The error currently propagates to the global catch in `meeting-transcription-start`, which calls `rollbackMeetingTranscriptionStart()` — the user sees the meeting indicator appear and immediately vanish. The renderer (`meetingRecordingStore`) already gracefully handles `systemAudioMode === "unsupported"` as "continue with mic only", so propagating the downgraded mode is sufficient — no renderer changes needed.

## Cross-platform impact

- **Other macOS (Apple Silicon, working Intels)**: no behavior change — happy path returns the same mode/strategy as before.
- **Windows**: untouched — `loopback` strategy returns through the existing branch with the same wrapped shape.
- **Linux**: untouched — the `portal-helper → browser-portal` fallback keeps the same fall-through semantics; only the return shape was wrapped.
- **IPC contract**: unchanged. The `meeting-transcription-start` payload still returns `{ success, systemAudioMode, systemAudioStrategy, oneOnOneAttendee }`.

Fixes #744

## Test plan

- [ ] Apple Silicon Mac: start a meeting recording → both mic + system audio captured (happy path).
- [ ] Intel Mac where native tap is broken: start a meeting recording → recording continues with mic only, debug log shows "Native system audio tap failed ... falling back to mic-only".
- [ ] Linux: portal-helper failure still falls back to browser-portal (unchanged behavior).
- [ ] Windows: meeting recording starts with loopback (unchanged behavior).
- [ ] All three meeting start paths exercised: warm-start reuse, local provider, realtime provider.