### PR TITLE
fix(linux): detect Konsole on X11 via /proc/<pid>/comm, route through shift+Insert

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1127,6 +1127,23 @@ class ClipboardManager {
       }
     };
 
+    // Some terminals (notably Konsole on X11) intermittently report no WM_CLASS via
+    // xdotool, leaving WM_CLASS detection blind. Fall back to the owning process
+    // name from /proc/<pid>/comm so terminal-aware paste keys still get chosen.
+    const preDetectWindowComm = (windowId) => {
+      if (!xdotoolExists || (isWayland && !xwaylandAvailable)) return null;
+      try {
+        const args = windowId ? ["getwindowpid", windowId] : ["getactivewindow", "getwindowpid"];
+        const result = spawnSync("xdotool", args, { timeout: 1000 });
+        if (result.status !== 0) return null;
+        const pid = parseInt(result.stdout.toString().trim(), 10);
+        if (!Number.isFinite(pid) || pid <= 0) return null;
+        return fs.readFileSync(`/proc/${pid}/comm`, "utf8").toLowerCase().trim() || null;
+      } catch {
+        return null;
+      }
+    };
+
     const targetWindowId = preDetectTargetWindow();
     let detectedWindowClass = preDetectWindowClass(targetWindowId);
 
@@ -1144,16 +1161,33 @@ class ClipboardManager {
       }
     }
 
