### PR TITLE
feat: configurable request timeout for self-hosted LLM endpoints

### DIFF
--- a/src/components/settings/InferenceConfigEditor.tsx
+++ b/src/components/settings/InferenceConfigEditor.tsx
@@ -13,6 +13,7 @@ import ReasoningModelSelector from "../ReasoningModelSelector";
 import EnterpriseSection from "../EnterpriseSection";
 import OpenAICompatiblePanel from "../OpenAICompatiblePanel";
 import { Toggle } from "../ui/toggle";
+import { Input } from "../ui/input";
 import type { InferenceMode } from "../../types/electron";
 import type { InferenceScope } from "../../config/inferenceScopes";
 import {
@@ -58,6 +59,8 @@ export default function InferenceConfigEditor({ scope, onModeChange }: Inference
   const { t } = useTranslation();
   const config = useSettingsStore(useShallow((s) => selectResolvedLLMConfig(s, scope)));
   const isSignedIn = useSettingsStore((s) => s.isSignedIn);
+  const selfHostedRequestTimeoutMs = useSettingsStore((s) => s.selfHostedRequestTimeoutMs);
+  const setSelfHostedRequestTimeoutMs = useSettingsStore((s) => s.setSelfHostedRequestTimeoutMs);
 
   const prefix = MODE_LABEL_PREFIX[scope];
   const modes: InferenceModeOption[] = [
@@ -177,6 +180,31 @@ export default function InferenceConfigEditor({ scope, onModeChange }: Inference
             </p>
           }
         />
+      )}
+
+      {config.mode === "self-hosted" && (
+        <div className="flex items-start justify-between gap-3 pt-1">
+          <div className="flex-1 min-w-0">
+            <h4 className="text-sm font-medium text-foreground">
+              {t("reasoning.requestTimeout.label")}
+            </h4>
+            <p className="text-xs text-muted-foreground">{t("reasoning.requestTimeout.help")}</p>
+          </div>
+          <Input
+            type="number"
+            min={10}
+            max={3600}
+            step={10}
+            value={Math.round(selfHostedRequestTimeoutMs / 1000)}
+            onChange={(e) => {
+              const secs = parseInt(e.target.value, 10);
+              if (Number.isFinite(secs) && secs >= 10) {
+                setSelfHostedRequestTimeoutMs(secs * 1000);
+              }
+            }}
+            className="h-8 text-sm w-24 text-right"
+          />
+        </div>
       )}
 
       {showThinkingToggle && (

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -370,6 +370,10 @@
       "label": "Disable thinking output",
       "help": "Skips reasoning tokens for cleaner output. Recommended for cleanup. Some servers ignore this hint."
     },
+    "requestTimeout": {
+      "label": "Request timeout (seconds)",
+      "help": "How long to wait for a response from your self-hosted server. Increase this for large models that generate slowly."
+    },
     "selfHosted": {
       "endpointHelp": "Point to an OpenAI-compatible server on your local network (e.g. Ollama, LM Studio, vLLM, or llama-server)."
     },

--- a/src/services/BaseReasoningService.ts
+++ b/src/services/BaseReasoningService.ts
@@ -12,6 +12,8 @@ export interface ReasoningConfig {
   customApiKey?: string;
   provider?: string;
   disableThinking?: boolean;
+  /** Override the HTTP request timeout (ms) for self-hosted / LAN LLM requests. */
+  requestTimeoutMs?: number;
 }
 
 export abstract class BaseReasoningService {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -176,9 +176,10 @@ class ReasoningService extends BaseReasoningService {
       requestBody: JSON.stringify(requestBody).substring(0, 200),
     });
 
+    const requestTimeoutMs = config.requestTimeoutMs ?? getSettings().selfHostedRequestTimeoutMs ?? 120000;
     const response = await withRetry(async () => {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 30000);
+      const timeoutId = setTimeout(() => controller.abort(), requestTimeoutMs);
       try {
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
@@ -233,7 +234,7 @@ class ReasoningService extends BaseReasoningService {
         return jsonResponse;
       } catch (error) {
         if ((error as Error).name === "AbortError") {
-          throw new Error("Request timed out after 30s");
+          throw new Error(`Request timed out after ${requestTimeoutMs / 1000}s`);
         }
         throw error;
       } finally {
@@ -303,11 +304,15 @@ class ReasoningService extends BaseReasoningService {
 
     const startTime = Date.now();
     try {
+      const resolvedConfig: ReasoningConfig = {
+        requestTimeoutMs: getSettings().selfHostedRequestTimeoutMs ?? 120000,
+        ...config,
+      };
       const result = await handler.call({
         text,
         model: trimmedModel,
         agentName,
-        config,
+        config: resolvedConfig,
         ctx: this.providerContext,
       });
 
@@ -421,7 +426,8 @@ class ReasoningService extends BaseReasoningService {
 
     this.streamAbortController = new AbortController();
     const controller = this.streamAbortController;
-    const timeoutId = setTimeout(() => controller.abort(), 60000);
+    const streamTimeoutMs = config.requestTimeoutMs ?? getSettings().selfHostedRequestTimeoutMs ?? 120000;
+    const timeoutId = setTimeout(() => controller.abort(), streamTimeoutMs);
 
     let response: Response;
     try {

--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -171,7 +171,8 @@ export const openaiProvider: InferenceProvider = {
 
       for (const { url: endpoint, type } of endpointCandidates) {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        const timeoutMs = config.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
         try {
           const maxTokens =
             config.maxTokens ||
@@ -237,7 +238,7 @@ export const openaiProvider: InferenceProvider = {
           return res.json();
         } catch (error) {
           if ((error as Error).name === "AbortError") {
-            throw new Error("Request timed out after 30s");
+            throw new Error(`Request timed out after ${timeoutMs / 1000}s`);
           }
           lastError = error as Error;
           if (type === "responses") {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -35,6 +35,14 @@ function readString(key: string, fallback: string): string {
   return localStorage.getItem(key) ?? fallback;
 }
 
+function readNumber(key: string, fallback: number): number {
+  if (!isBrowser) return fallback;
+  const stored = localStorage.getItem(key);
+  if (stored === null) return fallback;
+  const parsed = Number(stored);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function readBoolean(key: string, fallback: boolean): boolean {
   if (!isBrowser) return fallback;
   const stored = localStorage.getItem(key);
@@ -390,6 +398,9 @@ export interface SettingsState
   remoteTranscriptionUrl: string;
   cleanupMode: InferenceMode;
   cleanupRemoteUrl: string;
+  /** Request timeout in ms for self-hosted / LAN LLM calls. Default: 120000 (2 min). */
+  selfHostedRequestTimeoutMs: number;
+  setSelfHostedRequestTimeoutMs: (ms: number) => void;
 
   meetingTranscriptionMode: InferenceMode;
   meetingUseLocalWhisper: boolean;
@@ -604,6 +615,13 @@ function createStringSetter(key: string) {
 
 function createBooleanSetter(key: string) {
   return (value: boolean) => {
+    if (isBrowser) localStorage.setItem(key, String(value));
+    useSettingsStore.setState({ [key]: value });
+  };
+}
+
+function createNumberSetter(key: string) {
+  return (value: number) => {
     if (isBrowser) localStorage.setItem(key, String(value));
     useSettingsStore.setState({ [key]: value });
   };
@@ -881,6 +899,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     return "openwhispr" as InferenceMode;
   })(),
   cleanupRemoteUrl: readString("cleanupRemoteUrl", ""),
+  selfHostedRequestTimeoutMs: readNumber("selfHostedRequestTimeoutMs", 120000),
 
   meetingTranscriptionMode: (() => {
     const v = readString("meetingTranscriptionMode", "openwhispr");
@@ -930,6 +949,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setRemoteTranscriptionUrl: createStringSetter("remoteTranscriptionUrl"),
   setCleanupMode: createStringSetter("cleanupMode") as (mode: InferenceMode) => void,
   setCleanupRemoteUrl: createStringSetter("cleanupRemoteUrl"),
+  setSelfHostedRequestTimeoutMs: createNumberSetter("selfHostedRequestTimeoutMs"),
 
   setMeetingTranscriptionMode: createStringSetter("meetingTranscriptionMode") as (
     mode: InferenceMode


### PR DESCRIPTION
- Add `requestTimeoutMs` field to `ReasoningConfig` so callers can override the HTTP timeout per-request
- Add `selfHostedRequestTimeoutMs` setting to the settings store (default 120 s, persisted in localStorage)
- Inject the setting automatically in `processText` and `processTextStreaming` so no callsite changes are needed
- Update `callChatCompletionsApi` (LAN/custom) and `openai.ts` (custom endpoint) to respect the configured timeout
- Add a numeric "Request timeout" input in the Self-Hosted panel of `InferenceConfigEditor` (shown for all LLM scopes)
- Add `reasoning.requestTimeout` i18n keys

Previously timeouts were hardcoded at 30 s (text cleanup) and 60 s (streaming), which caused failures with large self-hosted models.