### PR TITLE
fix(linux): paste via Shift+Insert when window context is unknown

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -21,6 +21,16 @@
 #include <atspi/atspi.h>
 #endif
 
+/* Paste key sequence. SHIFT_INSERT is the universal Linux paste shortcut —
+ * works in terminals and GUI apps, and (unlike Ctrl+V) isn't intercepted by
+ * TUI agents as "paste image". Used when window class is unknown on Wayland
+ * or when targeting Konsole (which silently drops simulated Ctrl+Shift+V). */
+typedef enum {
+    PASTE_MODE_CTRL_V        = 0,
+    PASTE_MODE_CTRL_SHIFT_V  = 1,
+    PASTE_MODE_SHIFT_INSERT  = 2,
+} paste_mode_t;
+
 #ifdef HAVE_GIO
 #include <gio/gio.h>
 
@@ -33,6 +43,7 @@
 #define PORTAL_KEY_LEFTCTRL  29
 #define PORTAL_KEY_LEFTSHIFT 42
 #define PORTAL_KEY_V         47
+#define PORTAL_KEY_INSERT    110
 
 static int portal_exit_code = 0;
 
@@ -42,7 +53,7 @@ typedef struct {
     char            *session_handle;
     char            *restore_token;
     guint            signal_id;
-    int              use_shift;
+    paste_mode_t     mode;
 } PortalData;
 
 static char *get_sender_path(GDBusConnection *conn)
@@ -64,64 +75,39 @@ static guint subscribe_response(PortalData *app, const char *request_path,
         callback, app, NULL);
 }
 
-static void portal_send_paste(PortalData *app)
+static void portal_emit_key(PortalData *app, gint32 keycode, guint32 pressed,
+                            const char *label)
 {
     GError *err = NULL;
-    GVariant *opts;
-
-    opts = g_variant_new("a{sv}", NULL);
+    GVariant *opts = g_variant_new("a{sv}", NULL);
     g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
         PORTAL_IFACE, "NotifyKeyboardKeycode",
-        g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_LEFTCTRL, (guint32)1),
+        g_variant_new("(o@a{sv}iu)", app->session_handle, opts, keycode, pressed),
         NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-    if (err) { fprintf(stderr, "Ctrl press: %s\n", err->message); g_clear_error(&err); }
+    if (err) { fprintf(stderr, "%s: %s\n", label, err->message); g_clear_error(&err); }
+}
 
-    if (app->use_shift) {
-        opts = g_variant_new("a{sv}", NULL);
-        g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
-            PORTAL_IFACE, "NotifyKeyboardKeycode",
-            g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                           (gint32)PORTAL_KEY_LEFTSHIFT, (guint32)1),
-            NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-        if (err) { fprintf(stderr, "Shift press: %s\n", err->message); g_clear_error(&err); }
+static void portal_send_paste(PortalData *app)
+{
+    if (app->mode == PASTE_MODE_SHIFT_INSERT) {
+        portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 1, "Shift press");
+        portal_emit_key(app, PORTAL_KEY_INSERT,    1, "Insert press");
+        usleep(20000);
+        portal_emit_key(app, PORTAL_KEY_INSERT,    0, "Insert release");
+        portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 0, "Shift release");
+    } else {
+        const int use_shift = (app->mode == PASTE_MODE_CTRL_SHIFT_V);
+
+        portal_emit_key(app, PORTAL_KEY_LEFTCTRL, 1, "Ctrl press");
+        if (use_shift)
+            portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 1, "Shift press");
+        portal_emit_key(app, PORTAL_KEY_V, 1, "V press");
+        usleep(20000);
+        portal_emit_key(app, PORTAL_KEY_V, 0, "V release");
+        if (use_shift)
+            portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 0, "Shift release");
+        portal_emit_key(app, PORTAL_KEY_LEFTCTRL, 0, "Ctrl release");
     }
