### PR TITLE
fix(audio): retry on default mic when the pinned deviceId is stale

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -11,6 +11,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { reacquireIfDead } from "./micTrackHealth";
+import { isStaleDeviceError } from "./staleMicDevice";
 import { shouldSaveDiscardedRecording } from "./discardedRecording";
 import { getSettings, getEffectiveCleanupModel, isCloudCleanupMode } from "../stores/settingsStore";
 import { shouldSkipTranscriptionApiKey } from "./transcriptionAuth";
@@ -292,7 +293,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return this.sttConfig?.streamingProvider || defaultProvider;
   }
 
-  async getAudioConstraints() {
+  async getAudioConstraints(forceDefaultMic = false) {
     const { preferBuiltInMic: preferBuiltIn, selectedMicDeviceId: selectedDeviceId } =
       getSettings();
 
@@ -306,6 +307,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       autoGainControl: false,
       channelCount: 2,
     };
+
+    // Pinned device was unavailable (Chromium rotates IDs / device unplugged); fall back to the
+    // system default for this capture without discarding the saved preference. See #900.
+    if (forceDefaultMic) {
+      logger.debug("Using default microphone (pinned device unavailable)", {}, "audio");
+      return { audio: noProcessing };
+    }
 
     if (preferBuiltIn) {
       if (this.cachedMicDeviceId) {
@@ -367,13 +375,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  async startRecording() {
+  async startRecording(forceDefaultMic = false) {
     try {
       if (this.isRecording || this.isProcessing || this.mediaRecorder?.state === "recording") {
         return false;
       }
 
-      const constraints = await this.getAudioConstraints();
+      const constraints = await this.getAudioConstraints(forceDefaultMic);
       const micStream = await reacquireIfDead(
         await navigator.mediaDevices.getUserMedia(constraints),
         () => {
@@ -509,6 +517,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       return true;
     } catch (error) {
+      if (isStaleDeviceError(error) && !forceDefaultMic) {
+        // Pinned mic is gone (Chromium rotates IDs / device unplugged). Retry once on the default mic. See #900.
+        logger.warn("Pinned microphone unavailable, retrying on default mic", {}, "audio");
+        this.cachedMicDeviceId = null;
+        return this.startRecording(true);
+      }
+
       let errorTitle = "Recording Error";
       let errorDescription = `Failed to access microphone: ${error.message}`;
 
@@ -2416,7 +2431,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return this.persistentAudioContext;
   }
 
-  async startStreamingRecording() {
+  async startStreamingRecording(forceDefaultMic = false) {
     try {
       if (this.streamingStartInProgress) {
         return false;
@@ -2431,7 +2446,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.stopRequestedDuringStreamingStart = false;
 
       const t0 = performance.now();
-      const constraints = await this.getAudioConstraints();
+      const constraints = await this.getAudioConstraints(forceDefaultMic);
       const tConstraints = performance.now();
 
       // 1. Get mic stream (can take 10-15s on cold macOS mic driver)
@@ -2637,8 +2652,21 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
       return true;
     } catch (error) {
+      const stopRequested = this.stopRequestedDuringStreamingStart;
       this.streamingStartInProgress = false;
       this.stopRequestedDuringStreamingStart = false;
+
+      if (isStaleDeviceError(error) && !forceDefaultMic && !stopRequested) {
+        // Pinned mic is gone (Chromium rotates IDs / device unplugged). Retry once on the default mic. See #900.
+        logger.warn("Pinned microphone unavailable, retrying streaming on default mic", {}, "streaming");
+        this.cachedMicDeviceId = null;
+        await this.cleanupStreaming();
+        this.isRecording = false;
+        this.recordingStartTime = null;
+        this.onStateChange?.({ isRecording: false, isProcessing: false, isStreaming: false });
+        return this.startStreamingRecording(true);
+      }
+
       logger.error("Failed to start streaming recording", { error: error.message }, "streaming");
 
       let errorTitle = "Streaming Error";

--- a/src/helpers/staleMicDevice.js
+++ b/src/helpers/staleMicDevice.js
@@ -1,0 +1,10 @@
+// Detects the OverconstrainedError getUserMedia throws when a saved deviceId no
+// longer matches any device. Chromium rotates mediaDevices IDs over time, so a
+// pinned { deviceId: { exact } } eventually goes stale and recording fails. See #900.
+export function isStaleDeviceError(error) {
+  if (!error || error.name !== "OverconstrainedError") return false;
+  // deviceId is the only constraint pinned with { exact }; treat an unknown/empty
+  // constraint as the device too, but skip a known non-deviceId constraint.
+  const constraint = error.constraint;
+  return !constraint || constraint === "deviceId";
+}

--- a/test/helpers/staleMicDevice.test.js
+++ b/test/helpers/staleMicDevice.test.js
@@ -1,0 +1,78 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/staleMicDevice.js");
+
+test("treats an OverconstrainedError on deviceId as a stale device", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(
+    isStaleDeviceError({ name: "OverconstrainedError", constraint: "deviceId" }),
+    true
+  );
+});
+
+test("treats an OverconstrainedError with an empty constraint as a stale device", async () => {
+  // Chromium sometimes reports OverconstrainedError without naming the constraint.
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ name: "OverconstrainedError", constraint: "" }), true);
+});
+
+test("treats an OverconstrainedError with no constraint property as a stale device", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ name: "OverconstrainedError" }), true);
+});
+
+test("does not treat an OverconstrainedError on a non-deviceId constraint as stale", async () => {
+  // Guards against wiping a valid mic pick when some other exact constraint fails.
+  const { isStaleDeviceError } = await load();
+  assert.equal(
+    isStaleDeviceError({ name: "OverconstrainedError", constraint: "channelCount" }),
+    false
+  );
+});
+
+test("reads constraint from a getter without throwing", async () => {
+  const { isStaleDeviceError } = await load();
+  const error = {
+    name: "OverconstrainedError",
+    get constraint() {
+      return "deviceId";
+    },
+  };
+  assert.equal(isStaleDeviceError(error), true);
+});
+
+test("returns false for NotFoundError", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ name: "NotFoundError" }), false);
+});
+
+test("returns false for NotAllowedError", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ name: "NotAllowedError" }), false);
+});
+
+test("returns false for NotReadableError (mic in use)", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ name: "NotReadableError" }), false);
+});
+
+test("returns false for a generic Error", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError(new Error("boom")), false);
+});
+
+test("returns false for an object without a name", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError({ constraint: "deviceId" }), false);
+});
+
+test("returns false for null", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError(null), false);
+});
+
+test("returns false for undefined", async () => {
+  const { isStaleDeviceError } = await load();
+  assert.equal(isStaleDeviceError(undefined), false);
+});


