### PR TITLE
Add preload and idle-timeout settings for the local cleanup model

### DIFF
--- a/main.js
+++ b/main.js
@@ -420,6 +420,18 @@ function initializeDeferredManagers() {
       "clipboard"
     );
   });
+
+  if (process.env.CLEANUP_PRELOAD_ON_START === "true") {
+    const modelManager = require("./src/helpers/modelManagerBridge").default;
+    modelManager.preloadModel().catch((err) => {
+      require("./src/helpers/debugLogger").warn(
+        "cleanup model preload error",
+        { error: err?.message },
+        "model"
+      );
+    });
+  }
+
   clipboardManager.preWarmAccessibility();
   trayManager = new TrayManager();
   globeKeyManager = new GlobeKeyManager();

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -418,6 +418,11 @@ function NoteFormattingSettings() {
 
 function AiModelsSection({ useCleanupModel, setUseCleanupModel, toast }: AiModelsSectionProps) {
   const { t } = useTranslation();
+  const cleanupProvider = useSettingsStore((s) => s.cleanupProvider);
+  const cleanupPreloadOnStart = useSettingsStore((s) => s.cleanupPreloadOnStart);
+  const cleanupIdleTimeoutMinutes = useSettingsStore((s) => s.cleanupIdleTimeoutMinutes);
+  const setCleanupPreloadOnStart = useSettingsStore((s) => s.setCleanupPreloadOnStart);
+  const setCleanupIdleTimeoutMinutes = useSettingsStore((s) => s.setCleanupIdleTimeoutMinutes);
 
   const handleCleanupModeChange = (mode: InferenceMode) => {
     const toastKey = CLEANUP_MODE_TOAST_KEY[mode];
@@ -446,6 +451,48 @@ function AiModelsSection({ useCleanupModel, setUseCleanupModel, toast }: AiModel
         <>
           <InferenceConfigEditor scope="dictationCleanup" onModeChange={handleCleanupModeChange} />
           <GpuDeviceSelector purpose="intelligence" />
+          {cleanupProvider === "local" && (
+            <SettingsPanel>
+              <SettingsPanelRow>
+                <SettingsRow
+                  label={t("settingsPage.aiModels.preloadOnStart")}
+                  description={t("settingsPage.aiModels.preloadOnStartDescription")}
+                >
+                  <Toggle checked={cleanupPreloadOnStart} onChange={setCleanupPreloadOnStart} />
+                </SettingsRow>
+              </SettingsPanelRow>
+              <SettingsPanelRow>
+                <SettingsRow
+                  label={t("settingsPage.aiModels.idleTimeout")}
+                  description={t("settingsPage.aiModels.idleTimeoutDescription")}
+                >
+                  <Select
+                    value={String(cleanupIdleTimeoutMinutes)}
+                    onValueChange={(v) => setCleanupIdleTimeoutMinutes(Number(v))}
+                  >
+                    <SelectTrigger className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="5">
+                        {t("settingsPage.aiModels.idleMinutes", { count: 5 })}
+                      </SelectItem>
+                      <SelectItem value="15">
+                        {t("settingsPage.aiModels.idleMinutes", { count: 15 })}
+                      </SelectItem>
+                      <SelectItem value="30">
+                        {t("settingsPage.aiModels.idleMinutes", { count: 30 })}
+                      </SelectItem>
+                      <SelectItem value="60">
+                        {t("settingsPage.aiModels.idleMinutes", { count: 60 })}
+                      </SelectItem>
+                      <SelectItem value="0">{t("settingsPage.aiModels.idleNever")}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </SettingsRow>
+              </SettingsPanelRow>
+            </SettingsPanel>
+          )}
         </>
       )}
     </div>

--- a/src/helpers/idleTimeout.js
+++ b/src/helpers/idleTimeout.js
@@ -1,0 +1,14 @@
+// Resolves how long the local cleanup model stays loaded after its last use.
+// A value of 0 means never unload while the app is open. Invalid or negative
+// values fall back to the default so a bad setting cannot disable cleanup.
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+
+function resolveIdleTimeoutMs(env = process.env) {
+  const raw = env.CLEANUP_IDLE_TIMEOUT_MS;
+  if (raw === undefined || raw === null || raw === "") return DEFAULT_IDLE_TIMEOUT_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) return DEFAULT_IDLE_TIMEOUT_MS;
+  return Math.floor(value);
+}
+
+module.exports = { DEFAULT_IDLE_TIMEOUT_MS, resolveIdleTimeoutMs };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2827,6 +2827,17 @@ class IPCHandlers {
         });
       }
 
