### PR TITLE
feat: add keep-alive ping for self-hosted transcription servers

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -888,4 +888,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getUpdateNotificationData: () => ipcRenderer.invoke("get-update-notification-data"),
   updateNotificationReady: () => ipcRenderer.invoke("update-notification-ready"),
   updateNotificationRespond: (action) => ipcRenderer.invoke("update-notification-respond", action),
+
+  selfHostedKeepAliveStart: (url) => ipcRenderer.invoke("self-hosted-keep-alive-start", url),
+  selfHostedKeepAliveStop: () => ipcRenderer.invoke("self-hosted-keep-alive-stop"),
 });

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -28,6 +28,7 @@ const {
 } = require("./speakerAssignmentPolicy");
 const { downsample24kTo16k, pcm16ToWav } = require("../utils/audioUtils");
 const postMigrationDetector = require("./postMigrationDetector");
+const SelfHostedKeepAlive = require("./selfHostedKeepAlive");
 const {
   DEFAULT_EXPECTED_SPEAKER_COUNT,
   MAX_SPEAKER_COUNT,
@@ -306,6 +307,7 @@ class IPCHandlers {
     this.audioStorageManager = new AudioStorageManager();
     this._audioCleanupInterval = null;
     this._noteFilesEnabled = false;
+    this._selfHostedKeepAlive = new SelfHostedKeepAlive();
     this.speakerDiarizationEnabled = true;
     this.activeMeetingSpeakerConfig = null;
     this.whisperVadSettings = {
@@ -7498,6 +7500,14 @@ class IPCHandlers {
       this.databaseManager.saveNoteSpeakerEmbeddings(noteId, buffers);
       this._tryAutoLabelOneOnOne(noteId);
       return { success: true };
+    });
+
+    ipcMain.handle("self-hosted-keep-alive-start", (_event, url) => {
+      this._selfHostedKeepAlive.start(url);
+    });
+
+    ipcMain.handle("self-hosted-keep-alive-stop", () => {
+      this._selfHostedKeepAlive.stop();
     });
   }
 

--- a/src/helpers/selfHostedKeepAlive.js
+++ b/src/helpers/selfHostedKeepAlive.js
@@ -1,0 +1,151 @@
+const http = require("http");
+const https = require("https");
+const debugLogger = require("./debugLogger");
+
+const INTERVAL_MS = 120_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const SAMPLE_RATE = 16000;
+const SILENCE_DURATION_S = 0.1;
+const NUM_SAMPLES = Math.floor(SAMPLE_RATE * SILENCE_DURATION_S);
+
+function buildSilentWav() {
+  const dataSize = NUM_SAMPLES * 2;
+  const buf = Buffer.alloc(44 + dataSize);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(SAMPLE_RATE, 24);
+  buf.writeUInt32LE(SAMPLE_RATE * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(dataSize, 40);
+  return buf;
+}
+
+const SILENT_WAV = buildSilentWav();
+const BOUNDARY = "----OpenWhisprKeepAlive";
+
+class SelfHostedKeepAlive {
+  constructor() {
+    this._timer = null;
+    this._url = null;
+    this._model = null;
+  }
+
+  start(serverUrl) {
+    if (!serverUrl || !serverUrl.trim()) return;
+
+    const normalized = serverUrl.trim().replace(/\/+$/, "");
+    if (this._url === normalized && this._timer) return;
+
+    this.stop();
+    this._url = normalized;
+    this._model = null;
+    this._ping();
+    this._timer = setInterval(() => this._ping(), INTERVAL_MS);
+    debugLogger.debug("Self-hosted keep-alive started", { url: this._url, intervalMs: INTERVAL_MS });
+  }
+
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+      debugLogger.debug("Self-hosted keep-alive stopped", { url: this._url });
+    }
+    this._url = null;
+    this._model = null;
+  }
+
+  isRunning() {
+    return this._timer !== null;
+  }
+
+  _ping() {
+    if (!this._url) return;
+
+    if (!this._model) {
+      this._fetchModelThenTranscribe();
+    } else {
+      this._sendTranscription();
+    }
+  }
+
+  _fetchModelThenTranscribe() {
+    let target;
+    try {
+      target = new URL(this._url + "/models");
+    } catch {
+      return;
+    }
+
+    const client = target.protocol === "https:" ? https : http;
+    const req = client.get(target, { timeout: REQUEST_TIMEOUT_MS }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => {
+        try {
+          const data = JSON.parse(body);
+          const firstModel = data?.data?.[0]?.id;
+          if (firstModel) {
+            this._model = firstModel;
+            debugLogger.debug("Self-hosted keep-alive resolved model", { model: this._model });
+            this._sendTranscription();
+          }
+        } catch {
+          // malformed response, skip
+        }
+      });
+    });
+    req.on("error", () => {});
+    req.on("timeout", () => req.destroy());
+  }
+
+  _sendTranscription() {
+    if (!this._url || !this._model) return;
+
+    let target;
+    try {
+      target = new URL(this._url + "/audio/transcriptions");
+    } catch {
+      return;
+    }
+
+    const parts = [
+      `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="keepalive.wav"\r\n` +
+        `Content-Type: audio/wav\r\n\r\n`,
+      SILENT_WAV,
+      `\r\n--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="model"\r\n\r\n` +
+        `${this._model}\r\n` +
+        `--${BOUNDARY}--\r\n`,
+    ];
+
+    const bodyParts = parts.map((p) => (typeof p === "string" ? Buffer.from(p) : p));
+    const body = Buffer.concat(bodyParts);
+
+    const client = target.protocol === "https:" ? https : http;
+    const req = client.request(
+      target,
+      {
+        method: "POST",
+        timeout: REQUEST_TIMEOUT_MS,
+        headers: {
+          "Content-Type": `multipart/form-data; boundary=${BOUNDARY}`,
+          "Content-Length": body.length,
+        },
+      },
+      (res) => { res.resume(); }
+    );
+    req.on("error", () => {});
+    req.on("timeout", () => req.destroy());
+    req.end(body);
+  }
+}
+
+module.exports = SelfHostedKeepAlive;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1951,4 +1951,26 @@ export async function initializeSettings(): Promise<void> {
       useSettingsStore.setState({ [data.key]: data.value });
     }
   });