-
-    opts = g_variant_new("a{sv}", NULL);
-    g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
-        PORTAL_IFACE, "NotifyKeyboardKeycode",
-        g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_V, (guint32)1),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-    if (err) { fprintf(stderr, "V press: %s\n", err->message); g_clear_error(&err); }
-
-    usleep(20000);
-
-    opts = g_variant_new("a{sv}", NULL);
-    g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
-        PORTAL_IFACE, "NotifyKeyboardKeycode",
-        g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_V, (guint32)0),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-    if (err) { fprintf(stderr, "V release: %s\n", err->message); g_clear_error(&err); }
-
-    if (app->use_shift) {
-        opts = g_variant_new("a{sv}", NULL);
-        g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
-            PORTAL_IFACE, "NotifyKeyboardKeycode",
-            g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                           (gint32)PORTAL_KEY_LEFTSHIFT, (guint32)0),
-            NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-        if (err) { fprintf(stderr, "Shift release: %s\n", err->message); g_clear_error(&err); }
-    }
-
-    opts = g_variant_new("a{sv}", NULL);
-    g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
-        PORTAL_IFACE, "NotifyKeyboardKeycode",
-        g_variant_new("(o@a{sv}iu)", app->session_handle, opts,
-                       (gint32)PORTAL_KEY_LEFTCTRL, (guint32)0),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
-    if (err) { fprintf(stderr, "Ctrl release: %s\n", err->message); g_clear_error(&err); }
 
     g_main_loop_quit(app->loop);
 }
@@ -278,10 +264,10 @@ static gboolean on_portal_timeout(gpointer user_data)
     return G_SOURCE_REMOVE;
 }
 
-static int paste_via_portal(int use_shift, const char *restore_token)
+static int paste_via_portal(paste_mode_t mode, const char *restore_token)
 {
     PortalData app = { 0 };
-    app.use_shift = use_shift;
+    app.mode = mode;
     if (restore_token) app.restore_token = g_strdup(restore_token);
 
     GError *err = NULL;
@@ -475,7 +461,12 @@ static void emit(int fd, int type, int code, int val) {
     }
 }
 
