### PR TITLE
fix(reasoning): stop sending Groq-incompatible thinking-suppression params (chat_template_kwargs, reasoning_effort:none)

### DIFF
--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -14,20 +14,36 @@ function usesOllamaDialect(providerKey: string): boolean {
   return window.localStorage?.getItem("remoteReasoningType") !== "openai-compatible";
 }
 
-// Groq and custom OpenAI-compatible endpoints (e.g. Cerebras) do strict request
-// validation: both reject `chat_template_kwargs`, and only accept reasoning_effort
-// `low` | `medium` | `high` (not `none`). Verified against the live Groq and
-// Cerebras `gpt-oss-120b` APIs. For these providers send the lowest accepted
-// effort and omit `chat_template_kwargs`. Every other provider is left unchanged.
-const STRICT_REASONING_PROVIDERS = new Set(["groq", "custom"]);
+// Endpoints with strict OpenAI-compatible validation that reject BOTH
+// `chat_template_kwargs` and `reasoning_effort: "none"` — they only accept
+// `low` | `medium` | `high`. Verified against the live Groq and Cerebras
+// `gpt-oss-120b` APIs.
+//
+// `groq` is a first-class provider. Cerebras is configured as a custom
+// OpenAI-compatible endpoint, so it is matched by URL only — other custom
+// endpoints (e.g. self-hosted vLLM / SGLang, which DO accept
+// `chat_template_kwargs`) must keep their existing behaviour.
+function isStrictReasoningEndpoint(providerKey: string, config: ReasoningConfig): boolean {
+  if (providerKey === "groq") return true;
+  if (providerKey === "custom") {
+    return (config.baseUrl ?? "").toLowerCase().includes("cerebras.ai");
+  }
+  return false;
+}
 
