### PR TITLE
fix(reasoning): use dictation agent's own credentials in self-hosted mode

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -38,7 +38,10 @@ function resolveReasoningRoute(text, settings, agentName) {
         provider,
         lanUrl: isSelfHostedAgent ? settings.dictationAgentRemoteUrl : undefined,
         baseUrl: isCustomAgent ? settings.dictationAgentCloudBaseUrl || undefined : undefined,
-        customApiKey: isCustomAgent ? settings.dictationAgentCustomApiKey || undefined : undefined,
+        customApiKey:
+          isCustomAgent || isSelfHostedAgent
+            ? settings.dictationAgentCustomApiKey || undefined
+            : undefined,
         systemPrompt: resolvePrompt("dictationAgent", {
           agentName,
           language: settings.preferredLanguage,

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -6,13 +6,17 @@ import logger from "../../../utils/logger";
 export const lanProvider: InferenceProvider = {
   id: "lan",
   async call({ text, model, agentName, config, ctx }) {
-    const lanUrl = (config.lanUrl || getSettings().cleanupRemoteUrl).trim();
+    const isAgentCall = !!config.lanUrl;
+    const settings = getSettings();
+    const lanUrl = (config.lanUrl || settings.cleanupRemoteUrl).trim();
     logger.logReasoning("LAN_START", { url: lanUrl, agentName, model });
 
     try {
       const baseUrl = ensureV1Suffix(lanUrl);
       const endpoint = buildApiUrl(baseUrl, "/chat/completions");
-      const apiKey = config.customApiKey?.trim() || getSettings().cleanupCustomApiKey?.trim() || "";
+      const apiKey =
+        config.customApiKey?.trim() ||
+        (isAgentCall ? "" : settings.cleanupCustomApiKey?.trim() || "");
       const resolvedModel = model?.trim() || "default";
       return await ctx.callChatCompletionsApi(
         endpoint,

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -16,7 +16,8 @@ export const lanProvider: InferenceProvider = {
       const endpoint = buildApiUrl(baseUrl, "/chat/completions");
       const apiKey =
         config.customApiKey?.trim() ||
-        (isAgentCall ? "" : settings.cleanupCustomApiKey?.trim() || "");
+        (isAgentCall ? "" : settings.cleanupCustomApiKey?.trim()) ||
+        "";
       const resolvedModel = model?.trim() || "default";
       return await ctx.callChatCompletionsApi(
         endpoint,


### PR DESCRIPTION
## Summary

The self-hosted Dictation Agent silently used the **Dictation Cleanup**'s URL and API key. Users who pointed the agent at a different self-hosted server (or a different key) would hit auth failures or talk to the wrong endpoint.

Two-line fix in two places:

- `resolveReasoningRoute` (audioManager.js) now passes `dictationAgentCustomApiKey` for self-hosted agent calls (previously only for the custom-cloud provider case).
- `lanProvider` (lan.ts) no longer falls back to `cleanupCustomApiKey` when the caller has already supplied a `lanUrl` — i.e. when the call originated from the agent route. Cleanup-path behavior is unchanged.

## Test plan

- [ ] Configure Dictation Cleanup with one self-hosted endpoint and key
- [ ] Configure Dictation Agent self-hosted with a different endpoint and key
- [ ] Invoke the agent by name — verify the request hits the agent's endpoint with the agent's key (not the cleanup's)
- [ ] Plain dictation still uses the cleanup endpoint and key
- [ ] Leaving the agent key blank no longer leaks the cleanup key