+      if (prefs.cleanupPreloadOnStart) {
+        setVars.CLEANUP_PRELOAD_ON_START = "true";
+      } else {
+        clearVars.push("CLEANUP_PRELOAD_ON_START");
+      }
+
+      if (typeof prefs.cleanupIdleTimeoutMinutes === "number") {
+        const minutes = Math.max(0, Math.floor(prefs.cleanupIdleTimeoutMinutes));
+        setVars.CLEANUP_IDLE_TIMEOUT_MS = String(minutes * 60 * 1000);
+      }
+
       this._syncStartupEnv(setVars, clearVars);
     });
 

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -8,6 +8,7 @@ const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
+const { resolveIdleTimeoutMs } = require("./idleTimeout");
 
 const PORT_RANGE_START = 8200;
 const PORT_RANGE_END = 8220;
@@ -17,7 +18,6 @@ const HEALTH_CHECK_INTERVAL_MS = 5000;
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const STARTUP_POLL_INTERVAL_MS = 500;
 const HEALTH_CHECK_FAILURE_THRESHOLD = 3;
-const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
 class LlamaServerManager {
   constructor() {
@@ -408,13 +408,18 @@ class LlamaServerManager {
 
   resetIdleTimer() {
     this.clearIdleTimer();
+    const timeoutMs = resolveIdleTimeoutMs();
+    if (timeoutMs <= 0) {
+      // Idle timeout disabled (Never): keep the model loaded while the app is open.
+      return;
+    }
     this.idleTimer = setTimeout(() => {
       debugLogger.info("llama-server idle timeout reached, stopping to free VRAM", {
-        timeoutMs: IDLE_TIMEOUT_MS,
+        timeoutMs,
         model: this.modelPath ? path.basename(this.modelPath) : null,
       });
       this.stop();
-    }, IDLE_TIMEOUT_MS);
+    }, timeoutMs);
   }
 
   clearIdleTimer() {

--- a/src/helpers/modelManagerBridge.js
+++ b/src/helpers/modelManagerBridge.js
@@ -318,6 +318,41 @@ class ModelManager {
     }
   }
 
+  // Starts the local cleanup model in the background so the first dictation
+  // does not pay the cold start. No-op unless a local cleanup model is
+  // configured and downloaded. Never throws.
+  async preloadModel() {
+    try {
+      this.ensureInitialized();
+      if (process.env.CLEANUP_PROVIDER !== "local") return false;
+      const modelId = process.env.LOCAL_CLEANUP_MODEL;
+      if (!modelId) return false;
+
+      const modelInfo = this.findModelById(modelId);
+      if (!modelInfo) return false;
+
+      const modelPath = path.join(this.modelsDir, modelInfo.model.fileName);
+      if (!(await this.checkModelValid(modelPath))) return false;
+
+      if (this.serverManager.ready && this.currentServerModelId === modelId) return true;
+
+      await this.serverManager.start(modelPath, {
+        contextSize: modelInfo.model.contextLength || 4096,
+        threads: 4,
+        gpuLayers: 99,
+      });
+      this.currentServerModelId = modelId;
+      debugLogger.logReasoning("PRELOAD_SERVER_STARTED", {
+        model: modelId,
+        port: this.serverManager.port,
+      });
+      return true;
+    } catch (error) {
+      debugLogger.error("Cleanup model preload failed", { error: error.message });
+      return false;
+    }
+  }
+
   async runInference(modelId, prompt, options = {}) {
     this.ensureInitialized();
     const startTime = Date.now();

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -32,6 +32,8 @@ export interface CleanupSettings {
   useDictationAgent: boolean;
   cleanupModel: string;
   cleanupProvider: string;
+  cleanupPreloadOnStart: boolean;
+  cleanupIdleTimeoutMinutes: number;
   cleanupCloudBaseUrl?: string;
   cleanupCloudMode: string;
   cleanupMode: InferenceMode;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -144,6 +144,8 @@ function useSettingsInternal() {
     parakeetModel,
     cleanupProvider,
     cleanupModel,
+    cleanupPreloadOnStart,
+    cleanupIdleTimeoutMinutes,
     dictationAgentProvider,
     dictationAgentModel,
   } = store;
@@ -159,6 +161,8 @@ function useSettingsInternal() {
         model: model || undefined,
         cleanupProvider,
         cleanupModel: cleanupProvider === "local" ? cleanupModel : undefined,
+        cleanupPreloadOnStart,
+        cleanupIdleTimeoutMinutes,
         dictationAgentProvider,
         dictationAgentModel: dictationAgentProvider === "local" ? dictationAgentModel : undefined,
       })
@@ -176,6 +180,8 @@ function useSettingsInternal() {
     parakeetModel,
     cleanupProvider,
     cleanupModel,
+    cleanupPreloadOnStart,
+    cleanupIdleTimeoutMinutes,
     dictationAgentProvider,
     dictationAgentModel,
   ]);

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1160,6 +1160,12 @@
       "description": "Bereinigt Transkriptionen, verarbeitet Befehle und korrigiert Fehler unter Beibehaltung Ihres Stils.",
       "enableTextCleanup": "Textbereinigung aktivieren",
       "enableTextCleanupDescription": "KI entfernt Füllwörter, korrigiert Grammatik und Zeichensetzung",
+      "preloadOnStart": "Modell beim Start vorladen",
+      "preloadOnStartDescription": "Lädt das Bereinigungsmodell beim Öffnen von OpenWhispr, damit das erste Diktat schnell ist.",
+      "idleTimeout": "Bei Inaktivität entladen",
+      "idleTimeoutDescription": "Gibt GPU-Speicher nach dieser Inaktivität frei. Wähle Nie, um das Modell geladen zu lassen, solange OpenWhispr geöffnet ist.",
+      "idleNever": "Nie",
+      "idleMinutes": "{{count}} Minuten",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Cloud-Anbieter",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1341,6 +1341,12 @@
       "description": "Clean up transcriptions, handle commands, and fix errors while preserving your tone.",
       "enableTextCleanup": "Enable text cleanup",
       "enableTextCleanupDescription": "Use AI to remove filler words, fix grammar, and polish punctuation",
+      "preloadOnStart": "Preload model on startup",
+      "preloadOnStartDescription": "Load the cleanup model when OpenWhispr opens so the first dictation is fast.",
+      "idleTimeout": "Unload when idle",
+      "idleTimeoutDescription": "Free GPU memory after this much inactivity. Choose Never to keep the model loaded while OpenWhispr is open.",
+      "idleNever": "Never",
+      "idleMinutes": "{{count}} minutes",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Cloud Providers",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1208,6 +1208,12 @@
       "description": "Corrige transcripciones, gestiona comandos y soluciona errores preservando tu tono.",
       "enableTextCleanup": "Activar corrección de texto",
       "enableTextCleanupDescription": "La IA elimina muletillas, corrige gramática y puntuación",
+      "preloadOnStart": "Precargar el modelo al iniciar",
+      "preloadOnStartDescription": "Carga el modelo de limpieza al abrir OpenWhispr para que el primer dictado sea rápido.",
+      "idleTimeout": "Descargar cuando esté inactivo",
+      "idleTimeoutDescription": "Libera memoria de la GPU tras este tiempo de inactividad. Elige Nunca para mantener el modelo cargado mientras OpenWhispr esté abierto.",
+      "idleNever": "Nunca",
+      "idleMinutes": "{{count}} minutos",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Proveedores en la nube",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1208,6 +1208,12 @@
       "description": "Corrige les transcriptions, gère les commandes et corrige les erreurs tout en préservant votre ton.",
       "enableTextCleanup": "Activer la correction de texte",
       "enableTextCleanupDescription": "L'IA supprime les mots de remplissage, corrige la grammaire et la ponctuation",
+      "preloadOnStart": "Précharger le modèle au démarrage",
+      "preloadOnStartDescription": "Charge le modèle de nettoyage à l'ouverture d'OpenWhispr pour que la première dictée soit rapide.",
+      "idleTimeout": "Décharger en cas d'inactivité",
+      "idleTimeoutDescription": "Libère la mémoire du GPU après cette inactivité. Choisissez Jamais pour garder le modèle chargé tant qu'OpenWhispr est ouvert.",
+      "idleNever": "Jamais",
+      "idleMinutes": "{{count}} minutes",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Fournisseurs cloud",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1160,6 +1160,12 @@
       "description": "Correggi le trascrizioni, gestisci i comandi e risolvi gli errori preservando il tuo tono.",
       "enableTextCleanup": "Attiva correzione testo",
       "enableTextCleanupDescription": "L'IA rimuove parole superflue, corregge grammatica e punteggiatura",
+      "preloadOnStart": "Precarica il modello all'avvio",
+      "preloadOnStartDescription": "Carica il modello di pulizia all'apertura di OpenWhispr in modo che la prima dettatura sia veloce.",
+      "idleTimeout": "Scarica quando inattivo",
+      "idleTimeoutDescription": "Libera la memoria della GPU dopo questa inattività. Scegli Mai per mantenere il modello caricato mentre OpenWhispr è aperto.",
+      "idleNever": "Mai",
+      "idleMinutes": "{{count}} minuti",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Provider cloud",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1160,6 +1160,12 @@
       "description": "文字起こしのクリーンアップ、コマンド処理、エラー修正を行いながら、あなたの話し方を維持します。",
       "enableTextCleanup": "テキスト補正を有効にする",
       "enableTextCleanupDescription": "AI がフィラーワードを除去し、文法と句読点を整える",
+      "preloadOnStart": "起動時にモデルをプリロード",
+      "preloadOnStartDescription": "OpenWhispr の起動時にクリーンアップモデルを読み込み、最初の音声入力を高速化します。",
+      "idleTimeout": "アイドル時にアンロード",
+      "idleTimeoutDescription": "この時間アイドル状態が続くと GPU メモリを解放します。OpenWhispr を開いている間モデルを保持するには「しない」を選びます。",
+      "idleNever": "しない",
+      "idleMinutes": "{{count}} 分",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "クラウドプロバイダー",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1132,6 +1132,12 @@
       "description": "Limpe transcrições, processe comandos e corrija erros preservando seu tom de voz.",
       "enableTextCleanup": "Ativar limpeza de texto",
       "enableTextCleanupDescription": "A IA remove palavras de preenchimento, corrige gramática e pontuação",
+      "preloadOnStart": "Pré-carregar o modelo ao iniciar",
+      "preloadOnStartDescription": "Carrega o modelo de limpeza ao abrir o OpenWhispr para que o primeiro ditado seja rápido.",
+      "idleTimeout": "Descarregar quando ocioso",
+      "idleTimeoutDescription": "Libera memória da GPU após esse tempo de inatividade. Escolha Nunca para manter o modelo carregado enquanto o OpenWhispr estiver aberto.",
+      "idleNever": "Nunca",
+      "idleMinutes": "{{count}} minutos",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Provedores na nuvem",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1160,6 +1160,12 @@
       "description": "Очищайте транскрипции, обрабатывайте команды и исправляйте ошибки, сохраняя вашу манеру речи.",
       "enableTextCleanup": "Включить очистку текста",
       "enableTextCleanupDescription": "ИИ убирает слова-паразиты, исправляет грамматику и пунктуацию",
+      "preloadOnStart": "Предзагружать модель при запуске",
+      "preloadOnStartDescription": "Загружает модель очистки при открытии OpenWhispr, чтобы первая диктовка была быстрой.",
+      "idleTimeout": "Выгружать при простое",
+      "idleTimeoutDescription": "Освобождает память GPU после простоя. Выберите Никогда, чтобы модель оставалась загруженной, пока открыт OpenWhispr.",
+      "idleNever": "Никогда",
+      "idleMinutes": "{{count}} мин.",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "Облачные провайдеры",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1155,6 +1155,12 @@
       "description": "整理转录文本、处理指令、修正错误，同时保留你的语气风格。",
       "enableTextCleanup": "启用文本整理",
       "enableTextCleanupDescription": "AI 去除语气词，修正语法和标点",
+      "preloadOnStart": "启动时预加载模型",
+      "preloadOnStartDescription": "在 OpenWhispr 启动时加载清理模型，使首次听写更快。",
+      "idleTimeout": "空闲时卸载",
+      "idleTimeoutDescription": "在此空闲时长后释放 GPU 内存。选择从不可在 OpenWhispr 打开期间保持模型加载。",
+      "idleNever": "从不",
+      "idleMinutes": "{{count}} 分钟",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "云服务商",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1155,6 +1155,12 @@
       "description": "整理轉錄文字、處理指令、修正錯誤，同時保留你的語調。",
       "enableTextCleanup": "啟用文字整理",
       "enableTextCleanupDescription": "AI 移除語助詞，修正文法和標點",
+      "preloadOnStart": "啟動時預先載入模型",
+      "preloadOnStartDescription": "在 OpenWhispr 啟動時載入清理模型，讓首次聽寫更快。",
+      "idleTimeout": "閒置時卸載",
+      "idleTimeoutDescription": "在此閒置時間後釋放 GPU 記憶體。選擇永不可在 OpenWhispr 開啟期間保持模型載入。",
+      "idleNever": "永不",
+      "idleMinutes": "{{count}} 分鐘",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
         "providers": "雲端供應商",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -129,6 +129,7 @@ const BOOLEAN_SETTINGS = new Set([
   "noteFilesEnabled",
   "showTranscriptionPreview",
   "cleanupDisableThinking",
+  "cleanupPreloadOnStart",
   "dictationAgentDisableThinking",
   "noteFormattingDisableThinking",
   "chatAgentDisableThinking",
@@ -143,6 +144,7 @@ const ARRAY_SETTINGS = new Set(["customDictionary", "gcalAccounts"]);
 
 const NUMERIC_SETTINGS = new Set([
   "audioRetentionDays",
+  "cleanupIdleTimeoutMinutes",
   "whisperVadThreshold",
   "whisperVadMinSpeechDurationMs",
   "whisperVadMinSilenceDurationMs",
@@ -486,6 +488,8 @@ export interface SettingsState
   setUseDictationAgent: (value: boolean) => void;
   setCleanupModel: (value: string) => void;
   setCleanupProvider: (value: string) => void;
+  setCleanupPreloadOnStart: (value: boolean) => void;
+  setCleanupIdleTimeoutMinutes: (minutes: number) => void;
   setUiLanguage: (language: string) => void;
 
   setOpenaiApiKey: (key: string) => void;
@@ -716,6 +720,14 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   useDictationAgent: readBoolean("useDictationAgent", true),
   cleanupModel: readString("cleanupModel", ""),
   cleanupProvider: readString("cleanupProvider", "openai"),
+  cleanupPreloadOnStart: readBoolean("cleanupPreloadOnStart", false),
+  cleanupIdleTimeoutMinutes: (() => {
+    if (!isBrowser) return 5;
+    const stored = localStorage.getItem("cleanupIdleTimeoutMinutes");
+    if (stored === null) return 5;
+    const parsed = parseInt(stored, 10);
+    return isNaN(parsed) || parsed < 0 ? 5 : parsed;
+  })(),
 
   // Secrets hydrate from main process in initializeSettings, never from localStorage.
   openaiApiKey: "",
@@ -1019,6 +1031,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setUseDictationAgent: createBooleanSetter("useDictationAgent"),
   setCleanupProvider: createStringSetter("cleanupProvider"),
   setCleanupModel: createStringSetter("cleanupModel"),
+  setCleanupPreloadOnStart: createBooleanSetter("cleanupPreloadOnStart"),
+  setCleanupIdleTimeoutMinutes: (minutes: number) => {
+    if (isBrowser) localStorage.setItem("cleanupIdleTimeoutMinutes", String(minutes));
+    set({ cleanupIdleTimeoutMinutes: minutes });
+  },
 
   setCustomDictionary: (words: string[]) => {
     if (isBrowser) localStorage.setItem("customDictionary", JSON.stringify(words));
@@ -1434,6 +1451,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
       s.setUseDictationAgent(settings.useDictationAgent);
     if (settings.cleanupModel !== undefined) s.setCleanupModel(settings.cleanupModel);
     if (settings.cleanupProvider !== undefined) s.setCleanupProvider(settings.cleanupProvider);
+    if (settings.cleanupPreloadOnStart !== undefined)
+      s.setCleanupPreloadOnStart(settings.cleanupPreloadOnStart);
+    if (settings.cleanupIdleTimeoutMinutes !== undefined)
+      s.setCleanupIdleTimeoutMinutes(settings.cleanupIdleTimeoutMinutes);
     if (settings.cleanupCloudBaseUrl !== undefined)
       s.setCleanupCloudBaseUrl(settings.cleanupCloudBaseUrl);
     if (settings.cleanupCloudMode !== undefined) s.setCleanupCloudMode(settings.cleanupCloudMode);

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -699,6 +699,8 @@ declare global {
         model?: string;
         cleanupProvider: string;
         cleanupModel?: string;
+        cleanupPreloadOnStart?: boolean;
+        cleanupIdleTimeoutMinutes?: number;
         dictationAgentProvider: string;
         dictationAgentModel?: string;
       }) => Promise<void>;

--- a/test/helpers/idleTimeout.test.js
+++ b/test/helpers/idleTimeout.test.js
@@ -1,0 +1,21 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveIdleTimeoutMs, DEFAULT_IDLE_TIMEOUT_MS } = require("../../src/helpers/idleTimeout");
+
+test("defaults to five minutes when unset", () => {
+  assert.equal(resolveIdleTimeoutMs({}), DEFAULT_IDLE_TIMEOUT_MS);
+  assert.equal(DEFAULT_IDLE_TIMEOUT_MS, 5 * 60 * 1000);
+});
+
+test("uses the configured milliseconds", () => {
+  assert.equal(resolveIdleTimeoutMs({ CLEANUP_IDLE_TIMEOUT_MS: "1800000" }), 1800000);
+});
+
+test("zero means never (returns 0)", () => {
+  assert.equal(resolveIdleTimeoutMs({ CLEANUP_IDLE_TIMEOUT_MS: "0" }), 0);
+});
+
+test("invalid or negative values fall back to the default", () => {
+  assert.equal(resolveIdleTimeoutMs({ CLEANUP_IDLE_TIMEOUT_MS: "abc" }), DEFAULT_IDLE_TIMEOUT_MS);
+  assert.equal(resolveIdleTimeoutMs({ CLEANUP_IDLE_TIMEOUT_MS: "-1" }), DEFAULT_IDLE_TIMEOUT_MS);
+});


### PR DESCRIPTION
## Summary

Adds two settings for the local cleanup LLM so users can trade a little VRAM for consistently fast cleanup:

- Preload model on startup: loads the local cleanup model when the app opens, so the first dictation does not pay the cold start.
- Unload when idle: makes the existing idle-unload timeout configurable (5, 15, 30, 60 minutes, or Never). Never keeps the model loaded while the app is open.

Both default to current behavior (preload off, 5 minute idle), so existing users are unaffected.

## Motivation

The cleanup model is unloaded after a hardcoded 5 minutes idle (IDLE_TIMEOUT_MS in src/helpers/llamaServer.js). On GPU backends the next dictation then pays a cold start (model load, and on Vulkan, shader compilation), which can be slow. These settings let people who keep the app open avoid that.

## Changes

- src/helpers/idleTimeout.js: resolver for the idle timeout from CLEANUP_IDLE_TIMEOUT_MS (default 5 minutes, 0 means never), with a unit test.
- src/helpers/llamaServer.js: resetIdleTimer reads the resolver and does not arm the timer when the value is 0.
- src/helpers/modelManagerBridge.js: preloadModel starts the configured local cleanup model in the background (no-op if the provider is not local or the model is not downloaded).
- main.js: calls preloadModel on startup when CLEANUP_PRELOAD_ON_START is set.
- Settings plumbing: two new CleanupSettings fields, synced to the main process through the existing syncStartupPreferences IPC.
- src/components/SettingsPage.tsx: a preload toggle and an unload-when-idle select in the cleanup section, shown for local cleanup models.
- i18n: new keys added to all 10 locales.

## Test plan

- node --test test/helpers/idleTimeout.test.js
- node scripts/check-i18n.js
- Manual: set Unload when idle to Never and confirm the model stays loaded past 5 minutes; enable Preload on startup and confirm the server starts at launch; set a short idle and confirm the model unloads after it.
