### PR TITLE
Fix dictation hotkey double-trigger on KDE Wayland

### DIFF
--- a/main.js
+++ b/main.js
@@ -1351,29 +1351,13 @@ async function startApp() {
   if (process.platform === "linux") {
     debugLogger.debug("[Push-to-Talk] Linux Push-to-Talk setup starting");
 
-    const {
-      isGlobeLikeHotkey: isGlobeLike,
-      isModifierOnlyHotkey,
-    } = require("./src/helpers/hotkeyManager");
-    const isValidHotkey = (hotkey) => hotkey && !isGlobeLike(hotkey);
+    const { shouldUseNativeKeyListener } = require("./src/helpers/hotkeyManager");
 
-    const isRightSideMod = (hotkey) =>
-      /^Right(Control|Ctrl|Alt|Option|Shift|Super|Win|Meta|Command|Cmd)$/i.test(hotkey);
-
-    const needsNativeListener = (hotkey, mode) => {
-      if (!isValidHotkey(hotkey)) return false;
-      // Push-to-talk needs the native /dev/input listener for key-down/key-up;
-      // there the compositor's single toggle is a harmless no-op on release.
-      // Tap mode is what breaks: the native listener and the GNOME/KDE/Hyprland
-      // shortcut both react to one keypress with opposite effects (one toggles
-      // recording on, the other off), leaving an empty recording that backends
-      // reject ("Audio file might be corrupted or unsupported"). So in tap mode
-      // skip the native listener when a compositor shortcut owns the hotkey.
-      // See issue #864.
-      if (mode === "push") return true;
-      if (hotkeyManager.isUsingNativeShortcut()) return false;
-      return isRightSideMod(hotkey) || isModifierOnlyHotkey(hotkey);
-    };
+    // Whether to run the native /dev/input listener for the current hotkey/mode.
+    // The decision and the issue #864 reasoning live in shouldUseNativeKeyListener;
+    // here we just feed it the live compositor-shortcut state.
+    const needsNativeListener = (hotkey, mode) =>
+      shouldUseNativeKeyListener(hotkey, mode, hotkeyManager.isUsingNativeShortcut());
 
     linuxKeyManager.on("key-down", (_key) => {
       if (!isLiveWindow(windowManager.mainWindow)) return;

--- a/main.js
+++ b/main.js
@@ -1362,7 +1362,16 @@ async function startApp() {
 
     const needsNativeListener = (hotkey, mode) => {
       if (!isValidHotkey(hotkey)) return false;
+      // Push-to-talk needs the native /dev/input listener for key-down/key-up;
+      // there the compositor's single toggle is a harmless no-op on release.
+      // Tap mode is what breaks: the native listener and the GNOME/KDE/Hyprland
+      // shortcut both react to one keypress with opposite effects (one toggles
+      // recording on, the other off), leaving an empty recording that backends
+      // reject ("Audio file might be corrupted or unsupported"). So in tap mode
+      // skip the native listener when a compositor shortcut owns the hotkey.
+      // See issue #864.
       if (mode === "push") return true;
+      if (hotkeyManager.isUsingNativeShortcut()) return false;
       return isRightSideMod(hotkey) || isModifierOnlyHotkey(hotkey);
     };
 

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -553,6 +553,31 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       return;
     }
 
+    // A recording that started and stopped within a few milliseconds (an accidental
+    // double-tap, or a hotkey double-trigger) yields an empty WebM container with no
+    // audio frames. Transcription backends reject it with "Audio file might be
+    // corrupted or unsupported". Skip it like the silence gate instead of surfacing
+    // an error. See issue #864.
+    const MIN_RECORDING_SECONDS = 0.2;
+    const MIN_AUDIO_BYTES = 256;
+    const recordingSeconds =
+      typeof metadata?.durationSeconds === "number" ? metadata.durationSeconds : null;
+    const blobSize = audioBlob?.size ?? 0;
+    if (
+      (recordingSeconds !== null && recordingSeconds < MIN_RECORDING_SECONDS) ||
+      blobSize < MIN_AUDIO_BYTES
+    ) {
+      logger.info(
+        "Skipping transcription: recording too short or empty to contain speech",
+        { blobSize, durationSeconds: recordingSeconds },
+        "audio"
+      );
+      this.isProcessing = false;
+      this.onStateChange?.({ isRecording: false, isProcessing: false });
+      this.onTranscriptionComplete?.({ success: true, text: "" });
+      return;
+    }
+
     try {
       const useLocalWhisper = settings.useLocalWhisper;
       const localProvider = settings.localTranscriptionProvider;

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -15,6 +15,7 @@ import { shouldSkipTranscriptionApiKey } from "./transcriptionAuth";
 import { detectAgentName } from "../config/agentDetection";
 import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
+import { isEmptyRecording } from "./recordingGuard";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
 const REALTIME_MODELS = new Set(["gpt-4o-mini-transcribe", "gpt-4o-transcribe"]);
@@ -553,23 +554,17 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       return;
     }
 
-    // A recording that started and stopped within a few milliseconds (an accidental
-    // double-tap, or a hotkey double-trigger) yields an empty WebM container with no
-    // audio frames. Transcription backends reject it with "Audio file might be
-    // corrupted or unsupported". Skip it like the silence gate instead of surfacing
-    // an error. See issue #864.
-    const MIN_RECORDING_SECONDS = 0.2;
-    const MIN_AUDIO_BYTES = 256;
-    const recordingSeconds =
-      typeof metadata?.durationSeconds === "number" ? metadata.durationSeconds : null;
+    // A recording with no audio frames — an accidental double-tap or a hotkey
+    // double-trigger that toggles on and off within milliseconds — is just an empty
+    // WebM container that backends reject ("Audio file might be corrupted or
+    // unsupported"). Skip it like the silence gate instead of surfacing an error.
+    // Gated by size only: a genuinely short real utterance can be brief yet still
+    // carry audio, so a duration gate would drop it. See issue #864.
     const blobSize = audioBlob?.size ?? 0;
-    if (
-      (recordingSeconds !== null && recordingSeconds < MIN_RECORDING_SECONDS) ||
-      blobSize < MIN_AUDIO_BYTES
-    ) {
+    if (isEmptyRecording(blobSize)) {
       logger.info(
-        "Skipping transcription: recording too short or empty to contain speech",
-        { blobSize, durationSeconds: recordingSeconds },
+        "Skipping transcription: recording is empty (no audio captured)",
+        { blobSize },
         "audio"
       );
       this.isProcessing = false;

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -63,6 +63,20 @@ function isMouseButtonHotkey(hotkey) {
   return /^MouseButton[45]$/i.test(hotkey || "");
 }
 
+// Decide whether the native /dev/input key listener should run for a hotkey.
+// In tap mode, when a compositor shortcut (GNOME/KDE/Hyprland) already owns the
+// hotkey (isUsingNativeShortcut), the native listener must stay off: otherwise it
+// and the compositor both fire for one keypress and the recording toggles on then
+// instantly off, leaving an empty blob. Push-to-talk still needs the native
+// listener for key-down/key-up, where the compositor's single toggle is a no-op
+// on release. See issue #864.
+function shouldUseNativeKeyListener(hotkey, mode, isUsingNativeShortcut) {
+  if (!hotkey || isGlobeLikeHotkey(hotkey)) return false;
+  if (mode === "push") return true;
+  if (isUsingNativeShortcut) return false;
+  return isRightSideModifier(hotkey) || isModifierOnlyHotkey(hotkey);
+}
+
 function normalizeToAccelerator(hotkey) {
   let accelerator = hotkey.startsWith("Fn+") ? hotkey.slice(3) : hotkey;
   accelerator = accelerator
@@ -1206,3 +1220,4 @@ module.exports.isGlobeLikeHotkey = isGlobeLikeHotkey;
 module.exports.isModifierOnlyHotkey = isModifierOnlyHotkey;
 module.exports.isRightSideModifier = isRightSideModifier;
 module.exports.isMouseButtonHotkey = isMouseButtonHotkey;
+module.exports.shouldUseNativeKeyListener = shouldUseNativeKeyListener;

--- a/src/helpers/recordingGuard.js
+++ b/src/helpers/recordingGuard.js
@@ -1,0 +1,13 @@
+// A recorded WebM/Opus blob with no audio frames — produced when the dictation
+// hotkey toggles recording on and off within milliseconds (an accidental
+// double-tap, or the KDE double-trigger fixed in main.js) — is essentially just
+// the container header, well under 256 bytes. Real speech, even a single short
+// word, produces far more. We gate on size, not wall-clock duration: a genuinely
+// short utterance can last under any reasonable time threshold yet still carry
+// real audio, so a duration gate would silently drop it. See issue #864.
+export const MIN_AUDIO_BYTES = 256;
+
+export function isEmptyRecording(blobSize) {
+  const size = typeof blobSize === "number" && Number.isFinite(blobSize) ? blobSize : 0;
+  return size < MIN_AUDIO_BYTES;
+}

--- a/test/helpers/nativeKeyListenerDecision.test.js
+++ b/test/helpers/nativeKeyListenerDecision.test.js
@@ -1,0 +1,60 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/hotkeyManager.js");
+
+// usingNativeShortcut = true  -> a compositor (GNOME/KDE/Hyprland) owns the hotkey
+// usingNativeShortcut = false -> plain X11 / Windows / macOS (no compositor shortcut)
+
+test("issue #864: compositor + tap + modifier-only does NOT start the native listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("Control+Super", "tap", true), false);
+});
+
+test("compositor + tap + normal key does NOT start the native listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("F8", "tap", true), false);
+});
+
+test("compositor + tap + right-side modifier does NOT start the native listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("RightControl", "tap", true), false);
+});
+
+test("compositor + push KEEPS the native listener (push-to-talk preserved)", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("Control+Super", "push", true), true);
+  assert.equal(shouldUseNativeKeyListener("F8", "push", true), true);
+});
+
+test("no compositor + tap + modifier-only still starts the listener (X11 unchanged)", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("Control+Super", "tap", false), true);
+});
+
+test("no compositor + tap + right-side modifier still starts the listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("RightControl", "tap", false), true);
+});
+
+test("no compositor + tap + normal key does not start the listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("F8", "tap", false), false);
+});
+
+test("no compositor + push always starts the listener", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  assert.equal(shouldUseNativeKeyListener("F8", "push", false), true);
+});
+
+test("GLOBE / Fn / empty / null never start the listener, any mode or compositor", async () => {
+  const { shouldUseNativeKeyListener } = await load();
+  for (const usingNative of [true, false]) {
+    for (const mode of ["tap", "push"]) {
+      assert.equal(shouldUseNativeKeyListener("GLOBE", mode, usingNative), false);
+      assert.equal(shouldUseNativeKeyListener("Fn", mode, usingNative), false);
+      assert.equal(shouldUseNativeKeyListener("", mode, usingNative), false);
+      assert.equal(shouldUseNativeKeyListener(null, mode, usingNative), false);
+    }
+  }
+});