+
+  const syncKeepAlive = () => {
+    const { transcriptionMode, remoteTranscriptionUrl } = useSettingsStore.getState();
+    const url = (remoteTranscriptionUrl || "").trim();
+    if (transcriptionMode === "self-hosted" && url.length > 0) {
+      window.electronAPI?.selfHostedKeepAliveStart?.(url);
+    } else {
+      window.electronAPI?.selfHostedKeepAliveStop?.();
+    }
+  };
+
+  syncKeepAlive();
+  useSettingsStore.subscribe(
+    (state, prev) => {
+      if (
+        state.transcriptionMode !== prev.transcriptionMode ||
+        state.remoteTranscriptionUrl !== prev.remoteTranscriptionUrl
+      ) {
+        syncKeepAlive();
+      }
+    }
+  );
 }

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1824,6 +1824,8 @@ declare global {
       markTranscriptionSynced?: (id: number, cloudId: string) => Promise<void>;
       getPendingTranscriptionDeletes?: () => Promise<TranscriptionItem[]>;
       hardDeleteTranscription?: (id: number) => Promise<{ success: boolean; id: number }>;
+      selfHostedKeepAliveStart?: (url: string) => Promise<void>;
+      selfHostedKeepAliveStop?: () => Promise<void>;
     };
 
     api?: {

--- a/test/helpers/selfHostedKeepAlive.test.js
+++ b/test/helpers/selfHostedKeepAlive.test.js
@@ -1,0 +1,133 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+function createKeepAlive() {
+  const SelfHostedKeepAlive = require("../../src/helpers/selfHostedKeepAlive");
+  return new SelfHostedKeepAlive();
+}
+
+test("isRunning returns false before start", () => {
+  const ka = createKeepAlive();
+  assert.equal(ka.isRunning(), false);
+});
+
+test("isRunning returns true after start with valid URL", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1");
+  assert.equal(ka.isRunning(), true);
+  ka.stop();
+});
+
+test("stop clears the timer", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1");
+  ka.stop();
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start with empty URL does not activate", () => {
+  const ka = createKeepAlive();
+  ka.start("");
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start with whitespace-only URL does not activate", () => {
+  const ka = createKeepAlive();
+  ka.start("   ");
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start with same URL does not restart timer", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1");
+  const firstTimer = ka._timer;
+  ka.start("http://localhost:8000/v1");
+  assert.equal(ka._timer, firstTimer);
+  ka.stop();
+});
+
+test("start with different URL restarts timer", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1");
+  const firstTimer = ka._timer;
+  ka.start("http://localhost:9000/v1");
+  assert.notEqual(ka._timer, firstTimer);
+  ka.stop();
+});
+
+test("stop is safe to call multiple times", () => {
+  const ka = createKeepAlive();
+  ka.stop();
+  ka.stop();
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start with null URL does not activate", () => {
+  const ka = createKeepAlive();
+  ka.start(null);
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start with undefined URL does not activate", () => {
+  const ka = createKeepAlive();
+  ka.start(undefined);
+  assert.equal(ka.isRunning(), false);
+});
+
+test("start normalizes trailing slashes before comparing URLs", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1/");
+  const firstTimer = ka._timer;
+  ka.start("http://localhost:8000/v1");
+  assert.equal(ka._timer, firstTimer);
+  ka.stop();
+});
+
+test("start trims whitespace from URL", () => {
+  const ka = createKeepAlive();
+  ka.start("  http://localhost:8000/v1  ");
+  assert.equal(ka.isRunning(), true);
+  assert.equal(ka._url, "http://localhost:8000/v1");
+  ka.stop();
+});
+
+test("first ping fetches /models to resolve model name", () => {
+  const ka = createKeepAlive();
+  ka._url = "http://localhost:8000/v1";
+  assert.equal(ka._model, null);
+  const http = require("http");
+  const originalGet = http.get;
+  let requestedUrl = null;
+  http.get = (url) => {
+    requestedUrl = url.href || url.toString();
+    return { on: () => {} };
+  };
+  ka._ping();
+  http.get = originalGet;
+  assert.equal(requestedUrl, "http://localhost:8000/v1/models");
+});
+
+test("subsequent ping sends transcription when model is cached", () => {
+  const ka = createKeepAlive();
+  ka._url = "http://localhost:8000/v1";
+  ka._model = "test-model";
+  const http = require("http");
+  const originalRequest = http.request;
+  let requestedUrl = null;
+  http.request = (url) => {
+    requestedUrl = url.href || url.toString();
+    return { on: () => {}, end: () => {} };
+  };
+  ka._ping();
+  http.request = originalRequest;
+  assert.equal(requestedUrl, "http://localhost:8000/v1/audio/transcriptions");
+});
+
+test("stop after start clears internal URL and model references", () => {
+  const ka = createKeepAlive();
+  ka.start("http://localhost:8000/v1");
+  ka._model = "cached-model";
+  ka.stop();
+  assert.equal(ka._url, null);
+  assert.equal(ka._model, null);
+});


### PR DESCRIPTION
## Summary

Self-hosted transcription servers (faster-whisper, etc.) offload models from VRAM after idle periods, causing multi-second delays when transcription resumes. This adds an automatic keep-alive that sends a minimal silent audio transcription every 120 seconds, resetting the server's idle timer so the model stays loaded.

The keep-alive activates automatically when self-hosted mode is configured with a URL and stops when the user switches to a different mode. No settings or UI changes needed.

Fixes #766

## Changes

- src/helpers/selfHostedKeepAlive.js: new module that pings the server with a 0.1s silent WAV transcription every 120s, resolving the model name from /v1/models on first ping
- src/helpers/ipcHandlers.js: two IPC handlers to start/stop the keep-alive from the renderer
- preload.js: bridge methods for the new IPC handlers
- src/stores/settingsStore.ts: Zustand subscription that auto-starts/stops keep-alive when transcriptionMode or remoteTranscriptionUrl changes
- src/types/electron.ts: type definitions for the new preload APIs
- test/helpers/selfHostedKeepAlive.test.js: 15 tests covering lifecycle, URL validation, model resolution, and transcription ping routing