### PR TITLE
feat: add Claude Opus 4.8 to the Anthropic model picker

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1762,7 +1762,8 @@
         "groq_compound_mini": "Schnelles Compound-System, 3x niedrigere Latenz",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, 256K Kontext",
         "openai_gpt_5_5": "Frontier-Modell für komplexes Reasoning",
-        "anthropic_claude_opus_4_7": "Leistungsstärkstes Claude-Modell",
+        "anthropic_claude_opus_4_8": "Leistungsstärkstes Claude-Modell",
+        "anthropic_claude_opus_4_7": "Leistungsstarkes Opus-Modell",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1862,7 +1862,8 @@
         "groq_compound_mini": "Fast compound system, 3x lower latency",
         "groq_kimi_k2_0905": "Moonshot AI's 1T MoE, 256K context",
         "openai_gpt_5_5": "Frontier model for complex reasoning",
-        "anthropic_claude_opus_4_7": "Most capable Claude model",
+        "anthropic_claude_opus_4_8": "Most capable Claude model",
+        "anthropic_claude_opus_4_7": "Powerful Opus model",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1810,7 +1810,8 @@
         "groq_compound_mini": "Sistema compound rápido, 3x menor latencia",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, contexto 256K",
         "openai_gpt_5_5": "Modelo frontier para razonamiento complejo",
-        "anthropic_claude_opus_4_7": "Modelo Claude más capaz",
+        "anthropic_claude_opus_4_8": "Modelo Claude más capaz",
+        "anthropic_claude_opus_4_7": "Modelo Opus potente",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1810,7 +1810,8 @@
         "groq_compound_mini": "Système compound rapide, 3x latence réduite",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, contexte 256K",
         "openai_gpt_5_5": "Modèle frontier pour le raisonnement complexe",
-        "anthropic_claude_opus_4_7": "Modèle Claude le plus performant",
+        "anthropic_claude_opus_4_8": "Modèle Claude le plus performant",
+        "anthropic_claude_opus_4_7": "Modèle Opus puissant",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1762,7 +1762,8 @@
         "groq_compound_mini": "Sistema compound veloce, 3x latenza ridotta",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, contesto 256K",
         "openai_gpt_5_5": "Modello frontier per ragionamento complesso",
-        "anthropic_claude_opus_4_7": "Modello Claude più capace",
+        "anthropic_claude_opus_4_8": "Modello Claude più capace",
+        "anthropic_claude_opus_4_7": "Modello Opus potente",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1762,7 +1762,8 @@
         "groq_compound_mini": "高速 Compound システム、3x 低レイテンシー",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE、256K コンテキスト",
         "openai_gpt_5_5": "複雑な推論のためのフロンティアモデル",
-        "anthropic_claude_opus_4_7": "最も高性能な Claude モデル",
+        "anthropic_claude_opus_4_8": "最も高性能な Claude モデル",
+        "anthropic_claude_opus_4_7": "高性能な Opus モデル",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1734,7 +1734,8 @@
         "groq_compound_mini": "Sistema compound rápido, 3x menor latência",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, contexto 256K",
         "openai_gpt_5_5": "Modelo frontier para raciocínio complexo",
-        "anthropic_claude_opus_4_7": "Modelo Claude mais capaz",
+        "anthropic_claude_opus_4_8": "Modelo Claude mais capaz",
+        "anthropic_claude_opus_4_7": "Modelo Opus potente",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1762,7 +1762,8 @@
         "groq_compound_mini": "Быстрая система Compound, 3x ниже задержка",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE, контекст 256K",
         "openai_gpt_5_5": "Фронтирная модель для сложного рассуждения",
-        "anthropic_claude_opus_4_7": "Самая мощная модель Claude",
+        "anthropic_claude_opus_4_8": "Самая мощная модель Claude",
+        "anthropic_claude_opus_4_7": "Мощная модель Opus",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1757,7 +1757,8 @@
         "groq_compound_mini": "快速 Compound 系统，3x 更低延迟",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE，256K 上下文",
         "openai_gpt_5_5": "复杂推理前沿模型",
-        "anthropic_claude_opus_4_7": "最强大的 Claude 模型",
+        "anthropic_claude_opus_4_8": "最强大的 Claude 模型",
+        "anthropic_claude_opus_4_7": "强大的 Opus 模型",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1757,7 +1757,8 @@
         "groq_compound_mini": "快速 Compound 系統，3x 更低延遲",
         "groq_kimi_k2_0905": "Moonshot AI 1T MoE，256K 上下文",
         "openai_gpt_5_5": "複雜推理前沿模型",
-        "anthropic_claude_opus_4_7": "最強大的 Claude 模型",
+        "anthropic_claude_opus_4_8": "最強大的 Claude 模型",
+        "anthropic_claude_opus_4_7": "強大的 Opus 模型",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",
         "anthropic_claude_opus_4_5": "Earlier Opus model"
       },

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -273,9 +273,15 @@
           "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5"
         },
         {
+          "id": "claude-opus-4-8",
+          "name": "Claude Opus 4.8",
+          "description": "Most capable Claude model, 1M context",
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_8"
+        },
+        {
           "id": "claude-opus-4-7",
           "name": "Claude Opus 4.7",
-          "description": "Most capable Claude model, 1M context",
+          "description": "Powerful Opus model, 1M context",
           "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_7"
         },
         {


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.8 to the Anthropic models in the Language Models picker, as the new flagship. The 4.7 entry's description is updated so it no longer reads as the most capable model.

## Changes

- src/models/modelRegistryData.json: add the claude-opus-4-8 entry before claude-opus-4-7 and adjust the 4.7 description
- src/locales/{de,en,es,fr,it,ja,pt,ru,zh-CN,zh-TW}/translation.json: add the anthropic_claude_opus_4_8 description key and update anthropic_claude_opus_4_7