--- a/test/helpers/recordingGuard.test.js
+++ b/test/helpers/recordingGuard.test.js
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/recordingGuard.js");
+
+test("flags an empty WebM container (issue #864 double-trigger, ~110 bytes)", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(110), true);
+});
+
+test("flags a zero-byte blob", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(0), true);
+});
+
+test("flags 255 bytes (just under the threshold)", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(255), true);
+});
+
+test("allows exactly 256 bytes (boundary)", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(256), false);
+});
+
+test("allows a short real utterance with real audio bytes (no silent data loss)", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(3000), false);
+});
+
+test("allows a normal full-length recording", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(1674472), false);
+});
+
+test("treats missing / null / NaN size as empty (defensive)", async () => {
+  const { isEmptyRecording } = await load();
+  assert.equal(isEmptyRecording(undefined), true);
+  assert.equal(isEmptyRecording(null), true);
+  assert.equal(isEmptyRecording(NaN), true);
+});
+
+test("MIN_AUDIO_BYTES is 256", async () => {
+  const { MIN_AUDIO_BYTES } = await load();
+  assert.equal(MIN_AUDIO_BYTES, 256);
+});


### PR DESCRIPTION
## Summary

On KDE Plasma Wayland the dictation hotkey double-fired in tap mode. setupHotkey registers the hotkey with KGlobalAccel (so isUsingNativeShortcut() is true), but a separate block in main.js also started the native /dev/input key listener whenever needsNativeListener() returned true. With the KDE default Control+Super (a modifier-only combo KWin handles natively) both fired for one press: the native KEY_DOWN toggled recording on and the KDE shortcut toggled it off on release. The result was an empty WebM the backend rejects as "Audio file might be corrupted or unsupported", shown to the user as "Transcription Error".

