### PR TITLE
fix: persist Dictation Cleanup custom API key across restarts

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1592,6 +1592,13 @@ export function setResolvedLLMConfig(
     if (value === undefined) continue;
     const storeKey = def.storeKeys[field as keyof InferenceScopeStoreKeys];
     if (!storeKey) continue;
+    // cleanupCustomApiKey is a secret kept in the OS secure store, not
+    // localStorage (which is stripped on startup). Route it through the
+    // dedicated setter so it survives restarts.
+    if (storeKey === "cleanupCustomApiKey") {
+      useSettingsStore.getState().setCleanupCustomApiKey(value as string);
+      continue;
+    }
     if (isBrowser) {
       localStorage.setItem(
         storeKey as string,


### PR DESCRIPTION
## Summary

Fixes #885 — the **Dictation Cleanup** custom-provider API key was silently wiped on every app restart, causing cleanup requests to fail with HTTP 401 and fall back to pasting the raw transcription.

## Root cause

All four inference scopes (Dictation Cleanup, Voice Agent, Note Formatting, Chat) edit their custom API key in Settings through one generic writer, `setResolvedLLMConfig`, which only wrote to `localStorage`.

That works for the other three scopes because their custom keys live in `localStorage` permanently. But `cleanupCustomApiKey` is different — it is a **secret backed by the OS secure store** (`CUSTOM_CLEANUP_API_KEY`, encrypted via Electron `safeStorage`). On startup the app:

1. reads `cleanupCustomApiKey` back from the **secure store** (where the UI never wrote it), and
2. **strips** `cleanupCustomApiKey` from `localStorage` (it is in `STALE_SECRET_LOCALSTORAGE_KEYS`).

So the key entered via Settings → Language Models → Dictation Cleanup was saved only to `localStorage`, then read from an empty secure store and wiped from `localStorage` on the next launch. The dedicated `setCleanupCustomApiKey` setter (used by Notes onboarding and `updateApiKeys`) already persists to the secure store correctly — the Settings editor just wasn't using it.

## Fix

Route the cleanup scope's `customApiKey` through the existing `setCleanupCustomApiKey` setter, which encrypts it to the secure store and invalidates the API-key cache — consistent with how the value is read back on startup. One guard, no new abstractions, other three scopes untouched.

## End-to-end trace (verified)

- **Write:** Settings editor → `setResolvedLLMConfig` → `setCleanupCustomApiKey` → `debouncedSaveSecret("cleanupCustom")` → IPC `save-cleanup-custom-key` → `EnvironmentManager.saveCleanupCustomKey` → encrypted `.enc` on disk.
- **Read (startup):** `initializeSettings` → IPC `get-cleanup-custom-key` → `EnvironmentManager.getCleanupCustomKey` → store state → shown in UI.
- **Consume:** `ReasoningService.getApiKey("custom")` reads the secure store first, falls back to store state. Both populated after the fix.
- Clearing the field deletes the `.enc` file (empty value → `_deleteSecretKey`), as before.

## Impact on current users

- Users who set a Dictation Cleanup custom key via Settings need to **re-enter it once** after updating; it then persists permanently.
- Users who configured it via Notes onboarding or the legacy reasoning key path are unaffected (those already wrote to the secure store).
- No IPC/API/type/signature changes; the other three scopes are unchanged.

## Verification

- `npm run typecheck` — clean
- `eslint` on the changed file — clean