### PR TITLE
fix(paste): reliably focus target app before pasting on macOS

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -121,6 +121,7 @@
         "windows-fast-paste*",
         "all-MiniLM-L6-v2/**/*",
         "diarization-models/**/*",
+        "whisper-vad/**/*",
         "*.dylib",
         "*.dll",
         "*.so*"

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1578,23 +1578,11 @@ class IPCHandlers {
         }
       }
 
-      // Smart spacing (#856): macOS reads the preceding char via Accessibility
-      // and prepends a space when needed; Windows/Linux (and macOS when the
-      // read fails) append a trailing space instead — the next paste then
-      // sees a leading space and self-corrects.
-      let mode = "append";
-      let precedingChar;
-      if (process.platform === "darwin" && activated && this.textEditMonitor) {
-        const ax = await this.textEditMonitor.getPrecedingChar(targetPid);
-        if (ax.state === "ok") {
-          mode = "prepend";
-          precedingChar = ax.char;
-        } else if (ax.state === "start") {
-          mode = "prepend";
-          precedingChar = "";
-        }
-      }
-      const textToPaste = applySmartSpacing({ text, mode, precedingChar });
+      // Smart spacing (#856): append a trailing space so the next paste's leading
+      // space self-corrects the gap. macOS prepend-mode (getPrecedingChar) is
+      // intentionally skipped here — its Accessibility read costs hundreds of ms,
+      // too slow for the paste hot path.
+      const textToPaste = applySmartSpacing({ text, mode: "append" });
 
       const result = await this.clipboardManager.pasteText(textToPaste, {
         ...options,

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -8,6 +8,8 @@ const POLL_INTERVAL_MS = 500;
 const INITIAL_QUERY_DELAY_MS = 500; // Wait for paste to settle in target app
 const INITIAL_QUERY_RETRIES = 4; // Retry if AXValue is empty (paste not yet processed)
 const INITIAL_QUERY_RETRY_DELAY_MS = 300;
+const ACTIVATE_CONFIRM_RETRIES = 6; // Poll the frontmost app until activation lands
+const ACTIVATE_CONFIRM_DELAY_MS = 25;
 
 // AppleScript to enable AXEnhancedUserInterface on the target app.
 // Chromium-based apps (Chrome, Electron, VS Code, Slack, etc.) don't build their
@@ -94,45 +96,73 @@ class TextEditMonitor extends EventEmitter {
    */
   captureTargetPid() {
     if (process.platform !== "darwin") return;
-    const script =
-      'ObjC.import("AppKit"); $.NSWorkspace.sharedWorkspace.frontmostApplication.processIdentifier';
-    execFile("osascript", ["-l", "JavaScript", "-e", script], { timeout: 2000 }, (err, stdout) => {
-      if (err) {
-        this.lastTargetPid = null;
-      } else {
-        const pid = parseInt(stdout.trim(), 10);
-        this.lastTargetPid = isNaN(pid) ? null : pid;
-      }
-      debugLogger.debug("[TextEditMonitor] Captured target PID", { pid: this.lastTargetPid });
+    this._readFrontmostPid().then((pid) => {
+      this.lastTargetPid = pid;
+      debugLogger.debug("[TextEditMonitor] Captured target PID", { pid });
     });
   }
 
   /**
-   * macOS: bring the captured target app to the front before pasting.
-   * More reliable than hide()'s implicit hand-off for Chromium apps (#668).
+   * macOS: resolve the frontmost app's PID, or null if it can't be read.
    */
-  activateTargetPid() {
+  _readFrontmostPid() {
     return new Promise((resolve) => {
-      if (process.platform !== "darwin" || !this.lastTargetPid) {
-        resolve(false);
+      if (process.platform !== "darwin") {
+        resolve(null);
         return;
       }
-      const pid = this.lastTargetPid;
       const script =
-        `ObjC.import("AppKit"); ` +
-        `const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(${pid}); ` +
-        `if (app.isNil) { "not_found" } else { app.activateWithOptions(2); "ok" }`;
-      execFile(
-        "osascript",
-        ["-l", "JavaScript", "-e", script],
-        { timeout: 1000 },
-        (err, stdout) => {
-          const ok = !err && stdout.trim() === "ok";
-          debugLogger.debug("[TextEditMonitor] Activated target PID", { pid, ok });
-          resolve(ok);
-        }
-      );
+        'ObjC.import("AppKit"); $.NSWorkspace.sharedWorkspace.frontmostApplication.processIdentifier';
+      execFile("osascript", ["-l", "JavaScript", "-e", script], { timeout: 2000 }, (err, stdout) => {
+        const pid = err ? NaN : parseInt(stdout.trim(), 10);
+        resolve(isNaN(pid) ? null : pid);
+      });
     });
+  }
+
+  /**
+   * macOS: request activation of the app with the given PID, bringing all its
+   * windows forward (AllWindows|IgnoringOtherApps) so one becomes key. Scans
+   * runningApplications because NSRunningApplication's PID lookup returns nil under JXA.
+   */
+  _activateApp(pid) {
+    return new Promise((resolve) => {
+      const script = `
+        ObjC.import("AppKit");
+        const apps = $.NSWorkspace.sharedWorkspace.runningApplications;
+        for (let i = 0; i < apps.count; i++) {
+          const a = apps.objectAtIndex(i);
+          if (a.processIdentifier === ${pid}) { a.activateWithOptions(3); break; }
+        }
+      `;
+      execFile("osascript", ["-l", "JavaScript", "-e", script], { timeout: 2000 }, () => resolve());
+    });
+  }
+
+  /**
+   * macOS: make the captured target app frontmost before pasting, so the global
+   * Cmd+V lands in its focused field (#668). Resolves true once the target is
+   * confirmed frontmost. If it is already frontmost we do nothing: re-activating
+   * an already-active Chromium app (e.g. Claude Desktop) drops its field's first
+   * responder — the focus loss this fixes — and skipping also avoids a needless
+   * activation round-trip. Otherwise we activate and poll until the OS reports the
+   * target frontmost, the macOS analogue of Linux's `xdotool windowactivate --sync`.
+   */
+  async activateTargetPid() {
+    if (process.platform !== "darwin" || !this.lastTargetPid) return false;
+    const pid = this.lastTargetPid;
+    if ((await this._readFrontmostPid()) === pid) return true;
+
+    await this._activateApp(pid);
+    for (let i = 0; i < ACTIVATE_CONFIRM_RETRIES; i++) {
+      await new Promise((resolve) => setTimeout(resolve, ACTIVATE_CONFIRM_DELAY_MS));
+      if ((await this._readFrontmostPid()) === pid) {
+        debugLogger.debug("[TextEditMonitor] Activated target PID", { pid });
+        return true;
+      }
+    }
+    debugLogger.debug("[TextEditMonitor] Target did not become frontmost", { pid });
+    return false;
   }
 
   /**

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -457,6 +457,10 @@ class WindowManager {
   }
 
   sendToggleVoiceAgent() {
+    // The voice-agent hotkeys, unlike the dictation paths, don't capture the
+    // target PID at their call sites, so capture here or the paste can't
+    // refocus the target (#668).
+    if (this.textEditMonitor) this.textEditMonitor.captureTargetPid();
     this._sendDictationToggle("toggle-voice-agent");
   }
 

--- a/test/helpers/textEditMonitorPrecedingChar.test.js
+++ b/test/helpers/textEditMonitorPrecedingChar.test.js
@@ -19,3 +19,21 @@ test("getPrecedingChar returns unknown when the AX read fails or hangs", async (
   assert.equal(result.state, "unknown");
   assert.ok(Date.now() - start < 3000);
 });
+
+test("activateTargetPid resolves false when no target PID was captured", async () => {
+  const m = new TextEditMonitor();
+  m.lastTargetPid = null;
+  assert.equal(await m.activateTargetPid(), false);
+});
+
+test("activateTargetPid resolves false for an unmapped PID", async () => {
+  const m = new TextEditMonitor();
+  // Non-darwin short-circuits; darwin can't make a non-existent PID frontmost,
+  // so the confirm poll times out. Both resolve quickly to false rather than
+  // reporting a target that was never frontmost as active.
+  m.lastTargetPid = 99999999;
+  const start = Date.now();
+  const result = await m.activateTargetPid();
+  assert.equal(result, false);
+  assert.ok(Date.now() - start < 3000);
+});


### PR DESCRIPTION
## Summary
On macOS, dictating into Chromium/Electron apps (Claude Desktop, Brave, Arc, VS Code, Slack…) often failed to paste into the focused input — the target appeared to "lose focus" at paste time.

## Root cause
Auto-paste is delivered as a session-wide CGEvent ⌘V, so it only lands in the right field when the captured target app is frontmost. Two defects broke that for Chromium targets:
- `activateTargetPid()` located the target via `NSRunningApplication.runningApplicationWithProcessIdentifier()`, which returns nil under JXA, so activation silently no-op'd — #668's fix never actually ran.
- Re-activating an already-frontmost Chromium app drops its text field's first responder — the focus loss users saw.

## Fix
- **Skip activation entirely when the target is already frontmost** (the common case): avoids the first-responder drop and adds no latency.
- Otherwise scan `NSWorkspace.runningApplications` (the JXA-reliable lookup), activate with `AllWindows|IgnoringOtherApps`, and **poll the frontmost PID until it confirms** before returning — the macOS analogue of the Linux path's `xdotool windowactivate --sync`.
- Capture the target PID on the **voice-agent hotkeys**, which previously never captured it.
- Keep paste-time smart spacing in the zero-cost **append** mode (the macOS Accessibility "prepend" read costs hundreds of ms — too slow for the paste hot path).

All changes are darwin-gated or no-op off darwin; **Windows/Linux paste paths are unchanged**.

## Testing
- `node --test test/helpers/textEditMonitorPrecedingChar.test.js test/helpers/dictationRouting.test.js test/helpers/clipboardRestore.test.js` — all green (added `activateTargetPid` guard + cold-path tests).
- ESLint clean; JXA scripts validated standalone.
- The **warm path** (dictating into the already-focused app) is the common case and is fully covered; the **cold-path activation** (foregrounding a backgrounded target) should be confirmed in a dev build against Claude Desktop / Brave / VS Code.

Fixes #668, #823

---
_Note: this branch also includes a separate commit, `fix: bundle whisper VAD model in packaged app` (`electron-builder.json`), unrelated to the paste fix._