### PR TITLE
feat(transcription): add Corti as BYOK medical transcription provider

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -555,6 +555,27 @@ contextBridge.exposeInMainWorld("electronAPI", {
     (callback) => (_event, data) => callback(data)
   ),
 
+  // Corti streaming (BYOK)
+  cortiStreamingWarmup: (options) => ipcRenderer.invoke("corti-streaming-warmup", options),
+  cortiStreamingStart: (options) => ipcRenderer.invoke("corti-streaming-start", options),
+  cortiStreamingSend: (audioBuffer) => ipcRenderer.send("corti-streaming-send", audioBuffer),
+  cortiStreamingFinalize: () => ipcRenderer.send("corti-streaming-finalize"),
+  cortiStreamingStop: () => ipcRenderer.invoke("corti-streaming-stop"),
+  cortiStreamingStatus: () => ipcRenderer.invoke("corti-streaming-status"),
+  onCortiPartialTranscript: registerListener(
+    "corti-partial-transcript",
+    (callback) => (_event, text) => callback(text)
+  ),
+  onCortiFinalTranscript: registerListener(
+    "corti-final-transcript",
+    (callback) => (_event, text) => callback(text)
+  ),
+  onCortiError: registerListener("corti-error", (callback) => (_event, error) => callback(error)),
+  onCortiSessionEnd: registerListener(
+    "corti-session-end",
+    (callback) => (_event, data) => callback(data)
+  ),
+
   // Meeting transcription (streaming, dual-channel)
   meetingTranscriptionPrepare: (options) =>
     ipcRenderer.invoke("meeting-transcription-prepare", options),

--- a/preload.js
+++ b/preload.js
@@ -358,6 +358,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveMistralKey: (key) => ipcRenderer.invoke("save-mistral-key", key),
   proxyMistralTranscription: (data) => ipcRenderer.invoke("proxy-mistral-transcription", data),
 
+  // Corti API
+  getCortiClientId: () => ipcRenderer.invoke("get-corti-client-id"),
+  saveCortiClientId: (key) => ipcRenderer.invoke("save-corti-client-id", key),
+  getCortiClientSecret: () => ipcRenderer.invoke("get-corti-client-secret"),
+  saveCortiClientSecret: (key) => ipcRenderer.invoke("save-corti-client-secret", key),
+  proxyCortiTranscription: (data) => ipcRenderer.invoke("proxy-corti-transcription", data),
+
   // Custom endpoint API keys
   getCustomTranscriptionKey: () => ipcRenderer.invoke("get-custom-transcription-key"),
   saveCustomTranscriptionKey: (key) => ipcRenderer.invoke("save-custom-transcription-key", key),

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Download, Trash2, Cloud, Lock, X, Zap, Check } from "lucide-react";
 import { ProviderIcon } from "./ui/ProviderIcon";
 import { ProviderTabs } from "./ui/ProviderTabs";
@@ -202,8 +203,64 @@ const CLOUD_PROVIDER_TABS = [
   { id: "openai", name: "OpenAI" },
   { id: "groq", name: "Groq" },
   { id: "mistral", name: "Mistral" },
+  { id: "corti", name: "Corti" },
   { id: "custom", name: "Custom" },
 ];
+
+interface ProviderCredentialField {
+  key:
+    | "openaiApiKey"
+    | "groqApiKey"
+    | "mistralApiKey"
+    | "cortiClientId"
+    | "cortiClientSecret"
+    | "cortiEnvironment"
+    | "cortiTenant";
+  input: "secret" | "text" | "select";
+  labelKey?: string;
+  placeholder?: string;
+  options?: Array<{ value: string; label: string }>;
+}
+
+const PROVIDER_CREDENTIALS: Record<
+  string,
+  { consoleUrl: string; fields: ProviderCredentialField[] }
+> = {
+  openai: {
+    consoleUrl: "https://platform.openai.com/api-keys",
+    fields: [{ key: "openaiApiKey", input: "secret" }],
+  },
+  groq: {
+    consoleUrl: "https://console.groq.com/keys",
+    fields: [{ key: "groqApiKey", input: "secret" }],
+  },
+  mistral: {
+    consoleUrl: "https://console.mistral.ai/api-keys",
+    fields: [{ key: "mistralApiKey", input: "secret" }],
+  },
+  corti: {
+    consoleUrl: "https://console.corti.app",
+    fields: [
+      { key: "cortiClientId", input: "secret", labelKey: "transcription.corti.clientId" },
+      { key: "cortiClientSecret", input: "secret", labelKey: "transcription.corti.clientSecret" },
+      {
+        key: "cortiEnvironment",
+        input: "select",
+        labelKey: "transcription.corti.environment",
+        options: [
+          { value: "us", label: "US" },
+          { value: "eu", label: "EU" },
+        ],
+      },
+      {
+        key: "cortiTenant",
+        input: "text",
+        labelKey: "transcription.corti.tenant",
+        placeholder: "base",
+      },
+    ],
+  },
+};
 
 const VALID_CLOUD_PROVIDER_IDS = CLOUD_PROVIDER_TABS.map((p) => p.id);
 
