### PR TITLE
fix(notes): cap live speaker count to expected count in note recordings

### DIFF
--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -8,7 +8,7 @@ const { resolveBinaryPath, gracefulStopProcess } = require("../utils/serverUtils
 const { getModelsDirForService } = require("./modelDirUtils");
 const { convertToWav } = require("./ffmpegUtils");
 const { getSafeTempDir } = require("./safeTempDir");
-const { applyProvisionalSpeaker, applyConfirmedSpeaker } = require("./speakerAssignmentPolicy");
+const { applyConfirmedSpeaker } = require("./speakerAssignmentPolicy");
 const sidecarPidFile = require("./sidecarPidFile");
 const {
   transcriptsOverlap,
@@ -459,8 +459,6 @@ class DiarizationManager {
       return null;
     };
 
-    let fallbackSpeakerIndex = speakerSet.size;
-
     return deduped.map((seg, index) => {
       const enriched = { ...seg };
 
@@ -505,12 +503,6 @@ class DiarizationManager {
             speaker: speakerMap.get(bestSpeaker) || bestSpeaker,
             speakerIsPlaceholder: false,
           });
-        } else if (!enriched.speaker) {
-          applyProvisionalSpeaker(enriched, {
-            speaker: `speaker_${fallbackSpeakerIndex}`,
-            speakerIsPlaceholder: true,
-          });
-          fallbackSpeakerIndex += 1;
         }
       }
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -7600,7 +7600,9 @@ class IPCHandlers {
         );
         this.activeMeetingSpeakerConfig = { enabled, expectedCount };
         liveSpeakerIdentifier.setEnabled(enabled);
-        liveSpeakerIdentifier.setMaxSpeakers(expectedCount);
+        // Live identification only labels other speakers (the mic track is "you"),
+        // so cap at expectedCount - 1 to match resolveSessionMaxSpeakers().
+        liveSpeakerIdentifier.setMaxSpeakers(Math.max(1, expectedCount - 1));
         return { success: true };
       } catch (error) {
         return { success: false, error: error.message };

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1021,11 +1021,7 @@ class WindowManager {
   showDictationPanel(options = {}) {
     const { focus = false } = options;
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-      const wasHidden = !this.mainWindow.isVisible() || this.mainWindow.isMinimized();
-
-      if (wasHidden) {
-        this._repositionToCursorDisplay();
-      }
+      this._repositionToCursorDisplay();
 
       if (this.mainWindow.isMinimized()) {
         this.mainWindow.restore();

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -537,6 +537,16 @@ function reserveSpeakerIndex(speakerId?: string) {
   nextPlaceholderSpeakerIndex = Math.max(nextPlaceholderSpeakerIndex, idx + 1);
 }
 
+// Other-speaker cap is expectedCount - 1 (the mic track is "you"); mirrors the
+// backend cap so live labels can't climb past the count the user expects.
+function mintPlaceholderSpeakerId(): string {
+  const expected = useMeetingRecordingStore.getState().sessionExpectedCount;
+  const cap = Math.max(1, expected - 1);
+  const index = Math.min(nextPlaceholderSpeakerIndex, cap - 1);
+  nextPlaceholderSpeakerIndex = Math.max(nextPlaceholderSpeakerIndex, index + 1);
+  return `speaker_${index}`;
+}
+
 function assignProvisionalSpeaker(segment: TranscriptSegment): TranscriptSegment {
   if (segment.source !== "system" || segment.speaker) return segment;
 
@@ -584,8 +594,7 @@ function assignProvisionalSpeaker(segment: TranscriptSegment): TranscriptSegment
     });
   }
 
-  const speakerId = `speaker_${nextPlaceholderSpeakerIndex}`;
-  nextPlaceholderSpeakerIndex += 1;
+  const speakerId = mintPlaceholderSpeakerId();
 
   return normalizeTranscriptSegment({
     ...segment,
@@ -888,9 +897,13 @@ export async function startRecording(args: StartRecordingArgs): Promise<void> {
           } else {
             useMeetingRecordingStore.setState({ systemPartial: data.text });
             if (!systemPartialSpeakerIdValue) {
-              const speakerId = `speaker_${nextPlaceholderSpeakerIndex}`;
-              nextPlaceholderSpeakerIndex += 1;
-              setSystemPartialSpeakerIdentity(speakerId, null);
+              // Reuse the recent system speaker before minting — the partial id is
+              // cleared after every final, so always minting spawned one per utterance.
+              const carried = getRecentSystemSpeaker(Date.now());
+              setSystemPartialSpeakerIdentity(
+                carried?.speakerId ?? mintPlaceholderSpeakerId(),
+                carried?.speakerName ?? null
+              );
             }
           }
           return;


### PR DESCRIPTION
## Problem

When you start a **normal note recording** (Personal Notes), the speaker UI correctly defaults to **one other person** — but as recording continues, the per-segment **"Speaker N"** labels climb to *Speaker 2, 3, 4, 5...* even when only one other person is present. The expected-speaker count was not applied consistently.

## Root cause & fix

The "other speaker" cap should be `expectedCount - 1` (the mic track is always "you"). Two places didn't honor it:

### Renderer — `meetingRecordingStore.ts` (the visible symptom)
Placeholder speaker ids (`speaker_N`) were minted without the cap the backend enforces:
- The system **partial** path minted a fresh `speaker_N` on every partial whenever the partial id was null. Because that id is cleared after **every** system *final*, each utterance produced a new speaker — **bypassing the 8s carry-forward reuse entirely**.
- `assignProvisionalSpeaker` minted unbounded on any speech gap > 8s.

**Fix:** add `mintPlaceholderSpeakerId()` which clamps the placeholder index to `expectedCount - 1` (mirroring the backend's `createSpeakerRemapper` cap), and reuse the most recent system speaker in the partial path before minting.

### Backend — `ipcHandlers.js` (latent consistency bug)
`meeting-set-session-speaker-config` set the live identifier cap to `expectedCount` instead of `expectedCount - 1`, so changing the speaker stepper mid-recording allowed one extra cluster vs. what `resolveSessionMaxSpeakers()` sets at start.

**Fix:** cap at `Math.max(1, expectedCount - 1)` so both code paths agree.

## Behavior after fix

The cap scales with the user's setting — it allows up to the expected number of speakers, it just can't climb past it:

| Expected | Allowed placeholders | Shows up to |
|---|---|---|
| 1 other | `speaker_0` | "Speaker 1" |
| 2 others | `speaker_0`, `speaker_1` | "Speaker 2" |
| 3 others | `speaker_0..2` | "Speaker 3" |

## Scope / risk

- Placeholders are provisional and overwritten by backend `meeting-speaker-identified` events, so the renderer change only affects the interim display.
- `expectedCount` is clamped to `[1, MAX_SPEAKER_COUNT]` at both sites, so the index can never go negative.
- Typecheck, ESLint, and Prettier all pass.

## Testing

- [ ] Start a normal note recording with one other person — confirm labels stay at "Speaker 1" and no longer climb.
- [ ] Bump the stepper to 2-3 others mid-recording — confirm placeholders scale to that cap, not beyond.

---

## Additional fix — multi-monitor: recorder follows the cursor's display

> Unrelated to the speaker-count fix, bundled here for convenience.

**Problem:** On multi-monitor setups, the dictation/recorder panel stopped appearing on whichever monitor you were working on — it stayed on whatever display it was last on.

**Root cause:** `_repositionToCursorDisplay()` (which moves the panel to the cursor's display) was only called from `showDictationPanel()` when the window transitioned from **hidden → visible**. With the persistent floating icon (the default — `floatingIconAutoHide` is `false`), the panel is always visible, so that hidden→visible transition never happens and the panel never followed the cursor. The behavior only worked for users who enabled "auto-hide floating icon".

**Fix:** always call `_repositionToCursorDisplay()` on show. The method already no-ops when the panel is already on the cursor's display, so this is safe for the always-visible icon.

- [ ] On a multi-monitor setup, move the cursor to a second display and trigger dictation — confirm the panel appears on that display.
