### PR TITLE
fix: stop transcription sync crash and fix Start Recording race

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -869,9 +869,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   meetingNotificationRespond: (detectionId, action) =>
     ipcRenderer.invoke("meeting-notification-respond", detectionId, action),
   joinCalendarMeeting: (eventId) => ipcRenderer.invoke("join-calendar-meeting", eventId),
-  onNavigateToMeetingNote: registerListener(
-    "navigate-to-meeting-note",
-    (callback) => (_event, data) => callback(data)
+  getPendingMeetingNoteNavigation: () => ipcRenderer.invoke("get-pending-meeting-note-navigation"),
+  onMeetingNoteNavigationPending: registerListener(
+    "meeting-note-navigation-pending",
+    (callback) => () => callback()
   ),
   onNavigateToNote: registerListener(
     "navigate-to-note",

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -298,8 +298,10 @@ export default function ControlPanel() {
     detect();
   }, [useLocalWhisper, localTranscriptionProvider, useCleanupModel, gpuBannerDismissed]);
 
-  const handleMeetingNoteNavigation = useCallback(
-    (data: { noteId: number; folderId: number; event: any; trigger?: string }) => {
+  useEffect(() => {
+    const drain = async () => {
+      const data = await window.electronAPI?.getPendingMeetingNoteNavigation?.();
+      if (!data) return;
       setActiveFolderId(data.folderId);
       setActiveNoteId(data.noteId);
       setActiveView("personal-notes");
@@ -315,19 +317,11 @@ export default function ControlPanel() {
       ) {
         window.electronAPI?.snapToMeetingMode?.();
       }
-    },
-    []
-  );
-
-  useEffect(() => {
-    const drain = async () => {
-      const data = await window.electronAPI?.getPendingMeetingNoteNavigation?.();
-      if (data) handleMeetingNoteNavigation(data);
     };
     drain();
     const cleanup = window.electronAPI?.onMeetingNoteNavigationPending?.(drain);
     return () => cleanup?.();
-  }, [handleMeetingNoteNavigation]);
+  }, []);
 
   useEffect(() => {
     const cleanup = window.electronAPI?.onNavigateToNote?.((data) => {

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -298,8 +298,8 @@ export default function ControlPanel() {
     detect();
   }, [useLocalWhisper, localTranscriptionProvider, useCleanupModel, gpuBannerDismissed]);
 
-  useEffect(() => {
-    const cleanup = window.electronAPI?.onNavigateToMeetingNote?.((data) => {
+  const handleMeetingNoteNavigation = useCallback(
+    (data: { noteId: number; folderId: number; event: any; trigger?: string }) => {
       setActiveFolderId(data.folderId);
       setActiveNoteId(data.noteId);
       setActiveView("personal-notes");
@@ -315,9 +315,19 @@ export default function ControlPanel() {
       ) {
         window.electronAPI?.snapToMeetingMode?.();
       }
-    });
+    },
+    []
+  );
+
+  useEffect(() => {
+    const drain = async () => {
+      const data = await window.electronAPI?.getPendingMeetingNoteNavigation?.();
+      if (data) handleMeetingNoteNavigation(data);
+    };
+    drain();
+    const cleanup = window.electronAPI?.onMeetingNoteNavigationPending?.(drain);
     return () => cleanup?.();
-  }, []);
+  }, [handleMeetingNoteNavigation]);
 
   useEffect(() => {
     const cleanup = window.electronAPI?.onNavigateToNote?.((data) => {

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -2470,7 +2470,7 @@ class DatabaseManager {
       stmt.run(
         cloudTranscription.client_transcription_id,
         cloudTranscription.id,
-        cloudTranscription.text,
+        cloudTranscription.text ?? "",
         cloudTranscription.raw_text || null,
         cloudTranscription.status || "completed",
         cloudTranscription.created_at

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -7272,6 +7272,10 @@ class IPCHandlers {
       return this.windowManager?._pendingNotificationData ?? null;
     });
 
+    ipcMain.handle("get-pending-meeting-note-navigation", async () => {
+      return this.windowManager?.consumePendingMeetingNoteNavigation() ?? null;
+    });
+
     ipcMain.handle("meeting-notification-ready", async () => {
       this.windowManager?.showNotificationWindow();
     });

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -200,8 +200,7 @@ class MeetingDetectionEngine {
           }
         }
 
-        await this.windowManager.createControlPanelWindow();
-        this.windowManager.sendToControlPanel("navigate-to-meeting-note", {
+        await this.windowManager.queueMeetingNoteNavigation({
           noteId: noteResult.note.id,
           folderId: meetingsFolder.id,
           event: detection.event,
@@ -268,9 +267,7 @@ class MeetingDetectionEngine {
 
     this.broadcastToWindows("note-added", noteResult.note);
 
-    await this.windowManager.createControlPanelWindow();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    this.windowManager.sendToControlPanel("navigate-to-meeting-note", {
+    await this.windowManager.queueMeetingNoteNavigation({
       noteId: noteResult.note.id,
       folderId: meetingsFolder.id,
       event,
@@ -310,9 +307,7 @@ class MeetingDetectionEngine {
 
     this.broadcastToWindows("note-added", updateResult?.note || noteResult.note);
 
-    await this.windowManager.createControlPanelWindow();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    this.windowManager.sendToControlPanel("navigate-to-meeting-note", {
+    await this.windowManager.queueMeetingNoteNavigation({
       noteId: noteResult.note.id,
       folderId: meetingsFolder.id,
       event: calEvent,

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -40,6 +40,7 @@ class WindowManager {
     this._agentAnimationState = null;
     this._panelStartPosition = "bottom-right";
     this._isDictatingToggle = false;
+    this._pendingMeetingNoteNavigation = null;
 
     app.on("before-quit", () => {
       this.isQuitting = true;
@@ -1295,6 +1296,18 @@ class WindowManager {
     } else {
       win.webContents.send(channel, data);
     }
+  }
+
+  async queueMeetingNoteNavigation(payload) {
+    this._pendingMeetingNoteNavigation = payload;
+    await this.createControlPanelWindow();
+    this.sendToControlPanel("meeting-note-navigation-pending");
+  }
+
+  consumePendingMeetingNoteNavigation() {
+    const payload = this._pendingMeetingNoteNavigation;
+    this._pendingMeetingNoteNavigation = null;
+    return payload;
   }
 
   snapControlPanelToMeetingMode() {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -510,7 +510,9 @@ class SyncService {
   }
 
   private async pushPendingTranscriptions(): Promise<void> {
-    const pending = (await window.electronAPI.getPendingTranscriptions?.()) ?? [];
+    const pending = ((await window.electronAPI.getPendingTranscriptions?.()) ?? []).filter(
+      (t) => !!t.text?.trim()
+    );
     if (pending.length === 0) return;
 
     for (let i = 0; i < pending.length; i += TRANSCRIPTION_BATCH_SIZE) {
@@ -561,6 +563,8 @@ class SyncService {
             if (local) await window.electronAPI.hardDeleteTranscription?.(local.id);
             continue;
           }
+
+          if (!cloudT.text) continue;
 
           if (!local) {
             await window.electronAPI.upsertTranscriptionFromCloud?.(

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1741,14 +1741,13 @@ declare global {
         action: string
       ) => Promise<{ success: boolean }>;
       joinCalendarMeeting?: (eventId: string) => Promise<{ success: boolean }>;
-      onNavigateToMeetingNote?: (
-        callback: (data: {
-          noteId: number;
-          folderId: number;
-          event: any;
-          trigger?: "hotkey" | "manual" | "calendar-join";
-        }) => void
-      ) => () => void;
+      getPendingMeetingNoteNavigation?: () => Promise<{
+        noteId: number;
+        folderId: number;
+        event: any;
+        trigger?: "hotkey" | "manual" | "calendar-join";
+      } | null>;
+      onMeetingNoteNavigationPending?: (callback: () => void) => () => void;
       onNavigateToNote?: (
         callback: (data: { noteId: number; folderId: number | null }) => void
       ) => () => void;


### PR DESCRIPTION
## Summary

Two production fixes shipped as separate commits.

### `fix(sync)` — transcription sync no longer crashes on empty rows

- **Symptom:** Console spam `SqliteError: NOT NULL constraint failed: transcriptions.text` and `Transcription pull failed`.
- **Cause:** Local SQLite enforces `text NOT NULL` but earlier failed transcriptions were pushed up with empty/null text. Re-pulling them aborted the entire sync loop.
- **Fix:** Filter empty/whitespace-only rows out of the push, skip them on the pull, and keep a final `?? ""` coalesce as a safety net in `upsertTranscriptionFromCloud`.
- **User impact:** Background sync stops erroring. Failed transcriptions stay local.

### `fix(meeting)` — Start Recording from the meeting-detected notification reliably starts the recording

- **Symptom:** Clicking "Start Recording" sometimes opened the note but did not begin recording.
- **Cause:** Race condition. After `createControlPanelWindow()`, main fired `navigate-to-meeting-note` once the page finished loading, but before React mounted and attached its listener — so the event was lost. A `setTimeout(50)` workaround in two of the three call sites masked the issue inconsistently.
- **Fix:** Replace the push-based IPC with the same store-and-drain handshake the meeting-detected notification window already uses. Main stores the payload on `WindowManager._pendingMeetingNoteNavigation`; the renderer drains it on mount and re-drains on a lightweight `meeting-note-navigation-pending` signal. Removes the 50ms sleep workarounds.
- **User impact:** Start Recording reliably begins recording on a fresh control panel, no perceptible difference when it currently works.

## Notes

- Both fixes follow patterns already in the codebase (sync filter conventions; the notification window's ready handshake).
- No new dependencies, no new windows, no migrations, no settings changes.
- All three internal call sites of the old `navigate-to-meeting-note` IPC are migrated; the old preload/type entries are removed.