### PR TITLE
fix: skip evdev listener in tap mode when KDE shortcuts are active

### DIFF
--- a/main.js
+++ b/main.js
@@ -1363,6 +1363,7 @@ async function startApp() {
     const needsNativeListener = (hotkey, mode) => {
       if (!isValidHotkey(hotkey)) return false;
       if (mode === "push") return true;
+      if (hotkeyManager.useKDE) return false;
       return isRightSideMod(hotkey) || isModifierOnlyHotkey(hotkey);
     };
 

--- a/test/helpers/needsNativeListener.test.js
+++ b/test/helpers/needsNativeListener.test.js
@@ -1,0 +1,70 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isGlobeLikeHotkey,
+  isModifierOnlyHotkey,
+} = require("../../src/helpers/hotkeyManager");
+
+const isRightSideMod = (hotkey) =>
+  /^Right(Control|Ctrl|Alt|Option|Shift|Super|Win|Meta|Command|Cmd)$/i.test(hotkey);
+
+const isValidHotkey = (hotkey) => hotkey && !isGlobeLikeHotkey(hotkey);
+
+function makeNeedsNativeListener(hotkeyManager) {
+  return (hotkey, mode) => {
+    if (!isValidHotkey(hotkey)) return false;
+    if (mode === "push") return true;
+    if (hotkeyManager.useKDE) return false;
+    return isRightSideMod(hotkey) || isModifierOnlyHotkey(hotkey);
+  };
+}
+
+test("KDE active + tap + modifier-only → false (no evdev)", () => {
+  const fn = makeNeedsNativeListener({ useKDE: true });
+  assert.equal(fn("Control+Super", "tap"), false);
+});
+
+test("KDE active + push + modifier-only → true (evdev needed for key-up)", () => {
+  const fn = makeNeedsNativeListener({ useKDE: true });
+  assert.equal(fn("Control+Super", "push"), true);
+});
+
+test("KDE active + tap + normal hotkey → false (KGlobalAccel handles it)", () => {
+  const fn = makeNeedsNativeListener({ useKDE: true });
+  assert.equal(fn("Alt+R", "tap"), false);
+});
+
+test("KDE active + tap + right-side modifier → false", () => {
+  const fn = makeNeedsNativeListener({ useKDE: true });
+  assert.equal(fn("RightAlt", "tap"), false);
+});
+
+test("no KDE + tap + modifier-only → true (evdev needed)", () => {
+  const fn = makeNeedsNativeListener({ useKDE: false });
+  assert.equal(fn("Control+Super", "tap"), true);
+});
+
+test("no KDE + tap + right-side modifier → true", () => {
+  const fn = makeNeedsNativeListener({ useKDE: false });
+  assert.equal(fn("RightShift", "tap"), true);
+});
+
+test("no KDE + tap + normal hotkey → false (no evdev needed)", () => {
+  const fn = makeNeedsNativeListener({ useKDE: false });
+  assert.equal(fn("Alt+R", "tap"), false);
+});
+
+test("no KDE + push + any hotkey → true", () => {
+  const fn = makeNeedsNativeListener({ useKDE: false });
+  assert.equal(fn("Alt+R", "push"), true);
+  assert.equal(fn("F8", "push"), true);
+  assert.equal(fn("Control+Super", "push"), true);
+});
+
+test("invalid hotkey → false regardless of KDE or mode", () => {
+  const fn = makeNeedsNativeListener({ useKDE: true });
+  assert.equal(fn(null, "tap"), false);
+  assert.equal(fn("", "push"), false);
+  assert.equal(fn(undefined, "tap"), false);
+});


### PR DESCRIPTION
## Summary

On KDE Plasma 6 (Wayland), modifier-only hotkeys like `Control+Super` in tap mode cause a double-trigger: LinuxKeyManager (evdev) fires on KEY_DOWN and KGlobalAccel fires on KEY_UP, toggling recording on and off within ~125ms. The recording blob is too small to transcribe.

The fix adds a single guard in `needsNativeListener()` that skips the evdev listener when KDE shortcuts are active in tap mode. KGlobalAccel becomes the sole toggle source, eliminating the conflict. Push mode is unaffected since evdev is still needed for KEY_DOWN/KEY_UP detection.

Fixes #847

## Changes

- `main.js` -- added `if (hotkeyManager.useKDE) return false;` in the Linux `needsNativeListener` function, preventing evdev from starting in tap mode when KGlobalAccel already handles the shortcut
- `test/helpers/needsNativeListener.test.js` -- 9 unit tests covering all combinations of KDE active/inactive, tap/push mode, modifier-only/normal/right-side-mod hotkeys, and invalid inputs