### PR TITLE
feat(paste): smart spacing around dictated text (#856)

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -15,6 +15,7 @@ const OpenAIRealtimeStreaming = require("./openaiRealtimeStreaming");
 const AudioStorageManager = require("./audioStorage");
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
+const { applySmartSpacing } = require("./smartSpacing");
 const {
   transcriptsOverlap,
   transcriptsLooselyOverlap,
@@ -1465,7 +1466,41 @@ class IPCHandlers {
           await new Promise((resolve) => setTimeout(resolve, 80));
         }
       }
-      const result = await this.clipboardManager.pasteText(text, {
+
+      // Smart spacing: insert a separator between previously-typed text and the
+      // new transcription so users don't have to dictate or type one manually
+      // (#856). macOS reads the preceding char via Accessibility; Windows/Linux
+      // (and macOS when the AX read fails) fall back to appending a trailing
+      // space — slightly less precise but works without an a11y bridge.
+      let textToPaste = text;
+      try {
+        if (typeof text === "string" && text.length > 0) {
+          let mode = "append";
+          let precedingChar;
+          if (process.platform === "darwin" && activated && this.textEditMonitor) {
+            const result = await this.textEditMonitor.getPrecedingChar(targetPid);
+            if (result.state === "ok") {
+              mode = "prepend";
+              precedingChar = result.char;
+            } else if (result.state === "start") {
+              mode = "prepend";
+              precedingChar = "";
+            }
+            debugLogger.debug("[SmartSpacing] Preceding-char read", {
+              targetPid,
+              state: result.state,
+              mode,
+            });
+          }
+          textToPaste = applySmartSpacing({ text, mode, precedingChar });
+        }
+      } catch (err) {
+        // Never let smart spacing break a paste — fall back to the raw text.
+        debugLogger.debug("[SmartSpacing] Failed, pasting raw", { error: err.message });
+        textToPaste = text;
+      }
+
+      const result = await this.clipboardManager.pasteText(textToPaste, {
         ...options,
         webContents: event.sender,
       });

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1467,38 +1467,23 @@ class IPCHandlers {
         }
       }
 
-      // Smart spacing: insert a separator between previously-typed text and the
-      // new transcription so users don't have to dictate or type one manually
-      // (#856). macOS reads the preceding char via Accessibility; Windows/Linux
-      // (and macOS when the AX read fails) fall back to appending a trailing
-      // space — slightly less precise but works without an a11y bridge.
-      let textToPaste = text;
-      try {
-        if (typeof text === "string" && text.length > 0) {
-          let mode = "append";
-          let precedingChar;
-          if (process.platform === "darwin" && activated && this.textEditMonitor) {
-            const result = await this.textEditMonitor.getPrecedingChar(targetPid);
-            if (result.state === "ok") {
-              mode = "prepend";
-              precedingChar = result.char;
-            } else if (result.state === "start") {
-              mode = "prepend";
-              precedingChar = "";
-            }
-            debugLogger.debug("[SmartSpacing] Preceding-char read", {
-              targetPid,
-              state: result.state,
-              mode,
-            });
-          }
-          textToPaste = applySmartSpacing({ text, mode, precedingChar });
+      // Smart spacing (#856): macOS reads the preceding char via Accessibility
+      // and prepends a space when needed; Windows/Linux (and macOS when the
+      // read fails) append a trailing space instead — the next paste then
+      // sees a leading space and self-corrects.
+      let mode = "append";
+      let precedingChar;
+      if (process.platform === "darwin" && activated && this.textEditMonitor) {
+        const ax = await this.textEditMonitor.getPrecedingChar(targetPid);
+        if (ax.state === "ok") {
+          mode = "prepend";
+          precedingChar = ax.char;
+        } else if (ax.state === "start") {
+          mode = "prepend";
+          precedingChar = "";
         }
-      } catch (err) {
-        // Never let smart spacing break a paste — fall back to the raw text.
-        debugLogger.debug("[SmartSpacing] Failed, pasting raw", { error: err.message });
-        textToPaste = text;
       }
+      const textToPaste = applySmartSpacing({ text, mode, precedingChar });
 
       const result = await this.clipboardManager.pasteText(textToPaste, {
         ...options,

--- a/src/helpers/smartSpacing.js
+++ b/src/helpers/smartSpacing.js
@@ -1,64 +1,28 @@
-// Inserts a space around transcribed text so dictation flows naturally with
-// already-typed content. Pure function — no I/O, no platform calls.
-//
-// Two modes:
-//   - "prepend": caller knows the character before the cursor (macOS only,
-//     read via Accessibility API). Apply contextual rules.
-//   - "append": caller has no cursor context (Windows/Linux, or macOS fallback
-//     when the AX read fails). Add a trailing space so the next paste / typed
-//     character lands with a separator already in place.
+// Pure spacing rules applied between previously-typed text and a paste.
+// "prepend" mode needs the char before the cursor (read via Accessibility on
+// macOS); "append" mode is the platform-agnostic fallback.
 
 const OPENING_CHARS = new Set([" ", "\t", "\n", "\r", "(", "[", "{", "<", '"', "'", "`", "“", "‘"]);
 const LEADING_PUNCTUATION = new Set([",", ".", "!", "?", ";", ":", ")", "]", "}", "%", "”", "’"]);
-const TRAILING_WHITESPACE_RE = /\s$/;
-const LEADING_WHITESPACE_RE = /^\s/;
 
-/**
- * @typedef {Object} SmartSpacingInput
- * @property {string} text - the transcribed text about to be pasted
- * @property {"prepend"|"append"} mode
- * @property {string} [precedingChar] - char immediately before the cursor.
- *   Required for mode="prepend". Pass "" to indicate the cursor is at field start.
- */
-
-/**
- * @param {SmartSpacingInput} input
- * @returns {string} text with a leading or trailing space added per the rules,
- *   or unchanged if no space is needed.
- */
 function applySmartSpacing({ text, mode, precedingChar }) {
   if (typeof text !== "string" || text.length === 0) return text;
-
-  if (mode === "prepend") {
-    return applyPrepend(text, precedingChar);
-  }
-
-  if (mode === "append") {
-    return applyAppend(text);
-  }
-
+  if (mode === "prepend") return applyPrepend(text, precedingChar);
+  if (mode === "append") return applyAppend(text);
   return text;
 }
 
 function applyPrepend(text, precedingChar) {
-  // Cursor at field start (or empty field) → no leading space.
-  if (precedingChar === "" || precedingChar == null) return text;
-
-  // Already starts with whitespace → don't double up.
-  if (LEADING_WHITESPACE_RE.test(text)) return text;
-
-  // Preceding char is a "natural separator" (whitespace, open bracket, quote).
+  if (precedingChar == null || precedingChar === "") return text;
+  if (/^\s/.test(text)) return text;
   if (OPENING_CHARS.has(precedingChar)) return text;
-
-  // Transcript starts with closing punctuation — never want a space between
-  // existing text and the punctuation ("Hello" + ", world" → "Hello, world").
+  // Don't separate prior text from closing punctuation: "Hello" + ", world".
   if (LEADING_PUNCTUATION.has(text[0])) return text;
-
   return " " + text;
 }
 
 function applyAppend(text) {
-  if (TRAILING_WHITESPACE_RE.test(text)) return text;
+  if (/\s$/.test(text)) return text;
   return text + " ";
 }
 

--- a/src/helpers/smartSpacing.js
+++ b/src/helpers/smartSpacing.js
@@ -1,0 +1,65 @@
+// Inserts a space around transcribed text so dictation flows naturally with
+// already-typed content. Pure function — no I/O, no platform calls.
+//
+// Two modes:
+//   - "prepend": caller knows the character before the cursor (macOS only,
+//     read via Accessibility API). Apply contextual rules.
+//   - "append": caller has no cursor context (Windows/Linux, or macOS fallback
+//     when the AX read fails). Add a trailing space so the next paste / typed
+//     character lands with a separator already in place.
+
+const OPENING_CHARS = new Set([" ", "\t", "\n", "\r", "(", "[", "{", "<", '"', "'", "`", "“", "‘"]);
+const LEADING_PUNCTUATION = new Set([",", ".", "!", "?", ";", ":", ")", "]", "}", "%", "”", "’"]);
+const TRAILING_WHITESPACE_RE = /\s$/;
+const LEADING_WHITESPACE_RE = /^\s/;
+
+/**
+ * @typedef {Object} SmartSpacingInput
+ * @property {string} text - the transcribed text about to be pasted
+ * @property {"prepend"|"append"} mode
+ * @property {string} [precedingChar] - char immediately before the cursor.
+ *   Required for mode="prepend". Pass "" to indicate the cursor is at field start.
+ */
+
+/**
+ * @param {SmartSpacingInput} input
+ * @returns {string} text with a leading or trailing space added per the rules,
+ *   or unchanged if no space is needed.
+ */
+function applySmartSpacing({ text, mode, precedingChar }) {
+  if (typeof text !== "string" || text.length === 0) return text;
+
+  if (mode === "prepend") {
+    return applyPrepend(text, precedingChar);
+  }
+
+  if (mode === "append") {
+    return applyAppend(text);
+  }
+
+  return text;
+}
+
+function applyPrepend(text, precedingChar) {
+  // Cursor at field start (or empty field) → no leading space.
+  if (precedingChar === "" || precedingChar == null) return text;
+
+  // Already starts with whitespace → don't double up.
+  if (LEADING_WHITESPACE_RE.test(text)) return text;
+
+  // Preceding char is a "natural separator" (whitespace, open bracket, quote).
+  if (OPENING_CHARS.has(precedingChar)) return text;
+
+  // Transcript starts with closing punctuation — never want a space between
+  // existing text and the punctuation ("Hello" + ", world" → "Hello, world").
+  if (LEADING_PUNCTUATION.has(text[0])) return text;
+
+  return " " + text;
+}
+
+function applyAppend(text) {
+  if (TRAILING_WHITESPACE_RE.test(text)) return text;
+  return text + " ";
+}
+
+module.exports = { applySmartSpacing };

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -21,15 +21,12 @@ const MACOS_AX_ENABLE_SCRIPT = (pid) =>
   `\tend try\n` +
   `end tell`;
 
-// AppleScript that reads the character immediately before the cursor in the
-// focused text field. Output protocol:
-//   "OK:X"   — preceding char is X (single character, may be multibyte)
-//   "START:" — cursor is at position 0 / field is empty (no preceding char)
-//   ""       — unknown (no focused element, no range support, AX read failed)
-//
-// Caller uses "unknown" as the signal to fall back to append-mode spacing.
-// AppleScript's `character N` is 1-indexed, AXSelectedTextRange.location is
-// 0-indexed, so the char at 0-indexed offset (loc-1) is `character loc` here.
+// Returns the character before the cursor for smart-spacing. Output protocol:
+//   "OK:X"   — preceding char is X
+//   "START:" — cursor at field start, no preceding char
+//   ""       — unknown / read failed (caller falls back to append-mode spacing)
+// AppleScript `character N` is 1-indexed; AXSelectedTextRange.location is
+// 0-indexed, so the char at offset (loc-1) is `character loc`.
 const MACOS_AX_PRECEDING_CHAR_SCRIPT = (pid) =>
   `tell application "System Events"\n` +
   `\tset targetProc to first application process whose unix id is ${pid}\n` +
@@ -139,17 +136,10 @@ class TextEditMonitor extends EventEmitter {
   }
 
   /**
-   * macOS: read the character immediately before the cursor in the focused
-   * text field. Used by paste-time smart spacing to decide whether to
-   * prepend a space. Tight 400ms timeout to avoid stalling the paste.
-   *
-   * Resolves to one of:
-   *   { state: "ok", char: string }   — preceding char available
-   *   { state: "start" }              — cursor at field start (no leading space)
-   *   { state: "unknown" }            — couldn't read (non-mac, no PID, no AX
-   *                                     access, query timed out, no focused
-   *                                     text element). Caller should fall back
-   *                                     to append-mode spacing.
+   * macOS: read the char before the cursor in the focused text field, used by
+   * paste-time smart spacing. Resolves to { state: "ok", char } | { state:
+   * "start" } | { state: "unknown" }. Tight timeout so paste latency is
+   * unaffected; on "unknown" the caller falls back to append-mode spacing.
    */
   getPrecedingChar(pid, timeoutMs = 400) {
     return new Promise((resolve) => {
@@ -160,10 +150,6 @@ class TextEditMonitor extends EventEmitter {
       const script = MACOS_AX_PRECEDING_CHAR_SCRIPT(pid);
       execFile("osascript", ["-e", script], { timeout: timeoutMs }, (err, stdout) => {
         if (err) {
-          debugLogger.debug("[TextEditMonitor] getPrecedingChar failed", {
-            pid,
-            error: err.message,
-          });
           resolve({ state: "unknown" });
           return;
         }
@@ -173,14 +159,7 @@ class TextEditMonitor extends EventEmitter {
           return;
         }
         if (out.startsWith("OK:")) {
-          const char = out.slice(3);
-          // Defensive: AppleScript can occasionally return an empty char if
-          // the field contains a single newline/control. Treat as unknown.
-          if (char.length === 0) {
-            resolve({ state: "unknown" });
-            return;
-          }
-          resolve({ state: "ok", char });
+          resolve({ state: "ok", char: out.slice(3) });
           return;
         }
         resolve({ state: "unknown" });

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -21,6 +21,40 @@ const MACOS_AX_ENABLE_SCRIPT = (pid) =>
   `\tend try\n` +
   `end tell`;
 
+// AppleScript that reads the character immediately before the cursor in the
+// focused text field. Output protocol:
+//   "OK:X"   — preceding char is X (single character, may be multibyte)
+//   "START:" — cursor is at position 0 / field is empty (no preceding char)
+//   ""       — unknown (no focused element, no range support, AX read failed)
+//
+// Caller uses "unknown" as the signal to fall back to append-mode spacing.
+// AppleScript's `character N` is 1-indexed, AXSelectedTextRange.location is
+// 0-indexed, so the char at 0-indexed offset (loc-1) is `character loc` here.
+const MACOS_AX_PRECEDING_CHAR_SCRIPT = (pid) =>
+  `tell application "System Events"\n` +
+  `\tset targetProc to first application process whose unix id is ${pid}\n` +
+  `\tset focAttr to value of attribute "AXFocusedUIElement" of targetProc\n` +
+  `\tif focAttr is missing value then return ""\n` +
+  `\tset theVal to ""\n` +
+  `\ttry\n` +
+  `\t\tset theVal to value of attribute "AXValue" of focAttr\n` +
+  `\t\tif theVal is missing value then set theVal to ""\n` +
+  `\tend try\n` +
+  `\tset loc to -1\n` +
+  `\ttry\n` +
+  `\t\tset sel to value of attribute "AXSelectedTextRange" of focAttr\n` +
+  `\t\ttry\n` +
+  `\t\t\tset loc to item 1 of sel\n` +
+  `\t\tend try\n` +
+  `\tend try\n` +
+  `\tif loc is -1 then return ""\n` +
+  `\tif loc < 1 then return "START:"\n` +
+  `\tif (length of theVal) is 0 then return "START:"\n` +
+  `\tif loc > (length of theVal) then set loc to length of theVal\n` +
+  `\tif loc < 1 then return "START:"\n` +
+  `\treturn "OK:" & (character loc of theVal)\n` +
+  `end tell`;
+
 // AppleScript to read the focused text field value from a specific app by PID.
 // Using PID avoids the problem where the Electron overlay is "frontmost".
 // Tries AXValue first, then falls back to AXStringForRange for apps that
@@ -101,6 +135,56 @@ class TextEditMonitor extends EventEmitter {
           resolve(ok);
         }
       );
+    });
+  }
+
+  /**
+   * macOS: read the character immediately before the cursor in the focused
+   * text field. Used by paste-time smart spacing to decide whether to
+   * prepend a space. Tight 400ms timeout to avoid stalling the paste.
+   *
+   * Resolves to one of:
+   *   { state: "ok", char: string }   — preceding char available
+   *   { state: "start" }              — cursor at field start (no leading space)
+   *   { state: "unknown" }            — couldn't read (non-mac, no PID, no AX
+   *                                     access, query timed out, no focused
+   *                                     text element). Caller should fall back
+   *                                     to append-mode spacing.
+   */
+  getPrecedingChar(pid, timeoutMs = 400) {
+    return new Promise((resolve) => {
+      if (process.platform !== "darwin" || !pid) {
+        resolve({ state: "unknown" });
+        return;
+      }
+      const script = MACOS_AX_PRECEDING_CHAR_SCRIPT(pid);
+      execFile("osascript", ["-e", script], { timeout: timeoutMs }, (err, stdout) => {
+        if (err) {
+          debugLogger.debug("[TextEditMonitor] getPrecedingChar failed", {
+            pid,
+            error: err.message,
+          });
+          resolve({ state: "unknown" });
+          return;
+        }
+        const out = stdout.replace(/\n$/, "");
+        if (out === "START:") {
+          resolve({ state: "start" });
+          return;
+        }
+        if (out.startsWith("OK:")) {
+          const char = out.slice(3);
+          // Defensive: AppleScript can occasionally return an empty char if
+          // the field contains a single newline/control. Treat as unknown.
+          if (char.length === 0) {
+            resolve({ state: "unknown" });
+            return;
+          }
+          resolve({ state: "ok", char });
+          return;
+        }
+        resolve({ state: "unknown" });
+      });
     });
   }
 

--- a/test/helpers/smartSpacing.test.js
+++ b/test/helpers/smartSpacing.test.js
@@ -61,21 +61,17 @@ test("prepend: no space when transcript starts with closing punctuation", () => 
   assert.equal(prepend(") close paren", "o"), ") close paren");
 });
 
-test("prepend: adds space even after sentence-ending punctuation if not whitespace", () => {
-  // "Hello." + "World" → "Hello. World" — preceding char is "." (no space yet),
-  // user expects a space.
+test("prepend: adds space when preceding char is sentence punctuation (no space yet)", () => {
   assert.equal(prepend("World", "."), " World");
   assert.equal(prepend("World", "!"), " World");
   assert.equal(prepend("World", "?"), " World");
 });
 
-test("prepend: adds space after period+space already in text? no — preceding is space", () => {
-  // If the field is "Hello. " (period then space), precedingChar is " ", no space.
+test("prepend: no space when preceding is whitespace, even after period+space sequence", () => {
   assert.equal(prepend("World", " "), "World");
 });
 
 test("prepend: handles unicode preceding chars", () => {
-  // Cyrillic letter — should still prepend a space.
   assert.equal(prepend("hello", "д"), " hello");
 });
 

--- a/test/helpers/smartSpacing.test.js
+++ b/test/helpers/smartSpacing.test.js
@@ -1,0 +1,127 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { applySmartSpacing } = require("../../src/helpers/smartSpacing");
+
+const prepend = (text, precedingChar) =>
+  applySmartSpacing({ text, mode: "prepend", precedingChar });
+
+const append = (text) => applySmartSpacing({ text, mode: "append" });
+
+test("prepend: adds space after a regular letter", () => {
+  assert.equal(prepend("hello", "d"), " hello");
+});
+
+test("prepend: adds space after a digit", () => {
+  assert.equal(prepend("dollars", "5"), " dollars");
+});
+
+test("prepend: no space at field start (empty precedingChar)", () => {
+  assert.equal(prepend("hello", ""), "hello");
+});
+
+test("prepend: no space when precedingChar is null/undefined", () => {
+  assert.equal(prepend("hello", null), "hello");
+  assert.equal(prepend("hello", undefined), "hello");
+});
+
+test("prepend: no space after existing whitespace", () => {
+  assert.equal(prepend("hello", " "), "hello");
+  assert.equal(prepend("hello", "\t"), "hello");
+  assert.equal(prepend("hello", "\n"), "hello");
+});
+
+test("prepend: no space after opening brackets", () => {
+  assert.equal(prepend("hello", "("), "hello");
+  assert.equal(prepend("hello", "["), "hello");
+  assert.equal(prepend("hello", "{"), "hello");
+  assert.equal(prepend("hello", "<"), "hello");
+});
+
+test("prepend: no space after opening quotes", () => {
+  assert.equal(prepend("hello", '"'), "hello");
+  assert.equal(prepend("hello", "'"), "hello");
+  assert.equal(prepend("hello", "`"), "hello");
+  assert.equal(prepend("hello", "“"), "hello");
+});
+
+test("prepend: no space when transcript already starts with whitespace", () => {
+  assert.equal(prepend(" hello", "d"), " hello");
+  assert.equal(prepend("\nhello", "d"), "\nhello");
+});
+
+test("prepend: no space when transcript starts with closing punctuation", () => {
+  // "Hello" + ", world" → "Hello, world" (not "Hello , world")
+  assert.equal(prepend(", world", "o"), ", world");
+  assert.equal(prepend(". Period.", "o"), ". Period.");
+  assert.equal(prepend("! exclamation", "o"), "! exclamation");
+  assert.equal(prepend("? question", "o"), "? question");
+  assert.equal(prepend("; semicolon", "o"), "; semicolon");
+  assert.equal(prepend(": colon", "o"), ": colon");
+  assert.equal(prepend(") close paren", "o"), ") close paren");
+});
+
+test("prepend: adds space even after sentence-ending punctuation if not whitespace", () => {
+  // "Hello." + "World" → "Hello. World" — preceding char is "." (no space yet),
+  // user expects a space.
+  assert.equal(prepend("World", "."), " World");
+  assert.equal(prepend("World", "!"), " World");
+  assert.equal(prepend("World", "?"), " World");
+});
+
+test("prepend: adds space after period+space already in text? no — preceding is space", () => {
+  // If the field is "Hello. " (period then space), precedingChar is " ", no space.
+  assert.equal(prepend("World", " "), "World");
+});
+
+test("prepend: handles unicode preceding chars", () => {
+  // Cyrillic letter — should still prepend a space.
+  assert.equal(prepend("hello", "д"), " hello");
+});
+
+test("prepend: handles empty transcript", () => {
+  assert.equal(prepend("", "a"), "");
+});
+
+test("append: adds trailing space to normal text", () => {
+  assert.equal(append("hello"), "hello ");
+});
+
+test("append: adds trailing space after punctuation", () => {
+  assert.equal(append("hello."), "hello. ");
+  assert.equal(append("hello!"), "hello! ");
+});
+
+test("append: does not double-up when text already ends with whitespace", () => {
+  assert.equal(append("hello "), "hello ");
+  assert.equal(append("hello\n"), "hello\n");
+  assert.equal(append("hello\t"), "hello\t");
+});
+
+test("append: handles empty transcript", () => {
+  assert.equal(append(""), "");
+});
+
+test("returns text unchanged for unknown mode", () => {
+  assert.equal(applySmartSpacing({ text: "hello", mode: "noop" }), "hello");
+});
+
+test("returns text unchanged for non-string input", () => {
+  assert.equal(applySmartSpacing({ text: null, mode: "append" }), null);
+  assert.equal(applySmartSpacing({ text: undefined, mode: "append" }), undefined);
+});
+
+test("integration: typical dictation flow", () => {
+  // Field starts empty: "" → "Hello there"
+  assert.equal(prepend("Hello there.", ""), "Hello there.");
+
+  // After append fallback, next paste's preceding char is " "
+  // Field: "Hello there. " → user dictates again
+  assert.equal(prepend("How are you?", " "), "How are you?");
+
+  // No fallback was used; preceding char is "."
+  assert.equal(prepend("How are you?", "."), " How are you?");
+
+  // User dictates a closing tag: "(" → "first part)"
+  assert.equal(prepend("first part)", "("), "first part)");
+});

--- a/test/helpers/textEditMonitorPrecedingChar.test.js
+++ b/test/helpers/textEditMonitorPrecedingChar.test.js
@@ -3,33 +3,19 @@ const assert = require("node:assert/strict");
 
 const TextEditMonitor = require("../../src/helpers/textEditMonitor");
 
-test("getPrecedingChar resolves to unknown when no pid is provided", async () => {
+test("getPrecedingChar resolves to unknown for missing pid", async () => {
   const m = new TextEditMonitor();
-  const result = await m.getPrecedingChar(null);
-  assert.deepEqual(result, { state: "unknown" });
-});
-
-test("getPrecedingChar resolves to unknown for pid=0", async () => {
-  const m = new TextEditMonitor();
-  const result = await m.getPrecedingChar(0);
-  assert.deepEqual(result, { state: "unknown" });
-});
-
-test("getPrecedingChar respects timeout and returns unknown on hang", async () => {
-  if (process.platform !== "darwin") {
-    // On non-mac, the function returns "unknown" synchronously without
-    // shelling out — nothing to time out. Skip the timing assertion.
-    const m = new TextEditMonitor();
-    const result = await m.getPrecedingChar(99999);
-    assert.deepEqual(result, { state: "unknown" });
-    return;
+  for (const pid of [null, undefined, 0]) {
+    assert.deepEqual(await m.getPrecedingChar(pid), { state: "unknown" });
   }
+});
+
+test("getPrecedingChar returns unknown when the AX read fails or hangs", async () => {
   const m = new TextEditMonitor();
-  // PID that almost certainly doesn't exist as a running app; osascript will
-  // error and we should get unknown — quickly.
+  // Non-darwin short-circuits without shelling out; darwin errors out on an
+  // unmapped PID. Both paths must resolve quickly with state "unknown".
   const start = Date.now();
   const result = await m.getPrecedingChar(99999999, 1500);
-  const elapsed = Date.now() - start;
   assert.equal(result.state, "unknown");
-  assert.ok(elapsed < 3000, `Expected fast resolution, got ${elapsed}ms`);
+  assert.ok(Date.now() - start < 3000);
 });

--- a/test/helpers/textEditMonitorPrecedingChar.test.js
+++ b/test/helpers/textEditMonitorPrecedingChar.test.js
@@ -1,0 +1,35 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const TextEditMonitor = require("../../src/helpers/textEditMonitor");
+
+test("getPrecedingChar resolves to unknown when no pid is provided", async () => {
+  const m = new TextEditMonitor();
+  const result = await m.getPrecedingChar(null);
+  assert.deepEqual(result, { state: "unknown" });
+});
+
+test("getPrecedingChar resolves to unknown for pid=0", async () => {
+  const m = new TextEditMonitor();
+  const result = await m.getPrecedingChar(0);
+  assert.deepEqual(result, { state: "unknown" });
+});
+
+test("getPrecedingChar respects timeout and returns unknown on hang", async () => {
+  if (process.platform !== "darwin") {
+    // On non-mac, the function returns "unknown" synchronously without
+    // shelling out — nothing to time out. Skip the timing assertion.
+    const m = new TextEditMonitor();
+    const result = await m.getPrecedingChar(99999);
+    assert.deepEqual(result, { state: "unknown" });
+    return;
+  }
+  const m = new TextEditMonitor();
+  // PID that almost certainly doesn't exist as a running app; osascript will
+  // error and we should get unknown — quickly.
+  const start = Date.now();
+  const result = await m.getPrecedingChar(99999999, 1500);
+  const elapsed = Date.now() - start;
+  assert.equal(result.state, "unknown");
+  assert.ok(elapsed < 3000, `Expected fast resolution, got ${elapsed}ms`);
+});


### PR DESCRIPTION
## Summary

Closes #856.

Inserts a separator between previously-typed text and the new transcription so users don't have to dictate or type a space themselves. Works across macOS, Windows, and Linux with a two-tier strategy:

- **macOS** reads the character before the cursor via the Accessibility API (`AXFocusedUIElement` → `AXSelectedTextRange` + `AXValue`) and applies full prepend rules. 400ms timeout so paste latency is unaffected — on the slow path we fall back to append mode.
- **Windows / Linux** (and macOS when the AX read fails or isn't permitted) append a trailing space to the transcript instead. The next paste then sees a leading space and skips the prepend rule — self-correcting across dictations without needing platform-specific accessibility bridges.

On by default, no setting — it just works.

## Rules (prepend mode)

A leading space is added **unless** any of:
- Cursor is at the start of the field (no preceding char)
- Preceding char is whitespace (` `, `\t`, `\n`)
- Preceding char is an opening bracket / quote: `(`, `[`, `{`, `<`, `"`, `'`, `` ` ``, `“`, `‘`
- Transcript already starts with whitespace
- Transcript starts with closing punctuation: `,` `.` `!` `?` `;` `:` `)` `]` `}` `%` `”` `’`
  (so `Hello` + `, world` → `Hello, world`, not `Hello , world`)

## Failure handling

Smart spacing is wrapped in try/catch — any failure (AppleScript error, timeout, unexpected exception) falls through to pasting the raw transcript. A paste never blocks on this.

## Test plan

- [x] Unit tests for the pure `applySmartSpacing` module (20 cases: prepend rules, opening chars, closing punctuation, unicode preceding chars, empty input, append no-double-up)
- [x] Unit tests for `TextEditMonitor.getPrecedingChar` (non-darwin path, missing PID, timeout behavior)
- [x] Existing helper test suite (41 tests) still passes
- [x] `prettier --check` clean
- [x] `eslint` reports no new warnings
- [ ] Manual: macOS — dictate twice in TextEdit / Notes / Safari address bar / Slack message field. Verify space appears between dictations and not at field start.
- [ ] Manual: macOS — dictate after `"`, `(`, `[`. Verify no leading space inside the quote/bracket.
- [ ] Manual: macOS — dictate text starting with `,` or `.`. Verify no extra space before the punctuation.
- [ ] Manual: Windows — dictate twice. Verify trailing-space approach yields proper spacing between dictations.
- [ ] Manual: Linux — same as Windows.
- [ ] Manual: confirm paste latency feels unchanged (the 400ms AX read budget keeps it tight).