### PR TITLE
fix: skip API key check for self-hosted transcription servers

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -11,7 +11,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { getSettings, getEffectiveCleanupModel, isCloudCleanupMode } from "../stores/settingsStore";
-import { shouldSkipTranscriptionApiKey } from "./transcriptionAuth.js";
+import { shouldSkipTranscriptionApiKey } from "./transcriptionAuth";
 import { detectAgentName } from "../config/agentDetection";
 import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
@@ -827,10 +827,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   async getAPIKey() {
     const s = getSettings();
-    const provider = s.cloudTranscriptionProvider || "openai";
     if (shouldSkipTranscriptionApiKey(s)) {
       return null;
     }
+
+    const provider = s.cloudTranscriptionProvider || "openai";
 
     // Check cache (invalidate if provider changed)
     if (this.cachedApiKey !== null && this.cachedApiKeyProvider === provider) {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -827,6 +827,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   async getAPIKey() {
     const s = getSettings();
     const provider = s.cloudTranscriptionProvider || "openai";
+    const transcriptionMode = s.transcriptionMode || "";
+    const remoteUrl = (s.remoteTranscriptionUrl || "").trim();
+
+    if (transcriptionMode === "self-hosted" && remoteUrl.length > 0) {
+      return null;
+    }
 
     // Check cache (invalidate if provider changed)
     if (this.cachedApiKey !== null && this.cachedApiKeyProvider === provider) {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -11,6 +11,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { getSettings, getEffectiveCleanupModel, isCloudCleanupMode } from "../stores/settingsStore";
+import { shouldSkipTranscriptionApiKey } from "./transcriptionAuth.js";
 import { detectAgentName } from "../config/agentDetection";
 import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
@@ -827,10 +828,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   async getAPIKey() {
     const s = getSettings();
     const provider = s.cloudTranscriptionProvider || "openai";
-    const transcriptionMode = s.transcriptionMode || "";
-    const remoteUrl = (s.remoteTranscriptionUrl || "").trim();
-
-    if (transcriptionMode === "self-hosted" && remoteUrl.length > 0) {
+    if (shouldSkipTranscriptionApiKey(s)) {
       return null;
     }
 

--- a/src/helpers/transcriptionAuth.js
+++ b/src/helpers/transcriptionAuth.js
@@ -1,0 +1,5 @@
+export function shouldSkipTranscriptionApiKey(settings) {
+  const transcriptionMode = (settings.transcriptionMode || "").trim();
+  const remoteUrl = (settings.remoteTranscriptionUrl || "").trim();
+  return transcriptionMode === "self-hosted" && remoteUrl.length > 0;
+}

--- a/test/helpers/transcriptionAuth.test.js
+++ b/test/helpers/transcriptionAuth.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("returns true for self-hosted mode with configured URL", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(
+    shouldSkipTranscriptionApiKey({
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "http://localhost:8000/v1",
+    }),
+    true
+  );
+});
+
+test("returns false for self-hosted mode without URL", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(
+    shouldSkipTranscriptionApiKey({
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "",
+    }),
+    false
+  );
+});
+
+test("returns false for self-hosted mode with whitespace-only URL", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(
+    shouldSkipTranscriptionApiKey({
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "   ",
+    }),
+    false
+  );
+});
+
+test("returns false for openai cloud provider mode", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(
+    shouldSkipTranscriptionApiKey({
+      transcriptionMode: "",
+      cloudTranscriptionProvider: "openai",
+      remoteTranscriptionUrl: "",
+    }),
+    false
+  );
+});
+
+test("returns false when transcriptionMode is missing from settings", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(shouldSkipTranscriptionApiKey({}), false);
+});
+
+test("returns false for non-self-hosted mode even with URL configured", async () => {
+  const { shouldSkipTranscriptionApiKey } = await import(
+    "../../src/helpers/transcriptionAuth.js"
+  );
+  assert.equal(
+    shouldSkipTranscriptionApiKey({
+      transcriptionMode: "cloud",
+      remoteTranscriptionUrl: "http://localhost:8000/v1",
+    }),
+    false
+  );
+});


### PR DESCRIPTION
## Summary

Self-hosted transcription mode was unusable because the app validated an OpenAI API key before sending requests, even though self-hosted servers don't need one. Now `getAPIKey()` returns null when the user has configured a self-hosted server URL, and the Authorization header is omitted from the request.

Fixes #799

## Changes

- src/helpers/transcriptionAuth.js: new pure function `shouldSkipTranscriptionApiKey` that checks if we're in self-hosted mode with a configured URL
- src/helpers/audioManager.js: uses the new function to early-return null from `getAPIKey()`, skipping all provider-specific key validation
- test/helpers/transcriptionAuth.test.js: 6 tests covering self-hosted with/without URL, whitespace-only URL, cloud mode, empty settings, non-self-hosted mode with URL