### PR TITLE
fix(reasoning): honor disableThinking on the cleanup route

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -42,6 +42,7 @@ function resolveReasoningRoute(text, settings, agentName) {
           isCustomAgent || isSelfHostedAgent
             ? settings.dictationAgentCustomApiKey || undefined
             : undefined,
+        disableThinking: settings.dictationAgentDisableThinking,
         systemPrompt: resolvePrompt("dictationAgent", {
           agentName,
           language: settings.preferredLanguage,
@@ -51,7 +52,14 @@ function resolveReasoningRoute(text, settings, agentName) {
       },
     };
   }
-  if (cleanupReachable) return { kind: "cleanup" };
+  if (cleanupReachable) {
+    return {
+      kind: "cleanup",
+      config: {
+        disableThinking: settings.cleanupDisableThinking,
+      },
+    };
+  }
   return { kind: "skip" };
 }
 
@@ -1075,13 +1083,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         if (route.kind === "skip") return normalizedText;
 
         const targetModel = route.kind === "agent" ? route.model : cleanupModel;
-        const reasoningConfig = route.kind === "agent" ? route.config : undefined;
+        const reasoningConfig = route.config;
 
         logger.logReasoning("SENDING_TO_REASONING", {
           preparedTextLength: normalizedText.length,
           model: targetModel,
           provider: route.config?.provider || cleanupProvider,
           path: route.kind,
+          disableThinking: reasoningConfig?.disableThinking,
         });
 
         const result = await this.processWithReasoningModel(


### PR DESCRIPTION
## Summary
`resolveReasoningRoute` only forwarded `settings.dictationAgentDisableThinking` through the `agent` route. The `cleanup` route returned no `config`, so `settings.cleanupDisableThinking` was silently dropped before `processWithReasoningModel` ran — Qwen kept emitting `<think>` blocks during plain cleanup even with the toggle on.

## Changes
- Cleanup route now returns `{ kind: 'cleanup', config: { disableThinking: settings.cleanupDisableThinking } }` (still gated by `cleanupReachable`).
- Simplified the caller in `processTranscription`: `reasoningConfig` is now `route.config` for both routes (always defined).
- Added `disableThinking` to the `SENDING_TO_REASONING` debug log so we can see which path actually suppressed thinking.

## Test plan
- Set cleanup model to a local Qwen GGUF, toggle 'Disable thinking' for cleanup, dictate without addressing the agent → no `<think>` block in the output; debug log shows `disableThinking: true` on the `cleanup` path.
- Address the agent → still respects `dictationAgentDisableThinking` as before.
- Toggle 'Disable thinking' off → `<think>` blocks reappear (confirms wiring, not unrelated regression).