-function suppressThinking(requestBody: Record<string, unknown>, providerKey: string): void {
+function suppressThinking(
+  requestBody: Record<string, unknown>,
+  providerKey: string,
+  strict: boolean
+): void {
   if (providerKey === "gemini") {
     requestBody.reasoning_effort = "minimal";
     return;
   }
 
-  if (STRICT_REASONING_PROVIDERS.has(providerKey)) {
+  if (strict) {
+    // Groq / Cerebras: send the lowest accepted effort and omit
+    // `chat_template_kwargs` (both rejected by these endpoints).
     requestBody.reasoning_effort = "low";
     return;
   }
@@ -47,10 +63,11 @@ export function applyThinkingSuppression(
   config: ReasoningConfig
 ): void {
   const providerKey = provider.toLowerCase();
+  const strict = isStrictReasoningEndpoint(providerKey, config);
   const cloudModel = getCloudModel(model);
 
   if (cloudModel?.disableThinking && providerKey === "groq") {
-    suppressThinking(requestBody, providerKey);
+    suppressThinking(requestBody, providerKey, strict);
     return;
   }
 
@@ -60,5 +77,5 @@ export function applyThinkingSuppression(
   const knownModel = cloudModel || localModel;
   if (knownModel && !knownModel.supportsThinking) return;
 
-  suppressThinking(requestBody, providerKey);
+  suppressThinking(requestBody, providerKey, strict);
 }

--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -14,6 +14,21 @@ function usesOllamaDialect(providerKey: string): boolean {
   return window.localStorage?.getItem("remoteReasoningType") !== "openai-compatible";
 }
 
+// `chat_template_kwargs` is only understood by local inference servers
+// (llama.cpp, vLLM, SGLang, LM Studio). Cloud OpenAI-compatible APIs such as
+// Groq and Cerebras do strict request validation and reject it with
+// "property 'chat_template_kwargs' is unsupported".
+function isLocalServer(providerKey: string): boolean {
+  return providerKey === "local" || providerKey === "lan";
+}
+
+// `reasoning_effort: "none"` is not universally supported. Groq and Cerebras
+// only accept "low" | "medium" | "high" and return a 400 for "none". Use "low"
+// as the safe minimum, except for providers verified to accept "none" (xAI).
+function minimalReasoningEffort(providerKey: string): string {
+  return providerKey === "xai" ? "none" : "low";
+}
+
 function suppressThinking(requestBody: Record<string, unknown>, providerKey: string): void {
   if (providerKey === "gemini") {
     requestBody.reasoning_effort = "minimal";
@@ -23,9 +38,12 @@ function suppressThinking(requestBody: Record<string, unknown>, providerKey: str
   if (usesOllamaDialect(providerKey)) {
     requestBody.think = false;
   } else {
-    requestBody.reasoning_effort = "none";
+    requestBody.reasoning_effort = minimalReasoningEffort(providerKey);
   }
-  requestBody.chat_template_kwargs = { enable_thinking: false };
+
+  if (isLocalServer(providerKey)) {
+    requestBody.chat_template_kwargs = { enable_thinking: false };
+  }
 }
 
 export function applyThinkingSuppression(

--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -20,14 +20,34 @@ function usesOllamaDialect(providerKey: string): boolean {
 // `gpt-oss-120b` APIs.
 //
 // `groq` is a first-class provider. Cerebras is configured as a custom
-// OpenAI-compatible endpoint, so it is matched by URL only — other custom
+// OpenAI-compatible endpoint, so it is matched by hostname only — other custom
 // endpoints (e.g. self-hosted vLLM / SGLang, which DO accept
 // `chat_template_kwargs`) must keep their existing behaviour.
+
+// Match Cerebras by parsed hostname rather than a substring test, so a
+// look-alike host or a URL that merely contains "cerebras.ai" in its path
+// (e.g. "https://evil.example/cerebras.ai" or "https://cerebras.ai.attacker.com")
+// is not mistaken for the real endpoint.
+function isCerebrasEndpoint(baseUrl: string | undefined): boolean {
+  const raw = (baseUrl ?? "").trim();
+  if (!raw) return false;
+  let host: string;
+  try {
+    host = new URL(raw).hostname.toLowerCase();
+  } catch {
+    try {
+      // Tolerate scheme-less values like "api.cerebras.ai/v1".
+      host = new URL(`https://${raw}`).hostname.toLowerCase();
+    } catch {
+      return false;
+    }
+  }
+  return host === "cerebras.ai" || host.endsWith(".cerebras.ai");
+}
+
 function isStrictReasoningEndpoint(providerKey: string, config: ReasoningConfig): boolean {
   if (providerKey === "groq") return true;
-  if (providerKey === "custom") {
-    return (config.baseUrl ?? "").toLowerCase().includes("cerebras.ai");
-  }
+  if (providerKey === "custom") return isCerebrasEndpoint(config.baseUrl);
   return false;
 }
 

--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -14,20 +14,12 @@ function usesOllamaDialect(providerKey: string): boolean {
   return window.localStorage?.getItem("remoteReasoningType") !== "openai-compatible";
 }
 
-// `chat_template_kwargs` is only understood by local inference servers
-// (llama.cpp, vLLM, SGLang, LM Studio). Cloud OpenAI-compatible APIs such as
-// Groq and Cerebras do strict request validation and reject it with
-// "property 'chat_template_kwargs' is unsupported".
-function isLocalServer(providerKey: string): boolean {
-  return providerKey === "local" || providerKey === "lan";
-}
-
-// `reasoning_effort: "none"` is not universally supported. Groq and Cerebras
-// only accept "low" | "medium" | "high" and return a 400 for "none". Use "low"
-// as the safe minimum, except for providers verified to accept "none" (xAI).
-function minimalReasoningEffort(providerKey: string): string {
-  return providerKey === "xai" ? "none" : "low";
-}
+// Groq and custom OpenAI-compatible endpoints (e.g. Cerebras) do strict request
+// validation: both reject `chat_template_kwargs`, and only accept reasoning_effort
+// `low` | `medium` | `high` (not `none`). Verified against the live Groq and
+// Cerebras `gpt-oss-120b` APIs. For these providers send the lowest accepted
+// effort and omit `chat_template_kwargs`. Every other provider is left unchanged.
+const STRICT_REASONING_PROVIDERS = new Set(["groq", "custom"]);
 
 function suppressThinking(requestBody: Record<string, unknown>, providerKey: string): void {
   if (providerKey === "gemini") {
@@ -35,15 +27,17 @@ function suppressThinking(requestBody: Record<string, unknown>, providerKey: str
     return;
   }
 
+  if (STRICT_REASONING_PROVIDERS.has(providerKey)) {
+    requestBody.reasoning_effort = "low";
+    return;
+  }
+
   if (usesOllamaDialect(providerKey)) {
     requestBody.think = false;
   } else {
-    requestBody.reasoning_effort = minimalReasoningEffort(providerKey);
+    requestBody.reasoning_effort = "none";
   }
-
-  if (isLocalServer(providerKey)) {
-    requestBody.chat_template_kwargs = { enable_thinking: false };
-  }
+  requestBody.chat_template_kwargs = { enable_thinking: false };
 }
 
 export function applyThinkingSuppression(

--- a/src/services/ai/thinkingSuppression.ts
+++ b/src/services/ai/thinkingSuppression.ts
@@ -1,5 +1,6 @@
 import type { ReasoningConfig } from "../BaseReasoningService";
 import { getCloudModel, getLocalModel } from "../../models/ModelRegistry";
+import { getConfiguredOpenAIBase } from "./openaiBase";
 
 // Strict OpenAI-compatible servers (Groq, LM Studio, vLLM, LocalAI) reject
 // unknown fields like `think` with "property 'think' is unsupported". Only
@@ -31,23 +32,30 @@ function usesOllamaDialect(providerKey: string): boolean {
 function isCerebrasEndpoint(baseUrl: string | undefined): boolean {
   const raw = (baseUrl ?? "").trim();
   if (!raw) return false;
+  // Ensure an absolute URL with an authority component so a scheme-less value
+  // (e.g. "api.cerebras.ai/v1" or "cerebras.ai:443/v1") parses to a hostname
+  // instead of being misread as a "<scheme>:" URI with an empty host.
+  const absolute = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
   let host: string;
   try {
-    host = new URL(raw).hostname.toLowerCase();
+    host = new URL(absolute).hostname.toLowerCase();
   } catch {
-    try {
-      // Tolerate scheme-less values like "api.cerebras.ai/v1".
-      host = new URL(`https://${raw}`).hostname.toLowerCase();
-    } catch {
-      return false;
-    }
+    return false;
   }
   return host === "cerebras.ai" || host.endsWith(".cerebras.ai");
 }
 
 function isStrictReasoningEndpoint(providerKey: string, config: ReasoningConfig): boolean {
   if (providerKey === "groq") return true;
-  if (providerKey === "custom") return isCerebrasEndpoint(config.baseUrl);
+  if (providerKey === "custom") {
+    // Cerebras is reached as a custom OpenAI-compatible endpoint. The cleanup
+    // path omits `baseUrl` from config and relies on the configured fallback
+    // (getConfiguredOpenAIBase reads `cleanupCloudBaseUrl`), so mirror the exact
+    // resolution the request uses — see openai.ts and ReasoningService.ts:
+    // `config.baseUrl?.trim() || getConfiguredOpenAIBase()`.
+    const effectiveBase = config.baseUrl?.trim() || getConfiguredOpenAIBase();
+    return isCerebrasEndpoint(effectiveBase);
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary

With **"Disable thinking output"** enabled and a reasoning model on **Groq** or a **Cerebras** endpoint (reproduced with `gpt-oss-120b`), the cleanup request is rejected with HTTP 400, retried with exponential backoff, and after ~7 s OpenWhispr gives up and pastes the **raw, un‑cleaned** transcription.

`applyThinkingSuppression()` sends two parameters these endpoints reject:

1. **`chat_template_kwargs: { enable_thinking: false }`** → 400 `property 'chat_template_kwargs' is unsupported`
2. **`reasoning_effort: "none"`** → 400 `reasoning_effort must be one of low | medium | high`

## Scope

Limited to the endpoints **verified** to reject these params:

- **`groq`** — a first‑class provider.
- **Cerebras** — configured as a *custom* OpenAI‑compatible endpoint, so it's matched by URL (`config.baseUrl` contains `cerebras.ai`).

Crucially, **other custom endpoints are left untouched** — e.g. a self‑hosted **vLLM/SGLang** custom endpoint actually *accepts* (and needs) `chat_template_kwargs` to disable thinking, so blanket‑treating all `custom` endpoints would regress those. OpenAI / Anthropic / xAI / lan / local are also unchanged.

## Change

`src/services/ai/thinkingSuppression.ts`: an endpoint identified as strict (`groq`, or `custom` whose `baseUrl` is Cerebras) gets `reasoning_effort: "low"` and omits `chat_template_kwargs`. Every other provider/endpoint is byte‑for‑byte unchanged.

## Verified against the live APIs (`gpt-oss-120b`)

```
Groq:      reasoning_effort="none" -> 400   chat_template_kwargs -> 400   reasoning_effort="low" -> 200
Cerebras:  reasoning_effort="none" -> 400   chat_template_kwargs -> 400   reasoning_effort="low" -> 200
```

Diffing the produced request per scenario, **only `groq` and `custom@cerebras.ai` change**; `custom@localhost` (vLLM), `openai`, `anthropic`, `xai`, `gemini`, `lan`, `local` are identical to `main`. End‑to‑end on Groq `gpt-oss-120b`: pre‑fix request → 400 (`property 'chat_template_kwargs' is unsupported`); patched request → 200.

### Real-world trace (before the fix)

```
GROQ_REQUEST                       attempt 1
GROQ_API_ERROR_DETAIL  (400)       +0.05 s
GROQ_API_ERROR_DETAIL  (400)       +1.0 s backoff
GROQ_API_ERROR_DETAIL  (400)       +2.1 s backoff
GROQ_API_ERROR_DETAIL  (400)       +4.1 s backoff  -> PROVIDER_ERROR
-> pasted RAW transcription        reasoningProcessingDurationMs: 7220
```

Fixes #990
