### PR TITLE
feat(linux): add Nix flake for one-command install & github action

### DIFF
--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -1,0 +1,83 @@
+name: Update Nix package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get release version
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            version="$RELEASE_TAG"
+          else
+            version=$(gh release view --json tagName -q .tagName)
+          fi
+          version="${version#v}"
+          if ! echo "$version" | grep -qP '^\d+\.\d+\.\d+$'; then
+            echo "::error::Invalid version format: $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if update needed
+        id: check
+        run: |
+          current=$(grep 'version = ' nix/package.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          if [ "$current" = "${{ steps.release.outputs.version }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download AppImage and compute hash
+        if: steps.check.outputs.skip != 'true'
+        id: hash
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          url="https://github.com/${{ github.repository }}/releases/download/v${version}/OpenWhispr-${version}-linux-x86_64.AppImage"
+          tmpfile=$(mktemp)
+          curl -fSL --retry 3 --retry-delay 10 "$url" -o "$tmpfile"
+          sri="sha256-$(sha256sum "$tmpfile" | cut -d' ' -f1 | xxd -r -p | base64 -w0)"
+          rm "$tmpfile"
+          echo "sri=$sri" >> "$GITHUB_OUTPUT"
+
+      - name: Update nix/package.nix
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          hash="${{ steps.hash.outputs.sri }}"
+          sed -i "s|version = \".*\";|version = \"${version}\";|" nix/package.nix
+          sed -i "s|hash = \"sha256-.*\";|hash = \"${hash}\";|" nix/package.nix
+
+      - name: Create pull request
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          branch="nix/update-${version}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add nix/package.nix
+          git commit -m "nix: update to ${version}"
+          git push origin "$branch"
+
+          gh pr create \
+            --title "nix: update to ${version}" \
+            --body "Automated bump of the Nix package to v${version}."

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "OpenWhispr – privacy-first voice dictation, meeting transcription & notes";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          openwhispr = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          default = openwhispr;
+          openwhispr = openwhispr;
+        }
+      );
+
+      overlays.default = _final: _prev: {
+        openwhispr = self.packages.x86_64-linux.openwhispr;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,5 +27,7 @@
       overlays.default = _final: _prev: {
         openwhispr = self.packages.x86_64-linux.openwhispr;
       };
+
+      nixosModules.default = import ./nix/module.nix self;
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,56 @@
+# NixOS module for OpenWhispr.
+#
+# Installs the app and configures everything Wayland auto-paste needs, which is
+# the main pain point for Nix users (see issue #728): ydotool, the uinput kernel
+# module + udev rule, and the group memberships that let a user reach both.
+#
+# Example:
+#   programs.openwhispr = {
+#     enable = true;
+#     users = [ "alice" ];
+#   };
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.openwhispr;
+in
+{
+  options.programs.openwhispr = {
+    enable = lib.mkEnableOption "OpenWhispr voice dictation app with Wayland auto-paste support";
+
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "alice" ];
+      description = ''
+        Users to grant Wayland auto-paste access. Each listed user is added to the
+        ydotool group (to reach the ydotoold socket) and the uinput group (OpenWhispr's
+        own linux-fast-paste backend opens /dev/uinput directly). Leave empty to manage
+        group membership yourself.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ self.packages.${pkgs.system}.default ];
+
+    # ydotoold daemon + ydotool group + socket for Wayland keystroke injection.
+    programs.ydotool.enable = true;
+
+    # Load the uinput module and install its udev rule. programs.ydotool does not
+    # do this, and OpenWhispr's linux-fast-paste --uinput needs /dev/uinput directly.
+    hardware.uinput.enable = true;
+
+    users.users = lib.genAttrs cfg.users (_: {
+      extraGroups = [
+        config.programs.ydotool.group
+        "uinput"
+      ];
+    });
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,6 +18,26 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
+  # Runtime tools and libraries the AppImage needs but does not bundle.
+  # The wrapType2 FHS env already provides the base Chromium/GTK/X11/nss stack;
+  # host PATH still resolves compositor tools (hyprctl, qdbus, gsettings, systemctl).
+  extraPkgs = pkgs: with pkgs; [
+    # Clipboard + keystroke injection backends the app shells out to. See #728.
+    xdotool # X11/XWayland keystroke + active-window detection
+    wtype # wlroots (Sway/Hyprland) keystroke injection
+    ydotool # uinput-based keystroke injection (GNOME/KDE Wayland)
+    wl-clipboard # wl-copy / wl-paste
+    xclip # X11 clipboard + primary selection
+    xsel # X11 clipboard/primary fallback
+    kdotool # KDE Wayland active-window class detection for terminal-aware paste
+    playerctl # MPRIS media auto-pause fallback
+    # Libraries beyond the FHS defaults.
+    libsecret # Electron safeStorage keyring (API keys at rest)
+    libnotify # Electron desktop notifications
+    libpulseaudio # Chromium mic capture via PulseAudio/PipeWire
+    stdenv.cc.cc.lib # libstdc++/libgomp for bundled whisper/llama/sherpa/qdrant
+  ];
+
   extraInstallCommands = ''
     install -Dm444 ${appimageContents}/open-whispr.desktop \
       $out/share/applications/${pname}.desktop

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "openwhispr";
+  version = "1.7.2";
+
+  src = fetchurl {
+    url = "https://github.com/OpenWhispr/openwhispr/releases/download/v${version}/OpenWhispr-${version}-linux-x86_64.AppImage";
+    hash = "sha256-EPJTZFtd2bQ026KNcI/FOHfoAMu96HKfJxTPceTc5jw=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/open-whispr.desktop \
+      $out/share/applications/${pname}.desktop
+
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun --no-sandbox' 'Exec=${pname} --no-sandbox'
+
+    cp -r ${appimageContents}/usr/share/icons $out/share/icons
+  '';
+
+  meta = {
+    description = "Privacy-first desktop voice dictation, meeting transcription & notes";
+    homepage = "https://openwhispr.com/";
+    changelog = "https://github.com/OpenWhispr/openwhispr/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = pname;
+  };
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -40,6 +40,7 @@ import MicPermissionWarning from "./ui/MicPermissionWarning";
 import MicrophoneSettings from "./ui/MicrophoneSettings";
 import PermissionCard from "./ui/PermissionCard";
 import PasteToolsInfo from "./ui/PasteToolsInfo";
+import NixOsPasteInfo from "./ui/NixOsPasteInfo";
 import TranscriptionModelPicker from "./TranscriptionModelPicker";
 import SelfHostedPanel from "./SelfHostedPanel";
 import {
@@ -861,6 +862,7 @@ export default function SettingsPage({
     isKde?: boolean;
     hasXclip?: boolean;
     hasXsel?: boolean;
+    isNixOS?: boolean;
   } | null>(null);
   const [ydotoolGuideKey, setYdotoolGuideKey] = useState<string | null>(null);
 
@@ -2708,6 +2710,14 @@ export default function SettingsPage({
                   })}
                 />
                 {(() => {
+                  if (ydotoolStatus.isNixOS) {
+                    return (
+                      <NixOsPasteInfo
+                        status={ydotoolStatus}
+                        onRecheck={refreshYdotoolStatus}
+                      />
+                    );
+                  }
                   const checks = [
                     {
                       key: "hasYdotool",

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -2712,10 +2712,7 @@ export default function SettingsPage({
                 {(() => {
                   if (ydotoolStatus.isNixOS) {
                     return (
-                      <NixOsPasteInfo
-                        status={ydotoolStatus}
-                        onRecheck={refreshYdotoolStatus}
-                      />
+                      <NixOsPasteInfo status={ydotoolStatus} onRecheck={refreshYdotoolStatus} />
                     );
                   }
                   const checks = [

--- a/src/components/ui/NixOsPasteInfo.tsx
+++ b/src/components/ui/NixOsPasteInfo.tsx
@@ -1,0 +1,123 @@
+import { useTranslation } from "react-i18next";
+import { Copy, CircleCheck, CircleX, RotateCw } from "lucide-react";
+
+interface NixOsPasteInfoProps {
+  status: {
+    hasYdotool: boolean;
+    hasUinput: boolean;
+    daemonRunning: boolean;
+  };
+  onRecheck: () => void;
+}
+
+// Declarative config NixOS users paste into their system config. Not translated (it's code).
+const MANUAL_CONFIG = `programs.ydotool.enable = true;
+hardware.uinput.enable  = true;
+users.users.<you>.extraGroups = [ "ydotool" "uinput" ];`;
+
+const FLAKE_CONFIG = `# flake inputs
+inputs.openwhispr.url = "github:OpenWhispr/openwhispr";
+
+# in your NixOS modules
+imports = [ openwhispr.nixosModules.default ];
+programs.openwhispr = {
+  enable = true;
+  users = [ "<you>" ];
+};`;
+
+export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProps) {
+  const { t } = useTranslation();
+
+  const StatusPill = ({ ok, label }: { ok: boolean; label: string }) => (
+    <span className="inline-flex items-center gap-1 text-xs">
+      {ok ? (
+        <CircleCheck className="h-3.5 w-3.5 text-emerald-500" />
+      ) : (
+        <CircleX className="h-3.5 w-3.5 text-red-500" />
+      )}
+      <span className="font-mono">{label}</span>
+    </span>
+  );
+
+  const CodeBlock = ({ code }: { code: string }) => (
+    <div className="flex items-start gap-1.5">
+      <pre className="flex-1 text-[11px] bg-muted/60 rounded-md px-3 py-2 font-mono whitespace-pre-wrap break-all select-all overflow-x-auto">
+        {code}
+      </pre>
+      <button
+        onClick={() => navigator.clipboard.writeText(code)}
+        className="shrink-0 p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+        title={t("settingsPage.general.waylandPaste.copy", { defaultValue: "Copy" })}
+      >
+        <Copy className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="rounded-xl border border-border p-4 space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {t("settingsPage.general.waylandPaste.nixos.intro", {
+          defaultValue:
+            "You're on NixOS. Auto-paste needs ydotool and /dev/uinput access, which NixOS grants declaratively.",
+        })}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <span className="text-xs text-muted-foreground">
+          {t("settingsPage.general.waylandPaste.nixos.detected", {
+            defaultValue: "Detected",
+          })}
+          :
+        </span>
+        <StatusPill ok={status.hasYdotool} label="ydotool" />
+        <StatusPill ok={status.hasUinput} label="/dev/uinput" />
+        <StatusPill ok={status.daemonRunning} label="ydotoold" />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">
+          {t("settingsPage.general.waylandPaste.nixos.manualTitle", {
+            defaultValue: "Add this to your configuration",
+          })}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("settingsPage.general.waylandPaste.nixos.manualDesc", {
+            defaultValue: "Configure it yourself, then rebuild.",
+          })}
+        </p>
+        <CodeBlock code={MANUAL_CONFIG} />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium">
+          {t("settingsPage.general.waylandPaste.nixos.flakeTitle", {
+            defaultValue: "Installing via our flake?",
+          })}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("settingsPage.general.waylandPaste.nixos.flakeDesc", {
+            defaultValue:
+              "If you install OpenWhispr from the flake, programs.openwhispr.enable turns on ydotool, the uinput module and the group memberships for you.",
+          })}
+        </p>
+        <CodeBlock code={FLAKE_CONFIG} />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {t("settingsPage.general.waylandPaste.nixos.rebuildNote", {
+          defaultValue:
+            "Run sudo nixos-rebuild switch, then log out and back in so the group change and the /dev/uinput rule take effect. Replace <you> with your username.",
+        })}
+      </p>
+
+      <button
+        onClick={onRecheck}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <RotateCw className="w-3 h-3" />
+        {t("settingsPage.general.waylandPaste.recheck", { defaultValue: "Re-check" })}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/NixOsPasteInfo.tsx
+++ b/src/components/ui/NixOsPasteInfo.tsx
@@ -25,10 +25,8 @@ programs.openwhispr = {
   users = [ "<you>" ];
 };`;
 
-export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProps) {
-  const { t } = useTranslation();
-
-  const StatusPill = ({ ok, label }: { ok: boolean; label: string }) => (
+function StatusPill({ ok, label }: { ok: boolean; label: string }) {
+  return (
     <span className="inline-flex items-center gap-1 text-xs">
       {ok ? (
         <CircleCheck className="h-3.5 w-3.5 text-emerald-500" />
@@ -38,21 +36,28 @@ export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProp
       <span className="font-mono">{label}</span>
     </span>
   );
+}
 
-  const CodeBlock = ({ code }: { code: string }) => (
+function CodeBlock({ code, copyLabel }: { code: string; copyLabel: string }) {
+  return (
     <div className="flex items-start gap-1.5">
       <pre className="flex-1 text-[11px] bg-muted/60 rounded-md px-3 py-2 font-mono whitespace-pre-wrap break-all select-all overflow-x-auto">
         {code}
       </pre>
       <button
-        onClick={() => navigator.clipboard.writeText(code)}
+        onClick={() => navigator.clipboard.writeText(code).catch(() => {})}
         className="shrink-0 p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-        title={t("settingsPage.general.waylandPaste.copy", { defaultValue: "Copy" })}
+        title={copyLabel}
       >
         <Copy className="w-3.5 h-3.5" />
       </button>
     </div>
   );
+}
+
+export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProps) {
+  const { t } = useTranslation();
+  const copyLabel = t("settingsPage.general.waylandPaste.copy", { defaultValue: "Copy" });
 
   return (
     <div className="rounded-xl border border-border p-4 space-y-4">
@@ -86,7 +91,7 @@ export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProp
             defaultValue: "Configure it yourself, then rebuild.",
           })}
         </p>
-        <CodeBlock code={MANUAL_CONFIG} />
+        <CodeBlock code={MANUAL_CONFIG} copyLabel={copyLabel} />
       </div>
 
       <div className="space-y-2">
@@ -101,7 +106,7 @@ export default function NixOsPasteInfo({ status, onRecheck }: NixOsPasteInfoProp
               "If you install OpenWhispr from the flake, programs.openwhispr.enable turns on ydotool, the uinput module and the group memberships for you.",
           })}
         </p>
-        <CodeBlock code={FLAKE_CONFIG} />
+        <CodeBlock code={FLAKE_CONFIG} copyLabel={copyLabel} />
       </div>
 
       <p className="text-xs text-muted-foreground">

--- a/src/helpers/ensureYdotool.js
+++ b/src/helpers/ensureYdotool.js
@@ -173,6 +173,16 @@ async function ensureYdotool() {
   }
 }
 
+function isNixOS() {
+  try {
+    if (fs.existsSync("/etc/NIXOS")) return true;
+    const osRelease = fs.readFileSync("/etc/os-release", "utf8");
+    return /^ID=("?)nixos\1$/m.test(osRelease);
+  } catch {
+    return false;
+  }
+}
+
 function getYdotoolStatus() {
   const hasYdotool = commandExists("ydotool");
   const hasYdotoold = commandExists("ydotoold");
@@ -195,6 +205,7 @@ function getYdotoolStatus() {
     hasUinput,
     hasUdevRule,
     hasGroup,
+    isNixOS: isNixOS(),
     allGood: hasYdotool && hasYdotoold && daemonRunning && hasUinput && hasGroup,
   };
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1390,7 +1390,16 @@
             "step1Title": "xclip installieren"
           }
         },
-        "xclipDesc": "Zwischenablage-Tool für KDE-Wayland-Einfügen (xclip oder xsel)"
+        "xclipDesc": "Zwischenablage-Tool für KDE-Wayland-Einfügen (xclip oder xsel)",
+        "nixos": {
+          "intro": "Sie verwenden NixOS. Für das automatische Einfügen werden ydotool und Zugriff auf /dev/uinput benötigt, was NixOS deklarativ gewährt.",
+          "detected": "Erkannt",
+          "manualTitle": "Fügen Sie dies zu Ihrer Konfiguration hinzu",
+          "manualDesc": "Selbst konfigurieren, dann neu bauen.",
+          "flakeTitle": "Installation über unser flake?",
+          "flakeDesc": "Wenn Sie OpenWhispr über das flake installieren, aktiviert programs.openwhispr.enable automatisch ydotool, das uinput-Modul und die erforderlichen Gruppenmitgliedschaften.",
+          "rebuildNote": "Führen Sie sudo nixos-rebuild switch aus, dann ab- und wieder anmelden, damit die Gruppenänderung und die /dev/uinput-Regel wirksam werden. Ersetzen Sie <you> durch Ihren Benutzernamen."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1571,7 +1571,16 @@
             "step1Title": "Install xclip"
           }
         },
-        "xclipDesc": "Clipboard tool for KDE Wayland paste (xclip or xsel)"
+        "xclipDesc": "Clipboard tool for KDE Wayland paste (xclip or xsel)",
+        "nixos": {
+          "intro": "You're on NixOS. Auto-paste needs ydotool and /dev/uinput access, which NixOS grants declaratively.",
+          "detected": "Detected",
+          "manualTitle": "Add this to your configuration",
+          "manualDesc": "Configure it yourself, then rebuild.",
+          "flakeTitle": "Installing via our flake?",
+          "flakeDesc": "If you install OpenWhispr from the flake, programs.openwhispr.enable turns on ydotool, the uinput module and the group memberships for you.",
+          "rebuildNote": "Run sudo nixos-rebuild switch, then log out and back in so the group change and the /dev/uinput rule take effect. Replace <you> with your username."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1438,7 +1438,16 @@
             "step1Title": "Instalar xclip"
           }
         },
-        "xclipDesc": "Herramienta de portapapeles para pegado en KDE Wayland (xclip o xsel)"
+        "xclipDesc": "Herramienta de portapapeles para pegado en KDE Wayland (xclip o xsel)",
+        "nixos": {
+          "intro": "Estás en NixOS. El pegado automático necesita ydotool y acceso a /dev/uinput, que NixOS concede de forma declarativa.",
+          "detected": "Detectado",
+          "manualTitle": "Añade esto a tu configuración",
+          "manualDesc": "Configúralo tú mismo y luego reconstruye.",
+          "flakeTitle": "¿Instalando mediante nuestro flake?",
+          "flakeDesc": "Si instalas OpenWhispr desde el flake, programs.openwhispr.enable activa ydotool, el módulo uinput y las pertenencias de grupo por ti.",
+          "rebuildNote": "Ejecuta sudo nixos-rebuild switch, luego cierra sesión y vuelve a abrirla para que el cambio de grupo y la regla de /dev/uinput surtan efecto. Sustituye <you> por tu nombre de usuario."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1438,7 +1438,16 @@
             "step1Title": "Installer xclip"
           }
         },
-        "xclipDesc": "Outil de presse-papiers pour le collage KDE Wayland (xclip ou xsel)"
+        "xclipDesc": "Outil de presse-papiers pour le collage KDE Wayland (xclip ou xsel)",
+        "nixos": {
+          "intro": "Vous êtes sur NixOS. Le collage automatique nécessite ydotool et l'accès à /dev/uinput, que NixOS accorde de façon déclarative.",
+          "detected": "Détecté",
+          "manualTitle": "Ajoutez ceci à votre configuration",
+          "manualDesc": "Configurez-le vous-même, puis reconstruisez.",
+          "flakeTitle": "Vous installez via notre flake ?",
+          "flakeDesc": "Si vous installez OpenWhispr depuis le flake, programs.openwhispr.enable active ydotool, le module uinput et les appartenances aux groupes pour vous.",
+          "rebuildNote": "Exécutez sudo nixos-rebuild switch, puis déconnectez-vous et reconnectez-vous pour que le changement de groupe et la règle /dev/uinput prennent effet. Remplacez <you> par votre nom d'utilisateur."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1390,7 +1390,16 @@
             "step1Title": "Installa xclip"
           }
         },
-        "xclipDesc": "Strumento appunti per incollare in KDE Wayland (xclip o xsel)"
+        "xclipDesc": "Strumento appunti per incollare in KDE Wayland (xclip o xsel)",
+        "nixos": {
+          "intro": "Stai usando NixOS. L'incolla automatico richiede ydotool e l'accesso a /dev/uinput, che NixOS gestisce in modo dichiarativo.",
+          "detected": "Rilevato",
+          "manualTitle": "Aggiungi questo alla tua configurazione",
+          "manualDesc": "Configuralo tu stesso, poi ricostruisci.",
+          "flakeTitle": "Stai installando tramite il nostro flake?",
+          "flakeDesc": "Se installi OpenWhispr dal flake, programs.openwhispr.enable attiva ydotool, il modulo uinput e le appartenenze ai gruppi per te.",
+          "rebuildNote": "Esegui sudo nixos-rebuild switch, poi disconnettiti e riconnettiti affinché la modifica al gruppo e la regola /dev/uinput abbiano effetto. Sostituisci <you> con il tuo nome utente."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1390,7 +1390,16 @@
             "step1Title": "xclipをインストール"
           }
         },
-        "xclipDesc": "KDE Waylandの貼り付け用クリップボードツール（xclipまたはxsel）"
+        "xclipDesc": "KDE Waylandの貼り付け用クリップボードツール（xclipまたはxsel）",
+        "nixos": {
+          "intro": "NixOSをお使いです。自動貼り付けにはydotoolと/dev/uinputへのアクセスが必要で、NixOSでは宣言的に設定できます。",
+          "detected": "検出済み",
+          "manualTitle": "設定に以下を追加してください",
+          "manualDesc": "ご自身で設定してからリビルドしてください。",
+          "flakeTitle": "flakeからインストールする場合",
+          "flakeDesc": "flakeからOpenWhisprをインストールする場合、programs.openwhispr.enableを有効にするとydotool、uinputモジュール、グループのメンバーシップが自動で設定されます。",
+          "rebuildNote": "sudo nixos-rebuild switchを実行し、グループの変更と/dev/uinputのルールを反映させるためにログアウト後に再ログインしてください。<you>はあなたのユーザー名に置き換えてください。"
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1362,7 +1362,16 @@
             "step1Title": "Instalar xclip"
           }
         },
-        "xclipDesc": "Ferramenta de área de transferência para colar no KDE Wayland (xclip ou xsel)"
+        "xclipDesc": "Ferramenta de área de transferência para colar no KDE Wayland (xclip ou xsel)",
+        "nixos": {
+          "intro": "Está no NixOS. A colagem automática requer ydotool e acesso a /dev/uinput, que o NixOS concede de forma declarativa.",
+          "detected": "Detetado",
+          "manualTitle": "Adicione isto à sua configuração",
+          "manualDesc": "Configure manualmente e depois reconstrua.",
+          "flakeTitle": "A instalar pelo nosso flake?",
+          "flakeDesc": "Se instalar o OpenWhispr pelo flake, programs.openwhispr.enable ativa o ydotool, o módulo uinput e as associações de grupo por si.",
+          "rebuildNote": "Execute sudo nixos-rebuild switch, depois termine a sessão e volte a entrar para que a alteração de grupo e a regra /dev/uinput entrem em vigor. Substitua <you> pelo seu nome de utilizador."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1390,7 +1390,16 @@
             "step1Title": "Установить xclip"
           }
         },
-        "xclipDesc": "Инструмент буфера обмена для вставки в KDE Wayland (xclip или xsel)"
+        "xclipDesc": "Инструмент буфера обмена для вставки в KDE Wayland (xclip или xsel)",
+        "nixos": {
+          "intro": "Вы используете NixOS. Для автоматической вставки требуются ydotool и доступ к /dev/uinput — NixOS предоставляет это декларативно.",
+          "detected": "Обнаружено",
+          "manualTitle": "Добавьте это в свою конфигурацию",
+          "manualDesc": "Настройте вручную, затем выполните пересборку.",
+          "flakeTitle": "Устанавливаете через наш flake?",
+          "flakeDesc": "Если вы устанавливаете OpenWhispr из flake, programs.openwhispr.enable автоматически включает ydotool, модуль uinput и нужные группы пользователей.",
+          "rebuildNote": "Выполните sudo nixos-rebuild switch, затем выйдите из системы и войдите снова, чтобы изменение группы и правило /dev/uinput вступили в силу. Замените <you> на ваше имя пользователя."
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1385,7 +1385,16 @@
             "step1Title": "安装 xclip"
           }
         },
-        "xclipDesc": "KDE Wayland 粘贴用的剪贴板工具（xclip 或 xsel）"
+        "xclipDesc": "KDE Wayland 粘贴用的剪贴板工具（xclip 或 xsel）",
+        "nixos": {
+          "intro": "您正在使用 NixOS。自动粘贴需要 ydotool 和 /dev/uinput 访问权限，NixOS 通过声明式配置来授予这些权限。",
+          "detected": "已检测到",
+          "manualTitle": "将以下内容添加到您的配置中",
+          "manualDesc": "自行配置后重新构建。",
+          "flakeTitle": "通过我们的 flake 安装？",
+          "flakeDesc": "如果您通过 flake 安装 OpenWhispr，programs.openwhispr.enable 会自动为您启用 ydotool、uinput 模块以及相应的用户组权限。",
+          "rebuildNote": "运行 sudo nixos-rebuild switch，然后注销并重新登录，使组变更和 /dev/uinput 规则生效。将 <you> 替换为您的用户名。"
+        }
       },
       "updates": {
         "badges": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1385,7 +1385,16 @@
             "step1Title": "安裝 xclip"
           }
         },
-        "xclipDesc": "KDE Wayland 貼上用的剪貼簿工具（xclip 或 xsel）"
+        "xclipDesc": "KDE Wayland 貼上用的剪貼簿工具（xclip 或 xsel）",
+        "nixos": {
+          "intro": "你正在使用 NixOS。自動貼上需要 ydotool 及 /dev/uinput 存取權限，NixOS 以宣告式方式授予這些權限。",
+          "detected": "已偵測",
+          "manualTitle": "將以下內容加入你的設定",
+          "manualDesc": "自行設定後重新建置。",
+          "flakeTitle": "透過我們的 flake 安裝？",
+          "flakeDesc": "若你從 flake 安裝 OpenWhispr，programs.openwhispr.enable 會自動啟用 ydotool、uinput 模組及所需的群組成員資格。",
+          "rebuildNote": "執行 sudo nixos-rebuild switch，然後登出並重新登入，使群組變更與 /dev/uinput 規則生效。將 <you> 替換為你的使用者名稱。"
+        }
       },
       "updates": {
         "badges": {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -932,6 +932,7 @@ declare global {
         hasUinput: boolean;
         hasUdevRule: boolean;
         hasGroup: boolean;
+        isNixOS: boolean;
         allGood: boolean;
       }>;
 


### PR DESCRIPTION
## Summary

Adds a Nix flake so users can run `nix run github:OpenWhispr/openwhispr` without writing their own derivation. Includes a GitHub Action that auto-PRs version bumps when new releases are published.

This finishes solution 1 of issue #728 .