### PR TITLE
fix(realtime): migrate session events and config to OpenAI Realtime GA

### DIFF
--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -116,7 +116,7 @@ class OpenAIRealtimeStreaming {
       const event = JSON.parse(data.toString());
 
       switch (event.type) {
-        case "transcription_session.created": {
+        case "session.created": {
           if (this.preconfigured) {
             // Server-side ephemeral token already configured the session;
             // sending an update would strip language and noise-reduction.
@@ -138,17 +138,20 @@ class OpenAIRealtimeStreaming {
             if (!this.ws || this.ws.readyState !== WebSocket.OPEN) break;
             this.ws.send(
               JSON.stringify({
-                type: "transcription_session.update",
+                type: "session.update",
                 session: {
-                  input_audio_format: "pcm16",
-                  input_audio_transcription: {
-                    model: this.model,
-                  },
-                  turn_detection: {
-                    type: "server_vad",
-                    threshold: 0.6,
-                    silence_duration_ms: 600,
-                    prefix_padding_ms: 500,
+                  type: "transcription",
+                  audio: {
+                    input: {
+                      format: { type: "audio/pcm", rate: SAMPLE_RATE },
+                      transcription: { model: this.model },
+                      turn_detection: {
+                        type: "server_vad",
+                        threshold: 0.6,
+                        silence_duration_ms: 600,
+                        prefix_padding_ms: 500,
+                      },
+                    },
                   },
                 },
               })
@@ -157,7 +160,7 @@ class OpenAIRealtimeStreaming {
           break;
         }
 
-        case "transcription_session.updated": {
+        case "session.updated": {
           if (this.pendingResolve) {
             this.isConnected = true;
             this.isConnecting = false;


### PR DESCRIPTION
Closes #805.

## Why

OpenAI removed the Realtime Beta API on 2026-05-12. #787 dropped the \`OpenAI-Beta\` header (necessary for the WebSocket handshake), but explicitly punted on the wire format under the assumption that \"GA's deprecation window keeps the legacy names working.\" That assumption is wrong — GA is not wire-compatible with Beta. Confirmed against [Microsoft's GA migration guide](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/realtime-audio-preview-api-migration-guide) (same protocol OpenAI uses) and the [OpenAI Python SDK GA schemas](https://github.com/openai/openai-python/tree/main/src/openai/types/realtime).

So today, after #787, BYOK users get past the \`code 4000\` handshake but stall configuring the session: the server emits \`session.created\` while we listen for \`transcription_session.created\`, and our \`transcription_session.update\` is rejected.

## What

Three coupled changes to [openaiRealtimeStreaming.js](src/helpers/openaiRealtimeStreaming.js):

1. **Server event names:** \`transcription_session.created\` → \`session.created\`; \`transcription_session.updated\` → \`session.updated\`.
2. **Client event:** \`transcription_session.update\` → \`session.update\` with the new discriminated config:
   \`\`\`js
   {
     type: \"session.update\",
     session: {
       type: \"transcription\",
       audio: {
         input: {
           format: { type: \"audio/pcm\", rate: 24000 },
           transcription: { model },
           turn_detection: { type: \"server_vad\", ... },
         },
       },
     },
   }
   \`\`\`
3. \`SAMPLE_RATE\` reused for the format \`rate\` so the constant stays the single source of truth.

Out of scope (intentionally unchanged):
- **URL** \`?intent=transcription\` — community reports show it still works post-GA; the session-config event is what was actually broken.
- **Downstream events** (\`conversation.item.input_audio_transcription.delta\`/\`.completed\`, \`input_audio_buffer.*\`) — these are session-type-agnostic and remain valid in GA.

The managed-mode REST endpoint has the same Beta-only problem and is fixed in parallel at openwhispr-api#66.

## Verification

- \`npm run typecheck\` clean.
- \`npm run lint\` clean on touched file (3 pre-existing warnings in unrelated files).
- Schema cross-checked against \`realtime_transcription_session_create_request\` and \`realtime_audio_formats\` in the OpenAI Python SDK.

## Test plan

- [ ] BYOK: with an OpenAI key in Settings, start meeting recording and confirm transcript appears (no more \`Failed to create realtime session\`).
- [ ] Managed: after openwhispr-api#66 deploys, start meeting recording in cloud mode and confirm the \`preconfigured\` branch (server-issued ephemeral key) reaches \`session.created\` and skips the update send.
- [ ] Confirm partial and final transcript events still flow (these event names didn't change).