### PR TITLE
fix(ui): align Select trigger background with surrounding controls

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,12 +17,12 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-xl border border-border bg-input px-3.5 py-2 text-sm text-foreground shadow-none ring-offset-background transition-colors duration-200",
+      "flex h-10 w-full items-center justify-between rounded-xl border border-border bg-surface-1 px-3.5 py-2 text-sm text-foreground shadow-none ring-offset-background transition-colors duration-200",
       "placeholder:text-muted-foreground",
       "[&>span]:line-clamp-1",
       "focus:outline-none focus:ring-[3px] focus:ring-primary/15 focus:border-primary",
       "disabled:cursor-not-allowed disabled:opacity-50",
-      "dark:bg-surface-1 dark:border-border-subtle",
+      "dark:border-border-subtle",
       "dark:focus:ring-ring/10 dark:focus:border-border-active",
       className
     )}


### PR DESCRIPTION
## Summary
- The Select trigger used \`bg-input\` (\`#f9f6f1\` — parchment cream) in light mode, which read warmer/yellower than the controls next to it (e.g. \`HotkeyInput\` uses \`bg-surface-1\` = \`#fafafa\` neutral). The mismatch was most visible in **Settings → Hotkeys**, where the meeting-mode layout dropdown sits directly below a hotkey input.
- Switched the trigger to \`bg-surface-1\` so the light-mode control surface matches the other field-style controls. Dark mode is unchanged — the trigger already resolved to \`bg-surface-1\` there via the \`dark:\` variant, which is now redundant and removed.

## Test plan
- [ ] Light mode: open Settings → Hotkeys, confirm the "Full width / Side panel" dropdown trigger no longer reads as cream/yellow and visually matches the hotkey input above it.
- [ ] Light mode: spot-check other Select dropdowns across Settings (Language, Sound, AI Provider, etc.) — they should all look neutral, not warmer than surrounding controls.
- [ ] Dark mode: confirm dropdown trigger appearance is unchanged.
- [ ] Open a dropdown — confirm the trigger and the popover panel feel cohesive when stacked.