### PR TITLE
fix(network): route remaining GitHub/cloud/calendar fetches through Electron net

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ const {
   BrowserWindow,
   dialog,
   ipcMain,
+  net,
   session,
   systemPreferences,
 } = require("electron");
@@ -525,9 +526,10 @@ function getOauthCookieName() {
 // for the raw session.token the bearer plugin expects.
 async function exchangeSignedTokenForRawBearer(signedToken) {
   try {
-    const res = await fetch(`${resolveAuthUrl()}/api/auth/get-session`, {
+    const res = await net.fetch(`${resolveAuthUrl()}/api/auth/get-session`, {
       headers: { Cookie: `${getOauthCookieName()}=${signedToken}` },
       signal: AbortSignal.timeout(5000),
+      useSessionCookies: false,
     });
     if (!res.ok) return null;
     const data = await res.json();

--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -234,6 +234,22 @@ function downloadAttempt(url, tempPath, options) {
   });
 }
 
+async function fetchJson(url, options = {}) {
+  const headers = { "User-Agent": USER_AGENT, ...(options.headers || {}) };
+  const response = await net.fetch(url, {
+    method: "GET",
+    headers,
+    useSessionCookies: false,
+  });
+  if (!response.ok) {
+    const err = new Error(`HTTP ${response.status} fetching ${url}`);
+    err.isHttpError = true;
+    err.statusCode = response.status;
+    throw err;
+  }
+  return response.json();
+}
+
 async function downloadFile(url, destPath, options = {}) {
   const { onProgress, maxRetries = DEFAULT_MAX_RETRIES, signal, expectedSize = 0 } = options;
 
@@ -472,6 +488,7 @@ async function findFiles(dir, pattern, maxDepth = 5, depth = 0) {
 
 module.exports = {
   downloadFile,
+  fetchJson,
   createDownloadSignal,
   validateFileSize,
   cleanupStaleDownloads,

--- a/src/helpers/googleCalendarManager.js
+++ b/src/helpers/googleCalendarManager.js
@@ -1,5 +1,4 @@
-const https = require("https");
-const { Notification, BrowserWindow } = require("electron");
+const { net, Notification, BrowserWindow } = require("electron");
 const debugLogger = require("./debugLogger");
 const GoogleCalendarOAuth = require("./googleCalendarOAuth");
 
@@ -456,44 +455,26 @@ class GoogleCalendarManager {
   async _apiGet(path, accountEmail = null) {
     const accessToken = await this.oauth.getValidAccessToken(accountEmail);
     const urlString = path.startsWith("http") ? path : `${CALENDAR_API_BASE}${path}`;
-    const url = new URL(urlString);
 
-    return new Promise((resolve, reject) => {
-      const req = https.request(
-        {
-          hostname: url.hostname,
-          port: 443,
-          path: url.pathname + url.search,
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-        (res) => {
-          let data = "";
-          res.on("data", (chunk) => (data += chunk));
-          res.on("end", () => {
-            try {
-              const parsed = JSON.parse(data);
-              if (res.statusCode >= 400) {
-                const err = new Error(parsed.error?.message || `API error ${res.statusCode}`);
-                err.statusCode = res.statusCode;
-                reject(err);
-                return;
-              }
-              resolve(parsed);
-            } catch (e) {
-              reject(new Error(`Invalid JSON response: ${data.slice(0, 200)}`));
-            }
-          });
-        }
-      );
-      req.on("error", reject);
-      req.setTimeout(10000, () => {
-        req.destroy(new Error("Request timed out after 10s"));
-      });
-      req.end();
+    const response = await net.fetch(urlString, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(10000),
+      useSessionCookies: false,
     });
+    const text = await response.text();
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+    }
+    if (response.status >= 400) {
+      const err = new Error(parsed.error?.message || `API error ${response.status}`);
+      err.statusCode = response.status;
+      throw err;
+    }
+    return parsed;
   }
 }
 

--- a/src/helpers/googleCalendarOAuth.js
+++ b/src/helpers/googleCalendarOAuth.js
@@ -1,7 +1,6 @@
 const http = require("http");
-const https = require("https");
 const crypto = require("crypto");
-const { shell } = require("electron");
+const { net, shell } = require("electron");
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -226,36 +225,19 @@ class GoogleCalendarOAuth {
     }
   }
 
-  _httpsPost(urlString, body) {
-    const url = new URL(urlString);
-    return new Promise((resolve, reject) => {
-      const req = https.request(
-        {
-          hostname: url.hostname,
-          port: 443,
-          path: url.pathname,
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Content-Length": Buffer.byteLength(body),
-          },
-        },
-        (res) => {
-          let data = "";
-          res.on("data", (chunk) => (data += chunk));
-          res.on("end", () => {
-            try {
-              resolve(JSON.parse(data));
-            } catch (e) {
-              reject(new Error(`Invalid JSON response: ${data.slice(0, 200)}`));
-            }
-          });
-        }
-      );
-      req.on("error", reject);
-      req.write(body);
-      req.end();
+  async _httpsPost(urlString, body) {
+    const response = await net.fetch(urlString, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      useSessionCookies: false,
     });
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+    }
   }
 }
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2,8 +2,6 @@ const { ipcMain, app, shell, BrowserWindow, systemPreferences, net } = require("
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const http = require("http");
-const https = require("https");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
 const tokenStore = require("./tokenStore");
@@ -110,37 +108,23 @@ function buildMultipartBody(fileBuffer, fileName, contentType, fields = {}) {
   return { body: Buffer.concat(bodyParts), boundary };
 }
 
-function postMultipart(url, body, boundary, headers = {}) {
-  const httpModule = url.protocol === "https:" ? https : http;
-  return new Promise((resolve, reject) => {
-    const req = httpModule.request(
-      {
-        hostname: url.hostname,
-        port: url.port || (url.protocol === "https:" ? 443 : 80),
-        path: url.pathname,
-        method: "POST",
-        headers: {
-          "Content-Type": `multipart/form-data; boundary=${boundary}`,
-          "Content-Length": body.length,
-          ...headers,
-        },
-      },
-      (res) => {
-        let responseData = "";
-        res.on("data", (chunk) => (responseData += chunk));
-        res.on("end", () => {
-          try {
-            resolve({ statusCode: res.statusCode, data: JSON.parse(responseData) });
-          } catch (e) {
-            reject(new Error(`Invalid JSON response: ${responseData.slice(0, 200)}`));
-          }
-        });
-      }
-    );
-    req.on("error", reject);
-    req.write(body);
-    req.end();
+async function postMultipart(url, body, boundary, headers = {}) {
+  const response = await net.fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": `multipart/form-data; boundary=${boundary}`,
+      "Content-Length": String(body.length),
+      ...headers,
+    },
+    body,
+    useSessionCookies: false,
   });
+  const text = await response.text();
+  try {
+    return { statusCode: response.status, data: JSON.parse(text) };
+  } catch {
+    throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+  }
 }
 
 function interpretTranscribeResponse(data) {

--- a/src/helpers/llamaVulkanManager.js
+++ b/src/helpers/llamaVulkanManager.js
@@ -5,6 +5,7 @@ const { app } = require("electron");
 const debugLogger = require("./debugLogger");
 const {
   downloadFile,
+  fetchJson,
   createDownloadSignal,
   checkDiskSpace,
   cleanupStaleDownloads,
@@ -12,6 +13,13 @@ const {
   findFile,
   findFiles,
 } = require("./downloadUtils");
+
+function githubReleaseHeaders() {
+  const headers = { Accept: "application/vnd.github+json" };
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
 
 const GITHUB_RELEASE_URL = "https://api.github.com/repos/ggerganov/llama.cpp/releases/latest";
 
@@ -86,7 +94,7 @@ class LlamaVulkanManager {
       await fsPromises.mkdir(this.binDir, { recursive: true });
       await cleanupStaleDownloads(this.binDir);
 
-      const release = await this._fetchJson(GITHUB_RELEASE_URL);
+      const release = await fetchJson(GITHUB_RELEASE_URL, { headers: githubReleaseHeaders() });
       if (!release?.assets) throw new Error("Could not fetch llama.cpp release info");
 
       const config = this._getConfig();
@@ -172,41 +180,6 @@ class LlamaVulkanManager {
     return { success: true, deletedCount };
   }
 
-  _fetchJson(url) {
-    const https = require("https");
-    return new Promise((resolve, reject) => {
-      const headers = {
-        "User-Agent": "OpenWhispr/1.0",
-        Accept: "application/vnd.github+json",
-      };
-      const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-      if (token) headers.Authorization = `Bearer ${token}`;
-
-      https
-        .get(url, { headers, timeout: 15000 }, (res) => {
-          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-            res.resume();
-            this._fetchJson(res.headers.location).then(resolve, reject);
-            return;
-          }
-          if (res.statusCode !== 200) {
-            res.resume();
-            reject(new Error(`GitHub API returned ${res.statusCode}`));
-            return;
-          }
-          let data = "";
-          res.on("data", (chunk) => (data += chunk));
-          res.on("end", () => {
-            try {
-              resolve(JSON.parse(data));
-            } catch {
-              reject(new Error("Failed to parse GitHub release JSON"));
-            }
-          });
-        })
-        .on("error", reject);
-    });
-  }
 }
 
 module.exports = LlamaVulkanManager;

--- a/src/helpers/llamaVulkanManager.js
+++ b/src/helpers/llamaVulkanManager.js
@@ -179,7 +179,6 @@ class LlamaVulkanManager {
     debugLogger.info("Vulkan llama-server deleted", { deletedCount });
     return { success: true, deletedCount };
   }
-
 }
 
 module.exports = LlamaVulkanManager;

--- a/src/helpers/whisperCudaManager.js
+++ b/src/helpers/whisperCudaManager.js
@@ -1,11 +1,11 @@
 const fs = require("fs");
 const { promises: fsPromises } = require("fs");
 const path = require("path");
-const https = require("https");
 const { app } = require("electron");
 const debugLogger = require("./debugLogger");
 const {
   downloadFile,
+  fetchJson,
   createDownloadSignal,
   checkDiskSpace,
   cleanupStaleDownloads,
@@ -72,7 +72,9 @@ class WhisperCudaManager {
       throw new Error(`CUDA binaries not available for ${process.platform}`);
     }
 
-    const release = await this._fetchJson(GITHUB_RELEASE_URL);
+    const release = await fetchJson(GITHUB_RELEASE_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
     const assetName = PLATFORM_ASSET_NAMES[process.platform];
     const asset = release.assets?.find((a) => a.name === assetName);
 
@@ -239,55 +241,6 @@ class WhisperCudaManager {
     };
   }
 
-  _fetchJson(url) {
-    return new Promise((resolve, reject) => {
-      https
-        .get(
-          url,
-          {
-            headers: {
-              "User-Agent": "OpenWhispr/1.0",
-              Accept: "application/vnd.github+json",
-            },
-            timeout: 15000,
-          },
-          (res) => {
-            if (res.statusCode >= 300 && res.statusCode < 400) {
-              const location = res.headers.location;
-              if (!location) {
-                reject(new Error("Redirect without location header"));
-                return;
-              }
-              res.resume();
-              this._fetchJson(location).then(resolve, reject);
-              return;
-            }
-
-            if (res.statusCode !== 200) {
-              res.resume();
-              reject(new Error(`GitHub API returned HTTP ${res.statusCode}`));
-              return;
-            }
-
-            let data = "";
-            res.on("data", (chunk) => (data += chunk));
-            res.on("end", () => {
-              try {
-                resolve(JSON.parse(data));
-              } catch (e) {
-                reject(new Error(`Failed to parse GitHub API response: ${e.message}`));
-              }
-            });
-            res.on("error", reject);
-          }
-        )
-        .on("error", reject)
-        .on("timeout", function () {
-          this.destroy();
-          reject(new Error("GitHub API request timed out"));
-        });
-    });
-  }
 }
 
 module.exports = WhisperCudaManager;

--- a/src/helpers/whisperCudaManager.js
+++ b/src/helpers/whisperCudaManager.js
@@ -240,7 +240,6 @@ class WhisperCudaManager {
       freed_mb: Math.round(freedBytes / (1024 * 1024)),
     };
   }
-
 }
 
 module.exports = WhisperCudaManager;


### PR DESCRIPTION
## Summary

A user behind a corporate proxy reported that clicking **Enable GPU** in Language Models fails with `connect ETIMEDOUT <IP>:443`. PR #687 swapped 23 `fetch` sites onto `proxyFetch` but missed pre-existing private helpers that use raw Node `http`/`https`/global `fetch`. Those bypass Electron's network stack and ignore the OS proxy.

This PR finishes the proxy-aware migration. Five code paths were affected:

| Path | Impact |
|---|---|
| `LlamaVulkanManager._fetchJson` (GitHub release metadata) | ⚠️ Reported. Vulkan GPU enable. |
| `WhisperCudaManager._fetchJson` (GitHub release metadata) | CUDA GPU enable. |
| `ipcHandlers.postMultipart` (5 callers) | **Chunked** cloud transcribe, `cloud-transcribe` IPC, cloud-with-fallback, `transcribe-audio-file`, BYOK whisper-compatible uploads. |
| `googleCalendarOAuth._httpsPost` | Google token exchange / refresh / revoke. |
| `googleCalendarManager._apiGet` | All Calendar API reads. |
| `main.js` `exchangeSignedTokenForRawBearer` | Legacy desktop OAuth fallback. |

All migrate to `net.fetch(..., { useSessionCookies: false })`, matching the existing `proxyFetch` helper. `downloadUtils` gains a small shared `fetchJson` helper for the GitHub release metadata case.

## Non-breaking

- All migrated helpers are **private** to their file (`_`-prefixed or unexported). No public API, IPC channel, or preload surface changes.
- Return shapes preserved exactly:
  - `postMultipart` still resolves `{ statusCode, data }` with `data` = parsed JSON.
  - `_apiGet` still resolves parsed JSON; still throws `Error` with `.statusCode` on ≥ 400.
  - `_httpsPost` still resolves parsed JSON.
  - `exchangeSignedTokenForRawBearer` still resolves `string | null`.
- `googleCalendarManager._apiGet` 10s timeout preserved via `AbortSignal.timeout(10000)`.
- Dead `require("http")` / `require("https")` imports removed from migrated files (kept the local-callback `http` import in `googleCalendarOAuth.js`).

## Verification

- `npm run lint` — 0 errors (3 unrelated pre-existing warnings in `AcceptInvitationModal.tsx` and `ShareNoteDialog.tsx`).
- `npm run typecheck` — clean.
- `node --check` on every modified file — clean.
- Diff: +82 / −190 (most lines removed are the old Promise-wrapping boilerplate).

## Test plan

- [ ] Behind a corporate proxy / VPN with TLS inspection: click **Enable GPU** under Language Models → manifest fetch succeeds, Vulkan binary downloads, server activates.
- [ ] Same conditions: click **Enable GPU** under Speech-to-Text → CUDA binary downloads.
- [ ] Same conditions: record a long-form clip (> CLOUD_INLINE_LIMIT) on OpenWhispr Cloud → chunked upload succeeds.
- [ ] Same conditions: upload an audio file via OpenWhispr Cloud → succeeds.
- [ ] Same conditions: BYOK Whisper-compatible upload (OpenAI / Groq STT etc.) of an audio file → succeeds.
- [ ] Same conditions: connect Google Calendar (OAuth flow + initial sync) → succeeds.
- [ ] No proxy: regression check — short cloud transcribe, BYOK transcribe, Google Calendar sync, GPU enable flows still work end-to-end.