### PR TITLE
Add Azure AI Foundry / Azure OpenAI speech-to-text support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Transcription
+
+- **Azure AI Foundry / Azure OpenAI speech-to-text.** The custom transcription provider now recognizes Azure endpoints (`*.cognitiveservices.azure.com`, `*.openai.azure.com`, `*.services.ai.azure.com`) and builds the deployment-style URL Azure requires (`/openai/deployments/{model}/audio/transcriptions?api-version=...`) instead of the plain OpenAI `{base}/audio/transcriptions` shape, which returned `404 DeploymentNotFound`. Auth now uses Azure's `api-key` header on Azure hosts. Enter your resource endpoint as the URL and your exact deployment name in the Model field; `api-version` defaults to a transcribe-capable preview and can be overridden by appending `?api-version=...` to the endpoint.
+
 ## [1.7.3] - 2026-06-23
 
 A big release: two new transcription providers (Corti for clinical-grade medical dictation and xAI), a reworked onboarding flow built around what you'll use OpenWhispr for, spoken Snippets, a dedicated Voice Agent hotkey, a redesigned dictionary with cross-device sync, dedicated Audio Upload transcription settings, discarded-dictation history, OS-level notification controls, Linux PipeWire system-audio capture, new AI models, and a stack of fixes across paste, audio, settings, and Linux window managers.

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -952,6 +952,10 @@ export default function TranscriptionModelPicker({
                     className="h-8 text-sm"
                   />
                 </div>
+
+                {/azure\.com/i.test(cloudTranscriptionBaseUrl || "") && (
+                  <p className="text-xs text-muted-foreground">{t("transcription.azureHint")}</p>
+                )}
               </div>
             ) : (
               <div className="space-y-2">

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -2,7 +2,11 @@ import ReasoningService from "../services/ReasoningService";
 import { API_ENDPOINTS, buildApiUrl, normalizeBaseUrl } from "../config/constants";
 import logger from "../utils/logger";
 import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
-import { isSecureEndpoint } from "../utils/urlUtils";
+import {
+  isSecureEndpoint,
+  isAzureOpenAIEndpoint,
+  buildAzureTranscriptionUrl,
+} from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/auth";
 import { getBaseLanguageCode } from "../utils/languageSupport";
 import {
@@ -1606,7 +1610,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         formData.append("language", language);
       }
 
-      const endpoint = this.getTranscriptionEndpoint();
+      const endpoint = this.getTranscriptionEndpoint(model);
 
       // Groq rejects prompts > 896 chars (incl. when reached via "custom" provider).
       // 890 leaves margin for UTF-16 vs codepoint counting drift.
@@ -1762,7 +1766,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // Build headers - only include Authorization if we have an API key
       const headers = {};
       if (apiKey) {
-        headers.Authorization = `Bearer ${apiKey}`;
+        // Azure OpenAI authenticates API keys via the `api-key` header, not a
+        // Bearer token (which it reserves for Entra ID access tokens).
+        if (isAzureOpenAIEndpoint(endpoint)) {
+          headers["api-key"] = apiKey;
+        } else {
+          headers.Authorization = `Bearer ${apiKey}`;
+        }
       }
 
       logger.debug(
@@ -2005,12 +2015,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  getTranscriptionEndpoint() {
+  getTranscriptionEndpoint(deploymentName = "") {
     const s = getSettings();
     const currentProvider = s.cloudTranscriptionProvider || "openai";
     const currentBaseUrl = s.cloudTranscriptionBaseUrl || "";
     const transcriptionMode = s.transcriptionMode || "";
     const remoteUrl = (s.remoteTranscriptionUrl || "").trim();
+    const deployment = (deploymentName || "").trim();
 
     const isSelfHosted = transcriptionMode === "self-hosted" && remoteUrl.length > 0;
     const isCustomEndpoint = isSelfHosted || currentProvider === "custom";
@@ -2018,6 +2029,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     if (
       this.cachedTranscriptionEndpoint &&
       (this.cachedEndpointProvider !== currentProvider ||
+        this.cachedEndpointDeployment !== deployment ||
         this.cachedEndpointBaseUrl !== currentBaseUrl ||
         this.cachedEndpointMode !== transcriptionMode ||
         this.cachedEndpointRemoteUrl !== remoteUrl)
@@ -2083,6 +2095,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         this.cachedEndpointBaseUrl = currentBaseUrl;
         this.cachedEndpointMode = transcriptionMode;
         this.cachedEndpointRemoteUrl = remoteUrl;
+        this.cachedEndpointDeployment = deployment;
 
         logger.debug(
           "STT endpoint resolved",
@@ -2118,7 +2131,29 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
 
       let endpoint;
-      if (/\/audio\/(transcriptions|translations)$/i.test(normalizedBase)) {
+      if (isCustomEndpoint && isAzureOpenAIEndpoint(normalizedBase)) {
+        // Azure OpenAI routes by deployment in the URL path and requires an
+        // api-version query string — the plain {base}/audio/transcriptions
+        // shape returns DeploymentNotFound. Build the deployment-style URL.
+        // The api-version defaults to a transcribe-capable preview; a user can
+        // override it by appending ?api-version=... to their endpoint URL.
+        const azureUrl = buildAzureTranscriptionUrl(normalizedBase, deployment);
+        if (azureUrl) {
+          endpoint = azureUrl;
+          logger.debug(
+            "STT endpoint: built Azure deployment URL",
+            { base: normalizedBase, deployment, endpoint },
+            "transcription"
+          );
+        } else {
+          endpoint = buildApiUrl(normalizedBase, "/audio/transcriptions");
+          logger.warn(
+            "STT endpoint: Azure host detected but no deployment name; falling back to default path",
+            { base: normalizedBase, endpoint },
+            "transcription"
+          );
+        }
+      } else if (/\/audio\/(transcriptions|translations)$/i.test(normalizedBase)) {
         endpoint = normalizedBase;
         logger.debug("STT endpoint: using full path from config", { endpoint }, "transcription");
       } else {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API-Schlüssel (optional)",
     "getKey": "Schlüssel holen ->",
     "endpointUrl": "Endpoint-URL",
+    "azureHint": "Azure AI Foundry: Geben Sie Ihren Ressourcen-Endpunkt ein (z. B. https://your-resource.cognitiveservices.azure.com) und setzen Sie „Model“ auf den exakten Namen Ihrer Bereitstellung.",
     "customProvider": "Benutzerdefiniert",
     "fallback": {
       "whisperModelDescription": "Modell",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API Key (Optional)",
     "getKey": "Get key ->",
     "endpointUrl": "Endpoint URL",
+    "azureHint": "Azure AI Foundry: enter your resource endpoint (e.g. https://your-resource.cognitiveservices.azure.com) and set Model to your exact deployment name.",
     "customProvider": "Custom",
     "fallback": {
       "whisperModelDescription": "Model",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "Clave API (opcional)",
     "getKey": "Obtener clave ->",
     "endpointUrl": "URL del endpoint",
+    "azureHint": "Azure AI Foundry: introduce el endpoint de tu recurso (p. ej. https://your-resource.cognitiveservices.azure.com) y establece Modelo con el nombre exacto de tu implementación.",
     "customProvider": "Personalizado",
     "fallback": {
       "whisperModelDescription": "Modelo",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "Clé API (optionnelle)",
     "getKey": "Obtenir la clé ->",
     "endpointUrl": "URL du endpoint",
+    "azureHint": "Azure AI Foundry : saisissez l'endpoint de votre ressource (p. ex. https://your-resource.cognitiveservices.azure.com) et définissez Modèle sur le nom exact de votre déploiement.",
     "customProvider": "Personnalisé",
     "fallback": {
       "whisperModelDescription": "Modèle",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "Chiave API (opzionale)",
     "getKey": "Ottieni chiave ->",
     "endpointUrl": "URL endpoint",
+    "azureHint": "Azure AI Foundry: inserisci l'endpoint della tua risorsa (es. https://your-resource.cognitiveservices.azure.com) e imposta Modello con il nome esatto della tua distribuzione.",
     "customProvider": "Personalizzato",
     "fallback": {
       "whisperModelDescription": "Modello",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API キー（任意）",
     "getKey": "キーを取得 ->",
     "endpointUrl": "エンドポイント URL",
+    "azureHint": "Azure AI Foundry: リソースのエンドポイント（例: https://your-resource.cognitiveservices.azure.com）を入力し、モデルにデプロイの正確な名前を設定してください。",
     "customProvider": "カスタム",
     "fallback": {
       "whisperModelDescription": "モデル",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -491,6 +491,7 @@
     "apiKeyOptional": "Chave API (opcional)",
     "getKey": "Obter chave ->",
     "endpointUrl": "URL do endpoint",
+    "azureHint": "Azure AI Foundry: insira o endpoint do seu recurso (ex.: https://your-resource.cognitiveservices.azure.com) e defina Modelo com o nome exato da sua implantação.",
     "customProvider": "Personalizado",
     "fallback": {
       "whisperModelDescription": "Modelo",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API-ключ (необязательно)",
     "getKey": "Получить ключ ->",
     "endpointUrl": "URL конечной точки",
+    "azureHint": "Azure AI Foundry: укажите endpoint вашего ресурса (например, https://your-resource.cognitiveservices.azure.com) и задайте в поле «Model» точное имя вашего развёртывания.",
     "customProvider": "Пользовательский",
     "fallback": {
       "whisperModelDescription": "Модель",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API Key（可选）",
     "getKey": "获取密钥 ->",
     "endpointUrl": "端点 URL",
+    "azureHint": "Azure AI Foundry：输入你的资源终结点（例如 https://your-resource.cognitiveservices.azure.com），并将“模型”设置为你的确切部署名称。",
     "customProvider": "自定义",
     "fallback": {
       "whisperModelDescription": "模型",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -512,6 +512,7 @@
     "apiKeyOptional": "API Key（選填）",
     "getKey": "取得金鑰 ->",
     "endpointUrl": "端點 URL",
+    "azureHint": "Azure AI Foundry：輸入你的資源端點（例如 https://your-resource.cognitiveservices.azure.com），並將「模型」設定為你的確切部署名稱。",
     "customProvider": "自訂",
     "fallback": {
       "whisperModelDescription": "模型",

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -26,3 +26,59 @@ export function isSecureEndpoint(url: string): boolean {
     return false;
   }
 }
+
+const AZURE_HOST_SUFFIXES = [
+  ".openai.azure.com",
+  ".cognitiveservices.azure.com",
+  ".services.ai.azure.com",
+];
+
+// API version that supports the gpt-4o-transcribe / gpt-4o-mini-transcribe audio
+// models (and remains compatible with whisper-1). Used when the user doesn't
+// pin their own api-version in the endpoint URL.
+export const DEFAULT_AZURE_TRANSCRIPTION_API_VERSION = "2025-03-01-preview";
+
+export function isAzureOpenAIEndpoint(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return AZURE_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+  } catch {
+    return false;
+  }
+}
+
+// Azure OpenAI doesn't expose the plain OpenAI `{base}/audio/transcriptions`
+// shape — it routes by deployment in the path and requires an `api-version`
+// query string. Given the user's resource endpoint and the deployment name
+// (the "model" field), build the deployment-style URL Azure actually expects.
+//
+// If the user already pasted a full `.../audio/transcriptions` URL, it's
+// respected as-is so they can pin a custom path / api-version.
+export function buildAzureTranscriptionUrl(
+  base: string,
+  deployment: string,
+  apiVersion?: string
+): string | null {
+  try {
+    const parsed = new URL(base);
+    const path = parsed.pathname.replace(/\/+$/, "");
+
+    if (/\/audio\/(transcriptions|translations)$/i.test(path)) {
+      return parsed.toString();
+    }
+
+    const name = (deployment || "").trim();
+    if (!name) return null;
+
+    const version =
+      parsed.searchParams.get("api-version") ||
+      (apiVersion || "").trim() ||
+      DEFAULT_AZURE_TRANSCRIPTION_API_VERSION;
+
+    return `${parsed.origin}/openai/deployments/${encodeURIComponent(
+      name
+    )}/audio/transcriptions?api-version=${encodeURIComponent(version)}`;
+  } catch {
+    return null;
+  }
+}

--- a/test/helpers/azureTranscriptionUrl.test.js
+++ b/test/helpers/azureTranscriptionUrl.test.js
@@ -1,0 +1,53 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+
+test("isAzureOpenAIEndpoint detects Azure resource hosts", async () => {
+  const { isAzureOpenAIEndpoint } = await import("../../src/utils/urlUtils.ts");
+
+  assert.equal(
+    isAzureOpenAIEndpoint("https://r.cognitiveservices.azure.com/openai/v1"),
+    true
+  );
+  assert.equal(isAzureOpenAIEndpoint("https://r.openai.azure.com"), true);
+  assert.equal(isAzureOpenAIEndpoint("https://r.services.ai.azure.com/openai/v1"), true);
+  assert.equal(isAzureOpenAIEndpoint("https://api.openai.com/v1"), false);
+  assert.equal(isAzureOpenAIEndpoint("not a url"), false);
+});
+
+test("buildAzureTranscriptionUrl builds the deployment-style URL from a resource base", async () => {
+  const { buildAzureTranscriptionUrl } = await import("../../src/utils/urlUtils.ts");
+
+  assert.equal(
+    buildAzureTranscriptionUrl(
+      "https://my-resource.cognitiveservices.azure.com/openai/v1",
+      "gpt-4o-transcribe"
+    ),
+    "https://my-resource.cognitiveservices.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview"
+  );
+});
+
+test("buildAzureTranscriptionUrl honors an explicit api-version argument", async () => {
+  const { buildAzureTranscriptionUrl } = await import("../../src/utils/urlUtils.ts");
+
+  assert.equal(
+    buildAzureTranscriptionUrl("https://r.openai.azure.com", "whisper", "2024-06-01"),
+    "https://r.openai.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2024-06-01"
+  );
+});
+
+test("buildAzureTranscriptionUrl respects a full transcription URL the user already pasted", async () => {
+  const { buildAzureTranscriptionUrl } = await import("../../src/utils/urlUtils.ts");
+
+  const full =
+    "https://r.cognitiveservices.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview";
+  assert.equal(buildAzureTranscriptionUrl(full, "ignored"), full);
+});
+
+test("buildAzureTranscriptionUrl returns null when no deployment name is available", async () => {
+  const { buildAzureTranscriptionUrl } = await import("../../src/utils/urlUtils.ts");
+
+  assert.equal(buildAzureTranscriptionUrl("https://r.cognitiveservices.azure.com", ""), null);
+});


### PR DESCRIPTION
## Problem

Connecting an Azure AI Foundry (Azure OpenAI) speech-to-text deployment as a custom transcription provider fails with `404 DeploymentNotFound`, even when the deployment works in the Azure playground and via curl.

The custom STT path could only emit the plain OpenAI shape — `{base}/audio/transcriptions` with `Authorization: Bearer` and **no `api-version`**. Azure requires:
- the deployment in the **URL path** (`/openai/deployments/{deployment}/audio/transcriptions`),
- an **`api-version`** query string, and
- the **`api-key`** auth header (Bearer is reserved for Entra ID tokens).

The enterprise *language* model already works because it routes through the official `@ai-sdk/azure` SDK; the transcription path had no equivalent.

## Changes

- **`src/utils/urlUtils.ts`** — add `isAzureOpenAIEndpoint()` and `buildAzureTranscriptionUrl()` helpers.
- **`src/helpers/audioManager.js`** — the STT endpoint resolver detects Azure hosts (`*.cognitiveservices.azure.com`, `*.openai.azure.com`, `*.services.ai.azure.com`) and builds the deployment-style URL; auth switches to the `api-key` header on Azure hosts. `getTranscriptionEndpoint()` now takes the deployment (model) name.
- **`api-version`** defaults to a transcribe-capable preview (`2025-03-01-preview`) — deliberately **not** the enterprise LLM's `azureApiVersion` default (`2024-10-21`, which doesn't support `gpt-4o-transcribe`). Users can override it by appending `?api-version=...` to the endpoint URL, and a full `.../audio/transcriptions` URL is respected as-is.
- **UI** — a contextual Azure hint under the custom endpoint fields, with i18n keys added to all 10 locales (`check-i18n.js` passes).
- **Tests** — `test/helpers/azureTranscriptionUrl.test.js`.
- **CHANGELOG** — Unreleased entry.

## Usage

Custom provider → **Endpoint URL** = your resource endpoint (e.g. `https://your-resource.cognitiveservices.azure.com/openai/v1`), **Model** = your exact deployment name (e.g. `gpt-4o-transcribe`). Produces:

```
https://your-resource.cognitiveservices.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview
```

## Testing notes

The URL-builder logic was verified against real Azure values via a faithful transpilation; all locale JSON validated and the i18n consistency check passes. The `node --test` suite (including the new test) requires the repo's pinned Node 24 (native `.ts` type-stripping + ESM), so it was not run in the Node 18 dev environment used here.