### PR TITLE
fix(reasoning): propagate disableThinking on cleanup and agent routes

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -42,6 +42,7 @@ function resolveReasoningRoute(text, settings, agentName) {
           isCustomAgent || isSelfHostedAgent
             ? settings.dictationAgentCustomApiKey || undefined
             : undefined,
+        disableThinking: settings.dictationAgentDisableThinking,
         systemPrompt: resolvePrompt("dictationAgent", {
           agentName,
           language: settings.preferredLanguage,
@@ -51,7 +52,12 @@ function resolveReasoningRoute(text, settings, agentName) {
       },
     };
   }
-  if (cleanupReachable) return { kind: "cleanup" };
+  if (cleanupReachable) {
+    return {
+      kind: "cleanup",
+      config: { disableThinking: settings.cleanupDisableThinking },
+    };
+  }
   return { kind: "skip" };
 }
 
@@ -1075,13 +1081,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         if (route.kind === "skip") return normalizedText;
 
         const targetModel = route.kind === "agent" ? route.model : cleanupModel;
-        const reasoningConfig = route.kind === "agent" ? route.config : undefined;
+        const reasoningConfig = route.config;
 
         logger.logReasoning("SENDING_TO_REASONING", {
           preparedTextLength: normalizedText.length,
           model: targetModel,
           provider: route.config?.provider || cleanupProvider,
           path: route.kind,
+          disableThinking: reasoningConfig?.disableThinking,
         });
 
         const result = await this.processWithReasoningModel(
@@ -1358,7 +1365,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           const reasoned = await this.processWithReasoningModel(
             processedText,
             effectiveModel,
-            agentName
+            agentName,
+            route.config
           );
           if (reasoned) processedText = reasoned;
         }
@@ -2575,7 +2583,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             const reasoned = await this.processWithReasoningModel(
               finalText,
               effectiveModel,
-              agentName
+              agentName,
+              route.config
             );
             if (reasoned) finalText = reasoned;
             logger.info(


### PR DESCRIPTION
## Summary

`resolveReasoningRoute` returned a bare `{ kind: "cleanup" }` and the agent config omitted `disableThinking`, so both `cleanupDisableThinking` and `dictationAgentDisableThinking` were silently dropped before reaching `processWithReasoningModel`. Local Qwen kept emitting `<think>` blocks regardless of the toggle.

Three consumers existed; only one would have been fixed by simply patching the route. This PR finishes the job across all STT paths.

## Changes (one file, +13 / -4)

- `resolveReasoningRoute`
  - Agent route: add `disableThinking: settings.dictationAgentDisableThinking` to `config`.
  - Cleanup route: return `{ kind: "cleanup", config: { disableThinking: settings.cleanupDisableThinking } }`.
- `processTranscription` consumer
  - Use `route.config` for both kinds (skip-kind returns earlier, so it is always defined).
  - Log `disableThinking` in `SENDING_TO_REASONING` to surface which path actually suppressed thinking.
- `processWithOpenWhisprCloud` and `stopStreamingRecording`
  - BYOK-cleanup branches now forward `route.config` as the 4th argument to `processWithReasoningModel`, matching the agent branches in the same functions. Without this, OpenWhispr Cloud STT + local Qwen cleanup, and Deepgram/AssemblyAI/openai-realtime + local Qwen cleanup, would still drop the toggle.

No signature changes, no IPC changes, no new types, no new translation keys. `ReasoningConfig` already declared `disableThinking?: boolean` (`BaseReasoningService.ts`), and `localReasoningBridge` / `llamaServer` already consume it.

## Test plan

Cleanup model = local Qwen GGUF for all rows below.

- [ ] Local Whisper STT + toggle ON → no `<think>` in transcript; debug log shows `disableThinking: true`, `path: cleanup`.
- [ ] Local Whisper STT + toggle OFF → `<think>` blocks visible; log shows `disableThinking: false`.
- [ ] OpenWhispr Cloud STT + toggle ON → no `<think>` blocks.
- [ ] OpenWhispr Cloud STT + toggle OFF → `<think>` blocks visible.
- [ ] Deepgram (or AssemblyAI) streaming STT + toggle ON → no `<think>` blocks.
- [ ] Deepgram (or AssemblyAI) streaming STT + toggle OFF → `<think>` blocks visible.
- [ ] Address agent ("Hey \<name\>, …") with `dictationAgentDisableThinking: true` → no `<think>`.
- [ ] Same, with `dictationAgentDisableThinking: false` → `<think>` blocks visible.

## Risk

Renderer-only JS change; no native code, no platform branches. Defaults are unchanged (`cleanupDisableThinking` and `dictationAgentDisableThinking` both default to `true` in `settingsStore.ts`), so existing users see the same behavior they have today.