### PR TITLE
chore: bump bundled llama.cpp to b9763

### DIFF
--- a/scripts/download-llama-server.js
+++ b/scripts/download-llama-server.js
@@ -11,13 +11,11 @@ const {
   cleanupFiles,
 } = require("./lib/download-utils");
 
-const LLAMA_CPP_REPO = "ggerganov/llama.cpp";
+const LLAMA_CPP_REPO = "ggml-org/llama.cpp";
 
-// Pinned: whisper-server.exe (built against OpenWhispr/whisper.cpp 0.0.6) loads
-// ggml-*.dll from this script's output dir on Windows. Newer llama.cpp builds
-// bumped ggml's ABI and crash whisper-server on load_backend. Bump only after
-// verifying local Whisper starts on Windows.
-const LLAMA_CPP_TAG = process.env.LLAMA_CPP_VERSION || "b8857";
+// Pinned to a tested build that loads current GGUF models. whisper-server is
+// statically linked, so bumping this can't affect local Whisper.
+const LLAMA_CPP_TAG = process.env.LLAMA_CPP_VERSION || "b9763";
 
 const BINARIES = {
   "darwin-arm64": {

--- a/scripts/lib/download-utils.js
+++ b/scripts/lib/download-utils.js
@@ -320,9 +320,12 @@ function setExecutable(filePath) {
 }
 
 function cleanupFiles(binDir, prefix, keepPrefix) {
+  // Never delete shared libraries; only platform binaries. The b9763 split ships
+  // llama-server-impl.dll, which shares the "llama-server" prefix and must survive.
+  const isLibrary = (f) => /\.(dll|dylib)$/i.test(f) || /\.so(\.\d+)*$/.test(f);
   const files = fs.readdirSync(binDir).filter((f) => f.startsWith(prefix));
   files.forEach((file) => {
-    if (!file.startsWith(keepPrefix)) {
+    if (!file.startsWith(keepPrefix) && !isLibrary(file)) {
       const filePath = path.join(binDir, file);
       console.log(`Removing old binary: ${file}`);
       fs.unlinkSync(filePath);

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -9,10 +9,11 @@ const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
 
-const PORT_RANGE_START = 8200;
-const PORT_RANGE_END = 8220;
-const STARTUP_TIMEOUT_MS = 60000;
-const VULKAN_STARTUP_TIMEOUT_MS = 60000;
+// Range kept clear of cliBridge (8200-8219) to avoid port-bind collisions.
+const PORT_RANGE_START = 8221;
+const PORT_RANGE_END = 8240;
+const STARTUP_TIMEOUT_MS = 120000;
+const VULKAN_STARTUP_TIMEOUT_MS = 120000;
 const HEALTH_CHECK_INTERVAL_MS = 5000;
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const STARTUP_POLL_INTERVAL_MS = 500;
@@ -210,6 +211,10 @@ class LlamaServerManager {
     if (process.env.INTELLIGENCE_GPU_INDEX) {
       env.CUDA_VISIBLE_DEVICES = process.env.INTELLIGENCE_GPU_INDEX;
     }
+
+    // Disable llama.cpp auto-fit memory probing (adds ~70s to startup). Set via env
+    // so builds without --fit ignore it instead of erroring. See LLAMA_ARG_FIT.
+    env.LLAMA_ARG_FIT = process.env.LLAMA_ARG_FIT || "off";
 
     return env;
   }

--- a/src/helpers/llamaVulkanManager.js
+++ b/src/helpers/llamaVulkanManager.js
@@ -21,7 +21,10 @@ function githubReleaseHeaders() {
   return headers;
 }
 
-const GITHUB_RELEASE_URL = "https://api.github.com/repos/ggerganov/llama.cpp/releases/latest";
+// Pinned to the same build as the bundled CPU binary (download-llama-server.js).
+// Overridable via LLAMA_CPP_VERSION so GPU and CPU stay on one tested llama.cpp.
+const LLAMA_CPP_TAG = process.env.LLAMA_CPP_VERSION || "b9763";
+const GITHUB_RELEASE_URL = `https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/${LLAMA_CPP_TAG}`;
 
 const VULKAN_ASSETS = {
   "win32-x64": {


### PR DESCRIPTION
## Summary

The bundled llama.cpp server was pinned to b8857, which can't load current GGUF models (Qwen 3.5, Gemma 4) — they fail at load with a missing-tensor error. This bumps the pin to b9763 (and the repo to the renamed `ggml-org/llama.cpp`). b9763 ships llama-server as a thin launcher plus split `*-impl` libraries; on Windows `cleanupFiles` in `download-utils.js` was deleting `llama-server-impl.dll` (it shares the `llama-server` prefix), so the server died at startup with `0xC0000135` (DLL_NOT_FOUND). The fix makes `cleanupFiles` skip shared libraries. It also disables b9763's auto-fit probing (`LLAMA_ARG_FIT=off`, ~70s faster startup), raises the startup timeout, and moves the llama port range off cliBridge's `8200-8219`.

## Changes

- `scripts/download-llama-server.js`: pin b8857 → b9763; repo `ggerganov` → `ggml-org`; refresh the stale comment.
- `src/helpers/llamaVulkanManager.js`: pin the runtime Vulkan download to the same build (`LLAMA_CPP_VERSION` default b9763); repo `ggerganov` → `ggml-org`.
- `scripts/lib/download-utils.js`: `cleanupFiles` skips `.dll/.so/.dylib` so split-runtime libs like `llama-server-impl.dll` survive.
- `src/helpers/llamaServer.js`: startup timeout 60s → 120s; disable auto-fit via `LLAMA_ARG_FIT=off`; move port range to `8221-8240` (clear of cliBridge).
