### PR TITLE
fix(reasoning): require explicit name invocation to route to voice agent

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -26,7 +26,7 @@ function resolveReasoningRoute(text, settings, agentName) {
   if (!cleanupReachable && !agentReachable) return { kind: "skip" };
 
   const invoked = !!agentName && detectAgentName(text, agentName);
-  if (agentReachable && (!cleanupReachable || invoked)) {
+  if (agentReachable && invoked) {
     const provider = settings.dictationAgentProvider?.trim() || undefined;
     const isSelfHostedAgent =
       settings.dictationAgentMode === "self-hosted" && !!settings.dictationAgentRemoteUrl;
@@ -51,7 +51,8 @@ function resolveReasoningRoute(text, settings, agentName) {
       },
     };
   }
-  return { kind: "cleanup" };
+  if (cleanupReachable) return { kind: "cleanup" };
+  return { kind: "skip" };
 }
 
 const PLACEHOLDER_KEYS = {


### PR DESCRIPTION
## Summary

- Fixes #768: voice agent fires on every utterance when cleanup is off; doesn't reliably fire by name when cleanup is on.
- Root cause: `resolveReasoningRoute` bypassed name detection whenever `useCleanupModel` was off, making the agent the default reasoning path instead of an opt-in command channel.
- Now: the agent path requires `detectAgentName` to match. Otherwise, route to cleanup if reachable, else skip reasoning entirely (passthrough).

## Behavior

| `useDictationAgent` | `useCleanupModel` | Name said? | Route |
|---|---|---|---|
| OFF | OFF | — | skip |
| OFF | ON | — | cleanup |
| ON | OFF | no | skip *(was: agent — the bug)* |
| ON | OFF | yes | agent |
| ON | ON | no | cleanup |
| ON | ON | yes | agent |

## Notes

- 3-line change in `src/helpers/audioManager.js`. No settings migration, no IPC changes, no UI changes.
- All three consumers of `resolveReasoningRoute` already handle `kind: "skip"` by falling through and leaving the transcription untouched.
- Cleanup branches use the cleanup system prompt by default (`BaseReasoningService.getSystemPrompt`), so no agent behavior leaks when the toggle is off.