### PR TITLE
fix: serialize .env writes to prevent ENOENT rename race during onboarding

### DIFF
--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -58,6 +58,10 @@ const PERSISTED_KEYS = [
   "VERTEX_LOCATION",
 ];
 
+// Module-level so writes are serialized across all instances — hotkeyManager
+// creates its own EnvironmentManager alongside the main.js singleton.
+let envWriteQueue = Promise.resolve();
+
 class EnvironmentManager {
   constructor() {
     this.loadEnvironmentVariables();
@@ -213,7 +217,14 @@ class EnvironmentManager {
     );
   }
 
-  async _writeEnvFileAtomic(envPath) {
+  _writeEnvFileAtomic(envPath) {
+    // Concurrent write+rename pairs share the same .env.tmp path, and the
+    // loser's rename throws ENOENT (#903).
+    envWriteQueue = envWriteQueue.catch(() => {}).then(() => this._writeEnvFile(envPath));
+    return envWriteQueue;
+  }
+
+  async _writeEnvFile(envPath) {
     // Only strip plaintext secrets once migration has fully completed —
     // otherwise a partial-migration recovery can lose unencrypted secrets.
     const stripSecrets =


### PR DESCRIPTION
Fixes #903

## Problem

`_writeEnvFileAtomic()` writes to a fixed `.env.tmp` path and renames it over `.env`. `saveAllKeysToEnvFile()` has 15+ call sites with no serialization — 8 fire-and-forget setters in `environment.js`, the `save-all-keys-to-env` IPC handler, the settings-store debounce, several handlers in `ipcHandlers.js`, and `hotkeyManager.js` (which constructs its own `EnvironmentManager` instances). When two calls overlap, both write the same temp file, the first `rename` consumes it, and the loser throws `ENOENT`.

During onboarding this is 100% reproducible: `setDictationKey()` triggers a fire-and-forget write in the main process, and `OnboardingFlow` awaits `saveAllKeysToEnv()` immediately after. When the awaited IPC call loses the race, the renderer shows "Failed to persist API keys" even though the file was written correctly.

## Fix

Serialize writes through a **module-level** promise chain in `_writeEnvFileAtomic()` — module-level rather than per-instance because `hotkeyManager.js` creates its own `EnvironmentManager` instances alongside the `main.js` singleton, and the guarded resource is the per-process `.env` file. Each write+rename pair runs to completion before the next begins. A failed write rejects only its own caller and does not poison the queue.

Serialization was chosen over unique temp suffixes because env content is built from `process.env` at execution time — the final write always reflects the latest state, whereas concurrent unique-suffix writers could let a stale snapshot win the last rename. It also fixes the Windows variant of the same race (`EPERM` on concurrent renames).

No API changes: all callers already treat the method as promise-returning, and every call site is unaffected.

## Verification

- Standalone simulation of the exact write pattern: 10 concurrent unserialized writers → 9 `ENOENT` failures (reproduces the bug); 30 concurrent writers across 3 instances through the module-level queue → 0 failures, content intact, and a write after a prior failure still resolves.
- `npm run lint`, `npm run typecheck`, and `prettier --check` all pass.