### PR TITLE
fix(linux): propagate ydotool socket to spawned clients

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -350,7 +350,10 @@ class ClipboardManager {
 
     for (const socketPath of socketPaths) {
       try {
-        if (fs.statSync(socketPath)) return true;
+        fs.accessSync(socketPath, fs.constants.W_OK);
+        // Export so spawned ydotool clients inherit this socket instead of their own default.
+        process.env.YDOTOOL_SOCKET = socketPath;
+        return true;
       } catch {}
     }
 


### PR DESCRIPTION
## Problem

On Linux Wayland (GNOME/KDE), auto-paste spawns the `ydotool` CLI. `_isYdotoolDaemonRunning()` in `clipboard.js` detected the daemon's socket but **never exported it**. The spawned `ydotool` client then fell back to its own default resolution (`/tmp/.ydotool_socket`) — frequently a root-owned socket (`srw------- root root`) the user can't write to. The command connected to the wrong socket, was silently dropped, and the paste never happened — with no error surfaced.

Reported on Fedora 42 / GNOME Wayland with both a user `ydotoold` (`/run/user/1000/.ydotool_socket`) and a root `ydotoold` (`/tmp/.ydotool_socket`).

Closes #957

## Fix

In `_isYdotoolDaemonRunning()`:

1. **Propagate the socket** — set `process.env.YDOTOOL_SOCKET` to the detected socket so every spawned `ydotool` child inherits it (the client reads this env var; it has no socket-path flag). This is the only channel that can steer the child, and it matches how the app already holds runtime system state (`DISPLAY`, `WAYLAND_DISPLAY`, `XDG_*`) in `process.env`.
2. **Check usability, not just existence** — switch `fs.statSync` → `fs.accessSync(path, fs.constants.W_OK)`. Connecting to a unix-domain socket requires write permission, so a root-owned socket is now skipped instead of mistaken for a usable daemon. (Same idiom already used for the `/dev/uinput` check in this file.)

## Why this is safe for existing users

- Working setups are unchanged: if paste works today, the socket already exists and is writable, so `W_OK` passes exactly as before — we just additionally pin `ydotool` to the socket the app already validated.
- Non-Wayland / xdotool / wtype / native-binary paste paths never touch this code.
- Currently-broken (root-owned socket) users go from silent failure to either working (if a user socket exists) or the correct "start ydotoold" hint.
- No socket files are deleted — we never touch sockets we don't own.

## Testing

Linux/ydotool-only path; validated by the reporter on Fedora 42 / GNOME Wayland. `node --check` passes; function signature and return type are unchanged, so both call sites are unaffected.