### PR TITLE
fix(desktop): stop unnecessary macOS Keychain prompts on first launch

### DIFF
--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -87,17 +87,11 @@ class EnvironmentManager {
     }
   }
 
-  // Encryption init runs after construction; safeStorage fallback needs app.whenReady().
+  // Encryption initializes lazily. Probing it eagerly would touch the macOS
+  // Keychain before any window is visible. Migration and _loadAllSecrets are
+  // both no-ops on fresh installs, so neither path triggers Keychain until
+  // the user actually saves their first secret.
   async init() {
-    if (!this._encryptionAvailable()) {
-      debugLogger.warn(
-        "Secret encryption unavailable — secrets remain in plaintext .env",
-        { platform: process.platform },
-        "environment"
-      );
-      return;
-    }
-
     if (!fs.existsSync(this._getMigrationSentinelPath())) {
       await this._migrateToSecureStorage();
     }

--- a/src/helpers/secretCrypto.js
+++ b/src/helpers/secretCrypto.js
@@ -69,8 +69,10 @@ function _initKeychain() {
     } else {
       masterKey = crypto.randomBytes(KEY_LEN);
       entry.setPassword(masterKey.toString("base64"));
+      // Write the safeStorage backup only when the key is first generated.
+      // Re-writing on every launch invokes a second Keychain backend on macOS.
+      _saveMasterKeyBackup();
     }
-    _saveMasterKeyBackup();
     return true;
   } catch (error) {
     debugLogger.warn(


### PR DESCRIPTION
## Summary

On a fresh install, the desktop app prompts the macOS user for Keychain access multiple times before any window is even visible. This change drops first-launch prompts from ~3 to 0 with two small, targeted edits in [`src/helpers/environment.js`](src/helpers/environment.js) and [`src/helpers/secretCrypto.js`](src/helpers/secretCrypto.js).

## Root cause

`environmentManager.init()` runs from `app.whenReady()` and was eagerly calling `secretCrypto.isAvailable()` to decide whether to migrate / load secrets. That probe forced `_ensureInit()` to fire, which on a fresh install triggered:

1. `@napi-rs/keyring` `getPassword()` against the `OpenWhispr / secrets-master-key` item (prompt #1)
2. `@napi-rs/keyring` `setPassword()` for the newly-generated master key (prompt #2)
3. `safeStorage.encryptString()` for the backup blob, which lives under Electron's separate Chrome Safe Storage Keychain item (prompt #3)

All three fired before the first window painted, so the user saw a stack of Keychain dialogs with no context.

## Fix

**1. Lazy-init in `environment.init()`** — drop the eager `_encryptionAvailable()` check. Migration is already a no-op on fresh installs (the loop skips empty values) and `_loadAllSecrets()` is `ENOENT`-safe, so neither path touches the Keychain when there's nothing to do. The first `_saveKey()` from the renderer (when the user types an API key in Settings) is what now triggers `_ensureInit()` — at which point the prompt has obvious context.

**2. Write the safeStorage backup only when a new master key is generated** in `_initKeychain()`. Previously `_saveMasterKeyBackup()` ran on every successful init, invoking a second Keychain backend (`safeStorage`) every launch. The backup is a recovery path for the case where `@napi-rs/keyring` later becomes unavailable; it only needs to be written once.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Fresh install, no secrets entered | 2–3 prompts at app startup | 0 prompts |
| Fresh install, user enters first API key | 2–3 prompts at startup + 0 at save | 0 at startup + (silent on properly signed app, or contextual prompt at save) |
| Returning user with existing `.enc` files | 1–2 prompts at startup | 1 silent `getPassword` at startup (no backup re-write) |
| Linux without libsecret | early-return before migration | migration loop bails on first encrypt; behaviour identical for the user |

## Test plan

- [ ] On macOS: delete `~/Library/Application Support/OpenWhispr` and launch — confirm no Keychain dialog appears before window paint
- [ ] On macOS: in Settings, paste an OpenAI key — confirm it persists across restart (verifies lazy init still wires up correctly)
- [ ] On macOS: simulate a returning user — keep an existing `secure-keys/` folder and `.migrated` sentinel, launch — confirm secrets decrypt without prompts
- [ ] On Linux without a keyring: launch, save a key — confirm key persists in `process.env` for the session (matches prior behaviour; full disk persistence remains a pre-existing limitation)
- [ ] `npm run lint` clean
- [ ] `npm run typecheck` clean