### PR TITLE
Migrate OpenAI Realtime client from Beta to GA API

### DIFF
--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -66,7 +66,6 @@ class OpenAIRealtimeStreaming {
       this.ws = new WebSocket(url, {
         headers: {
           Authorization: `Bearer ${apiKey}`,
-          "OpenAI-Beta": "realtime=v1",
         },
       });
 
@@ -93,13 +92,15 @@ class OpenAIRealtimeStreaming {
       this.ws.on("close", (code, reason) => {
         const wasActive = this.isConnected;
         this.isConnecting = false;
+        const reasonText = reason?.toString() || "";
         debugLogger.debug("OpenAI Realtime WebSocket closed", {
           code,
-          reason: reason?.toString(),
+          reason: reasonText,
           wasActive,
         });
         if (this.pendingReject) {
-          this.pendingReject(new Error(`WebSocket closed before ready (code: ${code})`));
+          const detail = reasonText ? ` — ${reasonText}` : "";
+          this.pendingReject(new Error(`WebSocket closed before ready (code: ${code})${detail}`));
           this.pendingReject = null;
           this.pendingResolve = null;
         }
@@ -119,6 +120,7 @@ class OpenAIRealtimeStreaming {
       const event = JSON.parse(data.toString());
 
       switch (event.type) {
+        case "session.created":
         case "transcription_session.created": {
           if (this.preconfigured) {
             // Server-side ephemeral token already configured the session;
@@ -141,17 +143,25 @@ class OpenAIRealtimeStreaming {
             if (!this.ws || this.ws.readyState !== WebSocket.OPEN) break;
             this.ws.send(
               JSON.stringify({
-                type: "transcription_session.update",
+                type: "session.update",
                 session: {
-                  input_audio_format: "pcm16",
-                  input_audio_transcription: {
-                    model: this.model,
-                  },
-                  turn_detection: {
-                    type: "server_vad",
-                    threshold: 0.3,
-                    silence_duration_ms: 800,
-                    prefix_padding_ms: 500,
+                  type: "transcription",
+                  audio: {
+                    input: {
+                      format: {
+                        type: "audio/pcm",
+                        rate: SAMPLE_RATE,
+                      },
+                      transcription: {
+                        model: this.model,
+                      },
+                      turn_detection: {
+                        type: "server_vad",
+                        threshold: 0.3,
+                        silence_duration_ms: 800,
+                        prefix_padding_ms: 500,
+                      },
+                    },
                   },
                 },
               })
@@ -160,6 +170,7 @@ class OpenAIRealtimeStreaming {
           break;
         }
 
+        case "session.updated":
         case "transcription_session.updated": {
           if (this.pendingResolve) {
             this.isConnected = true;


### PR DESCRIPTION
## Problem

After OpenAI shut down the Realtime Beta API on 2026-05-07, dictation and meeting streaming fail with:

```
Streaming Error: The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API.
Failed to start streaming: WebSocket closed before ready (code: 4000)
```

The server rejects the `OpenAI-Beta: realtime=v1` header that v1.6.4 still sends, and the legacy `transcription_session.update` payload shape is no longer accepted on the GA endpoint.

## Fix

`src/helpers/openaiRealtimeStreaming.js`:

- Drop the `OpenAI-Beta: realtime=v1` header — its presence forces the deprecated Beta path.
- Send the GA `session.update` event with `session.type: "transcription"` and the nested `audio.input.{format,transcription,turn_detection}` structure (replaces the flat `input_audio_format` / `input_audio_transcription` / `turn_detection` layout).
- Accept both `session.created` / `session.updated` (GA) and the legacy `transcription_session.*` names on the receive side for compatibility.
- Surface the server-provided close `reason` text in the rejection error so future protocol mismatches are diagnosable from the renderer instead of just `(code: 4000)`.

The WebSocket URL stays at `/v1/realtime?intent=transcription` — this is the path the GA still honors for a pure transcription session. Switching to `?model=gpt-realtime` was tested and rejected with *"Passing a transcription session update event to a realtime session is not allowed"* because that query opens a speech-to-speech session.

## Test plan

- [x] Verified that without the patch, both dictation and meeting transcription throw the Beta error immediately on start
- [x] After patch: dictation streaming completes a real transcription round-trip end-to-end with `gpt-4o-mini-transcribe`
- [x] Server-side `session.updated` event arrives and resolves the connect promise
- [x] Close-reason text now propagates to the UI (verified by intentionally sending an invalid model)

## References

- OpenAI deprecation note (Beta → GA cutover 2026-05-07): https://platform.openai.com/docs/deprecations
- GA Realtime transcription guide: https://developers.openai.com/api/docs/guides/realtime-transcription