### PR DESCRIPTION
## Summary

Selecting a specific microphone, or relying on the built-in one, pins it with `{ deviceId: { exact } }` in `getAudioConstraints`. Chromium rotates media device IDs over time, so the saved id eventually matches no device and `getUserMedia` throws `OverconstrainedError`. Neither `startRecording` nor `startStreamingRecording` handled that error, so the user just saw the generic "Failed to access microphone" with no hint that the saved device was the problem.

When `getUserMedia` fails with a stale-device `OverconstrainedError`, recording now retries once on the system default mic. The saved preference is left untouched, so a device that comes back (a briefly unplugged USB mic) is picked up again automatically. A new `isStaleDeviceError` helper gates the fallback on the `deviceId` constraint specifically, so an unrelated constraint failure never triggers it.

Fixes #900

## Changes

- src/helpers/staleMicDevice.js: new pure helper `isStaleDeviceError`, true only for an `OverconstrainedError` whose failed constraint is `deviceId` (or unnamed)
- src/helpers/audioManager.js: `getAudioConstraints(forceDefaultMic)` returns default constraints when forced; `startRecording` and `startStreamingRecording` catch a stale-device error and retry once on the default mic, guarded against re-looping and logged; the streaming retry honors a stop requested mid-start
- test/helpers/staleMicDevice.test.js: 12 tests for deviceId/empty/unnamed constraints, non-deviceId constraints, and non-OverconstrainedError inputs
