### PR TITLE
fix: dictation hotkey silently dying in hyprland on config reload.

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -291,6 +291,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   setHotkeyListeningMode: (enabled, newHotkey) =>
     ipcRenderer.invoke("set-hotkey-listening-mode", enabled, newHotkey),
   getHotkeyModeInfo: () => ipcRenderer.invoke("get-hotkey-mode-info"),
+  getHyprlandConfigStatus: () => ipcRenderer.invoke("get-hyprland-config-status"),
   startWindowDrag: () => ipcRenderer.invoke("start-window-drag"),
   stopWindowDrag: () => ipcRenderer.invoke("stop-window-drag"),
   setMainWindowInteractivity: (interactive) =>

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -34,6 +34,7 @@ import { formatHotkeyLabel, getDefaultHotkey, isGlobeLikeHotkey } from "../utils
 import { useAuth } from "../hooks/useAuth";
 import { HotkeyInput } from "./ui/HotkeyInput";
 import { useHotkeyRegistration } from "../hooks/useHotkeyRegistration";
+import { useHotkeyModeInfo } from "../hooks/useHotkeyModeInfo";
 import { getValidationMessage } from "../utils/hotkeyValidator";
 import { validateHotkeyForSlot } from "../utils/hotkeyValidation";
 import { getCachedPlatform, getPlatform } from "../utils/platform";
@@ -105,12 +106,8 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [skipAuth, setSkipAuth] = useState(false);
   const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
   const [isModelDownloaded, setIsModelDownloaded] = useState(false);
-  const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
-  const [isUsingHyprland, setIsUsingHyprland] = useState(false);
-  const [hyprlandConfigStatus, setHyprlandConfigStatus] = useState<{
-    canWrite: boolean;
-    path: string;
-  } | null>(null);
+  const { isUsingNativeShortcut, isUsingHyprland, hyprlandConfigStatus, supportsPushToTalk } =
+    useHotkeyModeInfo("onboarding");
   const readableHotkey = formatHotkeyLabel(hotkey);
   const { alertDialog, confirmDialog, showAlertDialog, hideAlertDialog, hideConfirmDialog } =
     useDialogs();
@@ -181,28 +178,10 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const showProgress = currentStep > 0;
 
   useEffect(() => {
-    const checkHotkeyMode = async () => {
-      try {
-        const info = await window.electronAPI?.getHotkeyModeInfo();
-        if (info?.isUsingNativeShortcut) {
-          setIsUsingNativeShortcut(true);
-          if (!info.supportsPushToTalk) {
-            setActivationMode("tap");
-          }
-        }
-        if (info?.isUsingHyprland) {
-          setIsUsingHyprland(true);
-          const configStatus = await window.electronAPI?.getHyprlandConfigStatus?.();
-          if (configStatus) {
-            setHyprlandConfigStatus(configStatus);
-          }
-        }
-      } catch (error) {
-        logger.error("Failed to check hotkey mode", { error }, "onboarding");
-      }
-    };
-    checkHotkeyMode();
-  }, [setActivationMode]);
+    if (isUsingNativeShortcut && !supportsPushToTalk) {
+      setActivationMode("tap");
+    }
+  }, [isUsingNativeShortcut, supportsPushToTalk, setActivationMode]);
 
   // Update wizard UI when backend falls back to a different hotkey.
   // Only update local state — don't persist to localStorage so the app

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -100,6 +100,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
   const [isModelDownloaded, setIsModelDownloaded] = useState(false);
   const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
+  const [isUsingHyprland, setIsUsingHyprland] = useState(false);
   const readableHotkey = formatHotkeyLabel(hotkey);
   const { alertDialog, confirmDialog, showAlertDialog, hideAlertDialog, hideConfirmDialog } =
     useDialogs();
@@ -170,6 +171,9 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
           if (!info.supportsPushToTalk) {
             setActivationMode("tap");
           }
