### PR TITLE
fix(onnx): restore local semantic search in packaged builds

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -18,6 +18,7 @@
     "node_modules/**/*",
     "src/dist/**/*",
     "src/helpers/**/*",
+    "src/workers/**/*",
     "src/config/**/*",
     "src/constants/**/*",
     "src/locales/**/*",
@@ -88,7 +89,8 @@
     "**/node_modules/ffmpeg-static/**/*",
     "**/node_modules/better-sqlite3/**/*",
     "**/node_modules/onnxruntime-node/**/*",
-    "**/node_modules/@napi-rs/keyring/**/*"
+    "**/node_modules/@napi-rs/keyring/**/*",
+    "src/workers/**/*"
   ],
   "extraResources": [
     ".env",

--- a/src/helpers/speakerEmbeddings.js
+++ b/src/helpers/speakerEmbeddings.js
@@ -59,10 +59,10 @@ class SpeakerEmbeddings {
       samples.byteOffset + samples.byteLength
     );
 
+    // No transfer-list: MessagePortMain can't transfer ArrayBuffers, so the samples are cloned.
     const { embeddingBuffer } = await onnxWorkerClient.request(
       "speaker.extract",
-      { samplesBuffer },
-      [samplesBuffer]
+      { samplesBuffer }
     );
 
     if (!embeddingBuffer) return null;

--- a/src/workers/onnxWorker.js
+++ b/src/workers/onnxWorker.js
@@ -358,9 +358,8 @@ async function dispatch({ id, method, payload }) {
   }
   try {
     const result = await handler(payload || {});
-    const transferList = [];
-    if (result?.embeddingBuffer) transferList.push(result.embeddingBuffer);
-    return { reply: { id, result }, transferList };
+    // MessagePortMain transfers only ports, not ArrayBuffers — clone the result buffers instead.
+    return { reply: { id, result }, transferList: [] };
   } catch (err) {
     log("error", "handler threw", { method, error: err?.message, stack: err?.stack });
     return { reply: { id, error: { message: err?.message || String(err) } }, transferList: [] };


### PR DESCRIPTION
## Summary

Local semantic search (the ONNX embedding worker) never actually worked in packaged builds, for two independent reasons fixed here:

1. The worker script `src/workers/onnxWorker.js` was never packaged — the electron-builder `files` glob lists `src/helpers`, `src/config` and so on but omits `src/workers` — so `utilityProcess.fork` failed with `ERR_MODULE_NOT_FOUND`.
2. Once it loads, the worker crashed on every reply: it put the embedding `ArrayBuffer` in the `MessagePortMain` transfer list, but Electron's `MessagePortMain` transfers only ports, not ArrayBuffers (`TypeError: Port at index 0 is not a valid port`). Same on the `speaker.extract` send path.

Both failures were masked by the silent FTS5 keyword fallback, so the bug was latent in releases.

The fix packages `src/workers` (and unpacks it so the utilityProcess ESM resolver can load it from disk), and clones the embedding/sample buffers instead of transferring them (negligible cost — embeddings are ~1.5 KB).

Verified on a packaged Linux install: the worker spawns once and stays alive, with no `ERR_MODULE_NOT_FOUND` / `Port at index 0` / crash loop, and saving a note now indexes its vector in Qdrant (points_count 0 → 1).

## Changes

- `electron-builder.json`: add `src/workers/**/*` to `files` and `asarUnpack` so the ONNX worker ships and loads from disk.
- `src/workers/onnxWorker.js`: don't transfer the result ArrayBuffer over MessagePortMain — clone it.
- `src/helpers/speakerEmbeddings.js`: drop the samples ArrayBuffer from the request transfer list — clone it.