-    if (linuxFastPaste) {
-      const earlyIsTerminal = detectedWindowClass
-        ? terminalClasses.some((t) => detectedWindowClass.includes(t))
-        : false;
+    const detectedWindowComm = preDetectWindowComm(targetWindowId);
+    const windowSignals = [detectedWindowClass, detectedWindowComm].filter(Boolean);
+    const signalsMatch = (needle) => windowSignals.some((signal) => signal.includes(needle));
+    const detectedIsKonsole = signalsMatch("konsole");
+
+    // Konsole on X11 silently drops simulated Ctrl+Shift+V via XTest (a long-standing
+    // focus/grab quirk), and the native fast-paste binary uses XTest. Route Konsole+X11
+    // through the xdotool fallback instead, which sends shift+Insert with
+    // windowactivate --sync and reliably reaches the target window.
+    const skipFastPasteForKonsole = detectedIsKonsole && !isWayland;
+
+    if (linuxFastPaste && !skipFastPasteForKonsole) {
+      const earlyIsTerminal =
+        windowSignals.length > 0 ? terminalClasses.some((term) => signalsMatch(term)) : false;
 
       const spawnFastPaste = (args, label) =>
         new Promise((resolve, reject) => {
           debugLogger.debug(
             `Attempting native linux-fast-paste (${label})`,
-            { linuxFastPaste, args, targetWindowId, detectedWindowClass, earlyIsTerminal },
+            {
+              linuxFastPaste,
+              args,
+              targetWindowId,
+              detectedWindowClass,
+              detectedWindowComm,
+              earlyIsTerminal,
+            },
             "clipboard"
           );
           const proc = spawn(linuxFastPaste, args);
@@ -1336,18 +1370,20 @@ class ClipboardManager {
 
     // Terminals use Ctrl+Shift+V instead of Ctrl+V
     const isTerminal = () => {
-      if (!detectedWindowClass) return false;
-      const isTerminalWindow = terminalClasses.some((term) => detectedWindowClass.includes(term));
+      if (windowSignals.length === 0) return false;
+      const isTerminalWindow = terminalClasses.some((term) => signalsMatch(term));
       if (isTerminalWindow) {
-        this.safeLog(`🖥️ Terminal detected: ${detectedWindowClass}`);
+        this.safeLog(`🖥️ Terminal detected: ${windowSignals.join(" | ")}`);
       }
       return isTerminalWindow;
     };
 
     const inTerminal = isTerminal();
     // On Wayland, when window class is unknown, use Shift+Insert as universal paste
-    // (works in both terminals and GUI apps, avoids Ctrl+V printing ^V in terminals)
-    const useShiftInsert = isWayland && !detectedWindowClass;
+    // (works in both terminals and GUI apps, avoids Ctrl+V printing ^V in terminals).
+    // Konsole on X11 also prefers Shift+Insert because simulated Ctrl+Shift+V via XTest
+    // gets dropped (see skipFastPasteForKonsole above).
+    const useShiftInsert = detectedIsKonsole || (isWayland && !detectedWindowClass);
     const pasteKeys = useShiftInsert ? "shift+Insert" : inTerminal ? "ctrl+shift+v" : "ctrl+v";
 
     const canUseWtype = isWayland && isWlroots;
@@ -1361,7 +1397,7 @@ class ClipboardManager {
 
     if (targetWindowId) {
       this.safeLog(
-        `🎯 Targeting window ID ${targetWindowId} for paste (class: ${detectedWindowClass})`
+        `🎯 Targeting window ID ${targetWindowId} for paste (signals: ${windowSignals.join(" | ") || "none"})`
       );
     }
 
@@ -1415,6 +1451,7 @@ class ClipboardManager {
         availableTools: available.map((c) => c.cmd),
         targetWindowId,
         detectedWindowClass,
+        detectedWindowComm,
         inTerminal,
         useShiftInsert,
         pasteKeys,


### PR DESCRIPTION
## Summary

Fixes the terminal-paste failure reported in #184 where Konsole on X11 (and Codex/Claude Code running inside it) sees `No image found in clipboard` instead of the dictated text.

Root cause (from @JGKle's analysis in #184): on KDE/X11, `xdotool getwindowclassname` intermittently returns nothing for Konsole, so `detectedWindowClass` is null. With no detected class we fall through to plain `Ctrl+V`, which AI terminal agents interpret as image-paste.

## Changes

- **`/proc/<pid>/comm` fallback** ([clipboard.js:1130-1145](src/helpers/clipboard.js#L1130-L1145)) — when xdotool can see the window (X11 or XWayland), read the owning process name and fold it into a `windowSignals` array. Terminal-class matching now runs against both WM_CLASS and the process name, so Konsole gets detected even when WM_CLASS is missing.
- **Skip native fast-paste for Konsole + X11** ([clipboard.js:1170-1177](src/helpers/clipboard.js#L1170-L1177)) — `linux-fast-paste`'s XTest `Ctrl+Shift+V` is silently dropped by Konsole (long-standing focus/grab quirk). Route Konsole+X11 through the existing xdotool fallback (`windowactivate --sync` + `key shift+Insert`), which works reliably.
- **`useShiftInsert` covers Konsole** ([clipboard.js:1385-1389](src/helpers/clipboard.js#L1385-L1389)) — so the JS fallback picks Shift+Insert whether Konsole was detected via WM_CLASS or via comm.

No change to behavior for:
- Non-Konsole X11 terminals (still go through `linux-fast-paste` with `--terminal`)
- Konsole on KDE Wayland (still goes through portal path)
- GNOME Wayland terminals (still rely on AT-SPI2 detection from #734)
- Non-terminal apps (still `Ctrl+V`)

## Credit

Original patch and root-cause analysis by @JGKle in [#184](https://github.com/OpenWhispr/openwhispr/issues/184). This PR is a cleaned-up adaptation:
- swap the `"a | b"` joined-string signature for an explicit `windowSignals` array (cleaner substring checks)
- name and comment the Konsole-X11 skip so it's not undone in a future refactor
- preserve the 🖥️ emoji that got mangled in the original patch encoding

## Test plan

- [ ] Konsole + X11 + Codex/Claude Code → dictation pastes as text (was failing)
- [ ] Konsole + KDE Wayland → still works (no behavior change expected)
- [ ] xterm/gnome-terminal on X11 → still uses Ctrl+Shift+V (no behavior change)
- [ ] gnome-terminal on GNOME Wayland → still works via AT-SPI2 in `linux-fast-paste` (no behavior change)
- [ ] Firefox/VSCode/etc. on X11 → still uses Ctrl+V (no behavior change)
- [ ] `npm run lint` clean (no new warnings)
- [ ] `npm run typecheck` clean
- [ ] `npx prettier --check src/helpers/clipboard.js` clean