### PR TITLE
Quick duck patch for windows 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ LANGUAGE=
 # Optional: UI language for app interface and menus (en, es, fr, de, pt, it)
 UI_LANGUAGE=en
 
+# Optional: Duck system audio during dictation instead of pausing media.
+# Requires Settings > General > Sound Effects > Pause media during dictation to be enabled.
+# Volume is a percentage from 0 to 100 and is restored after recording stops.
+OPENWHISPR_MEDIA_ON_DICTATION=
+OPENWHISPR_AUDIO_DUCKING_VOLUME=25
+
 # Anthropic API Configuration (optional - for Claude AI processing)
 # Get your API key from: https://console.anthropic.com/api-keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/.github/workflows/build-windows-artifacts.yml
+++ b/.github/workflows/build-windows-artifacts.yml
@@ -1,0 +1,95 @@
+name: Build Windows artifacts
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: pwsh
+
+concurrency:
+  group: build-windows-artifacts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-windows:
+    name: Build Windows portable and installer
+    runs-on: windows-latest
+    timeout-minutes: 120
+
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+      VITE_AUTH_URL: ${{ vars.VITE_AUTH_URL }}
+      VITE_OPENWHISPR_API_URL: ${{ vars.VITE_OPENWHISPR_API_URL }}
+      VITE_OPENWHISPR_OAUTH_CALLBACK_URL: ${{ vars.VITE_OPENWHISPR_OAUTH_CALLBACK_URL }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Windows native optional packages
+        run: npm install @rollup/rollup-win32-x64-msvc lightningcss-win32-x64-msvc @tailwindcss/oxide-win32-x64-msvc --no-save
+
+      - name: Cache downloaded native binaries
+        uses: actions/cache@v4
+        with:
+          path: resources/bin
+          key: windows-x64-bin-${{ hashFiles('scripts/download-*.js') }}
+          restore-keys: windows-x64-bin-
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/electron/Cache
+          key: windows-electron-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: windows-electron-
+
+      - name: Create runtime env file
+        run: |
+          "GOOGLE_CALENDAR_CLIENT_ID=${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}" | Out-File -FilePath .env -Encoding utf8
+          "GOOGLE_CALENDAR_CLIENT_SECRET=${{ secrets.GOOGLE_CALENDAR_CLIENT_SECRET }}" | Out-File -FilePath .env -Encoding utf8 -Append
+
+      - name: Build portable executable and installer
+        run: |
+          npm run prebuild:win
+          npm run build:renderer
+          npx electron-builder --win nsis portable --x64 --publish never
+
+      - name: Show build output
+        if: always()
+        run: |
+          if (Test-Path dist) {
+            Get-ChildItem -Path dist -File | Sort-Object Name | Select-Object Name, Length, LastWriteTime
+          } else {
+            Write-Host "dist directory was not created."
+          }
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openwhispr-windows-${{ github.run_number }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            dist/*.exe
+            dist/*.blockmap
+            dist/latest*.yml

--- a/.github/workflows/build-windows-artifacts.yml
+++ b/.github/workflows/build-windows-artifacts.yml
@@ -27,6 +27,7 @@ jobs:
 
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      CSC_FOR_PULL_REQUEST: "false"
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
       GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
       VITE_AUTH_URL: ${{ vars.VITE_AUTH_URL }}
@@ -47,7 +48,7 @@ jobs:
         run: npm ci
 
       - name: Install Windows native optional packages
-        run: npm install @rollup/rollup-win32-x64-msvc lightningcss-win32-x64-msvc @tailwindcss/oxide-win32-x64-msvc --no-save
+        run: npm install @rollup/rollup-win32-x64-msvc lightningcss-win32-x64-msvc @tailwindcss/oxide-win32-x64-msvc --save-optional
 
       - name: Cache downloaded native binaries
         uses: actions/cache@v4
@@ -63,6 +64,10 @@ jobs:
           key: windows-electron-${{ hashFiles('**/package-lock.json') }}
           restore-keys: windows-electron-
 
+      - name: Create unsigned electron-builder config
+        run: |
+          node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync('electron-builder.json','utf8')); delete cfg.win.azureSignOptions; cfg.win.sign=null; cfg.win.signAndEditExecutable=false; cfg.win.verifyUpdateCodeSignature=false; cfg.publish=null; fs.writeFileSync('electron-builder.unsigned.json', JSON.stringify(cfg, null, 2));"
+
       - name: Create runtime env file
         run: |
           "GOOGLE_CALENDAR_CLIENT_ID=${{ secrets.GOOGLE_CALENDAR_CLIENT_ID }}" | Out-File -FilePath .env -Encoding utf8
@@ -72,7 +77,7 @@ jobs:
         run: |
           npm run prebuild:win
           npm run build:renderer
-          npx electron-builder --win nsis portable --x64 --publish never
+          npx electron-builder --config electron-builder.unsigned.json --win nsis portable --x64 --publish never
 
       - name: Show build output
         if: always()

--- a/.github/workflows/build-windows-artifacts.yml
+++ b/.github/workflows/build-windows-artifacts.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Create unsigned electron-builder config
         run: |
-          node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync('electron-builder.json','utf8')); delete cfg.win.azureSignOptions; cfg.win.sign=null; cfg.win.signAndEditExecutable=false; cfg.win.verifyUpdateCodeSignature=false; cfg.publish=null; fs.writeFileSync('electron-builder.unsigned.json', JSON.stringify(cfg, null, 2));"
+          node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync('electron-builder.json','utf8')); delete cfg.win.azureSignOptions; cfg.win.signAndEditExecutable=false; cfg.win.verifyUpdateCodeSignature=false; cfg.publish=null; fs.writeFileSync('electron-builder.unsigned.json', JSON.stringify(cfg, null, 2));"
 
       - name: Create runtime env file
         run: |