+        }
+        if (info?.isUsingHyprland) {
+          setIsUsingHyprland(true);
         }
       } catch (error) {
         logger.error("Failed to check hotkey mode", { error }, "onboarding");
@@ -615,10 +619,15 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
       <div className="rounded-lg border border-border-subtle bg-surface-1 overflow-hidden">
         {/* Hotkey section */}
         <div className="p-4 border-b border-border-subtle">
-          <div className="flex items-center justify-between mb-3">
+          <div className="mb-3">
             <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
               {t("onboarding.activation.hotkey")}
             </span>
+            {isUsingHyprland && (
+              <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">
+                {t("settingsPage.general.hotkey.hyprlandUnbindDescription")}
+              </p>
+            )}
           </div>
           <HotkeyInput
             value={hotkey}

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -18,6 +18,7 @@ import PermissionsSection from "./ui/PermissionsSection";
 import SupportDropdown from "./ui/SupportDropdown";
 import StepProgress from "./ui/StepProgress";
 import { AlertDialog, ConfirmDialog } from "./ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useDialogs } from "../hooks/useDialogs";
 import { usePermissions } from "../hooks/usePermissions";
@@ -101,6 +102,10 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [isModelDownloaded, setIsModelDownloaded] = useState(false);
   const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
   const [isUsingHyprland, setIsUsingHyprland] = useState(false);
+  const [hyprlandConfigStatus, setHyprlandConfigStatus] = useState<{
+    canWrite: boolean;
+    path: string;
+  } | null>(null);
   const readableHotkey = formatHotkeyLabel(hotkey);
   const { alertDialog, confirmDialog, showAlertDialog, hideAlertDialog, hideConfirmDialog } =
     useDialogs();
@@ -174,6 +179,10 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         }
         if (info?.isUsingHyprland) {
           setIsUsingHyprland(true);
+          const configStatus = await window.electronAPI?.getHyprlandConfigStatus?.();
+          if (configStatus) {
+            setHyprlandConfigStatus(configStatus);
+          }
         }
       } catch (error) {
         logger.error("Failed to check hotkey mode", { error }, "onboarding");
@@ -614,6 +623,19 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         </h2>
         <p className="text-xs text-muted-foreground">{t("onboarding.activation.description")}</p>
       </div>
+
+      {isUsingHyprland && hyprlandConfigStatus && !hyprlandConfigStatus.canWrite && (
+        <Alert>
+          <AlertTitle>
+            {t("settingsPage.general.hotkey.hyprlandConfigWriteWarningTitle")}
+          </AlertTitle>
+          <AlertDescription>
+            {t("settingsPage.general.hotkey.hyprlandConfigWriteWarningDescription", {
+              path: hyprlandConfigStatus.path,
+            })}
+          </AlertDescription>
+        </Alert>
+      )}
 
       {/* Unified control surface */}
       <div className="rounded-lg border border-border-subtle bg-surface-1 overflow-hidden">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -66,6 +66,7 @@ import PromptStudio from "./ui/PromptStudio";
 import { ProviderTabs } from "./ui/ProviderTabs";
 import { HotkeyInput } from "./ui/HotkeyInput";
 import { useHotkeyRegistration } from "../hooks/useHotkeyRegistration";
+import { useHotkeyModeInfo } from "../hooks/useHotkeyModeInfo";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { validateHotkeyForSlot } from "../utils/hotkeyValidation";
 import { getPlatform, getCachedPlatform } from "../utils/platform";
@@ -988,12 +989,8 @@ export default function SettingsPage({
     [dictationKey, meetingKey, chatAgentKey, t]
   );
 
-  const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
-  const [isUsingHyprland, setIsUsingHyprland] = useState(false);
-  const [hyprlandConfigStatus, setHyprlandConfigStatus] = useState<{
-    canWrite: boolean;
-    path: string;
-  } | null>(null);
+  const { isUsingNativeShortcut, isUsingHyprland, hyprlandConfigStatus, supportsPushToTalk } =
+    useHotkeyModeInfo("settings");
   const [effectiveDefaultHotkey, setEffectiveDefaultHotkey] = useState<string | null>(null);
   const [linuxPttAvailable, setLinuxPttAvailable] = useState(true);
 
@@ -1108,25 +1105,13 @@ export default function SettingsPage({
   }, [checkWhisperInstallation, getAppVersion]);
 
   useEffect(() => {
-    const checkHotkeyMode = async () => {
-      try {
-        const info = await window.electronAPI?.getHotkeyModeInfo();
-        if (info?.isUsingNativeShortcut) {
-          setIsUsingNativeShortcut(true);
-          if (!info.supportsPushToTalk) {
-            setActivationMode("tap");
-          }
-        }
-        if (info?.isUsingHyprland) {
-          setIsUsingHyprland(true);
-          const configStatus = await window.electronAPI?.getHyprlandConfigStatus?.();
-          if (configStatus) {
-            setHyprlandConfigStatus(configStatus);
-          }
-        }
-      } catch (error) {
-        logger.error("Failed to check hotkey mode", error, "settings");
-      }
+    if (isUsingNativeShortcut && !supportsPushToTalk) {
+      setActivationMode("tap");
+    }
+  }, [isUsingNativeShortcut, supportsPushToTalk, setActivationMode]);
+
+  useEffect(() => {
+    const loadEffectiveDefaultHotkey = async () => {
       try {
         const key = await window.electronAPI?.getEffectiveDefaultHotkey?.();
         if (key) setEffectiveDefaultHotkey(key);
@@ -1134,8 +1119,8 @@ export default function SettingsPage({
         logger.error("Failed to get effective default hotkey", error, "settings");
       }
     };
-    checkHotkeyMode();
-  }, [setActivationMode]);
+    loadEffectiveDefaultHotkey();
+  }, []);
 
   useEffect(() => {
     const cleanup = window.electronAPI?.onLinuxPttPermissionDenied?.(() => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -961,6 +961,7 @@ export default function SettingsPage({
   );
 
   const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
+  const [hyprlandConfigMissing, setHyprlandConfigMissing] = useState(false);
   const [effectiveDefaultHotkey, setEffectiveDefaultHotkey] = useState<string | null>(null);
   const [linuxPttAvailable, setLinuxPttAvailable] = useState(true);
 
@@ -1083,6 +1084,9 @@ export default function SettingsPage({
           if (!info.supportsPushToTalk) {
             setActivationMode("tap");
           }
+        }
+        if (info?.hyprlandConfigMissing) {
+          setHyprlandConfigMissing(true);
         }
       } catch (error) {
         logger.error("Failed to check hotkey mode", error, "settings");
@@ -3177,6 +3181,17 @@ EOF`,
       case "hotkeys":
         return (
           <div className="space-y-6">
+            {hyprlandConfigMissing && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertTitle>
+                  {t("settingsPage.general.hotkey.hyprlandConfigMissingTitle")}
+                </AlertTitle>
+                <AlertDescription>
+                  {t("settingsPage.general.hotkey.hyprlandConfigMissingDescription")}
+                </AlertDescription>
+              </Alert>
+            )}
             {/* Dictation Hotkey */}
             <div>
               <SectionHeader

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -971,7 +971,10 @@ export default function SettingsPage({
 
   const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
   const [isUsingHyprland, setIsUsingHyprland] = useState(false);
-  const [hyprlandConfigMissing, setHyprlandConfigMissing] = useState(false);
+  const [hyprlandConfigStatus, setHyprlandConfigStatus] = useState<{
+    canWrite: boolean;
+    path: string;
+  } | null>(null);
   const [effectiveDefaultHotkey, setEffectiveDefaultHotkey] = useState<string | null>(null);
   const [linuxPttAvailable, setLinuxPttAvailable] = useState(true);
 
@@ -1097,9 +1100,10 @@ export default function SettingsPage({
         }
         if (info?.isUsingHyprland) {
           setIsUsingHyprland(true);
-        }
-        if (info?.hyprlandConfigMissing) {
-          setHyprlandConfigMissing(true);
+          const configStatus = await window.electronAPI?.getHyprlandConfigStatus?.();
+          if (configStatus) {
+            setHyprlandConfigStatus(configStatus);
+          }
         }
       } catch (error) {
         logger.error("Failed to check hotkey mode", error, "settings");
@@ -3194,14 +3198,16 @@ EOF`,
       case "hotkeys":
         return (
           <div className="space-y-6">
-            {hyprlandConfigMissing && (
+            {isUsingHyprland && hyprlandConfigStatus && !hyprlandConfigStatus.canWrite && (
               <Alert>
                 <Info className="h-4 w-4" />
                 <AlertTitle>
-                  {t("settingsPage.general.hotkey.hyprlandConfigMissingTitle")}
+                  {t("settingsPage.general.hotkey.hyprlandConfigWriteWarningTitle")}
                 </AlertTitle>
                 <AlertDescription>
-                  {t("settingsPage.general.hotkey.hyprlandConfigMissingDescription")}
+                  {t("settingsPage.general.hotkey.hyprlandConfigWriteWarningDescription", {
+                    path: hyprlandConfigStatus.path,
+                  })}
                 </AlertDescription>
               </Alert>
             )}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -166,13 +166,22 @@ function SettingsPanelRow({
   );
 }
 
-function SectionHeader({ title, description }: { title: string; description?: string }) {
+function SectionHeader({
+  title,
+  description,
+  note,
+}: {
+  title: string;
+  description?: string;
+  note?: string;
+}) {
   return (
     <div className="mb-3">
       <h3 className="text-xs font-semibold text-foreground tracking-tight">{title}</h3>
       {description && (
         <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">{description}</p>
       )}
+      {note && <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">{note}</p>}
     </div>
   );
 }
@@ -961,6 +970,7 @@ export default function SettingsPage({
   );
 
   const [isUsingNativeShortcut, setIsUsingNativeShortcut] = useState(false);
+  const [isUsingHyprland, setIsUsingHyprland] = useState(false);
   const [hyprlandConfigMissing, setHyprlandConfigMissing] = useState(false);
   const [effectiveDefaultHotkey, setEffectiveDefaultHotkey] = useState<string | null>(null);
   const [linuxPttAvailable, setLinuxPttAvailable] = useState(true);
@@ -1084,6 +1094,9 @@ export default function SettingsPage({
           if (!info.supportsPushToTalk) {
             setActivationMode("tap");
           }
+        }
+        if (info?.isUsingHyprland) {
+          setIsUsingHyprland(true);
         }
         if (info?.hyprlandConfigMissing) {
           setHyprlandConfigMissing(true);
@@ -3197,6 +3210,7 @@ EOF`,
               <SectionHeader
                 title={t("settingsPage.general.hotkey.title")}
                 description={t("settingsPage.general.hotkey.description")}
+                note={isUsingHyprland && t("settingsPage.general.hotkey.hyprlandUnbindDescription")}
               />
               <SettingsPanel>
                 <SettingsPanelRow>

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -1188,9 +1188,9 @@ class HotkeyManager extends EventEmitter {
     return this.useHyprland;
   }
 
-  isHyprlandConfigMissing() {
-    if (!this.hyprlandManager) return false;
-    return !HyprlandShortcutManager.hasHyprlandConfig();
+  getHyprlandConfigStatus() {
+    if (!this.hyprlandManager) return null;
+    return HyprlandShortcutManager.getHyprlandConfigStatus();
   }
 
   isUsingKDE() {

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -1188,6 +1188,11 @@ class HotkeyManager extends EventEmitter {
     return this.useHyprland;
   }
 
+  isHyprlandConfigMissing() {
+    if (!this.hyprlandManager) return false;
+    return !HyprlandShortcutManager.hasHyprlandConfig();
+  }
+
   isUsingKDE() {
     return this.useKDE;
   }

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -324,8 +324,8 @@ class HyprlandShortcutManager {
     const sourceLine = `source = ./${BINDS_FILENAME}`;
     if (content.includes(`./${BINDS_FILENAME}`)) return;
 
-    const newContent = content.replace(/\n*$/, "") + "\n" + sourceLine + "\n";
-    fs.writeFileSync(mainConfig, newContent, "utf-8");
+    const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(mainConfig, `${separator}${sourceLine}\n`, "utf-8");
     debugLogger.log("[HyprlandShortcut] Added source directive to hyprland.conf");
   }
 

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -431,27 +431,30 @@ class HyprlandShortcutManager {
       return true;
     }
 
-    try {
-      this._removeBindFromConfig();
+    const binding = this.currentBinding;
 
-      execFileSync("hyprctl", ["keyword", "unbind", this.currentBinding], {
+    try {
+      execFileSync("hyprctl", ["keyword", "unbind", binding], {
         stdio: "pipe",
         timeout: 5000,
       });
-
-      debugLogger.log(
-        `[HyprlandShortcut] Keybinding "${this.currentBinding}" unregistered successfully`
-      );
-      this.currentBinding = null;
-      this.isRegistered = false;
-      return true;
     } catch (err) {
-      debugLogger.log("[HyprlandShortcut] Failed to unregister keybinding:", err.message);
-      // Even if unbind fails, clear state so we don't keep retrying
-      this.currentBinding = null;
-      this.isRegistered = false;
-      return false;
+      debugLogger.log(`[HyprlandShortcut] Runtime unbind for "${binding}" failed:`, err.message);
     }
+
+    try {
+      this._removeBindFromConfig();
+    } catch (err) {
+      debugLogger.log(
+        "[HyprlandShortcut] Failed to remove persisted keybinding:",
+        err.message
+      );
+    }
+
+    debugLogger.log(`[HyprlandShortcut] Keybinding "${binding}" unregistered successfully`);
+    this.currentBinding = null;
+    this.isRegistered = false;
+    return true;
   }
 
   /**

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -1,4 +1,7 @@
 const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
 const debugLogger = require("./debugLogger");
 
 const DBUS_SERVICE_NAME = "com.openwhispr.App";
@@ -41,6 +44,27 @@ const ELECTRON_TO_HYPRLAND_KEY = {
 // Supports: standalone keys (F4, Space), modifier+key combos, and modifier-only combos (Control+Super)
 const VALID_HOTKEY_PATTERN =
   /^((CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd)(\+(CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd))*(\+)?)?(F([1-9]|1[0-9]|2[0-4])|[A-Za-z0-9]|Space|Escape|Tab|Backspace|Delete|Insert|Home|End|PageUp|PageDown|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|Enter|PrintScreen|ScrollLock|Pause|Backquote|`)?$/i;
+
+const BINDS_FILENAME = "openwhispr-binds.conf";
+
+function getHyprConfigDir() {
+  if (process.env.HYPRLAND_CONFIG) {
+    return path.dirname(path.resolve(process.env.HYPRLAND_CONFIG));
+  }
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  return path.join(xdgConfigHome, "hypr");
+}
+
+function getHyprlandConfPath() {
+  if (process.env.HYPRLAND_CONFIG) {
+    return path.resolve(process.env.HYPRLAND_CONFIG);
+  }
+  return path.join(getHyprConfigDir(), "hyprland.conf");
+}
+
+function getBindsFilePath() {
+  return path.join(getHyprConfigDir(), BINDS_FILENAME);
+}
 
 let dbus = null;
 
@@ -231,9 +255,83 @@ class HyprlandShortcutManager {
     };
   }
 
+  _writeBindToConfig(bindLine) {
+    const bindsFile = getBindsFilePath();
+    fs.mkdirSync(path.dirname(bindsFile), { recursive: true });
+
+    let content = "";
+    try {
+      content = fs.readFileSync(bindsFile, "utf-8");
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+
+    const lines = content.split("\n").filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return true;
+      return !trimmed.includes(DBUS_SERVICE_NAME);
+    });
+
+    const header = "# OpenWhispr keybinds (managed automatically)\n";
+    const body = lines.join("\n").trim();
+    const newContent = header + (body ? body + "\n" : "") + bindLine + "\n";
+
+    fs.writeFileSync(bindsFile, newContent, "utf-8");
+  }
+
+  _removeBindFromConfig() {
+    const bindsFile = getBindsFilePath();
+    let content = "";
+    try {
+      content = fs.readFileSync(bindsFile, "utf-8");
+    } catch (err) {
+      if (err.code === "ENOENT") return;
+      throw err;
+    }
+
+    const lines = content.split("\n").filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return true;
+      return !trimmed.includes(DBUS_SERVICE_NAME);
+    });
+
+    fs.writeFileSync(bindsFile, lines.join("\n"), "utf-8");
+  }
+
+  _ensureSourceInMainConfig() {
+    const mainConfig = getHyprlandConfPath();
+    let content;
+    try {
+      content = fs.readFileSync(mainConfig, "utf-8");
+    } catch (err) {
+      if (err.code === "ENOENT") return;
+      throw err;
+    }
+
+    const sourceLine = `source = ./${BINDS_FILENAME}`;
+    if (content.includes(`./${BINDS_FILENAME}`)) return;
+
+    const newContent = content.replace(/\n*$/, "") + "\n" + sourceLine + "\n";
+    fs.writeFileSync(mainConfig, newContent, "utf-8");
+    debugLogger.log("[HyprlandShortcut] Added source directive to hyprland.conf");
+  }
+
+  static hasHyprlandConfig() {
+    const mainConfig = getHyprlandConfPath();
+    try {
+      fs.accessSync(mainConfig, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * Register a keybinding in Hyprland using hyprctl keyword bind.
    * The binding executes a dbus-send command that calls our Toggle() method.
+   *
+   * Also writes the bind to openwhispr-binds.conf (sourced from hyprland.conf)
+   * so it survives `hyprctl reload`.
    */
   async registerKeybinding(hotkey) {
     if (!HyprlandShortcutManager.isHyprland()) {
@@ -262,6 +360,9 @@ class HyprlandShortcutManager {
 
       // hyprctl keyword bind "MODS, key, exec, command"
       const bindValue = `${converted.bindKey}, exec, ${dbusCommand}`;
+
+      this._writeBindToConfig(`bind = ${bindValue}`);
+      this._ensureSourceInMainConfig();
 
       execFileSync("hyprctl", ["keyword", "bind", bindValue], {
         stdio: "pipe",
@@ -298,6 +399,8 @@ class HyprlandShortcutManager {
     }
 
     try {
+      this._removeBindFromConfig();
+
       execFileSync("hyprctl", ["keyword", "unbind", this.currentBinding], {
         stdio: "pipe",
         timeout: 5000,

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -266,15 +266,16 @@ class HyprlandShortcutManager {
       if (err.code !== "ENOENT") throw err;
     }
 
+    const header = "# OpenWhispr keybinds (managed automatically)";
     const lines = content.split("\n").filter((line) => {
       const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) return true;
+      if (!trimmed || trimmed === header) return false;
+      if (trimmed.startsWith("#")) return true;
       return !trimmed.includes(DBUS_SERVICE_NAME);
     });
 
-    const header = "# OpenWhispr keybinds (managed automatically)\n";
     const body = lines.join("\n").trim();
-    const newContent = header + (body ? body + "\n" : "") + bindLine + "\n";
+    const newContent = header + "\n" + (body ? body + "\n" : "") + bindLine + "\n";
 
     fs.writeFileSync(bindsFile, newContent, "utf-8");
   }

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -341,10 +341,10 @@ class HyprlandShortcutManager {
       try {
         fs.accessSync(mainConfig, fs.constants.W_OK);
         status.canWrite = true;
-      } catch (err) {
+      } catch {
         debugLogger.log("[HyprlandShortcut] Hyprland config is not writable:", mainConfig);
       }
-    } catch (err) {
+    } catch {
       debugLogger.log("[HyprlandShortcut] Hyprland config not found:", mainConfig);
     }
 

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -329,14 +329,26 @@ class HyprlandShortcutManager {
     debugLogger.log("[HyprlandShortcut] Added source directive to hyprland.conf");
   }
 
-  static hasHyprlandConfig() {
+  static getHyprlandConfigStatus() {
     const mainConfig = getHyprlandConfPath();
+    const status = {
+      path: mainConfig,
+      canWrite: false,
+    };
+
     try {
       fs.accessSync(mainConfig, fs.constants.F_OK);
-      return true;
-    } catch {
-      return false;
+      try {
+        fs.accessSync(mainConfig, fs.constants.W_OK);
+        status.canWrite = true;
+      } catch (err) {
+        debugLogger.log("[HyprlandShortcut] Hyprland config is not writable:", mainConfig);
+      }
+    } catch (err) {
+      debugLogger.log("[HyprlandShortcut] Hyprland config not found:", mainConfig);
     }
+
+    return status;
   }
 
   /**
@@ -445,10 +457,7 @@ class HyprlandShortcutManager {
     try {
       this._removeBindFromConfig();
     } catch (err) {
-      debugLogger.log(
-        "[HyprlandShortcut] Failed to remove persisted keybinding:",
-        err.message
-      );
+      debugLogger.log("[HyprlandShortcut] Failed to remove persisted keybinding:", err.message);
     }
 
     debugLogger.log(`[HyprlandShortcut] Keybinding "${binding}" unregistered successfully`);

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -46,6 +46,19 @@ const VALID_HOTKEY_PATTERN =
   /^((CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd)(\+(CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd))*(\+)?)?(F([1-9]|1[0-9]|2[0-4])|[A-Za-z0-9]|Space|Escape|Tab|Backspace|Delete|Insert|Home|End|PageUp|PageDown|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|Enter|PrintScreen|ScrollLock|Pause|Backquote|`)?$/i;
 
 const BINDS_FILENAME = "openwhispr-binds.conf";
+const MANAGED_HEADER_LINES = [
+  "# OpenWhispr keybinds (managed automatically)",
+  "# If you delete this file, also remove the matching source line from your Hyprland config.",
+];
+
+function isManagedHeaderLine(line) {
+  return MANAGED_HEADER_LINES.includes(line.trim());
+}
+
+function buildManagedBindsContent(lines = []) {
+  const body = lines.join("\n").trim();
+  return MANAGED_HEADER_LINES.join("\n") + "\n" + (body ? body + "\n" : "");
+}
 
 function getHyprConfigDir() {
   if (process.env.HYPRLAND_CONFIG) {
@@ -266,16 +279,14 @@ class HyprlandShortcutManager {
       if (err.code !== "ENOENT") throw err;
     }
 
-    const header = "# OpenWhispr keybinds (managed automatically)";
     const lines = content.split("\n").filter((line) => {
       const trimmed = line.trim();
-      if (!trimmed || trimmed === header) return false;
+      if (!trimmed || isManagedHeaderLine(trimmed)) return false;
       if (trimmed.startsWith("#")) return true;
       return !trimmed.includes(DBUS_SERVICE_NAME);
     });
 
-    const body = lines.join("\n").trim();
-    const newContent = header + "\n" + (body ? body + "\n" : "") + bindLine + "\n";
+    const newContent = buildManagedBindsContent([...lines, bindLine]);
 
     fs.writeFileSync(bindsFile, newContent, "utf-8");
   }
@@ -292,11 +303,12 @@ class HyprlandShortcutManager {
 
     const lines = content.split("\n").filter((line) => {
       const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) return true;
+      if (!trimmed || isManagedHeaderLine(trimmed)) return false;
+      if (trimmed.startsWith("#")) return true;
       return !trimmed.includes(DBUS_SERVICE_NAME);
     });
 
-    fs.writeFileSync(bindsFile, lines.join("\n"), "utf-8");
+    fs.writeFileSync(bindsFile, buildManagedBindsContent(lines), "utf-8");
   }
 
   _ensureSourceInMainConfig() {

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -352,8 +352,8 @@ class HyprlandShortcutManager {
     }
 
     try {
-      // First unregister any existing binding
-      if (this.currentBinding) {
+      // First unregister any existing OpenWhispr binding if the hotkey changed.
+      if (this.currentBinding && this.currentBinding !== converted.bindKey) {
         await this.unregisterKeybinding();
       }
 
@@ -362,8 +362,17 @@ class HyprlandShortcutManager {
       // hyprctl keyword bind "MODS, key, exec, command"
       const bindValue = `${converted.bindKey}, exec, ${dbusCommand}`;
 
-      this._writeBindToConfig(`bind = ${bindValue}`);
-      this._ensureSourceInMainConfig();
+      try {
+        execFileSync("hyprctl", ["keyword", "unbind", converted.bindKey], {
+          stdio: "pipe",
+          timeout: 5000,
+        });
+      } catch (err) {
+        debugLogger.log(
+          `[HyprlandShortcut] Pre-bind unbind for "${converted.bindKey}" failed, continuing:`,
+          err.message
+        );
+      }
 
       execFileSync("hyprctl", ["keyword", "bind", bindValue], {
         stdio: "pipe",
@@ -372,6 +381,17 @@ class HyprlandShortcutManager {
 
       this.currentBinding = converted.bindKey;
       this.isRegistered = true;
+
+      try {
+        this._writeBindToConfig(`bind = ${bindValue}`);
+        this._ensureSourceInMainConfig();
+      } catch (err) {
+        debugLogger.log(
+          "[HyprlandShortcut] Failed to persist keybinding; runtime bind is still active:",
+          err.message
+        );
+      }
+
       debugLogger.log(
         `[HyprlandShortcut] Keybinding "${hotkey}" (${converted.bindKey}) registered successfully`
       );

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2286,6 +2286,7 @@ class IPCHandlers {
         isUsingKDE: this.windowManager.isUsingKDEHotkeys(),
         isUsingNativeShortcut,
         supportsPushToTalk,
+        hyprlandConfigMissing: this.windowManager.isHyprlandConfigMissing(),
       };
     });
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2286,8 +2286,12 @@ class IPCHandlers {
         isUsingKDE: this.windowManager.isUsingKDEHotkeys(),
         isUsingNativeShortcut,
         supportsPushToTalk,
-        hyprlandConfigMissing: this.windowManager.isHyprlandConfigMissing(),
       };
+    });
+
+    ipcMain.handle("get-hyprland-config-status", async () => {
+      if (!this.windowManager.isUsingHyprlandHotkeys()) return null;
+      return this.windowManager.getHyprlandConfigStatus();
     });
 
     ipcMain.handle("register-cancel-hotkey", async (event, key) => {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -524,8 +524,8 @@ class WindowManager {
     return this.hotkeyManager.isUsingHyprland();
   }
 
-  isHyprlandConfigMissing() {
-    return this.hotkeyManager.isHyprlandConfigMissing();
+  getHyprlandConfigStatus() {
+    return this.hotkeyManager.getHyprlandConfigStatus();
   }
 
   isUsingKDEHotkeys() {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -524,6 +524,10 @@ class WindowManager {
     return this.hotkeyManager.isUsingHyprland();
   }
 
+  isHyprlandConfigMissing() {
+    return this.hotkeyManager.isHyprlandConfigMissing();
+  }
+
   isUsingKDEHotkeys() {
     return this.hotkeyManager.isUsingKDE();
   }

--- a/src/hooks/useHotkeyModeInfo.ts
+++ b/src/hooks/useHotkeyModeInfo.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import logger from "../utils/logger";
+
+export interface HyprlandConfigStatus {
+  canWrite: boolean;
+  path: string;
+}
+
+export interface HotkeyModeInfo {
+  isUsingNativeShortcut: boolean;
+  isUsingHyprland: boolean;
+  supportsPushToTalk: boolean;
+  hyprlandConfigStatus: HyprlandConfigStatus | null;
+}
+
+const DEFAULT_INFO: HotkeyModeInfo = {
+  isUsingNativeShortcut: false,
+  isUsingHyprland: false,
+  supportsPushToTalk: true,
+  hyprlandConfigStatus: null,
+};
+
+/**
+ * Resolves how the dictation hotkey is registered for the current session
+ * (native shortcut, Hyprland) and, on Hyprland, whether its config is
+ * persistable. `scope` tags log output for the calling surface.
+ */
+export function useHotkeyModeInfo(scope: string): HotkeyModeInfo {
+  const [modeInfo, setModeInfo] = useState<HotkeyModeInfo>(DEFAULT_INFO);
+
+  useEffect(() => {
+    let cancelled = false;
+    const checkHotkeyMode = async () => {
+      try {
+        const info = await window.electronAPI?.getHotkeyModeInfo?.();
+        if (!info || cancelled) return;
+        const hyprlandConfigStatus = info.isUsingHyprland
+          ? ((await window.electronAPI?.getHyprlandConfigStatus?.()) ?? null)
+          : null;
+        if (cancelled) return;
+        setModeInfo({
+          isUsingNativeShortcut: info.isUsingNativeShortcut,
+          isUsingHyprland: info.isUsingHyprland,
+          supportsPushToTalk: info.supportsPushToTalk,
+          hyprlandConfigStatus,
+        });
+      } catch (error) {
+        logger.error("Failed to check hotkey mode", { error }, scope);
+      }
+    };
+    checkHotkeyMode();
+    return () => {
+      cancelled = true;
+    };
+  }, [scope]);
+
+  return modeInfo;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1465,8 +1465,8 @@
         "linuxPttSetupTitle": "Hold to Speak needs setup",
         "linuxPttSetupDescription": "Your user needs access to keyboard input devices.",
         "linuxPttSetupNote": "After running the command, log out and log back in.",
-        "hyprlandConfigMissingTitle": "Hyprland config not found",
-        "hyprlandConfigMissingDescription": "Your hyprland.conf was not found, so keybinds will not survive config reload. Create a config at ~/.config/hypr/hyprland.conf for persistent keybinds.",
+        "hyprlandConfigWriteWarningTitle": "Hyprland keybinds will not persist",
+        "hyprlandConfigWriteWarningDescription": "OpenWhispr cannot write to {{path}}, so keybinds will not survive a Hyprland config reload. Make sure the file exists and is writable.",
         "hyprlandUnbindDescription": "On Hyprland, OpenWhispr claims the selected shortcut. Any existing Hyprland bind that uses the same key combination will be unbound when OpenWhispr registers its shortcut."
       },
       "meetingHotkey": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1464,7 +1464,9 @@
         "linuxPttPermissionDescription": "Run this command and log out/in: sudo usermod -aG input $USER",
         "linuxPttSetupTitle": "Hold to Speak needs setup",
         "linuxPttSetupDescription": "Your user needs access to keyboard input devices.",
-        "linuxPttSetupNote": "After running the command, log out and log back in."
+        "linuxPttSetupNote": "After running the command, log out and log back in.",
+        "hyprlandConfigMissingTitle": "Hyprland config not found",
+        "hyprlandConfigMissingDescription": "Your hyprland.conf was not found, so keybinds will not survive config reload. Create a config at ~/.config/hypr/hyprland.conf for persistent keybinds."
       },
       "meetingHotkey": {
         "title": "Meeting Mode Hotkey",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1466,7 +1466,8 @@
         "linuxPttSetupDescription": "Your user needs access to keyboard input devices.",
         "linuxPttSetupNote": "After running the command, log out and log back in.",
         "hyprlandConfigMissingTitle": "Hyprland config not found",
-        "hyprlandConfigMissingDescription": "Your hyprland.conf was not found, so keybinds will not survive config reload. Create a config at ~/.config/hypr/hyprland.conf for persistent keybinds."
+        "hyprlandConfigMissingDescription": "Your hyprland.conf was not found, so keybinds will not survive config reload. Create a config at ~/.config/hypr/hyprland.conf for persistent keybinds.",
+        "hyprlandUnbindDescription": "On Hyprland, OpenWhispr claims the selected shortcut. Any existing Hyprland bind that uses the same key combination will be unbound when OpenWhispr registers its shortcut."
       },
       "meetingHotkey": {
         "title": "Meeting Mode Hotkey",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -919,6 +919,7 @@ declare global {
         isUsingHyprland: boolean;
         isUsingNativeShortcut: boolean;
         supportsPushToTalk: boolean;
+        hyprlandConfigMissing: boolean;
       }>;
 
       // Wayland paste diagnostics

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -919,8 +919,8 @@ declare global {
         isUsingHyprland: boolean;
         isUsingNativeShortcut: boolean;
         supportsPushToTalk: boolean;
-        hyprlandConfigMissing: boolean;
       }>;
+      getHyprlandConfigStatus?: () => Promise<{ canWrite: boolean; path: string } | null>;
 
       // Wayland paste diagnostics
       getYdotoolStatus?: () => Promise<{


### PR DESCRIPTION
persist dictation hotkey to the hyprland config file to persist it across reloads and fallback to the keyword bind method if config doesn't exist.

fixes #914 