### PR TITLE
fix: read reasoning_content fallback for thinking-model inference

### DIFF
--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -479,7 +479,8 @@ class LlamaServerManager {
 
             try {
               const response = JSON.parse(data);
-              const text = response.choices?.[0]?.message?.content || "";
+              const message = response.choices?.[0]?.message;
+              const text = message?.content || message?.reasoning_content || "";
               resolve(text.trim());
             } catch (e) {
               reject(new Error(`Failed to parse llama-server response: ${e.message}`));


### PR DESCRIPTION
## Summary

Some llama-server builds detect Qwen 3/3.5 chat templates as thinking-enabled (thinking = 1) and route all model output to reasoning_content instead of content, even when enable_thinking: false is sent via chat_template_kwargs. This leaves content empty and the pipeline silently falls back to the raw transcription, making it look like Intelligence does nothing.

The fix reads reasoning_content as a fallback when content is empty. The existing think-tag stripping in localReasoningBridge already handles cleaning up the thinking output.

## Changes

- src/helpers/llamaServer.js: read message.reasoning_content when message.content is empty in the inference response parser