### PR TITLE
fix(desktop): make dictation overlay non-focusable to stop focus theft (#719)

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -52,7 +52,7 @@ const MAIN_WINDOW_CONFIG = {
   transparent: true,
   show: false,
   skipTaskbar: true,
-  focusable: true,
+  focusable: false,
   visibleOnAllWorkspaces: process.platform !== "win32",
   fullScreenable: false,
   hasShadow: false,


### PR DESCRIPTION
## Summary

- Fixes #719. The floating dictation icon was `focusable: true`, so on Linux WMs that honor the focusable hint (Sway, i3, wlroots compositors) the overlay grabbed focus when it appeared. The previously focused text field lost focus, and auto-paste landed in the overlay instead of the user's target app.
- `showInactive()` alone isn't enough — the WM still routes focus to focusable windows. Flipping `focusable: false` is the cross-platform equivalent of the `no_focus [instance="open-whispr"]` Sway-config workaround reporters were applying manually.
- Pattern matches sibling overlays in the same file (`NOTIFICATION_WINDOW_CONFIG`, `TRANSCRIPTION_PREVIEW_CONFIG`) which are already `focusable: false`.

## What still works

- Mic and cancel buttons — mouse clicks are delivered regardless of focus state.
- Drag — handled in the renderer via mouse events.
- Escape-to-cancel during recording — uses a global shortcut (`hotkeyManager.registerSlot("cancel", "Escape", ...)` in `ipcHandlers.js`), not a window key event. Fires regardless of focus.
- Tray "Show Dictation" action — the `{ focus: true }` option in `showDictationPanel` becomes a no-op for `.focus()`, but the window still becomes visible (the actual goal of that action).

## Behavior note

The in-renderer `document.addEventListener("keydown")` Escape-to-hide handler in `App.jsx` only fires when the overlay has keyboard focus. With `focusable: false` it stops firing. In practice this only ever worked when the overlay had stolen focus from another app — i.e. the exact bug this PR fixes. Users can still dismiss the overlay via the "Hide for now" item in the command menu, the tray "Hide Dictation" entry, or by letting auto-hide-when-idle take over.

On macOS the panel was already non-activating (`type: "panel"` + `skipTransformProcessType: true`), so the focus-cleanup block in `paste-text` IPC handler becomes mostly dead code — left in place as a safety net rather than removed in this PR.

## Test plan

- [ ] Linux Sway/i3: trigger dictation from a focused text field, transcribe a few words, confirm auto-paste lands in the target field (no longer in the overlay).
- [ ] Linux GNOME Wayland and KDE: same flow, confirm no regression.
- [ ] macOS: trigger dictation from a focused text field (e.g. Notes, Cursor), confirm auto-paste still works and focus stays in the target app.
- [ ] Windows: trigger dictation, confirm auto-paste still works.
- [ ] All platforms: click the mic button on the overlay (mouse-only) and confirm recording starts.
- [ ] All platforms: drag the overlay around and confirm drag still works.
- [ ] All platforms: while recording, press Escape and confirm the recording cancels.
- [ ] All platforms: toggle "Auto-hide when idle"; confirm the overlay reappears at the next hotkey press without stealing focus from the active app.