### PR TITLE
fix(audio): keep transcription when cloud cleanup returns empty

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1978,7 +1978,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             return res;
           });
 
-          if (reasonResult.success) {
+          // Cloud cleanup can return success with empty text; keep the raw transcription instead of wiping it.
+          if (reasonResult.success && reasonResult.text) {
             processedText = reasonResult.text;
           }
         } else if (route.kind === "cleanup") {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1422,7 +1422,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           return res;
         });
 
-        if (reasonResult.success) {
+        // Keep the raw transcription if cloud cleanup returns empty text;
+        // an empty cleanup result must not wipe good text (matches streaming path).
+        if (reasonResult.success && reasonResult.text) {
           processedText = reasonResult.text;
         }
       } else if (route.kind === "cleanup") {


### PR DESCRIPTION
## Summary

When dictating in OpenWhispr cloud mode, the cleanup step (/api/reason) sometimes returns an empty text field for a transcription that has real content. The batch cloud cleanup branch in audioManager.js did `if (reasonResult.success) processedText = reasonResult.text`, so an empty result overwrote the transcription: the user got "No Audio Detected", nothing was pasted, and no history entry or audio file was saved. The streaming branch already guards with `&& reasonResult.text`; this brings the batch branch in line, so an empty cleanup keeps the original transcription instead of wiping it.

## Changes

- src/helpers/audioManager.js: in the batch cloud cleanup path, replace the transcription with the cleanup result only when that result is non-empty, matching the streaming path.