The fix keeps the native listener off in tap mode when a compositor shortcut (GNOME/KDE/Hyprland) already owns the hotkey, so the compositor is the only handler. Push-to-talk is left alone: there the native listener is still needed for key-down/key-up and the compositor's single toggle is a no-op on release, so hold-to-talk keeps working on KDE. A second guard in processAudio skips empty recordings (a blob smaller than 256 bytes, i.e. a WebM container with no audio frames) instead of sending them to a backend; it gates on size rather than duration, so a genuinely short real word still transcribes.

Both decisions live in small pure helpers (shouldUseNativeKeyListener, isEmptyRecording) with node:test unit tests.

## Changes

- main.js: in the Linux block, decide the native key listener via shouldUseNativeKeyListener, so it does not run alongside the GNOME/KDE/Hyprland compositor shortcut in tap mode; push mode keeps it for push-to-talk
- src/helpers/hotkeyManager.js: add shouldUseNativeKeyListener (pure, exported)
- src/helpers/recordingGuard.js: add isEmptyRecording, which skips blobs smaller than 256 bytes
- src/helpers/audioManager.js: in processAudio, skip empty recordings via isEmptyRecording
- test/helpers/nativeKeyListenerDecision.test.js and test/helpers/recordingGuard.test.js: node:test unit tests for both guards

Fixes #864 #847
