### PR TITLE
fix: Update hotkey validation to allow longer macOS hotkeys

### DIFF
--- a/src/utils/hotkeyValidator.ts
+++ b/src/utils/hotkeyValidator.ts
@@ -554,10 +554,13 @@ export function validateHotkey(
     .map((part) => part.trim())
     .filter(Boolean);
 
-  if (parts.length > 3) {
+  if (parts.length > 5 || (parts.length > 3 && platform !== "darwin")) {
     return {
       valid: false,
-      error: "Shortcuts are limited to three keys.",
+      error:
+        platform !== "darwin"
+          ? "Shortcuts are limited to three keys."
+          : "Shortcuts are limited to five keys.",
       errorCode: "TOO_MANY_KEYS",
     };
   }


### PR DESCRIPTION
This lets macOS users bind Hyper-style shortcuts like Command+Option+Control+Shift+K. The previous three-key cap was a conservative cross-platform rule, but macOS can support these longer modifier chords and they reduce conflicts with common system/app shortcuts. Windows and Linux remain capped at three keys to avoid widening behavior on less predictable global shortcut backends.