@@ -273,6 +330,14 @@ export default function TranscriptionModelPicker({
   const setGroqApiKey = useSettingsStore((s) => s.setGroqApiKey);
   const mistralApiKey = useSettingsStore((s) => s.mistralApiKey);
   const setMistralApiKey = useSettingsStore((s) => s.setMistralApiKey);
+  const cortiClientId = useSettingsStore((s) => s.cortiClientId);
+  const setCortiClientId = useSettingsStore((s) => s.setCortiClientId);
+  const cortiClientSecret = useSettingsStore((s) => s.cortiClientSecret);
+  const setCortiClientSecret = useSettingsStore((s) => s.setCortiClientSecret);
+  const cortiEnvironment = useSettingsStore((s) => s.cortiEnvironment);
+  const setCortiEnvironment = useSettingsStore((s) => s.setCortiEnvironment);
+  const cortiTenant = useSettingsStore((s) => s.cortiTenant);
+  const setCortiTenant = useSettingsStore((s) => s.setCortiTenant);
   const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
   const setCustomTranscriptionApiKey = useSettingsStore((s) => s.setCustomTranscriptionApiKey);
   const effectiveLocal = mode === "local" ? true : mode === "cloud" ? false : useLocalWhisper;
@@ -630,6 +695,27 @@ export default function TranscriptionModelPicker({
     [cloudProviders, selectedCloudProvider]
   );
 
+  const providerCredentials =
+    PROVIDER_CREDENTIALS[selectedCloudProvider] ?? PROVIDER_CREDENTIALS.openai;
+  const credentialValues: Record<ProviderCredentialField["key"], string> = {
+    openaiApiKey,
+    groqApiKey,
+    mistralApiKey,
+    cortiClientId,
+    cortiClientSecret,
+    cortiEnvironment,
+    cortiTenant,
+  };
+  const credentialSetters: Record<ProviderCredentialField["key"], (value: string) => void> = {
+    openaiApiKey: setOpenaiApiKey,
+    groqApiKey: setGroqApiKey,
+    mistralApiKey: setMistralApiKey,
+    cortiClientId: setCortiClientId,
+    cortiClientSecret: setCortiClientSecret,
+    cortiEnvironment: setCortiEnvironment,
+    cortiTenant: setCortiTenant,
+  };
+
   const cloudModelOptions = useMemo(() => {
     if (!currentCloudProvider) return [];
     return currentCloudProvider.models.map((m) => ({
@@ -859,40 +945,55 @@ export default function TranscriptionModelPicker({
               </div>
             ) : (
               <div className="space-y-2">
-                <div className="space-y-1.5">
-                  <div className="flex items-center justify-between">
-                    <label className="text-xs font-medium text-foreground">
-                      {t("common.apiKey")}
-                    </label>
-                    <button
-                      type="button"
-                      onClick={createExternalLinkHandler(
-                        {
-                          groq: "https://console.groq.com/keys",
-                          mistral: "https://console.mistral.ai/api-keys",
-                          openai: "https://platform.openai.com/api-keys",
-                        }[selectedCloudProvider] || "https://platform.openai.com/api-keys"
+                {providerCredentials.fields.map((field, index) => (
+                  <div key={field.key} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label className="text-xs font-medium text-foreground">
+                        {field.labelKey ? t(field.labelKey) : t("common.apiKey")}
+                      </label>
+                      {index === 0 && (
+                        <button
+                          type="button"
+                          onClick={createExternalLinkHandler(providerCredentials.consoleUrl)}
+                          className="text-xs text-primary/70 hover:text-primary transition-colors cursor-pointer"
+                        >
+                          {t("transcription.getKey")}
+                        </button>
                       )}
-                      className="text-xs text-primary/70 hover:text-primary transition-colors cursor-pointer"
-                    >
-                      {t("transcription.getKey")}
-                    </button>
+                    </div>
+                    {field.input === "secret" ? (
+                      <ApiKeyInput
+                        apiKey={credentialValues[field.key]}
+                        setApiKey={credentialSetters[field.key]}
+                        label=""
+                        helpText=""
+                      />
+                    ) : field.input === "select" ? (
+                      <Select
+                        value={credentialValues[field.key]}
+                        onValueChange={credentialSetters[field.key]}
+                      >
+                        <SelectTrigger className="h-8 text-sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {field.options?.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <Input
+                        value={credentialValues[field.key]}
+                        onChange={(e) => credentialSetters[field.key](e.target.value)}
+                        placeholder={field.placeholder}
+                        className="h-8 text-sm"
+                      />
+                    )}
                   </div>
-                  <ApiKeyInput
-                    apiKey={
-                      { groq: groqApiKey, mistral: mistralApiKey, openai: openaiApiKey }[
-                        selectedCloudProvider
-                      ] || openaiApiKey
-                    }
-                    setApiKey={
-                      { groq: setGroqApiKey, mistral: setMistralApiKey, openai: setOpenaiApiKey }[
-                        selectedCloudProvider
-                      ] || setOpenaiApiKey
-                    }
-                    label=""
-                    helpText=""
-                  />
-                </div>
+                ))}
 
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-foreground">{t("common.model")}</label>

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -37,6 +37,7 @@ import {
   getSettings,
 } from "../../stores/settingsStore";
 import { generateNoteTitle } from "../../utils/generateTitle";
+import { getBaseLanguageCode } from "../../utils/languageSupport";
 
 const TranscriptionModelPicker = React.lazy(() => import("../TranscriptionModelPicker"));
 
@@ -121,6 +122,11 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     updateTranscriptionSettings,
   } = useSettings();
 
+  const cortiClientId = useSettingsStore((s) => s.cortiClientId);
+  const cortiClientSecret = useSettingsStore((s) => s.cortiClientSecret);
+  const cortiEnvironment = useSettingsStore((s) => s.cortiEnvironment);
+  const cortiTenant = useSettingsStore((s) => s.cortiTenant);
+  const preferredLanguage = useSettingsStore((s) => s.preferredLanguage);
   const isCloudCleanup = useSettingsStore(selectIsCloudCleanupMode);
   const effectiveCleanupModel = useSettingsStore((s) =>
     selectIsCloudCleanupMode(s) ? "" : s.cleanupModel
@@ -191,6 +197,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         if (cloudTranscriptionProvider === "custom") {
           // Custom providers only need a base URL; API key is truly optional
           if (!cancelled) setProviderReady(!!cloudTranscriptionBaseUrl?.trim());
+        } else if (cloudTranscriptionProvider === "corti") {
+          if (!cancelled) setProviderReady(!!(cortiClientId && cortiClientSecret));
         } else {
           const key =
             cloudTranscriptionProvider === "openai"
@@ -232,6 +240,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     groqApiKey,
     mistralApiKey,
     customTranscriptionApiKey,
+    cortiClientId,
+    cortiClientSecret,
   ]);
 
   const getActiveModelLabel = (): string => {
@@ -373,6 +383,10 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           apiKey: getActiveApiKey(),
           baseUrl: cloudTranscriptionBaseUrl || "",
           model: cloudTranscriptionModel,
+          provider: cloudTranscriptionProvider,
+          language: getBaseLanguageCode(preferredLanguage) || "en",
+          environment: cortiEnvironment,
+          tenant: cortiTenant,
         });
       }
 

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -111,6 +111,18 @@ const STREAMING_PROVIDERS = {
     onError: (cb) => window.electronAPI.onDictationRealtimeError(cb),
     onSessionEnd: (cb) => window.electronAPI.onDictationRealtimeSessionEnd(cb),
   },
+  corti: {
+    warmup: (opts) => window.electronAPI.cortiStreamingWarmup(opts),
+    start: (opts) => window.electronAPI.cortiStreamingStart(opts),
+    send: (buf) => window.electronAPI.cortiStreamingSend(buf),
+    finalize: () => window.electronAPI.cortiStreamingFinalize(),
+    stop: () => window.electronAPI.cortiStreamingStop(),
+    status: () => window.electronAPI.cortiStreamingStatus(),
+    onPartial: (cb) => window.electronAPI.onCortiPartialTranscript(cb),
+    onFinal: (cb) => window.electronAPI.onCortiFinalTranscript(cb),
+    onError: (cb) => window.electronAPI.onCortiError(cb),
+    onSessionEnd: (cb) => window.electronAPI.onCortiSessionEnd(cb),
+  },
 };
 
 class AudioManager {
@@ -251,16 +263,18 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   }
 
   getStreamingProvider() {
-    const { cloudTranscriptionModel } = getSettings();
-    if (REALTIME_MODELS.has(cloudTranscriptionModel)) {
-      return STREAMING_PROVIDERS["openai-realtime"];
-    }
-    const defaultProvider = this.context === "notes" ? "deepgram" : "openai-realtime";
-    const providerName = this.sttConfig?.streamingProvider || defaultProvider;
-    return STREAMING_PROVIDERS[providerName] || STREAMING_PROVIDERS[defaultProvider];
+    const fallback = this.context === "notes" ? "deepgram" : "openai-realtime";
+    return STREAMING_PROVIDERS[this.getStreamingProviderName()] || STREAMING_PROVIDERS[fallback];
   }
 
   getStreamingProviderName() {
+    const s = getSettings();
+    if (s.cloudTranscriptionProvider === "corti" && s.cloudTranscriptionMode === "byok") {
+      return "corti";
+    }
+    if (REALTIME_MODELS.has(s.cloudTranscriptionModel)) {
+      return "openai-realtime";
+    }
     const defaultProvider = this.context === "notes" ? "deepgram" : "openai-realtime";
     return this.sttConfig?.streamingProvider || defaultProvider;
   }
@@ -2130,6 +2144,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const s = getSettings();
     if (s.useLocalWhisper) return false;
 
+    // Corti (BYOK) streams over its own WSS — independent of OpenWhispr Cloud.
+    if (s.cloudTranscriptionProvider === "corti" && s.cloudTranscriptionMode === "byok") {
+      return !!(s.cortiClientId && s.cortiClientSecret);
+    }
+
     // For dictation/agent: respect sttConfig mode from the API — this allows
     // batch mode even for realtime-capable models (e.g. gpt-4o-mini-transcribe).
     if (this.context !== "notes" && this.sttConfig?.dictation?.mode === "batch") {
@@ -2169,6 +2188,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             preferredLanguage: warmupLang,
             cloudTranscriptionModel,
             cloudTranscriptionMode,
+            cortiEnvironment,
+            cortiTenant,
           } = getSettings();
           const res = await provider.warmup({
             sampleRate: 16000,
@@ -2176,6 +2197,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             keyterms: this.getKeyterms(),
             model: cloudTranscriptionModel,
             mode: cloudTranscriptionMode === "byok" ? "byok" : "openwhispr",
+            environment: cortiEnvironment,
+            tenant: cortiTenant,
           });
           // Throw error to trigger retry if AUTH_EXPIRED
           if (!res.success && res.code) {
@@ -2401,6 +2424,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           preferredLanguage: preferredLang,
           cloudTranscriptionModel,
           cloudTranscriptionMode,
+          cortiEnvironment,
+          cortiTenant,
           useLocalWhisper,
         } = getSettings();
         const res = await provider.start({
@@ -2409,6 +2434,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           keyterms: this.getKeyterms(),
           model: cloudTranscriptionModel,
           mode: cloudTranscriptionMode === "byok" ? "byok" : "openwhispr",
+          environment: cortiEnvironment,
+          tenant: cortiTenant,
         });
 
         if (!res.success) {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -910,6 +910,24 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         err.code = "API_KEY_MISSING";
         throw err;
       }
+    } else if (provider === "corti") {
+      // Tokens are minted in the main process; only verify credentials exist here
+      let clientId = s.cortiClientId;
+      let clientSecret = s.cortiClientSecret;
+      if (!clientId?.trim() || !clientSecret?.trim()) {
+        [clientId, clientSecret] = await Promise.all([
+          window.electronAPI.getCortiClientId?.(),
+          window.electronAPI.getCortiClientSecret?.(),
+        ]);
+      }
+      if (!clientId?.trim() || !clientSecret?.trim()) {
+        const err = new Error(
+          "Corti credentials not found. Please set your Client ID and Client Secret in the Control Panel."
+        );
+        err.code = "API_KEY_MISSING";
+        throw err;
+      }
+      apiKey = null;
     } else if (provider === "groq") {
       // Prefer store value (user-entered via UI) over main process (.env)
       apiKey = s.groqApiKey;
@@ -1569,6 +1587,37 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         throw new Error("No text transcribed - Mistral response was empty");
       }
 
+      // Corti uses OAuth client credentials and an interaction-based REST flow — proxy through main process
+      if (provider === "corti" && window.electronAPI?.proxyCortiTranscription) {
+        const audioBuffer = await optimizedAudio.arrayBuffer();
+        const proxyData = {
+          audioBuffer,
+          // Corti requires a concrete primaryLanguage; default to English when auto-detecting
+          language: language || "en",
+          environment: apiSettings.cortiEnvironment || "us",
+          tenant: (apiSettings.cortiTenant || "").trim() || "base",
+        };
+
+        const result = await window.electronAPI.proxyCortiTranscription(proxyData);
+        const proxyText = result?.text;
+
+        if (proxyText && proxyText.trim().length > 0) {
+          if (this.isDictionaryEcho(proxyText)) {
+            throw new Error("No audio detected");
+          }
+          timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
+          const rawText = proxyText;
+          const reasoningStart = performance.now();
+          const text = await this.processTranscription(proxyText, "corti");
+          timings.reasoningProcessingDurationMs = Math.round(performance.now() - reasoningStart);
+
+          const source = (await this.isReasoningAvailable()) ? "corti-reasoned" : "corti";
+          return { success: true, text, rawText, source, timings };
+        }
+
+        throw new Error("No text transcribed - Corti response was empty");
+      }
+
       logger.debug(
         "Making transcription API request",
         {
@@ -1799,6 +1848,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         const isGroqModel = trimmedModel.startsWith("whisper-large-v3");
         const isOpenAIModel = trimmedModel.startsWith("gpt-4o") || trimmedModel === "whisper-1";
         const isMistralModel = trimmedModel.startsWith("voxtral-");
+        const isCortiModel = trimmedModel.startsWith("corti-");
 
         if (provider === "groq" && isGroqModel) {
           return trimmedModel;
@@ -1809,12 +1859,16 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         if (provider === "mistral" && isMistralModel) {
           return trimmedModel;
         }
+        if (provider === "corti" && isCortiModel) {
+          return trimmedModel;
+        }
         // Model doesn't match provider - fall through to default
       }
 
       // Return provider-appropriate default
       if (provider === "groq") return "whisper-large-v3-turbo";
       if (provider === "mistral") return "voxtral-mini-latest";
+      if (provider === "corti") return "corti-transcribe";
       return "gpt-4o-mini-transcribe";
     } catch (error) {
       return "gpt-4o-mini-transcribe";

--- a/src/helpers/cortiAuth.js
+++ b/src/helpers/cortiAuth.js
@@ -1,0 +1,59 @@
+const { net } = require("electron");
+
+const CORTI_ENVIRONMENTS = new Set(["eu", "us"]);
+const TENANT_PATTERN = /^[a-zA-Z0-9_-]+$/;
+// Corti access tokens live 5 minutes; refresh early so in-flight requests never race expiry.
+const TOKEN_REFRESH_MARGIN_MS = 30_000;
+
+const tokenCache = new Map();
+
+function assertValidTarget(environment, tenant) {
+  if (!CORTI_ENVIRONMENTS.has(environment)) {
+    throw new Error(`Invalid Corti environment: ${environment}`);
+  }
+  if (!TENANT_PATTERN.test(tenant)) {
+    throw new Error("Invalid Corti tenant name");
+  }
+}
+
+async function getCortiToken({ environment, tenant, clientId, clientSecret }) {
+  assertValidTarget(environment, tenant);
+
+  const cacheKey = `${environment}/${tenant}/${clientId}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.value;
+  }
+
+  const response = await net.fetch(
+    `https://auth.${environment}.corti.app/realms/${tenant}/protocol/openid-connect/token`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: "openid",
+      }).toString(),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`Corti authentication failed: ${response.status} ${errorText}`.trim());
+  }
+
+  const data = await response.json();
+  if (!data.access_token) {
+    throw new Error("Corti authentication failed: no access token in response");
+  }
+
+  tokenCache.set(cacheKey, {
+    value: data.access_token,
+    expiresAt: Date.now() + (data.expires_in || 300) * 1000 - TOKEN_REFRESH_MARGIN_MS,
+  });
+  return data.access_token;
+}
+
+module.exports = { assertValidTarget, getCortiToken };

--- a/src/helpers/cortiStreaming.js
+++ b/src/helpers/cortiStreaming.js
@@ -1,0 +1,312 @@
+const WebSocket = require("ws");
+const debugLogger = require("./debugLogger");
+
+const SAMPLE_RATE = 16000;
+const WEBSOCKET_TIMEOUT_MS = 30000;
+const TERMINATION_TIMEOUT_MS = 5000;
+// Corti rejects audio sent before it acknowledges the config message, so buffer
+// any frames that arrive during the brief connect handshake.
+const PRECONFIG_BUFFER_MAX = 3 * SAMPLE_RATE * 2; // 3 seconds of 16-bit PCM
+const AUDIO_FORMAT = `audio/pcm; rate=${SAMPLE_RATE}; channels=1; bits=16`;
+
+// Corti's WSS transport: OAuth token in the query, a JSON config message after
+// open, then raw PCM frames. Mirrors the AssemblyAI/Deepgram streaming classes.
+class CortiStreaming {
+  constructor() {
+    this.ws = null;
+    this.sessionId = null;
+    this.isConnected = false;
+    this.onPartialTranscript = null;
+    this.onFinalTranscript = null;
+    this.onError = null;
+    this.onSessionEnd = null;
+    this.pendingResolve = null;
+    this.pendingReject = null;
+    this.connectionTimeout = null;
+    this.accumulatedText = "";
+    this.completedSegments = [];
+    this.closeResolve = null;
+    this.isDisconnecting = false;
+    this.configAccepted = false;
+    this.preConfigBuffer = [];
+    this.preConfigBufferSize = 0;
+    this.sessionStartedAt = null;
+    this.audioBytesSent = 0;
+    this.currentModel = "corti-transcribe";
+  }
+
+  buildWebSocketUrl(options) {
+    const params = new URLSearchParams({
+      "tenant-name": options.tenant,
+      token: `Bearer ${options.token}`,
+    });
+    return `wss://api.${options.environment}.corti.app/audio-bridge/v2/transcribe?${params}`;
+  }
+
+  buildConfiguration(options) {
+    const configuration = {
+      primaryLanguage: options.language && options.language !== "auto" ? options.language : "en",
+      interimResults: true,
+      automaticPunctuation: true,
+      audioFormat: AUDIO_FORMAT,
+    };
+    if (options.keyterms && options.keyterms.length > 0) {
+      configuration.keyterms = { terms: options.keyterms.map((term) => ({ term })) };
+    }
+    return configuration;
+  }
+
+  async connect(options = {}) {
+    const { token, environment, tenant } = options;
+    if (!token || !environment || !tenant) {
+      throw new Error("Corti streaming requires token, environment, and tenant");
+    }
+
+    if (this.isConnected) {
+      debugLogger.debug("Corti streaming already connected");
+      return;
+    }
+
+    this.accumulatedText = "";
+    this.completedSegments = [];
+    this.configAccepted = false;
+    this.preConfigBuffer = [];
+    this.preConfigBufferSize = 0;
+    this.audioBytesSent = 0;
+
+    const url = this.buildWebSocketUrl(options);
+    const configuration = this.buildConfiguration(options);
+    debugLogger.debug("Corti streaming connecting", { environment, tenant });
+
+    return new Promise((resolve, reject) => {
+      this.pendingResolve = resolve;
+      this.pendingReject = reject;
+
+      this.connectionTimeout = setTimeout(() => {
+        this.cleanup();
+        reject(new Error("Corti WebSocket connection timeout"));
+      }, WEBSOCKET_TIMEOUT_MS);
+
+      this.ws = new WebSocket(url);
+
+      this.ws.on("open", () => {
+        debugLogger.debug("Corti WebSocket connected, sending config");
+        this.ws.send(JSON.stringify({ type: "config", configuration }));
+      });
+
+      this.ws.on("message", (data) => {
+        this.handleMessage(data);
+      });
+
+      this.ws.on("error", (error) => {
+        debugLogger.error("Corti WebSocket error", { error: error.message });
+        this.cleanup();
+        if (this.pendingReject) {
+          this.pendingReject(error);
+          this.pendingReject = null;
+          this.pendingResolve = null;
+        }
+        this.onError?.(error);
+      });
+
+      this.ws.on("close", (code, reason) => {
+        const wasActive = this.isConnected;
+        debugLogger.debug("Corti WebSocket closed", {
+          code,
+          reason: reason?.toString(),
+          wasActive,
+        });
+        if (this.pendingReject) {
+          this.pendingReject(new Error(`Corti WebSocket closed before ready (code: ${code})`));
+          this.pendingReject = null;
+          this.pendingResolve = null;
+        }
+        if (this.closeResolve) {
+          this.closeResolve({ text: this.accumulatedText });
+        }
+        this.cleanup();
+        if (wasActive && !this.isDisconnecting) {
+          this.onError?.(new Error(`Connection lost (code: ${code})`));
+        }
+      });
+    });
+  }
+
+  handleMessage(data) {
+    let message;
+    try {
+      message = JSON.parse(data.toString());
+    } catch (err) {
+      debugLogger.error("Corti message parse error", { error: err.message });
+      return;
+    }
+
+    switch (message.type) {
+      case "CONFIG_ACCEPTED":
+        this.isConnected = true;
+        this.configAccepted = true;
+        this.sessionId = message.sessionId || null;
+        this.sessionStartedAt = Date.now();
+        clearTimeout(this.connectionTimeout);
+        this.flushPreConfigBuffer();
+        debugLogger.debug("Corti session started", { sessionId: this.sessionId });
+        if (this.pendingResolve) {
+          this.pendingResolve();
+          this.pendingResolve = null;
+          this.pendingReject = null;
+        }
+        break;
+
+      case "transcript": {
+        const text = message.data?.text;
+        if (!text) break;
+        if (message.data.isFinal) {
+          const trimmed = text.trim();
+          if (!trimmed) break;
+          this.completedSegments.push(trimmed);
+          this.accumulatedText = this.completedSegments.join(" ");
+          const startedAt =
+            this.sessionStartedAt != null && typeof message.data.start === "number"
+              ? this.sessionStartedAt + message.data.start * 1000
+              : Date.now();
+          this.onFinalTranscript?.(this.accumulatedText, startedAt);
+        } else {
+          this.onPartialTranscript?.(text);
+        }
+        break;
+      }
+
+      case "delta_usage":
+        if (this.closeResolve) {
+          this.closeResolve({ text: this.accumulatedText });
+          this.closeResolve = null;
+        }
+        break;
+
+      case "error":
+        debugLogger.error("Corti streaming error", { error: message.error });
+        this.onError?.(new Error(message.error?.title || message.error?.details || "Corti error"));
+        break;
+
+      default:
+        debugLogger.debug("Corti unknown message type", { type: message.type });
+    }
+  }
+
+  flushPreConfigBuffer() {
+    if (this.preConfigBuffer.length === 0) return;
+    debugLogger.debug("Corti flushing pre-config buffer", {
+      chunks: this.preConfigBuffer.length,
+      bytes: this.preConfigBufferSize,
+    });
+    for (const frame of this.preConfigBuffer) {
+      this.ws.send(frame);
+      this.audioBytesSent += frame.length;
+    }
+    this.preConfigBuffer = [];
+    this.preConfigBufferSize = 0;
+  }
+
+  sendAudio(pcmBuffer) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    if (!this.configAccepted) {
+      if (this.preConfigBufferSize < PRECONFIG_BUFFER_MAX) {
+        const copy = Buffer.from(pcmBuffer);
+        this.preConfigBuffer.push(copy);
+        this.preConfigBufferSize += copy.length;
+      }
+      return true;
+    }
+
+    this.audioBytesSent += pcmBuffer.length;
+    this.ws.send(pcmBuffer);
+    return true;
+  }
+
+  finalize() {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    this.ws.send(JSON.stringify({ type: "flush" }));
+    debugLogger.debug("Corti flush sent");
+    return true;
+  }
+
+  async disconnect(closeStream = true) {
+    if (!this.ws) return { text: this.accumulatedText };
+
+    this.isDisconnecting = true;
+
+    if (closeStream && this.ws.readyState === WebSocket.OPEN) {
+      // Flush buffered audio, wait for the trailing finals, then end the session.
+      this.ws.send(JSON.stringify({ type: "flush" }));
+
+      let timeoutId;
+      const result = await Promise.race([
+        new Promise((resolve) => {
+          this.closeResolve = resolve;
+        }),
+        new Promise((resolve) => {
+          timeoutId = setTimeout(() => {
+            debugLogger.debug("Corti close timeout, using accumulated text");
+            resolve({ text: this.accumulatedText });
+          }, TERMINATION_TIMEOUT_MS);
+        }),
+      ]);
+      clearTimeout(timeoutId);
+
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: "end" }));
+      }
+      this.closeResolve = null;
+      this.onSessionEnd?.({ text: result.text });
+      this.cleanup();
+      this.isDisconnecting = false;
+      return result;
+    }
+
+    const result = { text: this.accumulatedText };
+    this.cleanup();
+    this.isDisconnecting = false;
+    return result;
+  }
+
+  cleanup() {
+    clearTimeout(this.connectionTimeout);
+    this.connectionTimeout = null;
+    this.preConfigBuffer = [];
+    this.preConfigBufferSize = 0;
+
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch (err) {
+        // Ignore close errors
+      }
+      this.ws = null;
+    }
+
+    this.isConnected = false;
+    this.configAccepted = false;
+    this.sessionId = null;
+    this.closeResolve = null;
+  }
+
+  cleanupAll() {
+    this.cleanup();
+    this.accumulatedText = "";
+    this.completedSegments = [];
+  }
+
+  getStatus() {
+    return {
+      isConnected: this.isConnected,
+      sessionId: this.sessionId,
+    };
+  }
+}
+
+module.exports = CortiStreaming;

