### PR TITLE
Add direct ElevenLabs Scribe transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Transcription
+
+- **ElevenLabs Scribe v2 BYOK transcription.** Added ElevenLabs as a first-class cloud transcription provider using the native `/v1/speech-to-text` API with `xi-api-key`, `model_id=scribe_v2`, language hints, and custom dictionary keyterms. This covers batch dictation and Notes audio/video upload; realtime transcription remains on the existing streaming providers.
+
 ## [1.7.2] - 2026-05-20
 
 A small patch on top of 1.7.1: zero unnecessary macOS Keychain prompts on first launch, working cloud transcription on Electron's `net.fetch`, the Note Formatting selector now actually controls model routing, Wave Terminal pastes via the terminal path, and a notes view stability fix.

--- a/docs/network-allowlist.md
+++ b/docs/network-allowlist.md
@@ -61,6 +61,7 @@ provider. Skip any provider not in use.
 | `generativelanguage.googleapis.com` | HTTPS | 443 | Gemini API key configured. |
 | `api.groq.com` | HTTPS | 443 | Groq API key configured. |
 | `api.mistral.ai` | HTTPS | 443 | Mistral API key configured. |
+| `api.elevenlabs.io` | HTTPS | 443 | ElevenLabs API key configured for Scribe transcription. |
 
 ## Notes
 

--- a/preload.js
+++ b/preload.js
@@ -358,6 +358,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveMistralKey: (key) => ipcRenderer.invoke("save-mistral-key", key),
   proxyMistralTranscription: (data) => ipcRenderer.invoke("proxy-mistral-transcription", data),
 
+  // ElevenLabs API
+  getElevenLabsKey: () => ipcRenderer.invoke("get-elevenlabs-key"),
+  saveElevenLabsKey: (key) => ipcRenderer.invoke("save-elevenlabs-key", key),
+  proxyElevenLabsTranscription: (data) =>
+    ipcRenderer.invoke("proxy-elevenlabs-transcription", data),
+
   // Custom endpoint API keys
   getCustomTranscriptionKey: () => ipcRenderer.invoke("get-custom-transcription-key"),
   saveCustomTranscriptionKey: (key) => ipcRenderer.invoke("save-custom-transcription-key", key),

--- a/src/assets/icons/providers/elevenlabs.svg
+++ b/src/assets/icons/providers/elevenlabs.svg
@@ -1,0 +1,4 @@
+<svg width="876" height="876" viewBox="0 0 876 876" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M468 292H528V584H468V292Z" fill="black"/>
+<path d="M348 292H408V584H348V292Z" fill="black"/>
+</svg>

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -85,6 +85,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    elevenlabsApiKey,
     dictationKey,
     activationMode,
     setActivationMode,