--- a/src/helpers/mediaPlayer.js
+++ b/src/helpers/mediaPlayer.js
@@ -14,6 +14,8 @@ class MediaPlayer {
     this._pausedPlayers = []; // MPRIS players we paused (Linux)
     this._didPause = false; // Whether we sent a pause via toggle fallback
     this._pausedWinApps = []; // GSMTC app IDs we paused (Windows)
+    this._audioDuckActive = false;
+    this._audioDuckOriginalVolume = null;
   }
 
   _resolveLinuxFastPaste() {
@@ -92,7 +94,31 @@ class MediaPlayer {
     return null;
   }
 
+  _shouldDuckAudio() {
+    const mode = (process.env.OPENWHISPR_MEDIA_ON_DICTATION || "").trim().toLowerCase();
+    return mode === "duck" || process.env.OPENWHISPR_AUDIO_DUCKING_ENABLED === "true";
+  }
+
+  _getAudioDuckingTargetVolume() {
+    const raw =
+      process.env.OPENWHISPR_AUDIO_DUCKING_VOLUME ||
+      process.env.OPENWHISPR_DUCKING_VOLUME ||
+      process.env.OPENWHISPR_DUCK_VOLUME ||
+      "25";
+    return this._clampVolume(raw, 25);
+  }
+
+  _clampVolume(value, fallback = 25) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.max(0, Math.min(100, Math.round(parsed)));
+  }
+
   pauseMedia() {
+    if (this._shouldDuckAudio()) {
+      return this.duckAudio();
+    }
+
     try {
       if (process.platform === "linux") {
         return this._pauseLinux();
@@ -108,6 +134,10 @@ class MediaPlayer {
   }
 
   resumeMedia() {
+    if (this._audioDuckActive) {
+      return this.restoreAudio();
+    }
+
     try {
       if (process.platform === "linux") {
         return this._resumeLinux();
@@ -135,6 +165,229 @@ class MediaPlayer {
       debugLogger.warn("Media toggle failed", { error: err.message }, "media");
     }
     return false;
+  }
+
+  duckAudio(targetVolumePercent = this._getAudioDuckingTargetVolume()) {
+    try {
+      const target = this._clampVolume(targetVolumePercent, this._getAudioDuckingTargetVolume());
+      const current = this._getSystemVolumePercent();
+
+      if (current === null) {
+        debugLogger.warn("Audio ducking unavailable: could not read system volume", {}, "media");
+        return false;
+      }
+
+      if (!this._audioDuckActive) {
+        this._audioDuckOriginalVolume = current;
+        this._audioDuckActive = true;
+      }
+
+      if (current > target) {
+        const changed = this._setSystemVolumePercent(target);
+        if (!changed) {
+          debugLogger.warn("Audio ducking failed: could not set system volume", { target }, "media");
+          return false;
+        }
+      }
+
+      debugLogger.debug(
+        "Audio ducked for dictation",
+        { originalVolume: this._audioDuckOriginalVolume, targetVolume: target },
+        "media"
+      );
+      return true;
+    } catch (err) {
+      debugLogger.warn("Audio ducking failed", { error: err.message }, "media");
+      return false;
+    }
+  }
+
+  restoreAudio() {
+    if (!this._audioDuckActive) return false;
+
+    const originalVolume = this._audioDuckOriginalVolume;
+    this._audioDuckActive = false;
+    this._audioDuckOriginalVolume = null;
+
+    if (originalVolume === null || originalVolume === undefined) return false;
+
+    try {
+      const restored = this._setSystemVolumePercent(originalVolume);
+      if (restored) {
+        debugLogger.debug("Audio ducking restored system volume", { originalVolume }, "media");
+      } else {
+        debugLogger.warn("Audio ducking restore failed", { originalVolume }, "media");
+      }
+      return restored;
+    } catch (err) {
+      debugLogger.warn("Audio ducking restore failed", { error: err.message }, "media");
+      return false;
+    }
+  }
+
+  _getSystemVolumePercent() {
+    if (process.platform === "win32") return this._getWindowsVolumePercent();
+    if (process.platform === "darwin") return this._getMacVolumePercent();
+    if (process.platform === "linux") return this._getLinuxVolumePercent();
+    return null;
+  }
+
+  _setSystemVolumePercent(percent) {
+    const safePercent = this._clampVolume(percent);
+    if (process.platform === "win32") return this._setWindowsVolumePercent(safePercent);
+    if (process.platform === "darwin") return this._setMacVolumePercent(safePercent);
+    if (process.platform === "linux") return this._setLinuxVolumePercent(safePercent);
+    return false;
+  }
+
+  _windowsVolumeScript() {
+    return `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+[Guid("BCDE0395-E52F-467C-8E3D-C4579291692E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDeviceEnumerator {
+  int NotImpl1();
+  int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ppDevice);
+}
+
+[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDevice {
+  int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, out IAudioEndpointVolume ppInterface);
+}
+
+[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IAudioEndpointVolume {
+  int RegisterControlChangeNotify(IntPtr pNotify);
+  int UnregisterControlChangeNotify(IntPtr pNotify);
+  int GetChannelCount(out uint pnChannelCount);
+  int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
+  int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+  int GetMasterVolumeLevel(out float pfLevelDB);
+  int GetMasterVolumeLevelScalar(out float pfLevel);
+  int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
+  int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
+  int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
+  int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
+  int SetMute(bool bMute, Guid pguidEventContext);
+  int GetMute(out bool pbMute);
+  int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
+  int VolumeStepUp(Guid pguidEventContext);
+  int VolumeStepDown(Guid pguidEventContext);
+  int QueryHardwareSupport(out uint pdwHardwareSupportMask);
+  int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
+}
+
+[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+class MMDeviceEnumeratorComObject {}
+
+public class AudioEndpoint {
+  static IAudioEndpointVolume Endpoint() {
+    var enumerator = (IMMDeviceEnumerator)(new MMDeviceEnumeratorComObject());
+    IMMDevice device;
+    Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out device));
+    Guid iid = typeof(IAudioEndpointVolume).GUID;
+    IAudioEndpointVolume endpoint;
+    Marshal.ThrowExceptionForHR(device.Activate(ref iid, 23, IntPtr.Zero, out endpoint));
+    return endpoint;
+  }
+
+  public static float GetVolume() {
+    float value;
+    Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out value));
+    return value * 100.0f;
+  }
+
+  public static void SetVolume(float percent) {
+    percent = Math.Max(0.0f, Math.Min(100.0f, percent));
+    Guid g = Guid.Empty;
+    Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(percent / 100.0f, g));
+  }
+}
+"@
+`;
+  }
+
+  _runWindowsVolumePowerShell(command) {
+    return spawnSync(
+      "powershell",
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command],
+      { stdio: "pipe", timeout: 5000, windowsHide: true }
+    );
+  }
+
+  _getWindowsVolumePercent() {
+    const result = this._runWindowsVolumePowerShell(
+      `${this._windowsVolumeScript()}\n[AudioEndpoint]::GetVolume()`
+    );
+    if (result.status !== 0) return null;
+    const parsed = Number((result.stdout?.toString() || "").trim());
+    return Number.isFinite(parsed) ? this._clampVolume(parsed) : null;
+  }
+
+  _setWindowsVolumePercent(percent) {
+    const result = this._runWindowsVolumePowerShell(
+      `${this._windowsVolumeScript()}\n[AudioEndpoint]::SetVolume(${this._clampVolume(percent)})`
+    );
+    return result.status === 0;
+  }
+
+  _getMacVolumePercent() {
+    const result = spawnSync("osascript", ["-e", "output volume of (get volume settings)"], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    if (result.status !== 0) return null;
+    const parsed = Number((result.stdout?.toString() || "").trim());
+    return Number.isFinite(parsed) ? this._clampVolume(parsed) : null;
+  }
+
+  _setMacVolumePercent(percent) {
+    const result = spawnSync("osascript", ["-e", `set volume output volume ${this._clampVolume(percent)}`], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    return result.status === 0;
+  }
+
+  _getLinuxVolumePercent() {
+    const pactl = spawnSync("pactl", ["get-sink-volume", "@DEFAULT_SINK@"], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    if (pactl.status === 0) {
+      const output = pactl.stdout?.toString() || "";
+      const match = output.match(/(\d+)%/);
+      if (match) return this._clampVolume(match[1]);
+    }
+
+    const wpctl = spawnSync("wpctl", ["get-volume", "@DEFAULT_AUDIO_SINK@"], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    if (wpctl.status === 0) {
+      const output = wpctl.stdout?.toString() || "";
+      const match = output.match(/Volume:\s*([0-9.]+)/);
+      if (match) return this._clampVolume(Number(match[1]) * 100);
+    }
+
+    return null;
+  }
+
+  _setLinuxVolumePercent(percent) {
+    const safePercent = this._clampVolume(percent);
+    const pactl = spawnSync("pactl", ["set-sink-volume", "@DEFAULT_SINK@", `${safePercent}%`], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    if (pactl.status === 0) return true;
+
+    const wpctl = spawnSync("wpctl", ["set-volume", "@DEFAULT_AUDIO_SINK@", `${safePercent / 100}`], {
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    return wpctl.status === 0;
   }
 
   // --- Linux: MPRIS-aware pause/resume ---

--- a/src/helpers/mediaPlayer.js
+++ b/src/helpers/mediaPlayer.js
@@ -114,6 +114,10 @@ class MediaPlayer {
     return Math.max(0, Math.min(100, Math.round(parsed)));
   }
 
+  _compactProcessOutput(output) {
+    return (output || "").toString().trim().replace(/\s+/g, " ").slice(0, 600) || undefined;
+  }
+
   pauseMedia() {
     if (this._shouldDuckAudio()) {
       return this.duckAudio();
@@ -246,37 +250,61 @@ Add-Type -TypeDefinition @"
 using System;
 using System.Runtime.InteropServices;
 
-[Guid("BCDE0395-E52F-467C-8E3D-C4579291692E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public enum EDataFlow {
+  eRender = 0,
+  eCapture = 1,
+  eAll = 2
+}
+
+public enum ERole {
+  eConsole = 0,
+  eMultimedia = 1,
+  eCommunications = 2
+}
+
+[Flags]
+public enum CLSCTX : uint {
+  INPROC_SERVER = 0x1,
+  INPROC_HANDLER = 0x2,
+  LOCAL_SERVER = 0x4,
+  REMOTE_SERVER = 0x10,
+  ALL = INPROC_SERVER | INPROC_HANDLER | LOCAL_SERVER | REMOTE_SERVER
+}
+
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 interface IMMDeviceEnumerator {
-  int NotImpl1();
-  int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ppDevice);
+  [PreserveSig] int EnumAudioEndpoints(EDataFlow dataFlow, uint dwStateMask, IntPtr ppDevices);
+  [PreserveSig] int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, out IMMDevice ppDevice);
+  [PreserveSig] int GetDevice(string pwstrId, out IMMDevice ppDevice);
+  [PreserveSig] int RegisterEndpointNotificationCallback(IntPtr pClient);
+  [PreserveSig] int UnregisterEndpointNotificationCallback(IntPtr pClient);
 }
 
 [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 interface IMMDevice {
-  int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, out IAudioEndpointVolume ppInterface);
+  [PreserveSig] int Activate(ref Guid iid, CLSCTX dwClsCtx, IntPtr pActivationParams, out IAudioEndpointVolume ppInterface);
 }
 
 [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 interface IAudioEndpointVolume {
-  int RegisterControlChangeNotify(IntPtr pNotify);
-  int UnregisterControlChangeNotify(IntPtr pNotify);
-  int GetChannelCount(out uint pnChannelCount);
-  int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
-  int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
-  int GetMasterVolumeLevel(out float pfLevelDB);
-  int GetMasterVolumeLevelScalar(out float pfLevel);
-  int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
-  int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
-  int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
-  int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
-  int SetMute(bool bMute, Guid pguidEventContext);
-  int GetMute(out bool pbMute);
-  int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
-  int VolumeStepUp(Guid pguidEventContext);
-  int VolumeStepDown(Guid pguidEventContext);
-  int QueryHardwareSupport(out uint pdwHardwareSupportMask);
-  int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
+  [PreserveSig] int RegisterControlChangeNotify(IntPtr pNotify);
+  [PreserveSig] int UnregisterControlChangeNotify(IntPtr pNotify);
+  [PreserveSig] int GetChannelCount(out uint pnChannelCount);
+  [PreserveSig] int SetMasterVolumeLevel(float fLevelDB, Guid pguidEventContext);
+  [PreserveSig] int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+  [PreserveSig] int GetMasterVolumeLevel(out float pfLevelDB);
+  [PreserveSig] int GetMasterVolumeLevelScalar(out float pfLevel);
+  [PreserveSig] int SetChannelVolumeLevel(uint nChannel, float fLevelDB, Guid pguidEventContext);
+  [PreserveSig] int SetChannelVolumeLevelScalar(uint nChannel, float fLevel, Guid pguidEventContext);
+  [PreserveSig] int GetChannelVolumeLevel(uint nChannel, out float pfLevelDB);
+  [PreserveSig] int GetChannelVolumeLevelScalar(uint nChannel, out float pfLevel);
+  [PreserveSig] int SetMute([MarshalAs(UnmanagedType.Bool)] bool bMute, Guid pguidEventContext);
+  [PreserveSig] int GetMute(out bool pbMute);
+  [PreserveSig] int GetVolumeStepInfo(out uint pnStep, out uint pnStepCount);
+  [PreserveSig] int VolumeStepUp(Guid pguidEventContext);
+  [PreserveSig] int VolumeStepDown(Guid pguidEventContext);
+  [PreserveSig] int QueryHardwareSupport(out uint pdwHardwareSupportMask);
+  [PreserveSig] int GetVolumeRange(out float pflVolumeMindB, out float pflVolumeMaxdB, out float pflVolumeIncrementdB);
 }
 
 [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
@@ -286,23 +314,27 @@ public class AudioEndpoint {
   static IAudioEndpointVolume Endpoint() {
     var enumerator = (IMMDeviceEnumerator)(new MMDeviceEnumeratorComObject());
     IMMDevice device;
-    Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out device));
+    int hr = enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out device);
+    Marshal.ThrowExceptionForHR(hr);
     Guid iid = typeof(IAudioEndpointVolume).GUID;
     IAudioEndpointVolume endpoint;
-    Marshal.ThrowExceptionForHR(device.Activate(ref iid, 23, IntPtr.Zero, out endpoint));
+    hr = device.Activate(ref iid, CLSCTX.ALL, IntPtr.Zero, out endpoint);
+    Marshal.ThrowExceptionForHR(hr);
     return endpoint;
   }
 
   public static float GetVolume() {
     float value;
-    Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out value));
+    int hr = Endpoint().GetMasterVolumeLevelScalar(out value);
+    Marshal.ThrowExceptionForHR(hr);
     return value * 100.0f;
   }
 
   public static void SetVolume(float percent) {
     percent = Math.Max(0.0f, Math.Min(100.0f, percent));
     Guid g = Guid.Empty;
-    Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(percent / 100.0f, g));
+    int hr = Endpoint().SetMasterVolumeLevelScalar(percent / 100.0f, g);
+    Marshal.ThrowExceptionForHR(hr);
   }
 }
 "@
@@ -312,8 +344,8 @@ public class AudioEndpoint {
   _runWindowsVolumePowerShell(command) {
     return spawnSync(
       "powershell",
-      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command],
-      { stdio: "pipe", timeout: 5000, windowsHide: true }
+      ["-Sta", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command],
+      { stdio: "pipe", timeout: 7000, windowsHide: true }
     );
   }
 
@@ -321,16 +353,60 @@ public class AudioEndpoint {
     const result = this._runWindowsVolumePowerShell(
       `${this._windowsVolumeScript()}\n[AudioEndpoint]::GetVolume()`
     );
-    if (result.status !== 0) return null;
-    const parsed = Number((result.stdout?.toString() || "").trim());
-    return Number.isFinite(parsed) ? this._clampVolume(parsed) : null;
+    const stdout = (result.stdout?.toString() || "").trim();
+    const stderr = (result.stderr?.toString() || "").trim();
+
+    if (result.status !== 0) {
+      debugLogger.warn(
+        "Windows volume read failed",
+        {
+          status: result.status,
+          signal: result.signal,
+          stdout: this._compactProcessOutput(stdout),
+          stderr: this._compactProcessOutput(stderr),
+        },
+        "media"
+      );
+      return null;
+    }
+
+    const match = stdout.match(/-?\d+(?:\.\d+)?/);
+    const parsed = match ? Number(match[0]) : NaN;
+    if (!Number.isFinite(parsed)) {
+      debugLogger.warn(
+        "Windows volume read returned non-numeric output",
+        {
+          stdout: this._compactProcessOutput(stdout),
+          stderr: this._compactProcessOutput(stderr),
+        },
+        "media"
+      );
+      return null;
+    }
+
+    return this._clampVolume(parsed);
   }
 
   _setWindowsVolumePercent(percent) {
+    const target = this._clampVolume(percent);
     const result = this._runWindowsVolumePowerShell(
-      `${this._windowsVolumeScript()}\n[AudioEndpoint]::SetVolume(${this._clampVolume(percent)})`
+      `${this._windowsVolumeScript()}\n[AudioEndpoint]::SetVolume(${target})`
     );
-    return result.status === 0;
+    if (result.status !== 0) {
+      debugLogger.warn(
+        "Windows volume set failed",
+        {
+          target,
+          status: result.status,
+          signal: result.signal,
+          stdout: this._compactProcessOutput(result.stdout),
+          stderr: this._compactProcessOutput(result.stderr),
+        },
+        "media"
+      );
+      return false;
+    }
+    return true;
   }
 
   _getMacVolumePercent() {


### PR DESCRIPTION
## Summary

Adds configurable audio ducking for dictation, so background/system audio can be reduced while recording instead of being fully paused.

This reuses the existing `pauseMediaOnDictation` path and switches behaviour to ducking when configured via environment variables:

```env
OPENWHISPR_MEDIA_ON_DICTATION=duck
OPENWHISPR_AUDIO_DUCKING_VOLUME=25
```

## What changed

- Adds a duck/restore flow that saves the current system volume when dictation starts, lowers it to a configured percentage, then restores the original volume after dictation ends.
- Adds Windows system volume control using Core Audio through PowerShell/C#.
- Adds macOS support through `osascript` volume control.
- Adds Linux support through `pactl`, with `wpctl` fallback.
- Adds defensive logging for Windows volume read/set failures.
- Documents the new environment variables in `.env.example`.

## Testing

Tested manually on Windows with an installed OpenWhispr build:

- Set `OPENWHISPR_MEDIA_ON_DICTATION=duck`
- Set `OPENWHISPR_AUDIO_DUCKING_VOLUME=25`
- Enabled **Settings → General → Sound Effects → Pause media during dictation**
- Started dictation while speaker audio was playing
- Confirmed the app attempted ducking from the recording path
- After improving the Windows Core Audio helper, audio ducking worked as expected locally

## Notes

This is intentionally implemented as an environment-configurable MVP to keep the change small. A future UI pass could replace the current boolean setting with something like:

- Do nothing
- Pause media
- Duck audio

plus a duck-volume slider.