--- a/src/helpers/cortiStreaming.js
+++ b/src/helpers/cortiStreaming.js
@@ -295,12 +295,6 @@ class CortiStreaming {
     this.closeResolve = null;
   }
 
-  cleanupAll() {
-    this.cleanup();
-    this.accumulatedText = "";
-    this.completedSegments = [];
-  }
-
   getStatus() {
     return {
       isConnected: this.isConnected,

--- a/src/helpers/cortiTranscription.js
+++ b/src/helpers/cortiTranscription.js
@@ -1,60 +1,7 @@
 const { net } = require("electron");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
-
-const CORTI_ENVIRONMENTS = new Set(["eu", "us"]);
-const TENANT_PATTERN = /^[a-zA-Z0-9_-]+$/;
-// Corti access tokens live 5 minutes; refresh early so in-flight requests never race expiry.
-const TOKEN_REFRESH_MARGIN_MS = 30_000;
-
-let cachedToken = null;
-
-function assertValidTarget(environment, tenant) {
-  if (!CORTI_ENVIRONMENTS.has(environment)) {
-    throw new Error(`Invalid Corti environment: ${environment}`);
-  }
-  if (!TENANT_PATTERN.test(tenant)) {
-    throw new Error("Invalid Corti tenant name");
-  }
-}
-
-async function getAccessToken({ environment, tenant, clientId, clientSecret }) {
-  const cacheKey = `${environment}/${tenant}/${clientId}`;
-  if (cachedToken?.key === cacheKey && Date.now() < cachedToken.expiresAt) {
-    return cachedToken.value;
-  }
-
-  const response = await net.fetch(
-    `https://auth.${environment}.corti.app/realms/${tenant}/protocol/openid-connect/token`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        grant_type: "client_credentials",
-        client_id: clientId,
-        client_secret: clientSecret,
-        scope: "openid",
-      }).toString(),
-    }
-  );
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "");
-    throw new Error(`Corti authentication failed: ${response.status} ${errorText}`.trim());
-  }
-
-  const data = await response.json();
-  if (!data.access_token) {
-    throw new Error("Corti authentication failed: no access token in response");
-  }
-
-  cachedToken = {
-    key: cacheKey,
-    value: data.access_token,
-    expiresAt: Date.now() + (data.expires_in || 300) * 1000 - TOKEN_REFRESH_MARGIN_MS,
-  };
-  return data.access_token;
-}
+const { getCortiToken } = require("./cortiAuth");
 
 async function request(token, tenant, url, options = {}) {
   const response = await net.fetch(url, {
@@ -83,8 +30,7 @@ async function transcribeAudio({
   audioBuffer,
   language,
 }) {
-  assertValidTarget(environment, tenant);
-  const token = await getAccessToken({ environment, tenant, clientId, clientSecret });
+  const token = await getCortiToken({ environment, tenant, clientId, clientSecret });
   const base = `https://api.${environment}.corti.app/v2`;
 
   debugLogger.debug(

--- a/src/helpers/cortiTranscription.js
+++ b/src/helpers/cortiTranscription.js
@@ -19,6 +19,10 @@ async function request(token, tenant, url, options = {}) {
   return response;
 }
 
+async function requestJson(token, tenant, url, options) {
+  return (await request(token, tenant, url, options)).json();
+}
+
 // Corti's WSS /transcribe endpoint is a strictly real-time engine — replaying a
 // finished recording faster than real time drops audio. Pre-recorded dictation
 // goes through the interaction REST flow instead: create → upload → transcribe.
@@ -39,36 +43,40 @@ async function transcribeAudio({
     "transcription"
   );
 
-  const { interactionId } = await (
-    await request(token, tenant, `${base}/interactions/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        encounter: {
-          identifier: `openwhispr-${crypto.randomUUID()}`,
-          status: "completed",
-          type: "consultation",
-        },
-      }),
-    })
-  ).json();
+  const { interactionId } = await requestJson(token, tenant, `${base}/interactions/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      encounter: {
+        identifier: `openwhispr-${crypto.randomUUID()}`,
+        status: "completed",
+        type: "consultation",
+      },
+    }),
+  });
 
   try {
-    const { recordingId } = await (
-      await request(token, tenant, `${base}/interactions/${interactionId}/recordings/`, {
+    const { recordingId } = await requestJson(
+      token,
+      tenant,
+      `${base}/interactions/${interactionId}/recordings/`,
+      {
         method: "POST",
         headers: { "Content-Type": "application/octet-stream" },
         body: Buffer.from(audioBuffer),
-      })
-    ).json();
+      }
+    );
 
-    const transcript = await (
-      await request(token, tenant, `${base}/interactions/${interactionId}/transcripts/`, {
+    const transcript = await requestJson(
+      token,
+      tenant,
+      `${base}/interactions/${interactionId}/transcripts/`,
+      {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ recordingId, primaryLanguage: language, isDictation: true }),
-      })
-    ).json();
+      }
+    );
 
     return { text: (transcript.transcripts || []).map((utterance) => utterance.text).join(" ") };
   } finally {

--- a/src/helpers/cortiTranscription.js
+++ b/src/helpers/cortiTranscription.js
@@ -1,0 +1,142 @@
+const { net } = require("electron");
+const crypto = require("crypto");
+const debugLogger = require("./debugLogger");
+
+const CORTI_ENVIRONMENTS = new Set(["eu", "us"]);
+const TENANT_PATTERN = /^[a-zA-Z0-9_-]+$/;
+// Corti access tokens live 5 minutes; refresh early so in-flight requests never race expiry.
+const TOKEN_REFRESH_MARGIN_MS = 30_000;
+
+let cachedToken = null;
+
+function assertValidTarget(environment, tenant) {
+  if (!CORTI_ENVIRONMENTS.has(environment)) {
+    throw new Error(`Invalid Corti environment: ${environment}`);
+  }
+  if (!TENANT_PATTERN.test(tenant)) {
+    throw new Error("Invalid Corti tenant name");
+  }
+}
+
+async function getAccessToken({ environment, tenant, clientId, clientSecret }) {
+  const cacheKey = `${environment}/${tenant}/${clientId}`;
+  if (cachedToken?.key === cacheKey && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.value;
+  }
+
+  const response = await net.fetch(
+    `https://auth.${environment}.corti.app/realms/${tenant}/protocol/openid-connect/token`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: "openid",
+      }).toString(),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`Corti authentication failed: ${response.status} ${errorText}`.trim());
+  }
+
+  const data = await response.json();
+  if (!data.access_token) {
+    throw new Error("Corti authentication failed: no access token in response");
+  }
+
+  cachedToken = {
+    key: cacheKey,
+    value: data.access_token,
+    expiresAt: Date.now() + (data.expires_in || 300) * 1000 - TOKEN_REFRESH_MARGIN_MS,
+  };
+  return data.access_token;
+}
+
+async function request(token, tenant, url, options = {}) {
+  const response = await net.fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Tenant-Name": tenant,
+      ...options.headers,
+    },
+  });
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`Corti API Error: ${response.status} ${errorText}`.trim());
+  }
+  return response;
+}
+
+// Corti's WSS /transcribe endpoint is a strictly real-time engine — replaying a
+// finished recording faster than real time drops audio. Pre-recorded dictation
+// goes through the interaction REST flow instead: create → upload → transcribe.
+async function transcribeAudio({
+  environment,
+  tenant,
+  clientId,
+  clientSecret,
+  audioBuffer,
+  language,
+}) {
+  assertValidTarget(environment, tenant);
+  const token = await getAccessToken({ environment, tenant, clientId, clientSecret });
+  const base = `https://api.${environment}.corti.app/v2`;
+
+  debugLogger.debug(
+    "Corti transcription starting",
+    { environment, tenant, audioBytes: audioBuffer.byteLength, language },
+    "transcription"
+  );
+
+  const { interactionId } = await (
+    await request(token, tenant, `${base}/interactions/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        encounter: {
+          identifier: `openwhispr-${crypto.randomUUID()}`,
+          status: "completed",
+          type: "consultation",
+        },
+      }),
+    })
+  ).json();
+
+  try {
+    const { recordingId } = await (
+      await request(token, tenant, `${base}/interactions/${interactionId}/recordings/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: Buffer.from(audioBuffer),
+      })
+    ).json();
+
+    const transcript = await (
+      await request(token, tenant, `${base}/interactions/${interactionId}/transcripts/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ recordingId, primaryLanguage: language, isDictation: true }),
+      })
+    ).json();
+
+    return { text: (transcript.transcripts || []).map((utterance) => utterance.text).join(" ") };
+  } finally {
+    // Dictation audio must not persist on Corti's servers — deleting the
+    // interaction cascades to its recordings and transcripts.
+    request(token, tenant, `${base}/interactions/${interactionId}`, { method: "DELETE" }).catch(
+      (error) =>
+        debugLogger.error(
+          "Failed to delete Corti interaction",
+          { interactionId, error: error.message },
+          "transcription"
+        )
+    );
+  }
+}
+
+module.exports = { transcribeAudio };

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -14,6 +14,8 @@ const SECRET_KEYS = [
   "MISTRAL_API_KEY",
   "ASSEMBLYAI_API_KEY",
   "DEEPGRAM_API_KEY",
+  "CORTI_CLIENT_ID",
+  "CORTI_CLIENT_SECRET",
   "CUSTOM_TRANSCRIPTION_API_KEY",
   "CUSTOM_CLEANUP_API_KEY",
   "BEDROCK_ACCESS_KEY_ID",
@@ -303,6 +305,22 @@ class EnvironmentManager {
 
   saveDeepgramKey(key) {
     return this._saveKey("DEEPGRAM_API_KEY", key);
+  }
+
+  getCortiClientId() {
+    return this._getKey("CORTI_CLIENT_ID");
+  }
+
+  saveCortiClientId(key) {
+    return this._saveKey("CORTI_CLIENT_ID", key);
+  }
+
+  getCortiClientSecret() {
+    return this._getKey("CORTI_CLIENT_SECRET");
+  }
+
+  saveCortiClientSecret(key) {
+    return this._saveKey("CORTI_CLIENT_SECRET", key);
   }
 
   getCustomTranscriptionKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -659,6 +659,22 @@ class IPCHandlers {
     }
   }
 
+  // Mints a Corti access token from stored BYOK credentials. Shared by the
+  // dictation streaming handlers and the meeting realtime-token resolver.
+  async _mintStoredCortiToken(options = {}) {
+    const clientId = this.environmentManager.getCortiClientId();
+    const clientSecret = this.environmentManager.getCortiClientSecret();
+    if (!clientId || !clientSecret) {
+      const err = new Error("No Corti credentials configured. Add them in Settings.");
+      err.code = "NO_API";
+      throw err;
+    }
+    const environment = options.environment || "us";
+    const tenant = (options.tenant || "").trim() || "base";
+    const token = await getCortiToken({ environment, tenant, clientId, clientSecret });
+    return { token, environment, tenant };
+  }
+
   setupHandlers() {
     ipcMain.handle("window-minimize", () => {
       if (this.windowManager.controlPanelWindow) {
@@ -4256,18 +4272,8 @@ class IPCHandlers {
       }
 
       if (options.provider === "corti-realtime") {
-        const clientId = this.environmentManager.getCortiClientId();
-        const clientSecret = this.environmentManager.getCortiClientSecret();
-        if (!clientId || !clientSecret) {
-          throw new Error("No Corti credentials configured. Add them in Settings.");
-        }
         // One token covers both meeting streams; it's only used at the WSS handshake.
-        const token = await getCortiToken({
-          environment: options.environment || "us",
-          tenant: (options.tenant || "").trim() || "base",
-          clientId,
-          clientSecret,
-        });
+        const { token } = await this._mintStoredCortiToken(options);
         return streams === 2 ? [token, token] : token;
       }
 
@@ -7115,26 +7121,9 @@ class IPCHandlers {
       return this.deepgramStreaming.getStatus();
     });
 
-    // Corti BYOK streaming — tokens are minted locally from stored credentials.
-    const mintCortiStreamingToken = (options) => {
-      const clientId = this.environmentManager.getCortiClientId();
-      const clientSecret = this.environmentManager.getCortiClientSecret();
-      if (!clientId || !clientSecret) {
-        const err = new Error("Corti credentials not configured");
-        err.code = "NO_API";
-        throw err;
-      }
-      return getCortiToken({
-        environment: options.environment || "us",
-        tenant: (options.tenant || "").trim() || "base",
-        clientId,
-        clientSecret,
-      });
-    };
-
     ipcMain.handle("corti-streaming-warmup", async (_event, options = {}) => {
       try {
-        await mintCortiStreamingToken(options);
+        await this._mintStoredCortiToken(options);
         return { success: true };
       } catch (error) {
         return { success: false, error: error.message, code: error.code };
@@ -7150,7 +7139,7 @@ class IPCHandlers {
           await this.cortiStreaming.disconnect(false);
         }
 
-        const token = await mintCortiStreamingToken(options);
+        const { token, environment, tenant } = await this._mintStoredCortiToken(options);
         const win = BrowserWindow.fromWebContents(event.sender);
 
         this.cortiStreaming.onPartialTranscript = (text) => {
@@ -7168,8 +7157,8 @@ class IPCHandlers {
 
         await this.cortiStreaming.connect({
           token,
-          environment: options.environment || "us",
-          tenant: (options.tenant || "").trim() || "base",
+          environment,
+          tenant,
           language: options.language,
           keyterms: options.keyterms,
         });
@@ -7190,17 +7179,13 @@ class IPCHandlers {
 
     ipcMain.handle("corti-streaming-stop", async () => {
       try {
+        const model = this.cortiStreaming?.currentModel || "corti-transcribe";
         const audioBytesSent = this.cortiStreaming?.audioBytesSent || 0;
         let result = { text: "" };
         if (this.cortiStreaming) {
           result = await this.cortiStreaming.disconnect(true);
         }
-        return {
-          success: true,
-          text: result?.text || "",
-          model: "corti-transcribe",
-          audioBytesSent,
-        };
+        return { success: true, text: result?.text || "", model, audioBytesSent };
       } catch (error) {
         debugLogger.error("Corti streaming stop error", { error: error.message }, "streaming");
         return { success: false, error: error.message };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -11,7 +11,9 @@ const HyprlandShortcutManager = require("./hyprlandShortcut");
 const AssemblyAiStreaming = require("./assemblyAiStreaming");
 const { i18nMain, changeLanguage } = require("./i18nMain");
 const DeepgramStreaming = require("./deepgramStreaming");
+const CortiStreaming = require("./cortiStreaming");
 const OpenAIRealtimeStreaming = require("./openaiRealtimeStreaming");
+const { getCortiToken } = require("./cortiAuth");
 const AudioStorageManager = require("./audioStorage");
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
@@ -43,12 +45,14 @@ const STREAMING_CLIENT_BY_PROVIDER = {
   "openai-realtime": OpenAIRealtimeStreaming,
   "assemblyai-realtime": AssemblyAiStreaming,
   "deepgram-realtime": DeepgramStreaming,
+  "corti-realtime": CortiStreaming,
 };
 const ALLOWED_MEETING_PROVIDERS = new Set([
   "local",
   "openai-realtime",
   "assemblyai-realtime",
   "deepgram-realtime",
+  "corti-realtime",
 ]);
 
 function parseAttendees(raw) {
@@ -293,6 +297,7 @@ class IPCHandlers {
     this.sessionId = crypto.randomUUID();
     this.assemblyAiStreaming = null;
     this.deepgramStreaming = null;
+    this.cortiStreaming = null;
     this._dictationStreaming = null;
     this._dictationConnectPromise = null;
     this._dictationIdleTimer = null;
@@ -4250,6 +4255,22 @@ class IPCHandlers {
         });
       }
 
+      if (options.provider === "corti-realtime") {
+        const clientId = this.environmentManager.getCortiClientId();
+        const clientSecret = this.environmentManager.getCortiClientSecret();
+        if (!clientId || !clientSecret) {
+          throw new Error("No Corti credentials configured. Add them in Settings.");
+        }
+        // One token covers both meeting streams; it's only used at the WSS handshake.
+        const token = await getCortiToken({
+          environment: options.environment || "us",
+          tenant: (options.tenant || "").trim() || "base",
+          clientId,
+          clientSecret,
+        });
+        return streams === 2 ? [token, token] : token;
+      }
+
       if (options.mode === "byok") {
         const apiKey = this.environmentManager.getOpenAIKey();
         if (!apiKey) throw new Error("No OpenAI API key configured. Add your key in Settings.");
@@ -4322,6 +4343,9 @@ class IPCHandlers {
         model: options.model,
         language: options.language,
         preconfigured: options.mode !== "byok",
+        environment: options.environment,
+        tenant: options.tenant,
+        keyterms: options.keyterms,
       };
       const { mode: systemAudioMode } = await getMeetingSystemAudioPlan();
       let pairs;
@@ -7089,6 +7113,105 @@ class IPCHandlers {
         return { isConnected: false, sessionId: null };
       }
       return this.deepgramStreaming.getStatus();
+    });
+
+    // Corti BYOK streaming — tokens are minted locally from stored credentials.
+    const mintCortiStreamingToken = (options) => {
+      const clientId = this.environmentManager.getCortiClientId();
+      const clientSecret = this.environmentManager.getCortiClientSecret();
+      if (!clientId || !clientSecret) {
+        const err = new Error("Corti credentials not configured");
+        err.code = "NO_API";
+        throw err;
+      }
+      return getCortiToken({
+        environment: options.environment || "us",
+        tenant: (options.tenant || "").trim() || "base",
+        clientId,
+        clientSecret,
+      });
+    };
+
+    ipcMain.handle("corti-streaming-warmup", async (_event, options = {}) => {
+      try {
+        await mintCortiStreamingToken(options);
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: error.message, code: error.code };
+      }
+    });
+
+    ipcMain.handle("corti-streaming-start", async (event, options = {}) => {
+      try {
+        if (!this.cortiStreaming) {
+          this.cortiStreaming = new CortiStreaming();
+        }
+        if (this.cortiStreaming.isConnected) {
+          await this.cortiStreaming.disconnect(false);
+        }
+
+        const token = await mintCortiStreamingToken(options);
+        const win = BrowserWindow.fromWebContents(event.sender);
+
+        this.cortiStreaming.onPartialTranscript = (text) => {
+          if (win && !win.isDestroyed()) win.webContents.send("corti-partial-transcript", text);
+        };
+        this.cortiStreaming.onFinalTranscript = (text) => {
+          if (win && !win.isDestroyed()) win.webContents.send("corti-final-transcript", text);
+        };
+        this.cortiStreaming.onError = (error) => {
+          if (win && !win.isDestroyed()) win.webContents.send("corti-error", error.message);
+        };
+        this.cortiStreaming.onSessionEnd = (data) => {
+          if (win && !win.isDestroyed()) win.webContents.send("corti-session-end", data);
+        };
+
+        await this.cortiStreaming.connect({
+          token,
+          environment: options.environment || "us",
+          tenant: (options.tenant || "").trim() || "base",
+          language: options.language,
+          keyterms: options.keyterms,
+        });
+        return { success: true };
+      } catch (error) {
+        debugLogger.error("Corti streaming start error", { error: error.message }, "streaming");
+        return { success: false, error: error.message, code: error.code };
+      }
+    });
+
+    ipcMain.on("corti-streaming-send", (_event, audioBuffer) => {
+      this.cortiStreaming?.sendAudio(Buffer.from(audioBuffer));
+    });
+
+    ipcMain.on("corti-streaming-finalize", () => {
+      this.cortiStreaming?.finalize();
+    });
+
+    ipcMain.handle("corti-streaming-stop", async () => {
+      try {
+        const audioBytesSent = this.cortiStreaming?.audioBytesSent || 0;
+        let result = { text: "" };
+        if (this.cortiStreaming) {
+          result = await this.cortiStreaming.disconnect(true);
+        }
+        return {
+          success: true,
+          text: result?.text || "",
+          model: "corti-transcribe",
+          audioBytesSent,
+        };
+      } catch (error) {
+        debugLogger.error("Corti streaming stop error", { error: error.message }, "streaming");
+        return { success: false, error: error.message };
+      }
+    });
+
+    ipcMain.handle("corti-streaming-status", async () => {
+      if (!this.cortiStreaming) {
+        return { isConnected: false, sessionId: null };
+      }
+      return this.cortiStreaming.getStatus();
     });
 
     // Agent mode handlers

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2532,6 +2532,43 @@ class IPCHandlers {
       }
     );
 
+    ipcMain.handle("get-corti-client-id", async () => {
+      return this.environmentManager.getCortiClientId();
+    });
+
+    ipcMain.handle("save-corti-client-id", async (event, key) => {
+      return this.environmentManager.saveCortiClientId(key);
+    });
+
+    ipcMain.handle("get-corti-client-secret", async () => {
+      return this.environmentManager.getCortiClientSecret();
+    });
+
+    ipcMain.handle("save-corti-client-secret", async (event, key) => {
+      return this.environmentManager.saveCortiClientSecret(key);
+    });
+
+    ipcMain.handle(
+      "proxy-corti-transcription",
+      async (event, { audioBuffer, language, environment, tenant }) => {
+        const clientId = this.environmentManager.getCortiClientId();
+        const clientSecret = this.environmentManager.getCortiClientSecret();
+        if (!clientId || !clientSecret) {
+          throw new Error("Corti credentials not configured");
+        }
+
+        const { transcribeAudio } = require("./cortiTranscription");
+        return transcribeAudio({
+          environment,
+          tenant,
+          clientId,
+          clientSecret,
+          audioBuffer,
+          language,
+        });
+      }
+    );
+
     ipcMain.handle("get-custom-transcription-key", async () => {
       return this.environmentManager.getCustomTranscriptionKey();
     });
@@ -6234,13 +6271,13 @@ class IPCHandlers {
 
     ipcMain.handle(
       "transcribe-audio-file-byok",
-      async (event, { filePath, apiKey, baseUrl, model }) => {
+      async (
+        event,
+        { filePath, apiKey, baseUrl, model, provider, language, environment, tenant }
+      ) => {
         const fs = require("fs");
         const BYOK_FILE_SIZE_LIMIT = 25 * 1024 * 1024; // 25 MB
         try {
-          if (!apiKey) throw new Error("No API key configured. Add your key in Settings.");
-          if (!baseUrl) throw new Error("No transcription endpoint configured.");
-
           const fileSize = fs.statSync(filePath).size;
           if (fileSize > BYOK_FILE_SIZE_LIMIT) {
             return {
@@ -6248,6 +6285,27 @@ class IPCHandlers {
               error: "File too large. Maximum size for bring-your-own-key is 25 MB.",
             };
           }
+
+          if (provider === "corti") {
+            const clientId = this.environmentManager.getCortiClientId();
+            const clientSecret = this.environmentManager.getCortiClientSecret();
+            if (!clientId || !clientSecret) {
+              throw new Error("Corti credentials not configured. Add them in Settings.");
+            }
+            const { transcribeAudio } = require("./cortiTranscription");
+            const { text } = await transcribeAudio({
+              environment,
+              tenant,
+              clientId,
+              clientSecret,
+              audioBuffer: fs.readFileSync(filePath),
+              language: language || "en",
+            });
+            return { success: true, text };
+          }
+
+          if (!apiKey) throw new Error("No API key configured. Add your key in Settings.");
+          if (!baseUrl) throw new Error("No transcription endpoint configured.");
 
           const audioBuffer = fs.readFileSync(filePath);
           const ext = path.extname(filePath).toLowerCase().replace(".", "");

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -56,6 +56,8 @@ export interface ApiKeySettings {
   geminiApiKey: string;
   groqApiKey: string;
   mistralApiKey: string;
+  cortiClientId: string;
+  cortiClientSecret: string;
   customTranscriptionApiKey: string;
   cleanupCustomApiKey: string;
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Modell",
       "parakeetModelDescription": "NVIDIA-Parakeet-Modell"
     },
-    "whisperModels": "Whisper-Modelle"
+    "whisperModels": "Whisper-Modelle",
+    "corti": {
+      "clientId": "Client-ID",
+      "clientSecret": "Client-Secret",
+      "environment": "Datenregion",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1747,7 +1753,8 @@
         "openai_whisper_1": "Originales Whisper-Modell",
         "groq_whisper_large_v3": "Hochpräzise Spracherkennung",
         "groq_whisper_large_v3_turbo": "216x Echtzeitgeschwindigkeit",
-        "mistral_voxtral_mini_latest": "Schnelle mehrsprachige Transkription"
+        "mistral_voxtral_mini_latest": "Schnelle mehrsprachige Transkription",
+        "corti_transcribe": "Medizinische Transkription in klinischer Qualität"
       },
       "cloud": {
         "openai_gpt_5_2": "Starkes Reasoning-Modell",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Model",
       "parakeetModelDescription": "NVIDIA Parakeet Model"
     },
-    "whisperModels": "Whisper Models"
+    "whisperModels": "Whisper Models",
+    "corti": {
+      "clientId": "Client ID",
+      "clientSecret": "Client Secret",
+      "environment": "Data Region",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1847,7 +1853,8 @@
         "openai_whisper_1": "Original Whisper model",
         "groq_whisper_large_v3": "High accuracy speech recognition",
         "groq_whisper_large_v3_turbo": "216x real-time speed",
-        "mistral_voxtral_mini_latest": "Fast multilingual transcription"
+        "mistral_voxtral_mini_latest": "Fast multilingual transcription",
+        "corti_transcribe": "Clinical-grade medical transcription"
       },
       "cloud": {
         "openai_gpt_5_2": "Strong reasoning model",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Modelo",
       "parakeetModelDescription": "Modelo NVIDIA Parakeet"
     },
-    "whisperModels": "Modelos Whisper"
+    "whisperModels": "Modelos Whisper",
+    "corti": {
+      "clientId": "ID de cliente",
+      "clientSecret": "Secreto de cliente",
+      "environment": "Región de datos",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1795,7 +1801,8 @@
         "openai_whisper_1": "Modelo Whisper original",
         "groq_whisper_large_v3": "Reconocimiento de voz de alta precisión",
         "groq_whisper_large_v3_turbo": "Velocidad 216x en tiempo real",
-        "mistral_voxtral_mini_latest": "Transcripción multilingüe rápida"
+        "mistral_voxtral_mini_latest": "Transcripción multilingüe rápida",
+        "corti_transcribe": "Transcripción médica de nivel clínico"
       },
       "cloud": {
         "openai_gpt_5_2": "Modelo fuerte de razonamiento",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Modèle",
       "parakeetModelDescription": "Modèle NVIDIA Parakeet"
     },
-    "whisperModels": "Modèles Whisper"
+    "whisperModels": "Modèles Whisper",
+    "corti": {
+      "clientId": "ID client",
+      "clientSecret": "Secret client",
+      "environment": "Région des données",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1795,7 +1801,8 @@
         "openai_whisper_1": "Modèle Whisper original",
         "groq_whisper_large_v3": "Reconnaissance vocale haute précision",
         "groq_whisper_large_v3_turbo": "Vitesse 216x en temps réel",
-        "mistral_voxtral_mini_latest": "Transcription multilingue rapide"
+        "mistral_voxtral_mini_latest": "Transcription multilingue rapide",
+        "corti_transcribe": "Transcription médicale de qualité clinique"
       },
       "cloud": {
         "openai_gpt_5_2": "Modèle de raisonnement performant",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Modello",
       "parakeetModelDescription": "Modello NVIDIA Parakeet"
     },
-    "whisperModels": "Modelli Whisper"
+    "whisperModels": "Modelli Whisper",
+    "corti": {
+      "clientId": "ID client",
+      "clientSecret": "Client secret",
+      "environment": "Regione dei dati",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1747,7 +1753,8 @@
         "openai_whisper_1": "Modello Whisper originale",
         "groq_whisper_large_v3_turbo": "Velocità 216x in tempo reale",
         "groq_whisper_large_v3": "Modello Large v3, veloce e preciso",
-        "mistral_voxtral_mini_latest": "Trascrizione multilingue veloce"
+        "mistral_voxtral_mini_latest": "Trascrizione multilingue veloce",
+        "corti_transcribe": "Trascrizione medica di livello clinico"
       },
       "cloud": {
         "openai_gpt_5_2": "Modello di ragionamento potente",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "モデル",
       "parakeetModelDescription": "NVIDIA Parakeet モデル"
     },
-    "whisperModels": "Whisper モデル"
+    "whisperModels": "Whisper モデル",
+    "corti": {
+      "clientId": "クライアントID",
+      "clientSecret": "クライアントシークレット",
+      "environment": "データリージョン",
+      "tenant": "テナント"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1747,7 +1753,8 @@
         "openai_whisper_1": "オリジナル Whisper モデル",
         "groq_whisper_large_v3_turbo": "リアルタイムの 216 倍速",
         "groq_whisper_large_v3": "Large v3 モデル、高速かつ高精度",
-        "mistral_voxtral_mini_latest": "高速多言語文字起こし"
+        "mistral_voxtral_mini_latest": "高速多言語文字起こし",
+        "corti_transcribe": "臨床グレードの医療文字起こし"
       },
       "cloud": {
         "openai_gpt_5_2": "強力な推論モデル",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -401,7 +401,13 @@
       "whisperModelDescription": "Modelo",
       "parakeetModelDescription": "Modelo NVIDIA Parakeet"
     },
-    "whisperModels": "Modelos Whisper"
+    "whisperModels": "Modelos Whisper",
+    "corti": {
+      "clientId": "ID do cliente",
+      "clientSecret": "Segredo do cliente",
+      "environment": "Região de dados",
+      "tenant": "Tenant"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1719,7 +1725,8 @@
         "openai_whisper_1": "Modelo Whisper original",
         "groq_whisper_large_v3_turbo": "Velocidade 216x em tempo real",
         "groq_whisper_large_v3": "Modelo Large v3, rápido e preciso",
-        "mistral_voxtral_mini_latest": "Transcrição multilíngue rápida"
+        "mistral_voxtral_mini_latest": "Transcrição multilíngue rápida",
+        "corti_transcribe": "Transcrição médica de nível clínico"
       },
       "cloud": {
         "openai_gpt_5_2": "Modelo forte de raciocínio",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "Модель",
       "parakeetModelDescription": "Модель NVIDIA Parakeet"
     },
-    "whisperModels": "Модели Whisper"
+    "whisperModels": "Модели Whisper",
+    "corti": {
+      "clientId": "ID клиента",
+      "clientSecret": "Секрет клиента",
+      "environment": "Регион данных",
+      "tenant": "Тенант"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1747,7 +1753,8 @@
         "openai_whisper_1": "Оригинальная модель Whisper",
         "groq_whisper_large_v3_turbo": "Скорость в 216 раз быстрее реального времени",
         "groq_whisper_large_v3": "Модель Large v3, быстрая и точная",
-        "mistral_voxtral_mini_latest": "Быстрая многоязычная транскрипция"
+        "mistral_voxtral_mini_latest": "Быстрая многоязычная транскрипция",
+        "corti_transcribe": "Медицинская транскрипция клинического уровня"
       },
       "cloud": {
         "openai_gpt_5_2": "Сильная модель рассуждения",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "模型",
       "parakeetModelDescription": "NVIDIA Parakeet 模型"
     },
-    "whisperModels": "Whisper 模型"
+    "whisperModels": "Whisper 模型",
+    "corti": {
+      "clientId": "客户端 ID",
+      "clientSecret": "客户端密钥",
+      "environment": "数据区域",
+      "tenant": "租户"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1742,7 +1748,8 @@
         "openai_whisper_1": "原始 Whisper 模型",
         "groq_whisper_large_v3_turbo": "216 倍实时速度",
         "groq_whisper_large_v3": "Large v3 模型，快速且精准",
-        "mistral_voxtral_mini_latest": "快速多语言转录"
+        "mistral_voxtral_mini_latest": "快速多语言转录",
+        "corti_transcribe": "临床级医疗转录"
       },
       "cloud": {
         "openai_gpt_5_2": "强大的推理模型",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -429,7 +429,13 @@
       "whisperModelDescription": "模型",
       "parakeetModelDescription": "NVIDIA Parakeet 模型"
     },
-    "whisperModels": "Whisper 模型"
+    "whisperModels": "Whisper 模型",
+    "corti": {
+      "clientId": "用戶端 ID",
+      "clientSecret": "用戶端密鑰",
+      "environment": "資料區域",
+      "tenant": "租戶"
+    }
   },
   "hooks": {
     "audioRecording": {
@@ -1742,7 +1748,8 @@
         "openai_whisper_1": "原始 Whisper 模型",
         "groq_whisper_large_v3_turbo": "216 倍即時速度",
         "groq_whisper_large_v3": "Large v3 模型，快速且精準",
-        "mistral_voxtral_mini_latest": "快速多語言轉錄"
+        "mistral_voxtral_mini_latest": "快速多語言轉錄",
+        "corti_transcribe": "臨床級醫療轉錄"
       },
       "cloud": {
         "openai_gpt_5_2": "強大的推理模型",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -191,6 +191,19 @@
           "descriptionKey": "models.descriptions.transcription.mistral_voxtral_mini_latest"
         }
       ]
+    },
+    {
+      "id": "corti",
+      "name": "Corti",
+      "baseUrl": "https://api.us.corti.app/v2",
+      "models": [
+        {
+          "id": "corti-transcribe",
+          "name": "Corti Transcribe",
+          "description": "Clinical-grade medical transcription",
+          "descriptionKey": "models.descriptions.transcription.corti_transcribe"
+        }
+      ]
     }
   ],
   "cloudProviders": [

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -201,7 +201,8 @@
           "id": "corti-transcribe",
           "name": "Corti Transcribe",
           "description": "Clinical-grade medical transcription",
-          "descriptionKey": "models.descriptions.transcription.corti_transcribe"
+          "descriptionKey": "models.descriptions.transcription.corti_transcribe",
+          "streaming": true
         }
       ]
     }

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -124,6 +124,21 @@ const getMeetingTranscriptionOptions = () => {
     };
   }
 
+  // Corti (BYOK) streams over its own WSS — independent of the server-driven catalog.
+  const selectedProvider =
+    state.meetingCloudTranscriptionProvider || state.cloudTranscriptionProvider;
+  if (resolved.cloudTranscriptionMode === "byok" && selectedProvider === "corti") {
+    return {
+      provider: "corti-realtime" as const,
+      model: "corti-transcribe",
+      mode: "byok" as const,
+      language,
+      environment: state.cortiEnvironment,
+      tenant: state.cortiTenant,
+      keyterms: (state.customDictionary ?? []).filter(Boolean),
+    };
+  }
+
   const catalog = useStreamingProvidersStore.getState().providers;
   const provider =
     catalog?.find((p) => p.id === resolved.cloudTranscriptionProvider) ?? catalog?.[0];

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -493,8 +493,16 @@ export interface SettingsState
   setGeminiApiKey: (key: string) => void;
   setGroqApiKey: (key: string) => void;
   setMistralApiKey: (key: string) => void;
+  setCortiClientId: (key: string) => void;
+  setCortiClientSecret: (key: string) => void;
   setCustomTranscriptionApiKey: (key: string) => void;
   setCleanupCustomApiKey: (key: string) => void;
+
+  // Corti (BYOK)
+  cortiEnvironment: string;
+  cortiTenant: string;
+  setCortiEnvironment: (value: string) => void;
+  setCortiTenant: (value: string) => void;
 
   // Enterprise providers
   bedrockAuthMode: string;
@@ -619,6 +627,8 @@ const SECRET_IPC_SAVERS = {
   gemini: "saveGeminiKey",
   groq: "saveGroqKey",
   mistral: "saveMistralKey",
+  cortiClientId: "saveCortiClientId",
+  cortiClientSecret: "saveCortiClientSecret",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
   bedrockAccessKeyId: "saveBedrockAccessKeyId",
@@ -656,6 +666,8 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
   "geminiApiKey",
   "groqApiKey",
   "mistralApiKey",
+  "cortiClientId",
+  "cortiClientSecret",
   "customTranscriptionApiKey",
   "customReasoningApiKey",
   "cleanupCustomApiKey",
@@ -708,6 +720,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   cloudTranscriptionMode: readString("cloudTranscriptionMode", "openwhispr"),
   cleanupCloudMode: readString("cleanupCloudMode", "openwhispr"),
   cleanupCloudBaseUrl: readString("cleanupCloudBaseUrl", API_ENDPOINTS.OPENAI_BASE),
+  cortiEnvironment: readString("cortiEnvironment", "us"),
+  cortiTenant: readString("cortiTenant", "base"),
   customDictionary: readStringArray("customDictionary", []),
   assemblyAiStreaming: readBoolean("assemblyAiStreaming", true),
 
@@ -723,6 +737,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   geminiApiKey: "",
   groqApiKey: "",
   mistralApiKey: "",
+  cortiClientId: "",
+  cortiClientSecret: "",
   customTranscriptionApiKey: "",
   cleanupCustomApiKey: "",
 
@@ -1073,6 +1089,18 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     debouncedSaveSecret("mistral", key);
     invalidateApiKeyCaches("mistral");
   },
+  setCortiClientId: (key: string) => {
+    set({ cortiClientId: key });
+    debouncedSaveSecret("cortiClientId", key);
+    invalidateApiKeyCaches();
+  },
+  setCortiClientSecret: (key: string) => {
+    set({ cortiClientSecret: key });
+    debouncedSaveSecret("cortiClientSecret", key);
+    invalidateApiKeyCaches();
+  },
+  setCortiEnvironment: createStringSetter("cortiEnvironment"),
+  setCortiTenant: createStringSetter("cortiTenant"),
   setCustomTranscriptionApiKey: (key: string) => {
     set({ customTranscriptionApiKey: key });
     debouncedSaveSecret("customTranscription", key);
@@ -1446,6 +1474,8 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (keys.geminiApiKey !== undefined) s.setGeminiApiKey(keys.geminiApiKey);
     if (keys.groqApiKey !== undefined) s.setGroqApiKey(keys.groqApiKey);
     if (keys.mistralApiKey !== undefined) s.setMistralApiKey(keys.mistralApiKey);
+    if (keys.cortiClientId !== undefined) s.setCortiClientId(keys.cortiClientId);
+    if (keys.cortiClientSecret !== undefined) s.setCortiClientSecret(keys.cortiClientSecret);
     if (keys.customTranscriptionApiKey !== undefined)
       s.setCustomTranscriptionApiKey(keys.customTranscriptionApiKey);
     if (keys.cleanupCustomApiKey !== undefined) s.setCleanupCustomApiKey(keys.cleanupCustomApiKey);
@@ -1652,6 +1682,8 @@ export async function initializeSettings(): Promise<void> {
         gemini,
         groq,
         mistral,
+        cortiClientId,
+        cortiClientSecret,
         customTx,
         customRx,
         bedrockAccessKeyId,
@@ -1665,6 +1697,8 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getGeminiKey?.(),
         window.electronAPI.getGroqKey?.(),
         window.electronAPI.getMistralKey?.(),
+        window.electronAPI.getCortiClientId?.(),
+        window.electronAPI.getCortiClientSecret?.(),
         window.electronAPI.getCustomTranscriptionKey?.(),
         window.electronAPI.getCleanupCustomKey?.(),
         window.electronAPI.getBedrockAccessKeyId?.(),
@@ -1680,6 +1714,8 @@ export async function initializeSettings(): Promise<void> {
         geminiApiKey: gemini || "",
         groqApiKey: groq || "",
         mistralApiKey: mistral || "",
+        cortiClientId: cortiClientId || "",
+        cortiClientSecret: cortiClientSecret || "",
         customTranscriptionApiKey: customTx || "",
         cleanupCustomApiKey: customRx || "",
         bedrockAccessKeyId: bedrockAccessKeyId || "",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1458,6 +1458,34 @@ declare global {
         callback: (data: { audioDuration?: number; text?: string }) => void
       ) => () => void;
 
+      // Corti streaming (BYOK)
+      cortiStreamingWarmup?: (options?: {
+        environment?: string;
+        tenant?: string;
+        language?: string;
+        keyterms?: string[];
+      }) => Promise<{ success: boolean; error?: string; code?: string }>;
+      cortiStreamingStart?: (options?: {
+        environment?: string;
+        tenant?: string;
+        language?: string;
+        keyterms?: string[];
+      }) => Promise<{ success: boolean; error?: string; code?: string }>;
+      cortiStreamingSend?: (audioBuffer: ArrayBuffer) => void;
+      cortiStreamingFinalize?: () => void;
+      cortiStreamingStop?: () => Promise<{
+        success: boolean;
+        text?: string;
+        model?: string;
+        audioBytesSent?: number;
+        error?: string;
+      }>;
+      cortiStreamingStatus?: () => Promise<{ isConnected: boolean; sessionId: string | null }>;
+      onCortiPartialTranscript?: (callback: (text: string) => void) => () => void;
+      onCortiFinalTranscript?: (callback: (text: string) => void) => () => void;
+      onCortiError?: (callback: (error: string) => void) => () => void;
+      onCortiSessionEnd?: (callback: (data: { text?: string }) => void) => () => void;
+
       // Agent overlay
       resizeAgentWindow?: (width: number, height: number) => Promise<void>;
       getAgentWindowBounds?: () => Promise<{

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -976,6 +976,18 @@ declare global {
         contextBias?: string[];
       }) => Promise<{ text: string }>;
 
+      // Corti credential management
+      getCortiClientId?: () => Promise<string | null>;
+      saveCortiClientId?: (key: string) => Promise<void>;
+      getCortiClientSecret?: () => Promise<string | null>;
+      saveCortiClientSecret?: (key: string) => Promise<void>;
+      proxyCortiTranscription?: (data: {
+        audioBuffer: ArrayBuffer;
+        language: string;
+        environment: string;
+        tenant: string;
+      }) => Promise<{ text: string }>;
+
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;
       saveCustomTranscriptionKey?: (key: string) => Promise<void>;
@@ -1223,6 +1235,10 @@ declare global {
         apiKey: string;
         baseUrl: string;
         model: string;
+        provider?: string;
+        language?: string;
+        environment?: string;
+        tenant?: string;
       }) => Promise<{
         success: boolean;
         text?: string;


### PR DESCRIPTION
## Summary

Adds [Corti](https://www.corti.ai/speech-to-text) — clinical-grade medical speech-to-text — as a bring-your-own-key transcription provider, available for **dictation, uploaded-audio notes, and live note recording**. Users get credentials at console.corti.app and pick the Corti tab under Speech-to-Text → Cloud Providers (and the Note Recording tab).

## Two transports, both verified live

Corti has no static API keys: every call uses a short-lived OAuth2 client-credentials token, minted and cached in the main process (`cortiAuth.js`) so the renderer never sees the client secret.

**Batch (file-based)** — `cortiTranscription.js`: create interaction → upload recording → create transcript (sync, `isDictation`) → delete the interaction so no dictation audio persists on Corti's servers (404 confirmed after delete). Used for uploaded-audio notes and as the dictation fallback.

**Streaming (real-time WSS)** — `cortiStreaming.js`: a streaming client mirroring the existing AssemblyAI/Deepgram classes. Sends Corti's config message, buffers audio until `CONFIG_ACCEPTED`, then streams raw linear16 PCM frames; `flush`/`end` on stop. Used for live dictation and note recording.

> Note: Corti's WSS `/transcribe` is strictly real-time — replaying a finished recording faster than real time drops audio — which is exactly why batch uses the REST flow and live capture uses the WSS stream.

## Where Corti is available

| Surface | Transport | Status |
|---|---|---|
| Dictation | WSS streaming (partials while speaking) | ✅ |
| Uploaded-audio notes | Batch REST | ✅ |
| Note recording (meeting panel) | WSS streaming, **BYOK mode** | ✅ |
| Note recording, OpenWhispr-Cloud mode | — | out of scope (provider list is backend-driven) |

Custom-dictionary terms are passed to Corti as `keyterms` on the streaming path.

## How it's wired (follows existing conventions)

- **Credentials never reach the renderer** — Client ID/Secret stored encrypted via `SECRET_KEYS`/safeStorage; environment (US/EU) and tenant are non-secret settings. The picker's credential section is a per-provider field schema (Client ID, Secret, Data Region, Tenant) instead of hardcoded single-key maps.
- **Dictation streaming** — `corti-streaming-*` IPC family + preload bridge; `STREAMING_PROVIDERS.corti` in audioManager; `shouldUseStreaming` / `getStreamingProviderName` carve-outs route Corti BYOK through the streaming pipeline.
- **Note recording** — `corti-realtime` registered in `STREAMING_CLIENT_BY_PROVIDER`; `fetchRealtimeToken` mints a Corti token for BYOK; `connectRealtimeStreaming` threads environment/tenant/keyterms; `getMeetingTranscriptionOptions` resolves Corti BYOK independent of the server catalog. `corti-transcribe` marked `streaming` so it shows in the streaming-only picker.
- i18n strings in all 10 locales.

## Verification (live US API, real credentials)

- **Batch**: 50s medical dictation transcribed accurately in ~2.5s processing through the full in-app IPC path; interaction deleted after success and after failed transcript/upload; bad-credential and invalid-target errors readable.
- **Streaming**: real-time PCM streamed through the in-app `corti-streaming-*` IPC path → 46 interim partials + 6 finals, complete accurate transcript, keyterms applied (Metoprolol/Apixaban), clean stop.
- 7-scenario batch protocol suite + isolated streaming-class test pass; `typecheck`, `lint`, prettier, renderer build all green; existing providers regression-checked.

## Test plan

- [ ] Settings → Speech-to-Text → Cloud Providers → Corti, dictate (live partials should appear) on macOS/Windows
- [ ] Notes → Upload Audio with Corti selected
- [ ] Note Recording tab → Cloud Providers → Corti, record a note (BYOK)
- [ ] Switch back to OpenAI/Groq/Mistral and confirm unchanged behavior