-static int paste_via_uinput(int use_shift) {
+static void emit_key(int fd, int code, int val) {
+    emit(fd, EV_KEY, code, val);
+    emit(fd, EV_SYN, SYN_REPORT, 0);
+}
+
+static int paste_via_uinput(paste_mode_t mode) {
     int fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
     if (fd < 0) {
         fprintf(stderr, "Cannot open /dev/uinput: %s\n", strerror(errno));
@@ -485,7 +476,8 @@ static int paste_via_uinput(int use_shift) {
     if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 ||
         ioctl(fd, UI_SET_KEYBIT, KEY_LEFTCTRL) < 0 ||
         ioctl(fd, UI_SET_KEYBIT, KEY_LEFTSHIFT) < 0 ||
-        ioctl(fd, UI_SET_KEYBIT, KEY_V) < 0) {
+        ioctl(fd, UI_SET_KEYBIT, KEY_V) < 0 ||
+        ioctl(fd, UI_SET_KEYBIT, KEY_INSERT) < 0) {
         close(fd);
         return 4;
     }
@@ -505,32 +497,27 @@ static int paste_via_uinput(int use_shift) {
 
     usleep(50000);
 
-    emit(fd, EV_KEY, KEY_LEFTCTRL, 1);
-    emit(fd, EV_SYN, SYN_REPORT, 0);
+    if (mode == PASTE_MODE_SHIFT_INSERT) {
+        emit_key(fd, KEY_LEFTSHIFT, 1);
+        usleep(8000);
+        emit_key(fd, KEY_INSERT, 1);
+        usleep(8000);
+        emit_key(fd, KEY_INSERT, 0);
+        usleep(8000);
+        emit_key(fd, KEY_LEFTSHIFT, 0);
+    } else {
+        const int use_shift = (mode == PASTE_MODE_CTRL_SHIFT_V);
 
-    if (use_shift) {
-        emit(fd, EV_KEY, KEY_LEFTSHIFT, 1);
-        emit(fd, EV_SYN, SYN_REPORT, 0);
+        emit_key(fd, KEY_LEFTCTRL, 1);
+        if (use_shift) emit_key(fd, KEY_LEFTSHIFT, 1);
+        usleep(8000);
+        emit_key(fd, KEY_V, 1);
+        usleep(8000);
+        emit_key(fd, KEY_V, 0);
+        usleep(8000);
+        if (use_shift) emit_key(fd, KEY_LEFTSHIFT, 0);
+        emit_key(fd, KEY_LEFTCTRL, 0);
     }
-
-    usleep(8000);
-
-    emit(fd, EV_KEY, KEY_V, 1);
-    emit(fd, EV_SYN, SYN_REPORT, 0);
-    usleep(8000);
-
-    emit(fd, EV_KEY, KEY_V, 0);
-    emit(fd, EV_SYN, SYN_REPORT, 0);
-
-    usleep(8000);
-
-    if (use_shift) {
-        emit(fd, EV_KEY, KEY_LEFTSHIFT, 0);
-        emit(fd, EV_SYN, SYN_REPORT, 0);
-    }
-
-    emit(fd, EV_KEY, KEY_LEFTCTRL, 0);
-    emit(fd, EV_SYN, SYN_REPORT, 0);
 
     usleep(20000);
 
@@ -603,8 +590,42 @@ static int send_media_play_pause(void) {
     return 0;
 }
 
+/* Resolve the paste key sequence. --shift-insert wins outright (used when the
+ * caller already knows context is unknown or Konsole). Otherwise: terminal
+ * detection via atspi, then X11 class, then parent class — same fallback
+ * chain the binary used before this enum existed. */
+static paste_mode_t resolve_paste_mode(int force_terminal, int force_shift_insert,
+                                       Window target_window)
+{
+    if (force_shift_insert) return PASTE_MODE_SHIFT_INSERT;
+
+    int is_term = force_terminal;
+#ifdef HAVE_ATSPI
+    if (!is_term) { int r = detect_terminal_atspi(); if (r >= 0) is_term = r; }
+#endif
+    if (!is_term) {
+        Display *dpy = XOpenDisplay(NULL);
+        if (dpy) {
+            Window win = (target_window != None) ? target_window : get_active_window(dpy);
+            if (win != None) {
+                XClassHint hint;
+                if (XGetClassHint(dpy, win, &hint)) {
+                    is_term = is_terminal(hint.res_class) || is_terminal(hint.res_name);
+                    XFree(hint.res_name);
+                    XFree(hint.res_class);
+                } else {
+                    is_term = check_parent_terminal(dpy, win);
+                }
+            }
+            XCloseDisplay(dpy);
+        }
+    }
+    return is_term ? PASTE_MODE_CTRL_SHIFT_V : PASTE_MODE_CTRL_V;
+}
+
 int main(int argc, char *argv[]) {
     int force_terminal = 0;
+    int force_shift_insert = 0;
     int use_uinput = 0;
     int use_portal = 0;
     int media_play_pause = 0;
@@ -614,6 +635,8 @@ int main(int argc, char *argv[]) {
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--terminal") == 0) {
             force_terminal = 1;
+        } else if (strcmp(argv[i], "--shift-insert") == 0) {
+            force_shift_insert = 1;
         } else if (strcmp(argv[i], "--uinput") == 0) {
             use_uinput = 1;
         } else if (strcmp(argv[i], "--portal") == 0) {
@@ -633,28 +656,8 @@ int main(int argc, char *argv[]) {
 
     if (use_portal) {
 #ifdef HAVE_GIO
-        int shift = force_terminal;
-#ifdef HAVE_ATSPI
-        if (!shift) { int r = detect_terminal_atspi(); if (r >= 0) shift = r; }
-#endif
-        if (!shift) {
-            Display *dpy = XOpenDisplay(NULL);
-            if (dpy) {
-                Window win = (target_window != None) ? target_window : get_active_window(dpy);
-                if (win != None) {
-                    XClassHint hint;
-                    if (XGetClassHint(dpy, win, &hint)) {
-                        shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
-                        XFree(hint.res_name);
-                        XFree(hint.res_class);
-                    } else {
-                        shift = check_parent_terminal(dpy, win);
-                    }
-                }
-                XCloseDisplay(dpy);
-            }
-        }
-        return paste_via_portal(shift, restore_token);
+        paste_mode_t mode = resolve_paste_mode(force_terminal, force_shift_insert, target_window);
+        return paste_via_portal(mode, restore_token);
 #else
         fprintf(stderr, "portal support not compiled in\n");
         return 5;
@@ -663,28 +666,8 @@ int main(int argc, char *argv[]) {
 
     if (use_uinput) {
 #ifdef HAVE_UINPUT
-        int shift = force_terminal;
-#ifdef HAVE_ATSPI
-        if (!shift) { int r = detect_terminal_atspi(); if (r >= 0) shift = r; }
-#endif
-        if (!shift) {
-            Display *dpy = XOpenDisplay(NULL);
-            if (dpy) {
-                Window win = (target_window != None) ? target_window : get_active_window(dpy);
-                if (win != None) {
-                    XClassHint hint;
-                    if (XGetClassHint(dpy, win, &hint)) {
-                        shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
-                        XFree(hint.res_name);
-                        XFree(hint.res_class);
-                    } else {
-                        shift = check_parent_terminal(dpy, win);
-                    }
-                }
-                XCloseDisplay(dpy);
-            }
-        }
-        return paste_via_uinput(shift);
+        paste_mode_t mode = resolve_paste_mode(force_terminal, force_shift_insert, target_window);
+        return paste_via_uinput(mode);
 #else
         fprintf(stderr, "uinput support not compiled in\n");
         return 3;
@@ -704,40 +687,37 @@ int main(int argc, char *argv[]) {
         activate_window(dpy, target_window);
     }
 
-    Window win = (target_window != None) ? target_window : get_active_window(dpy);
+    paste_mode_t mode = resolve_paste_mode(force_terminal, force_shift_insert, target_window);
 
-    int use_shift = force_terminal;
-#ifdef HAVE_ATSPI
-    if (!use_shift) { int r = detect_terminal_atspi(); if (r >= 0) use_shift = r; }
-#endif
-    if (!use_shift && win != None) {
-        XClassHint hint;
-        if (XGetClassHint(dpy, win, &hint)) {
-            use_shift = is_terminal(hint.res_class) || is_terminal(hint.res_name);
-            XFree(hint.res_name);
-            XFree(hint.res_class);
-        } else {
-            use_shift = check_parent_terminal(dpy, win);
-        }
-    }
+    if (mode == PASTE_MODE_SHIFT_INSERT) {
+        KeyCode shift  = XKeysymToKeycode(dpy, XK_Shift_L);
+        KeyCode insert = XKeysymToKeycode(dpy, XK_Insert);
 
-    KeyCode ctrl = XKeysymToKeycode(dpy, XK_Control_L);
-    KeyCode shift = XKeysymToKeycode(dpy, XK_Shift_L);
-    KeyCode v = XKeysymToKeycode(dpy, XK_v);
-
-    XTestFakeKeyEvent(dpy, ctrl, True, CurrentTime);
-    if (use_shift)
         XTestFakeKeyEvent(dpy, shift, True, CurrentTime);
-    usleep(8000);
-
-    XTestFakeKeyEvent(dpy, v, True, CurrentTime);
-    usleep(8000);
-    XTestFakeKeyEvent(dpy, v, False, CurrentTime);
-
-    usleep(8000);
-    if (use_shift)
+        usleep(8000);
+        XTestFakeKeyEvent(dpy, insert, True, CurrentTime);
+        usleep(8000);
+        XTestFakeKeyEvent(dpy, insert, False, CurrentTime);
+        usleep(8000);
         XTestFakeKeyEvent(dpy, shift, False, CurrentTime);
-    XTestFakeKeyEvent(dpy, ctrl, False, CurrentTime);
+    } else {
+        const int use_shift = (mode == PASTE_MODE_CTRL_SHIFT_V);
+        KeyCode ctrl = XKeysymToKeycode(dpy, XK_Control_L);
+        KeyCode shift = XKeysymToKeycode(dpy, XK_Shift_L);
+        KeyCode v = XKeysymToKeycode(dpy, XK_v);
+
+        XTestFakeKeyEvent(dpy, ctrl, True, CurrentTime);
+        if (use_shift)
+            XTestFakeKeyEvent(dpy, shift, True, CurrentTime);
+        usleep(8000);
+        XTestFakeKeyEvent(dpy, v, True, CurrentTime);
+        usleep(8000);
+        XTestFakeKeyEvent(dpy, v, False, CurrentTime);
+        usleep(8000);
+        if (use_shift)
+            XTestFakeKeyEvent(dpy, shift, False, CurrentTime);
+        XTestFakeKeyEvent(dpy, ctrl, False, CurrentTime);
+    }
 
     XFlush(dpy);
     usleep(20000);

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -151,6 +151,80 @@ class ClipboardManager {
     clipboard.writeText(text);
   }
 
+  // PRIMARY selection (X11's "highlight to copy") is what terminals like alacritty,
+  // foot, konsole, xterm, and st bind Shift+Insert to. Mirror the transcription
+  // there so Shift+Insert pastes reliably regardless of which selection the
+  // terminal uses. Falls through wl-copy → xclip → xsel → Electron's selection
+  // target so we cover Wayland, X11, and XWayland setups.
+  _writePrimarySelection(text) {
+    if (process.platform !== "linux") return;
+
+    const { isWayland } = getLinuxSessionInfo();
+
+    if (isWayland && this.commandExists("wl-copy")) {
+      try {
+        const result = spawnSync("wl-copy", ["--primary", "--", text], { timeout: 50 });
+        if (result.status === 0) return;
+      } catch {}
+    }
+
+    if (this.commandExists("xclip")) {
+      try {
+        const result = spawnSync("xclip", ["-selection", "primary"], {
+          input: text,
+          timeout: 200,
+        });
+        if (result.status === 0) return;
+      } catch {}
+    }
+
+    if (this.commandExists("xsel")) {
+      try {
+        const result = spawnSync("xsel", ["--primary", "--input"], {
+          input: text,
+          timeout: 200,
+        });
+        if (result.status === 0) return;
+      } catch {}
+    }
+
+    try {
+      clipboard.writeText(text, "selection");
+    } catch {}
+  }
+
+  _readPrimarySelection() {
+    if (process.platform !== "linux") return null;
+
+    const { isWayland } = getLinuxSessionInfo();
+
+    if (isWayland && this.commandExists("wl-paste")) {
+      try {
+        const result = spawnSync("wl-paste", ["--primary", "--no-newline"], { timeout: 200 });
+        if (result.status === 0) return result.stdout.toString();
+      } catch {}
+    }
+
+    if (this.commandExists("xclip")) {
+      try {
+        const result = spawnSync("xclip", ["-selection", "primary", "-o"], { timeout: 200 });
+        if (result.status === 0) return result.stdout.toString();
+      } catch {}
+    }
+
+    if (this.commandExists("xsel")) {
+      try {
+        const result = spawnSync("xsel", ["--primary", "--output"], { timeout: 200 });
+        if (result.status === 0) return result.stdout.toString();
+      } catch {}
+    }
+
+    try {
+      return clipboard.readText("selection") || "";
+    } catch {}
+    return null;
+  }
+
   getNircmdPath() {
     if (this.nircmdChecked) {
       return this.nircmdPath;
@@ -349,10 +423,11 @@ class ClipboardManager {
     }
   }
 
-  _runPortalPaste(fastPasteBinary, useShift) {
+  _runPortalPaste(fastPasteBinary, { shiftInsert = false, terminal = false } = {}) {
     return new Promise((resolve, reject) => {
       const args = ["--portal"];
-      if (useShift) args.push("--terminal");
+      if (shiftInsert) args.push("--shift-insert");
+      else if (terminal) args.push("--terminal");
 
       const restoreToken = this._readPortalToken();
       if (restoreToken) {
@@ -590,12 +665,19 @@ class ClipboardManager {
     try {
       const shouldRestore = options.restoreClipboard !== false;
       const originalClipboard = shouldRestore ? this._saveClipboard() : null;
+      const originalPrimary =
+        platform === "linux" && shouldRestore ? this._readPrimarySelection() : null;
       if (shouldRestore) {
         this.safeLog("💾 Saved original clipboard:", originalClipboard.type);
       }
 
-      if (platform === "linux" && this._isWayland()) {
-        this._writeClipboardWayland(text, webContents);
+      if (platform === "linux") {
+        if (this._isWayland()) {
+          this._writeClipboardWayland(text, webContents);
+        } else {
+          clipboard.writeText(text);
+        }
+        this._writePrimarySelection(text);
       } else {
         clipboard.writeText(text);
       }
@@ -636,7 +718,9 @@ class ClipboardManager {
         }
         await this.pasteWindows(originalClipboard);
       } else {
-        method = (await this.pasteLinux(originalClipboard, options)) || "linux-tools";
+        method =
+          (await this.pasteLinux(originalClipboard, { ...options, originalPrimary })) ||
+          "linux-tools";
       }
 
       this.safeLog("✅ Paste operation complete", {
@@ -1036,6 +1120,7 @@ class ClipboardManager {
     const { isWayland, xwaylandAvailable, isGnome, isKde, isWlroots, isHyprland } =
       getLinuxSessionInfo();
     const webContents = options.webContents;
+    const originalPrimary = options.originalPrimary ?? null;
     const xdotoolExists = this.commandExists("xdotool");
     const wtypeExists = this.commandExists("wtype");
     const ydotoolExists = this.commandExists("ydotool");
@@ -1065,15 +1150,19 @@ class ClipboardManager {
     );
 
     const restoreClipboard = () => {
-      if (originalClipboard == null) return;
       const delay = isKde && isWayland ? RESTORE_DELAYS.linux_kde_wayland : RESTORE_DELAYS.linux;
-      setTimeout(() => {
-        if (isWayland && originalClipboard.type === "text") {
-          this._writeClipboardWayland(originalClipboard.data, webContents);
-        } else {
-          this._restoreClipboard(originalClipboard);
-        }
-      }, delay);
+      if (originalClipboard != null) {
+        setTimeout(() => {
+          if (isWayland && originalClipboard.type === "text") {
+            this._writeClipboardWayland(originalClipboard.data, webContents);
+          } else {
+            this._restoreClipboard(originalClipboard);
+          }
+        }, delay);
+      }
+      if (originalPrimary != null) {
+        setTimeout(() => this._writePrimarySelection(originalPrimary), delay);
+      }
     };
 
     const terminalClasses = [
@@ -1167,6 +1256,12 @@ class ClipboardManager {
     const signalsMatch = (needle) => windowSignals.some((signal) => signal.includes(needle));
     const detectedIsKonsole = signalsMatch("konsole");
 
+    // Shift+Insert is the universal Linux paste shortcut — works in terminals and
+    // GUI apps, and (unlike Ctrl+V) is not intercepted by TUI agents like Codex,
+    // Claude Code, or OpenCode as "paste image". Use it whenever the target window
+    // can't be classified, or for Konsole which silently drops simulated Ctrl+Shift+V.
+    const useShiftInsert = detectedIsKonsole || (isWayland && windowSignals.length === 0);
+
     // Konsole on X11 silently drops simulated Ctrl+Shift+V via XTest (a long-standing
     // focus/grab quirk), and the native fast-paste binary uses XTest. Route Konsole+X11
     // through the xdotool fallback instead, which sends shift+Insert with
@@ -1176,6 +1271,10 @@ class ClipboardManager {
     if (linuxFastPaste && !skipFastPasteForKonsole) {
       const earlyIsTerminal =
         windowSignals.length > 0 ? terminalClasses.some((term) => signalsMatch(term)) : false;
+      const appendModeFlag = (args) => {
+        if (useShiftInsert) args.push("--shift-insert");
+        else if (earlyIsTerminal) args.push("--terminal");
+      };
 
       const spawnFastPaste = (args, label) =>
         new Promise((resolve, reject) => {
@@ -1228,7 +1327,7 @@ class ClipboardManager {
       if (isWayland) {
         const tryUinputPaste = async () => {
           const args = ["--uinput"];
-          if (earlyIsTerminal) args.push("--terminal");
+          appendModeFlag(args);
           await spawnFastPaste(args, "uinput");
           this.safeLog("✅ Paste successful using native linux-fast-paste (uinput)");
           debugLogger.info(
@@ -1243,7 +1342,10 @@ class ClipboardManager {
           const MAX_PORTAL_RETRIES = 3;
           for (let attempt = 0; attempt < MAX_PORTAL_RETRIES; attempt++) {
             try {
-              const portalResult = await this._runPortalPaste(linuxFastPaste, earlyIsTerminal);
+              const portalResult = await this._runPortalPaste(linuxFastPaste, {
+                shiftInsert: useShiftInsert,
+                terminal: earlyIsTerminal,
+              });
               this.safeLog("✅ Paste successful using linux-fast-paste --portal (RemoteDesktop)");
               debugLogger.info(
                 "Paste successful",
@@ -1319,7 +1421,7 @@ class ClipboardManager {
         if (xwaylandAvailable) {
           const xtestArgs = [];
           if (targetWindowId) xtestArgs.push("--window", targetWindowId);
-          if (earlyIsTerminal) xtestArgs.push("--terminal");
+          appendModeFlag(xtestArgs);
 
           try {
             await spawnFastPaste(xtestArgs, "XTest/XWayland fallback");
@@ -1344,7 +1446,7 @@ class ClipboardManager {
       } else {
         const xtestArgs = [];
         if (targetWindowId) xtestArgs.push("--window", targetWindowId);
-        if (earlyIsTerminal) xtestArgs.push("--terminal");
+        appendModeFlag(xtestArgs);
 
         try {
           await spawnFastPaste(xtestArgs, "XTest");
@@ -1380,11 +1482,6 @@ class ClipboardManager {
     };
 
     const inTerminal = isTerminal();
-    // On Wayland, when window class is unknown, use Shift+Insert as universal paste
-    // (works in both terminals and GUI apps, avoids Ctrl+V printing ^V in terminals).
-    // Konsole on X11 also prefers Shift+Insert because simulated Ctrl+Shift+V via XTest
-    // gets dropped (see skipFastPasteForKonsole above).
-    const useShiftInsert = detectedIsKonsole || (isWayland && !detectedWindowClass);
     const pasteKeys = useShiftInsert ? "shift+Insert" : inTerminal ? "ctrl+shift+v" : "ctrl+v";
 
     const canUseWtype = isWayland && isWlroots;


### PR DESCRIPTION
## Summary

On Linux, when OpenWhispr can't detect the target window's class (typical for Wayland-native terminals on GNOME, since `xdotool` can't see them), it falls through to `Ctrl+V`. Modern TUI agents — Codex, Claude Code, OpenCode, anything Ink-based — bind `Ctrl+V` to "paste image" and surface `No image found in clipboard` instead of typing the dictation. Reported in #184 by @stefano5699 on Fedora GNOME.

## What changed

- **`linux-fast-paste.c`**: add `--shift-insert` flag. All three injection backends (uinput, portal/RemoteDesktop, XTest) now emit `Shift+Insert` when set. The existing `force_terminal` / atspi / X11 class detection logic is consolidated into a single `resolve_paste_mode()` helper returning a three-state enum (`CTRL_V`, `CTRL_SHIFT_V`, `SHIFT_INSERT`).
- **`clipboard.js`**: lift the `useShiftInsert` decision above the fast-paste call so the binary path honors it the same way the xdotool fallback already did. Updated condition is `detectedIsKonsole || (isWayland && windowSignals.length === 0)`.
- **PRIMARY selection mirror**: write the transcription to PRIMARY alongside CLIPBOARD on Linux. Terminals like alacritty, foot, konsole, and xterm bind `Shift+Insert` to PRIMARY, not CLIPBOARD — without this dual-write, the fix would only help vte-based terminals. `_readPrimarySelection` / `_writePrimarySelection` use the same `wl-copy → xclip → xsel → Electron` fallback chain as `_writeClipboardWayland`. Save/restore is gated on the existing `restoreClipboard` option, so `keepTranscriptionInClipboard=false` continues to leave both selections untouched after paste.

## Why Shift+Insert

It's the only Linux paste shortcut that's both terminal-safe (no TUI image-paste interception) and GUI-safe (GTK/Qt/Electron/browser text fields all honor it). `Ctrl+Shift+V` would fix the TUI case but breaks in some GUI apps that bind it to "paste without formatting". Shift+Insert has no widely-bound alternate meaning.

## Compatibility

- macOS / Windows: unchanged (Linux-only code paths).
- Linux pre-existing `--terminal` flag and Konsole+X11 xdotool routing: preserved.
- Binary is rebuilt from source on every install via `scripts/build-linux-fast-paste.js` (no release-pipeline coordination needed).
- `_runPortalPaste` signature change is internal; only caller is updated in the same commit.