@@ -700,6 +701,8 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
             return groqApiKey.trim().length > 0;
           } else if (cloudTranscriptionProvider === "mistral") {
             return mistralApiKey.trim().length > 0;
+          } else if (cloudTranscriptionProvider === "elevenlabs") {
+            return elevenlabsApiKey.trim().length > 0;
           } else if (cloudTranscriptionProvider === "custom") {
             // Custom can work without API key for local endpoints
             return true;

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -202,6 +202,7 @@ const CLOUD_PROVIDER_TABS = [
   { id: "openai", name: "OpenAI" },
   { id: "groq", name: "Groq" },
   { id: "mistral", name: "Mistral" },
+  { id: "elevenlabs", name: "ElevenLabs" },
   { id: "custom", name: "Custom" },
 ];
 
@@ -273,6 +274,8 @@ export default function TranscriptionModelPicker({
   const setGroqApiKey = useSettingsStore((s) => s.setGroqApiKey);
   const mistralApiKey = useSettingsStore((s) => s.mistralApiKey);
   const setMistralApiKey = useSettingsStore((s) => s.setMistralApiKey);
+  const elevenlabsApiKey = useSettingsStore((s) => s.elevenlabsApiKey);
+  const setElevenlabsApiKey = useSettingsStore((s) => s.setElevenlabsApiKey);
   const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
   const setCustomTranscriptionApiKey = useSettingsStore((s) => s.setCustomTranscriptionApiKey);
   const effectiveLocal = mode === "local" ? true : mode === "cloud" ? false : useLocalWhisper;
@@ -591,7 +594,7 @@ export default function TranscriptionModelPicker({
         const providerNormalized = normalizeBaseUrl(provider.baseUrl);
         if (normalized === providerNormalized) {
           onCloudProviderSelect(provider.id);
-          onCloudModelSelect("whisper-1");
+          onCloudModelSelect(provider.models[0]?.id || "whisper-1");
           break;
         }
       }
@@ -870,6 +873,7 @@ export default function TranscriptionModelPicker({
                         {
                           groq: "https://console.groq.com/keys",
                           mistral: "https://console.mistral.ai/api-keys",
+                          elevenlabs: "https://elevenlabs.io/app/settings/api-keys",
                           openai: "https://platform.openai.com/api-keys",
                         }[selectedCloudProvider] || "https://platform.openai.com/api-keys"
                       )}
@@ -880,12 +884,22 @@ export default function TranscriptionModelPicker({
                   </div>
                   <ApiKeyInput
                     apiKey={
-                      { groq: groqApiKey, mistral: mistralApiKey, openai: openaiApiKey }[
+                      {
+                        groq: groqApiKey,
+                        mistral: mistralApiKey,
+                        elevenlabs: elevenlabsApiKey,
+                        openai: openaiApiKey,
+                      }[
                         selectedCloudProvider
                       ] || openaiApiKey
                     }
                     setApiKey={
-                      { groq: setGroqApiKey, mistral: setMistralApiKey, openai: setOpenaiApiKey }[
+                      {
+                        groq: setGroqApiKey,
+                        mistral: setMistralApiKey,
+                        elevenlabs: setElevenlabsApiKey,
+                        openai: setOpenaiApiKey,
+                      }[
                         selectedCloudProvider
                       ] || setOpenaiApiKey
                     }

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -37,6 +37,7 @@ import {
   getSettings,
 } from "../../stores/settingsStore";
 import { generateNoteTitle } from "../../utils/generateTitle";
+import { getBaseLanguageCode } from "../../utils/languageSupport";
 
 const TranscriptionModelPicker = React.lazy(() => import("../TranscriptionModelPicker"));
 
@@ -117,7 +118,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    elevenlabsApiKey,
     customTranscriptionApiKey,
+    customDictionary,
     updateTranscriptionSettings,
   } = useSettings();
 
@@ -199,7 +202,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
                 ? groqApiKey
                 : cloudTranscriptionProvider === "mistral"
                   ? mistralApiKey
-                  : customTranscriptionApiKey;
+                  : cloudTranscriptionProvider === "elevenlabs"
+                    ? elevenlabsApiKey
+                    : customTranscriptionApiKey;
           if (!cancelled) setProviderReady(!!key);
         }
         return;
@@ -231,6 +236,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     openaiApiKey,
     groqApiKey,
     mistralApiKey,
+    elevenlabsApiKey,
     customTranscriptionApiKey,
   ]);
 
@@ -244,6 +250,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     const name =
       cloudTranscriptionProvider === "custom"
         ? t("notes.upload.custom")
+        : cloudTranscriptionProvider === "elevenlabs"
+          ? "ElevenLabs"
         : cloudTranscriptionProvider.charAt(0).toUpperCase() + cloudTranscriptionProvider.slice(1);
     return `${name} · ${cloudTranscriptionModel}`;
   };
@@ -256,6 +264,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         return groqApiKey;
       case "mistral":
         return mistralApiKey;
+      case "elevenlabs":
+        return elevenlabsApiKey;
       case "custom":
         return customTranscriptionApiKey || "";
       default:
@@ -373,6 +383,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           apiKey: getActiveApiKey(),
           baseUrl: cloudTranscriptionBaseUrl || "",
           model: cloudTranscriptionModel,
+          provider: cloudTranscriptionProvider,
+          language: getBaseLanguageCode(getSettings().preferredLanguage),
+          keyterms: customDictionary,
         });
       }
 

--- a/src/components/ui/ProviderIcon.tsx
+++ b/src/components/ui/ProviderIcon.tsx
@@ -6,7 +6,7 @@ interface ProviderIconProps {
   className?: string;
 }
 
