### PR TITLE
fix: discard dictionary prompt echo on silent audio

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -14,6 +14,7 @@ import { getSettings, getEffectiveCleanupModel, isCloudCleanupMode } from "../st
 import { detectAgentName } from "../config/agentDetection";
 import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
+import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
 const REALTIME_MODELS = new Set(["gpt-4o-mini-transcribe", "gpt-4o-transcribe"]);
@@ -207,6 +208,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   getCustomDictionaryPrompt() {
     const words = getSettings().customDictionary;
     return words.length > 0 ? words.join(", ") : null;
+  }
+
+  isDictionaryEcho(text) {
+    return matchesDictionaryPrompt(text, this.getCustomDictionaryPrompt());
   }
 
   setCallbacks({
@@ -712,6 +717,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       );
 
       if (result.success && result.text) {
+        if (this.isDictionaryEcho(result.text)) {
+          throw new Error("No audio detected");
+        }
         const rawText = result.text;
         const reasoningStart = performance.now();
         const text = await this.processTranscription(result.text, "local");
@@ -1316,6 +1324,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     timings.transcriptionProcessingDurationMs = Math.round(performance.now() - transcriptionStart);
 
     const rawText = result.text;
+    if (this.isDictionaryEcho(rawText)) {
+      throw new Error("No audio detected");
+    }
     let processedText = result.text;
     if (processedText && !this.skipReasoning) {
       const reasoningStart = performance.now();
@@ -1519,6 +1530,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         const proxyText = result?.text;
 
         if (proxyText && proxyText.trim().length > 0) {
+          if (this.isDictionaryEcho(proxyText)) {
+            throw new Error("No audio detected");
+          }
           timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
           const rawText = proxyText;
           const reasoningStart = performance.now();
@@ -1659,6 +1673,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       // Check for text - handle both empty string and missing field
       if (result.text && result.text.trim().length > 0) {
+        if (this.isDictionaryEcho(result.text)) {
+          throw new Error("No audio detected");
+        }
         timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
         const rawText = result.text;
 

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1749,6 +1749,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         );
       }
     } catch (error) {
+      if (error.message === "No audio detected") {
+        throw error;
+      }
+
       const isOpenAIMode = !getSettings().useLocalWhisper;
 
       if (allowLocalFallback && isOpenAIMode) {

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -16,8 +16,6 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   const dictWords = new Set(normalizedPrompt.split(" "));
   const uniqueTextWords = new Set(normalizedText.split(" "));
 
-  if (uniqueTextWords.size === 0 || dictWords.size === 0) return false;
-
   let matchCount = 0;
   for (const word of uniqueTextWords) {
     if (dictWords.has(word)) matchCount++;

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -1,0 +1,30 @@
+const normalize = (s) =>
+  s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+export function matchesDictionaryPrompt(text, dictionaryPrompt) {
+  if (!text || !dictionaryPrompt) return false;
+
+  const normalizedText = normalize(text);
+  const normalizedPrompt = normalize(dictionaryPrompt);
+
+  if (normalizedText === normalizedPrompt) return true;
+
+  const dictWords = new Set(normalizedPrompt.split(" "));
+  const uniqueTextWords = new Set(normalizedText.split(" "));
+
+  if (uniqueTextWords.size === 0 || dictWords.size === 0) return false;
+
+  let matchCount = 0;
+  for (const word of uniqueTextWords) {
+    if (dictWords.has(word)) matchCount++;
+  }
+
+  const textComposition = matchCount / uniqueTextWords.size;
+  const dictionaryUsage = matchCount / dictWords.size;
+
+  return textComposition >= 0.9 && dictionaryUsage >= 0.7;
+}

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -1,0 +1,159 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("detects verbatim echo of dictionary prompt", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("OpenWhispr, Parakeet, Alcahest", "OpenWhispr, Parakeet, Alcahest"),
+    true
+  );
+});
+
+test("detects echo when Whisper adds trailing period", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("OpenWhispr, Parakeet, Alcahest.", "OpenWhispr, Parakeet, Alcahest"),
+    true
+  );
+});
+
+test("detects echo with different capitalization", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("openwhispr, parakeet, alcahest", "OpenWhispr, Parakeet, Alcahest"),
+    true
+  );
+});
+
+test("detects echo when Whisper strips commas", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("OpenWhispr Parakeet Alcahest", "OpenWhispr, Parakeet, Alcahest"),
+    true
+  );
+});
+
+test("detects echo with extra whitespace", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("OpenWhispr,  Parakeet,  Alcahest", "OpenWhispr, Parakeet, Alcahest"),
+    true
+  );
+});
+
+test("does not flag legitimate speech containing dictionary words", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt(
+      "I just installed OpenWhispr and it works great",
+      "OpenWhispr, Parakeet, Alcahest"
+    ),
+    false
+  );
+});
+
+test("does not flag speech that partially overlaps with dictionary", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("OpenWhispr, Parakeet", "OpenWhispr, Parakeet, Alcahest"),
+    false
+  );
+});
+
+test("returns false when dictionary prompt is null", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(matchesDictionaryPrompt("some text", null), false);
+});
+
+test("returns false when text is null", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(matchesDictionaryPrompt(null, "OpenWhispr"), false);
+});
+
+test("returns false when both inputs are empty strings", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(matchesDictionaryPrompt("", ""), false);
+});
+
+test("handles single-word dictionary", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(matchesDictionaryPrompt("OpenWhispr", "OpenWhispr"), true);
+  assert.equal(matchesDictionaryPrompt("OpenWhispr is great", "OpenWhispr"), false);
+});
+
+test("handles unicode dictionary words with accents", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("Müller, François, José", "Müller, François, José"),
+    true
+  );
+  assert.equal(
+    matchesDictionaryPrompt("muller francois jose", "Müller, François, José"),
+    false
+  );
+});
+
+test("handles CJK dictionary words", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt("東京, 大阪", "東京, 大阪"),
+    true
+  );
+});
+
+test("detects repeated echo where Whisper loops the dictionary", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  const dict = "OpenWhispr, Parakeet, Alcahest";
+  const repeated = "OpenWhispr, Parakeet, Alcahest, OpenWhispr, Parakeet, Alcahest";
+  assert.equal(matchesDictionaryPrompt(repeated, dict), true);
+});
+
+test("detects echo with minor Whisper additions among dictionary words", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  const dict = "Alpha, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet";
+  const echoWithFiller = "Alpha Bravo Charlie Delta Echo Foxtrot Golf Hotel India Juliet the";
+  assert.equal(matchesDictionaryPrompt(echoWithFiller, dict), true);
+});
+
+test("does not flag completely unrelated text", async () => {
+  const { matchesDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  assert.equal(
+    matchesDictionaryPrompt(
+      "The quick brown fox jumps over the lazy dog",
+      "OpenWhispr, Parakeet, Alcahest"
+    ),
+    false
+  );
+});


### PR DESCRIPTION
## Summary

When Whisper receives silent audio with a custom dictionary prompt, it echoes the prompt content as if it were a real transcription. This is a well-documented Whisper behavior that causes all dictionary entries to be pasted when the user presses and releases the dictation hotkey without speaking.

The fix compares the transcription result against the dictionary prompt before processing. If the text is composed almost entirely of dictionary words (using word-set matching with dual thresholds), it gets treated as "no audio detected" instead of a valid transcription. This catches both verbatim echoes and the repeated-loop variant where Whisper cycles through the dictionary multiple times.

Fixes #842

## Changes

- `src/utils/dictionaryEchoFilter.js` adds `matchesDictionaryPrompt()`, a pure function that normalizes both strings and checks whether the transcription's unique words are a subset of the dictionary (90% text composition + 70% dictionary usage thresholds)
- `src/helpers/audioManager.js` imports the filter and calls `isDictionaryEcho()` in all four transcription paths: local Whisper, cloud OW, Mistral proxy, and BYOK/Groq direct
- `test/helpers/dictionaryEchoFilter.test.js` covers 16 cases: verbatim echo, repeated echo, added punctuation, case changes, stripped commas, legitimate speech, partial overlap, null/empty inputs, single-word dictionary, unicode, and CJK