### PR TITLE
fix(macos): holding Fn/Globe no longer triggers dictation in tap mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -1010,7 +1010,7 @@ async function startApp() {
               }
             }, MIN_HOLD_DURATION_MS);
           } else {
-            windowManager.sendToggleDictation();
+            globeKeyDownTime = Date.now();
           }
         } else {
           debugLogger?.debug("[Globe] Ignored — mainWindow not live");
@@ -1043,6 +1043,12 @@ async function startApp() {
             globeKeyIsRecording = false;
             debugLogger?.debug("[Globe] Stopping dictation (push release)");
             windowManager.sendStopDictation();
+          }
+        } else {
+          const heldMs = Date.now() - globeKeyDownTime;
+          globeKeyDownTime = 0;
+          if (heldMs <= MIN_HOLD_DURATION_MS) {
+            windowManager.sendToggleDictation();
           }
         }
       }


### PR DESCRIPTION
## Summary

- Issue: on macOS with activation mode set to `tap`, pressing and holding the Fn/Globe key (e.g. `Fn+F12` for volume) started dictation.
- Root cause: in `tap` mode, every `"globe-down"` toggled dictation immediately.
- Fix: in `tap` mode, dictation now toggles on `"globe-up"`, and only if the press was held for at most `MIN_HOLD_DURATION_MS`. A longer hold (Fn used as a modifier) is ignored.

Fixes #865.

## Changes

Minimal single-file change in `main.js` (7 lines).

## Tested

Built locally and tested on macOS Tahoe 26.3.1.