-const MONOCHROME_PROVIDERS = ["openai", "whisper", "anthropic", "openai-oss"];
+const MONOCHROME_PROVIDERS = ["openai", "whisper", "anthropic", "openai-oss", "elevenlabs"];
 
 export function ProviderIcon({ provider, className = "w-5 h-5" }: ProviderIconProps) {
   if (provider === "custom") {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -17,6 +17,8 @@ export const normalizeBaseUrl = (value?: string | null): string => {
     [/\/audio\/transcriptions$/i, ""],
     [/\/v1\/audio\/translations$/i, "/v1"],
     [/\/audio\/translations$/i, ""],
+    [/\/v1\/speech-to-text$/i, "/v1"],
+    [/\/speech-to-text$/i, ""],
   ];
 
   for (const [pattern, replacement] of suffixReplacements) {
@@ -76,6 +78,7 @@ export const API_ENDPOINTS = {
   GEMINI: "https://generativelanguage.googleapis.com/v1beta",
   GROQ_BASE: "https://api.groq.com/openai/v1",
   MISTRAL_BASE: "https://api.mistral.ai/v1",
+  ELEVENLABS_BASE: "https://api.elevenlabs.io/v1",
   TRANSCRIPTION_BASE: DEFAULT_TRANSCRIPTION_BASE,
   TRANSCRIPTION: buildApiUrl(DEFAULT_TRANSCRIPTION_BASE, "/audio/transcriptions"),
 } as const;

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -66,6 +66,7 @@ const PLACEHOLDER_KEYS = {
   openai: "your_openai_api_key_here",
   groq: "your_groq_api_key_here",
   mistral: "your_mistral_api_key_here",
+  elevenlabs: "your_elevenlabs_api_key_here",
 };
 
 const isValidApiKey = (key, provider = "openai") => {
@@ -884,6 +885,18 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         err.code = "API_KEY_MISSING";
         throw err;
       }
+    } else if (provider === "elevenlabs") {
+      apiKey = s.elevenlabsApiKey;
+      if (!isValidApiKey(apiKey, "elevenlabs")) {
+        apiKey = await window.electronAPI.getElevenLabsKey?.();
+      }
+      if (!isValidApiKey(apiKey, "elevenlabs")) {
+        const err = new Error(
+          "ElevenLabs API key not found. Please set your API key in the Control Panel."
+        );
+        err.code = "API_KEY_MISSING";
+        throw err;
+      }
     } else if (provider === "groq") {
       // Prefer store value (user-entered via UI) over main process (.env)
       apiKey = s.groqApiKey;
@@ -1537,6 +1550,35 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         throw new Error("No text transcribed - Mistral response was empty");
       }
 
+      if (provider === "elevenlabs" && window.electronAPI?.proxyElevenLabsTranscription) {
+        const audioBuffer = await optimizedAudio.arrayBuffer();
+        const result = await window.electronAPI.proxyElevenLabsTranscription({
+          audioBuffer,
+          apiKey,
+          model,
+          language,
+          keyterms: this.getKeyterms(),
+        });
+        const proxyText = result?.text;
+
+        if (proxyText && proxyText.trim().length > 0) {
+          timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
+          const rawText = proxyText;
+          const reasoningStart = performance.now();
+          const text = await this.processTranscription(proxyText, "elevenlabs");
+          timings.reasoningProcessingDurationMs = Math.round(performance.now() - reasoningStart);
+
+          const source = (await this.isReasoningAvailable()) ? "elevenlabs-reasoned" : "elevenlabs";
+          return { success: true, text, rawText, source, timings };
+        }
+
+        throw new Error("No text transcribed - ElevenLabs response was empty");
+      }
+
+      if (provider === "elevenlabs") {
+        throw new Error("ElevenLabs transcription bridge is unavailable in this build");
+      }
+
       logger.debug(
         "Making transcription API request",
         {
@@ -1754,6 +1796,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       if (provider === "custom") {
         return trimmedModel || "whisper-1";
       }
+      if (provider === "elevenlabs") {
+        return trimmedModel === "scribe_v2" ? trimmedModel : "scribe_v2";
+      }
 
       // Validate model matches provider to handle settings migration
       if (trimmedModel) {
@@ -1776,6 +1821,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // Return provider-appropriate default
       if (provider === "groq") return "whisper-large-v3-turbo";
       if (provider === "mistral") return "voxtral-mini-latest";
+      if (provider === "elevenlabs") return "scribe_v2";
       return "gpt-4o-mini-transcribe";
     } catch (error) {
       return "gpt-4o-mini-transcribe";
@@ -1830,6 +1876,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         base = API_ENDPOINTS.GROQ_BASE;
       } else if (currentProvider === "mistral") {
         base = API_ENDPOINTS.MISTRAL_BASE;
+      } else if (currentProvider === "elevenlabs") {
+        base = API_ENDPOINTS.ELEVENLABS_BASE;
       } else {
         // OpenAI or other standard providers
         base = API_ENDPOINTS.TRANSCRIPTION_BASE;
@@ -1893,7 +1941,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
 
       let endpoint;
-      if (/\/audio\/(transcriptions|translations)$/i.test(normalizedBase)) {
+      if (currentProvider === "elevenlabs") {
+        endpoint = buildApiUrl(normalizedBase, "/speech-to-text");
+        logger.debug(
+          "STT endpoint: using ElevenLabs speech-to-text path",
+          { base: normalizedBase, endpoint },
+          "transcription"
+        );
+      } else if (/\/audio\/(transcriptions|translations)$/i.test(normalizedBase)) {
         endpoint = normalizedBase;
         logger.debug("STT endpoint: using full path from config", { endpoint }, "transcription");
       } else {

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -12,6 +12,7 @@ const SECRET_KEYS = [
   "GEMINI_API_KEY",
   "GROQ_API_KEY",
   "MISTRAL_API_KEY",
+  "ELEVENLABS_API_KEY",
   "ASSEMBLYAI_API_KEY",
   "DEEPGRAM_API_KEY",
   "CUSTOM_TRANSCRIPTION_API_KEY",
@@ -287,6 +288,14 @@ class EnvironmentManager {
 
   saveMistralKey(key) {
     return this._saveKey("MISTRAL_API_KEY", key);
+  }
+
+  getElevenLabsKey() {
+    return this._getKey("ELEVENLABS_API_KEY");
+  }
+
+  saveElevenLabsKey(key) {
+    return this._saveKey("ELEVENLABS_API_KEY", key);
   }
 
   getAssemblyAIKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -62,6 +62,8 @@ function parseAttendees(raw) {
 }
 
 const MISTRAL_TRANSCRIPTION_URL = "https://api.mistral.ai/v1/audio/transcriptions";
+const ELEVENLABS_TRANSCRIPTION_URL = "https://api.elevenlabs.io/v1/speech-to-text";
+const ELEVENLABS_UNSUPPORTED_KEYTERM_CHARS = /[<>{}\[\]\\]/;
 
 // Debounce delay: wait for user to stop typing before processing corrections
 const AUTO_LEARN_DEBOUNCE_MS = 1500;
@@ -94,11 +96,13 @@ function buildMultipartBody(fileBuffer, fileName, contentType, fields = {}) {
   parts.push("\r\n");
 
   for (const [name, value] of Object.entries(fields)) {
-    if (value != null) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const fieldValue of values) {
+      if (fieldValue == null) continue;
       parts.push(
         `--${boundary}\r\n` +
           `Content-Disposition: form-data; name="${name}"\r\n\r\n` +
-          `${value}\r\n`
+          `${fieldValue}\r\n`
       );
     }
   }
@@ -149,6 +153,109 @@ function interpretTranscribeResponse(data) {
     throw new Error(data.data?.error || `API error: ${data.statusCode}`);
   }
   return data.data;
+}
+
+function normalizeElevenLabsKeyterms(keyterms) {
+  const rawTerms = Array.isArray(keyterms)
+    ? keyterms
+    : typeof keyterms === "string"
+      ? keyterms.split(",")
+      : [];
+  const normalized = [];
+  const seen = new Set();
+
+  for (const rawTerm of rawTerms) {
+    const term = String(rawTerm || "")
+      .trim()
+      .replace(/\s+/g, " ");
+    if (!term) continue;
+    if (term.length >= 50) continue;
+    if (term.split(/\s+/).length > 5) continue;
+    if (ELEVENLABS_UNSUPPORTED_KEYTERM_CHARS.test(term)) continue;
+
+    const dedupeKey = term.toLocaleLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    normalized.push(term);
+    if (normalized.length >= 1000) break;
+  }
+
+  return normalized;
+}
+
+function buildElevenLabsFields({ model, language, keyterms }) {
+  const fields = {
+    model_id: model || "scribe_v2",
+    timestamps_granularity: "none",
+    tag_audio_events: "false",
+  };
+  if (language && language !== "auto") {
+    fields.language_code = language;
+  }
+  const normalizedKeyterms = normalizeElevenLabsKeyterms(keyterms);
+  if (normalizedKeyterms.length > 0) {
+    fields.keyterms = normalizedKeyterms;
+  }
+  return fields;
+}
+
+function buildElevenLabsError(statusCode, data) {
+  const detail = data?.detail;
+  const message =
+    data?.error?.message ||
+    data?.error ||
+    data?.message ||
+    (typeof detail === "string" ? detail : detail?.message) ||
+    `API error: ${statusCode}`;
+  const err = new Error(`ElevenLabs API Error: ${statusCode} ${message}`);
+  if (statusCode === 401 || statusCode === 403) err.code = "INVALID_KEY";
+  else if (statusCode === 402) err.code = "PAYMENT_REQUIRED";
+  else if (statusCode === 429) err.code = "LIMIT_REACHED";
+  else if (statusCode >= 500) err.code = "SERVER_ERROR";
+  return err;
+}
+
+async function transcribeWithElevenLabs({
+  audioBuffer,
+  apiKey,
+  model,
+  language,
+  keyterms,
+  fileName = "audio.webm",
+  contentType = "audio/webm",
+}) {
+  const resolvedApiKey = (apiKey || "").trim();
+  if (!resolvedApiKey) {
+    const err = new Error("ElevenLabs API key not configured");
+    err.code = "API_KEY_MISSING";
+    throw err;
+  }
+
+  const buffer = Buffer.isBuffer(audioBuffer) ? audioBuffer : Buffer.from(audioBuffer);
+  const { body, boundary } = buildMultipartBody(
+    buffer,
+    fileName,
+    contentType,
+    buildElevenLabsFields({ model, language, keyterms })
+  );
+
+  const data = await postMultipart(new URL(ELEVENLABS_TRANSCRIPTION_URL), body, boundary, {
+    "xi-api-key": resolvedApiKey,
+  });
+
+  if (data.statusCode !== 200) {
+    throw buildElevenLabsError(data.statusCode, data.data);
+  }
+
+  const text = data.data?.text;
+  if (typeof text !== "string" || text.trim().length === 0) {
+    throw new Error("No text transcribed - ElevenLabs response was empty");
+  }
+
+  return {
+    text,
+    language: data.data?.language_code || data.data?.language || null,
+  };
 }
 
 async function chunkedCloudTranscribe({
@@ -490,6 +597,7 @@ class IPCHandlers {
   _resolveByokModel(provider, configuredModel) {
     const trimmed = (configuredModel || "").trim();
     if (provider === "custom") return trimmed || "whisper-1";
+    if (provider === "elevenlabs") return trimmed === "scribe_v2" ? trimmed : "scribe_v2";
     if (trimmed) {
       const isGroq = trimmed.startsWith("whisper-large-v3");
       const isOpenAI = trimmed.startsWith("gpt-4o") || trimmed === "whisper-1";
@@ -2512,6 +2620,28 @@ class IPCHandlers {
       }
     );
 
+    ipcMain.handle("get-elevenlabs-key", async () => {
+      return this.environmentManager.getElevenLabsKey();
+    });
+
+    ipcMain.handle("save-elevenlabs-key", async (event, key) => {
+      return this.environmentManager.saveElevenLabsKey(key);
+    });
+
+    ipcMain.handle(
+      "proxy-elevenlabs-transcription",
+      async (event, { audioBuffer, apiKey, model, language, keyterms }) => {
+        const resolvedApiKey = apiKey || this.environmentManager.getElevenLabsKey();
+        return transcribeWithElevenLabs({
+          audioBuffer,
+          apiKey: resolvedApiKey,
+          model,
+          language,
+          keyterms,
+        });
+      }
+    );
+
     ipcMain.handle("get-custom-transcription-key", async () => {
       return this.environmentManager.getCustomTranscriptionKey();
     });
@@ -3641,6 +3771,8 @@ class IPCHandlers {
           } else if (provider === "mistral") {
             apiKey = this.environmentManager.getMistralKey();
             endpoint = MISTRAL_TRANSCRIPTION_URL;
+          } else if (provider === "elevenlabs") {
+            apiKey = this.environmentManager.getElevenLabsKey();
           } else if (provider === "custom") {
             apiKey = this.environmentManager.getCustomTranscriptionKey();
             const base = (settings?.cloudTranscriptionBaseUrl || "").trim();
@@ -3657,25 +3789,36 @@ class IPCHandlers {
             throw new Error(`${provider} API key not configured`);
           }
 
-          const formData = new FormData();
-          formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
-          formData.append("model", model);
-          if (language) formData.append("language", language);
-          const headers = {};
-          if (provider === "mistral") {
-            headers["x-api-key"] = apiKey;
-          } else if (apiKey) {
-            headers.Authorization = `Bearer ${apiKey}`;
-          }
-
-          const response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
-          if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`${provider} API Error: ${response.status} ${errorText}`);
-          }
-          const data = await response.json();
-          if (data?.text) {
+          if (provider === "elevenlabs") {
+            const data = await transcribeWithElevenLabs({
+              audioBuffer: buffer,
+              apiKey,
+              model,
+              language,
+              keyterms: this._getDictionarySafe(),
+            });
             result = { text: data.text, source: provider, model };
+          } else {
+            const formData = new FormData();
+            formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
+            formData.append("model", model);
+            if (language) formData.append("language", language);
+            const headers = {};
+            if (provider === "mistral") {
+              headers["x-api-key"] = apiKey;
+            } else if (apiKey) {
+              headers.Authorization = `Bearer ${apiKey}`;
+            }
+
+            const response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
+            if (!response.ok) {
+              const errorText = await response.text();
+              throw new Error(`${provider} API Error: ${response.status} ${errorText}`);
+            }
+            const data = await response.json();
+            if (data?.text) {
+              result = { text: data.text, source: provider, model };
+            }
           }
         }
 
@@ -6214,12 +6357,11 @@ class IPCHandlers {
 
     ipcMain.handle(
       "transcribe-audio-file-byok",
-      async (event, { filePath, apiKey, baseUrl, model }) => {
+      async (event, { filePath, apiKey, baseUrl, model, provider, language, keyterms }) => {
         const fs = require("fs");
         const BYOK_FILE_SIZE_LIMIT = 25 * 1024 * 1024; // 25 MB
         try {
           if (!apiKey) throw new Error("No API key configured. Add your key in Settings.");
-          if (!baseUrl) throw new Error("No transcription endpoint configured.");
 
           const fileSize = fs.statSync(filePath).size;
           if (fileSize > BYOK_FILE_SIZE_LIMIT) {
@@ -6233,6 +6375,21 @@ class IPCHandlers {
           const ext = path.extname(filePath).toLowerCase().replace(".", "");
           const contentType = AUDIO_MIME_TYPES[ext] || "audio/mpeg";
           const fileName = path.basename(filePath);
+
+          if (provider === "elevenlabs") {
+            const result = await transcribeWithElevenLabs({
+              audioBuffer,
+              apiKey,
+              model,
+              language,
+              keyterms,
+              fileName,
+              contentType,
+            });
+            return { success: true, text: result.text, language: result.language };
+          }
+
+          if (!baseUrl) throw new Error("No transcription endpoint configured.");
 
           let transcriptionUrl = baseUrl.replace(/\/+$/, "");
           if (!transcriptionUrl.endsWith("/audio/transcriptions")) {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -56,6 +56,7 @@ export interface ApiKeySettings {
   geminiApiKey: string;
   groqApiKey: string;
   mistralApiKey: string;
+  elevenlabsApiKey: string;
   customTranscriptionApiKey: string;
   cleanupCustomApiKey: string;
 }
@@ -215,6 +216,7 @@ function useSettingsInternal() {
     geminiApiKey: store.geminiApiKey,
     groqApiKey: store.groqApiKey,
     mistralApiKey: store.mistralApiKey,
+    elevenlabsApiKey: store.elevenlabsApiKey,
     dictationKey: store.dictationKey,
     meetingKey: store.meetingKey,
     meetingHotkeyLayoutMode: store.meetingHotkeyLayoutMode,
@@ -250,6 +252,7 @@ function useSettingsInternal() {
     setGeminiApiKey: store.setGeminiApiKey,
     setGroqApiKey: store.setGroqApiKey,
     setMistralApiKey: store.setMistralApiKey,
+    setElevenlabsApiKey: store.setElevenlabsApiKey,
     customTranscriptionApiKey: store.customTranscriptionApiKey,
     setCustomTranscriptionApiKey: store.setCustomTranscriptionApiKey,
     cleanupCustomApiKey: store.cleanupCustomApiKey,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1747,7 +1747,8 @@
         "openai_whisper_1": "Originales Whisper-Modell",
         "groq_whisper_large_v3": "Hochpräzise Spracherkennung",
         "groq_whisper_large_v3_turbo": "216x Echtzeitgeschwindigkeit",
-        "mistral_voxtral_mini_latest": "Schnelle mehrsprachige Transkription"
+        "mistral_voxtral_mini_latest": "Schnelle mehrsprachige Transkription",
+        "elevenlabs_scribe_v2": "Präzise mehrsprachige Transkription mit Schlüsselbegriff-Prompting"
       },
       "cloud": {
         "openai_gpt_5_2": "Starkes Reasoning-Modell",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1847,7 +1847,8 @@
         "openai_whisper_1": "Original Whisper model",
         "groq_whisper_large_v3": "High accuracy speech recognition",
         "groq_whisper_large_v3_turbo": "216x real-time speed",
-        "mistral_voxtral_mini_latest": "Fast multilingual transcription"
+        "mistral_voxtral_mini_latest": "Fast multilingual transcription",
+        "elevenlabs_scribe_v2": "Accurate multilingual transcription with keyterm prompting"
       },
       "cloud": {
         "openai_gpt_5_2": "Strong reasoning model",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1795,7 +1795,8 @@
         "openai_whisper_1": "Modelo Whisper original",
         "groq_whisper_large_v3": "Reconocimiento de voz de alta precisión",
         "groq_whisper_large_v3_turbo": "Velocidad 216x en tiempo real",
-        "mistral_voxtral_mini_latest": "Transcripción multilingüe rápida"
+        "mistral_voxtral_mini_latest": "Transcripción multilingüe rápida",
+        "elevenlabs_scribe_v2": "Transcripción multilingüe precisa con indicaciones de términos clave"
       },
       "cloud": {
         "openai_gpt_5_2": "Modelo fuerte de razonamiento",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1795,7 +1795,8 @@
         "openai_whisper_1": "Modèle Whisper original",
         "groq_whisper_large_v3": "Reconnaissance vocale haute précision",
         "groq_whisper_large_v3_turbo": "Vitesse 216x en temps réel",
-        "mistral_voxtral_mini_latest": "Transcription multilingue rapide"
+        "mistral_voxtral_mini_latest": "Transcription multilingue rapide",
+        "elevenlabs_scribe_v2": "Transcription multilingue précise avec guidage par mots-clés"
       },
       "cloud": {
         "openai_gpt_5_2": "Modèle de raisonnement performant",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1747,7 +1747,8 @@
         "openai_whisper_1": "Modello Whisper originale",
         "groq_whisper_large_v3_turbo": "Velocità 216x in tempo reale",
         "groq_whisper_large_v3": "Modello Large v3, veloce e preciso",
-        "mistral_voxtral_mini_latest": "Trascrizione multilingue veloce"
+        "mistral_voxtral_mini_latest": "Trascrizione multilingue veloce",
+        "elevenlabs_scribe_v2": "Trascrizione multilingue accurata con suggerimenti di termini chiave"
       },
       "cloud": {
         "openai_gpt_5_2": "Modello di ragionamento potente",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1747,7 +1747,8 @@
         "openai_whisper_1": "オリジナル Whisper モデル",
         "groq_whisper_large_v3_turbo": "リアルタイムの 216 倍速",
         "groq_whisper_large_v3": "Large v3 モデル、高速かつ高精度",
-        "mistral_voxtral_mini_latest": "高速多言語文字起こし"
+        "mistral_voxtral_mini_latest": "高速多言語文字起こし",
+        "elevenlabs_scribe_v2": "キーワード補助に対応した高精度な多言語文字起こし"
       },
       "cloud": {
         "openai_gpt_5_2": "強力な推論モデル",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1719,7 +1719,8 @@
         "openai_whisper_1": "Modelo Whisper original",
         "groq_whisper_large_v3_turbo": "Velocidade 216x em tempo real",
         "groq_whisper_large_v3": "Modelo Large v3, rápido e preciso",
-        "mistral_voxtral_mini_latest": "Transcrição multilíngue rápida"
+        "mistral_voxtral_mini_latest": "Transcrição multilíngue rápida",
+        "elevenlabs_scribe_v2": "Transcrição multilíngue precisa com orientação por termos-chave"
       },
       "cloud": {
         "openai_gpt_5_2": "Modelo forte de raciocínio",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1747,7 +1747,8 @@
         "openai_whisper_1": "Оригинальная модель Whisper",
         "groq_whisper_large_v3_turbo": "Скорость в 216 раз быстрее реального времени",
         "groq_whisper_large_v3": "Модель Large v3, быстрая и точная",
-        "mistral_voxtral_mini_latest": "Быстрая многоязычная транскрипция"
+        "mistral_voxtral_mini_latest": "Быстрая многоязычная транскрипция",
+        "elevenlabs_scribe_v2": "Точная многоязычная транскрипция с подсказками ключевых терминов"
       },
       "cloud": {
         "openai_gpt_5_2": "Сильная модель рассуждения",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1742,7 +1742,8 @@
         "openai_whisper_1": "原始 Whisper 模型",
         "groq_whisper_large_v3_turbo": "216 倍实时速度",
         "groq_whisper_large_v3": "Large v3 模型，快速且精准",
-        "mistral_voxtral_mini_latest": "快速多语言转录"
+        "mistral_voxtral_mini_latest": "快速多语言转录",
+        "elevenlabs_scribe_v2": "支持关键词提示的高精度多语言转录"
       },
       "cloud": {
         "openai_gpt_5_2": "强大的推理模型",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1742,7 +1742,8 @@
         "openai_whisper_1": "原始 Whisper 模型",
         "groq_whisper_large_v3_turbo": "216 倍即時速度",
         "groq_whisper_large_v3": "Large v3 模型，快速且精準",
-        "mistral_voxtral_mini_latest": "快速多語言轉錄"
+        "mistral_voxtral_mini_latest": "快速多語言轉錄",
+        "elevenlabs_scribe_v2": "支援關鍵詞提示的高精度多語言轉錄"
       },
       "cloud": {
         "openai_gpt_5_2": "強大的推理模型",

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -66,6 +66,7 @@ export interface TranscriptionProviderData {
   id: string;
   name: string;
   baseUrl: string;
+  apiType?: "openai-compatible" | "elevenlabs";
   models: TranscriptionModelDefinition[];
 }
 

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -191,6 +191,20 @@
           "descriptionKey": "models.descriptions.transcription.mistral_voxtral_mini_latest"
         }
       ]
+    },
+    {
+      "id": "elevenlabs",
+      "name": "ElevenLabs",
+      "baseUrl": "https://api.elevenlabs.io/v1",
+      "apiType": "elevenlabs",
+      "models": [
+        {
+          "id": "scribe_v2",
+          "name": "Scribe v2",
+          "description": "Accurate multilingual transcription with keyterm prompting",
+          "descriptionKey": "models.descriptions.transcription.elevenlabs_scribe_v2"
+        }
+      ]
     }
   ],
   "cloudProviders": [

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -493,6 +493,7 @@ export interface SettingsState
   setGeminiApiKey: (key: string) => void;
   setGroqApiKey: (key: string) => void;
   setMistralApiKey: (key: string) => void;
+  setElevenlabsApiKey: (key: string) => void;
   setCustomTranscriptionApiKey: (key: string) => void;
   setCleanupCustomApiKey: (key: string) => void;
 
@@ -619,6 +620,7 @@ const SECRET_IPC_SAVERS = {
   gemini: "saveGeminiKey",
   groq: "saveGroqKey",
   mistral: "saveMistralKey",
+  elevenlabs: "saveElevenLabsKey",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
   bedrockAccessKeyId: "saveBedrockAccessKeyId",
@@ -656,6 +658,7 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
   "geminiApiKey",
   "groqApiKey",
   "mistralApiKey",
+  "elevenlabsApiKey",
   "customTranscriptionApiKey",
   "customReasoningApiKey",
   "cleanupCustomApiKey",
@@ -723,6 +726,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   geminiApiKey: "",
   groqApiKey: "",
   mistralApiKey: "",
+  elevenlabsApiKey: "",
   customTranscriptionApiKey: "",
   cleanupCustomApiKey: "",
 
@@ -1072,6 +1076,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ mistralApiKey: key });
     debouncedSaveSecret("mistral", key);
     invalidateApiKeyCaches("mistral");
+  },
+  setElevenlabsApiKey: (key: string) => {
+    set({ elevenlabsApiKey: key });
+    debouncedSaveSecret("elevenlabs", key);
+    invalidateApiKeyCaches();
   },
   setCustomTranscriptionApiKey: (key: string) => {
     set({ customTranscriptionApiKey: key });
@@ -1446,6 +1455,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (keys.geminiApiKey !== undefined) s.setGeminiApiKey(keys.geminiApiKey);
     if (keys.groqApiKey !== undefined) s.setGroqApiKey(keys.groqApiKey);
     if (keys.mistralApiKey !== undefined) s.setMistralApiKey(keys.mistralApiKey);
+    if (keys.elevenlabsApiKey !== undefined) s.setElevenlabsApiKey(keys.elevenlabsApiKey);
     if (keys.customTranscriptionApiKey !== undefined)
       s.setCustomTranscriptionApiKey(keys.customTranscriptionApiKey);
     if (keys.cleanupCustomApiKey !== undefined) s.setCleanupCustomApiKey(keys.cleanupCustomApiKey);
@@ -1652,6 +1662,7 @@ export async function initializeSettings(): Promise<void> {
         gemini,
         groq,
         mistral,
+        elevenlabs,
         customTx,
         customRx,
         bedrockAccessKeyId,
@@ -1665,6 +1676,7 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getGeminiKey?.(),
         window.electronAPI.getGroqKey?.(),
         window.electronAPI.getMistralKey?.(),
+        window.electronAPI.getElevenLabsKey?.(),
         window.electronAPI.getCustomTranscriptionKey?.(),
         window.electronAPI.getCleanupCustomKey?.(),
         window.electronAPI.getBedrockAccessKeyId?.(),
@@ -1680,6 +1692,7 @@ export async function initializeSettings(): Promise<void> {
         geminiApiKey: gemini || "",
         groqApiKey: groq || "",
         mistralApiKey: mistral || "",
+        elevenlabsApiKey: elevenlabs || "",
         customTranscriptionApiKey: customTx || "",
         cleanupCustomApiKey: customRx || "",
         bedrockAccessKeyId: bedrockAccessKeyId || "",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -976,6 +976,17 @@ declare global {
         contextBias?: string[];
       }) => Promise<{ text: string }>;
 
+      // ElevenLabs API key management
+      getElevenLabsKey?: () => Promise<string | null>;
+      saveElevenLabsKey?: (key: string) => Promise<void>;
+      proxyElevenLabsTranscription?: (data: {
+        audioBuffer: ArrayBuffer;
+        apiKey?: string | null;
+        model?: string;
+        language?: string;
+        keyterms?: string[];
+      }) => Promise<{ text: string; language?: string | null }>;
+
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;
       saveCustomTranscriptionKey?: (key: string) => Promise<void>;
@@ -1223,10 +1234,14 @@ declare global {
         apiKey: string;
         baseUrl: string;
         model: string;
+        provider?: string;
+        language?: string | null;
+        keyterms?: string[];
       }) => Promise<{
         success: boolean;
         text?: string;
         error?: string;
+        language?: string | null;
       }>;
 
       // Usage limit events

--- a/src/utils/providerIcons.ts
+++ b/src/utils/providerIcons.ts
@@ -11,6 +11,7 @@ import gemmaIcon from "@/assets/icons/providers/gemma.svg";
 import bedrockIcon from "@/assets/icons/providers/bedrock.svg";
 import azureIcon from "@/assets/icons/providers/azure.svg";
 import vertexIcon from "@/assets/icons/providers/vertex.svg";
+import elevenlabsIcon from "@/assets/icons/providers/elevenlabs.svg";
 
 export const PROVIDER_ICONS: Record<string, string> = {
   openai: openaiIcon,
@@ -27,13 +28,14 @@ export const PROVIDER_ICONS: Record<string, string> = {
   bedrock: bedrockIcon,
   azure: azureIcon,
   vertex: vertexIcon,
+  elevenlabs: elevenlabsIcon,
 };
 
 export function getProviderIcon(provider: string): string | undefined {
   return PROVIDER_ICONS[provider];
 }
 
-export const MONOCHROME_PROVIDERS = ["openai", "whisper", "anthropic", "openai-oss"] as const;
+export const MONOCHROME_PROVIDERS = ["openai", "whisper", "anthropic", "openai-oss", "elevenlabs"] as const;
 
 export function isMonochromeProvider(provider: string): boolean {
   return (MONOCHROME_PROVIDERS as readonly string[]).includes(provider);


### PR DESCRIPTION
## Summary

- Adds ElevenLabs as a first-class speech-to-text provider using the native Scribe v2 API.
- Stores a separate `ELEVENLABS_API_KEY` through the existing secure settings/preload/IPC path.
- Routes batch dictation and Notes audio/video upload to `/v1/speech-to-text` with `xi-api-key`, `model_id=scribe_v2`, optional `language_code`, and sanitized custom dictionary `keyterms`.
- Keeps realtime transcription out of scope for v1.

## Testing

- `npm run i18n:check`
- `npm run typecheck`
- `npm run lint` (passes with 3 pre-existing warnings in unrelated files)
- `npm run build:renderer`
- `node --check src/helpers/ipcHandlers.js`
- `node --check src/helpers/environment.js`
- `node --check preload.js`

## Notes

- All locale files include the new model description key.
- Manual macOS UI smoke and real-account ElevenLabs audio smoke are still pending because this was prepared from a headless Linux checkout.