### PR TITLE
feat(transcription): Azure OpenAI realtime streaming transcription (BYOK)

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -398,6 +398,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveAzureDeployment: (value) => ipcRenderer.invoke("save-azure-deployment", value),
   getAzureApiVersion: () => ipcRenderer.invoke("get-azure-api-version"),
   saveAzureApiVersion: (value) => ipcRenderer.invoke("save-azure-api-version", value),
+  getAzureTranscribeKey: () => ipcRenderer.invoke("get-azure-transcribe-key"),
+  saveAzureTranscribeKey: (key) => ipcRenderer.invoke("save-azure-transcribe-key", key),
+  getAzureTranscribeEndpoint: () => ipcRenderer.invoke("get-azure-transcribe-endpoint"),
+  saveAzureTranscribeEndpoint: (value) =>
+    ipcRenderer.invoke("save-azure-transcribe-endpoint", value),
+  getAzureTranscribeDeployment: () => ipcRenderer.invoke("get-azure-transcribe-deployment"),
+  saveAzureTranscribeDeployment: (value) =>
+    ipcRenderer.invoke("save-azure-transcribe-deployment", value),
+  getAzureTranscribeApiVersion: () => ipcRenderer.invoke("get-azure-transcribe-api-version"),
+  saveAzureTranscribeApiVersion: (value) =>
+    ipcRenderer.invoke("save-azure-transcribe-api-version", value),
   getVertexProject: () => ipcRenderer.invoke("get-vertex-project"),
   saveVertexProject: (value) => ipcRenderer.invoke("save-vertex-project", value),
   getVertexLocation: () => ipcRenderer.invoke("get-vertex-location"),

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -205,6 +205,7 @@ const CLOUD_PROVIDER_TABS = [
   { id: "xai", name: "xAI" },
   { id: "mistral", name: "Mistral" },
   { id: "corti", name: "Corti" },
+  { id: "azure", name: "Azure OpenAI" },
   { id: "custom", name: "Custom" },
 ];
 
@@ -217,9 +218,14 @@ interface ProviderCredentialField {
     | "cortiClientId"
     | "cortiClientSecret"
     | "cortiEnvironment"
-    | "cortiTenant";
+    | "cortiTenant"
+    | "azureTranscriptionApiKey"
+    | "azureTranscriptionEndpoint"
+    | "azureTranscriptionDeployment"
+    | "azureTranscriptionApiVersion";
   input: "secret" | "text" | "select";
   labelKey?: string;
+  helpKey?: string;
   placeholder?: string;
   options?: Array<{ value: string; label: string }>;
 }
@@ -263,6 +269,31 @@ const PROVIDER_CREDENTIALS: Record<
         input: "text",
         labelKey: "transcription.corti.tenant",
         placeholder: "base",
+      },
+    ],
+  },
+  azure: {
+    consoleUrl: "https://oai.azure.com/",
+    fields: [
+      { key: "azureTranscriptionApiKey", input: "secret" },
+      {
+        key: "azureTranscriptionEndpoint",
+        input: "text",
+        labelKey: "transcription.azure.endpoint",
+        placeholder: "https://your-resource.openai.azure.com",
+      },
+      {
+        key: "azureTranscriptionDeployment",
+        input: "text",
+        labelKey: "transcription.azure.deployment",
+        helpKey: "transcription.azure.deploymentHelp",
+        placeholder: "gpt-4o-mini-transcribe",
+      },
+      {
+        key: "azureTranscriptionApiVersion",
+        input: "text",
+        labelKey: "transcription.azure.apiVersion",
+        placeholder: "2025-04-01-preview",
       },
     ],
   },
@@ -346,6 +377,18 @@ export default function TranscriptionModelPicker({
   const setCortiEnvironment = useSettingsStore((s) => s.setCortiEnvironment);
   const cortiTenant = useSettingsStore((s) => s.cortiTenant);
   const setCortiTenant = useSettingsStore((s) => s.setCortiTenant);
+  const azureTranscriptionApiKey = useSettingsStore((s) => s.azureTranscriptionApiKey);
+  const setAzureTranscriptionApiKey = useSettingsStore((s) => s.setAzureTranscriptionApiKey);
+  const azureTranscriptionEndpoint = useSettingsStore((s) => s.azureTranscriptionEndpoint);
+  const setAzureTranscriptionEndpoint = useSettingsStore((s) => s.setAzureTranscriptionEndpoint);
+  const azureTranscriptionDeployment = useSettingsStore((s) => s.azureTranscriptionDeployment);
+  const setAzureTranscriptionDeployment = useSettingsStore(
+    (s) => s.setAzureTranscriptionDeployment
+  );
+  const azureTranscriptionApiVersion = useSettingsStore((s) => s.azureTranscriptionApiVersion);
+  const setAzureTranscriptionApiVersion = useSettingsStore(
+    (s) => s.setAzureTranscriptionApiVersion
+  );
   const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
   const setCustomTranscriptionApiKey = useSettingsStore((s) => s.setCustomTranscriptionApiKey);
   const effectiveLocal = mode === "local" ? true : mode === "cloud" ? false : useLocalWhisper;
@@ -714,6 +757,10 @@ export default function TranscriptionModelPicker({
     cortiClientSecret,
     cortiEnvironment,
     cortiTenant,
+    azureTranscriptionApiKey,
+    azureTranscriptionEndpoint,
+    azureTranscriptionDeployment,
+    azureTranscriptionApiVersion,
   };
   const credentialSetters: Record<ProviderCredentialField["key"], (value: string) => void> = {
     openaiApiKey: setOpenaiApiKey,
@@ -724,6 +771,10 @@ export default function TranscriptionModelPicker({
     cortiClientSecret: setCortiClientSecret,
     cortiEnvironment: setCortiEnvironment,
     cortiTenant: setCortiTenant,
+    azureTranscriptionApiKey: setAzureTranscriptionApiKey,
+    azureTranscriptionEndpoint: setAzureTranscriptionEndpoint,
+    azureTranscriptionDeployment: setAzureTranscriptionDeployment,
+    azureTranscriptionApiVersion: setAzureTranscriptionApiVersion,
   };
 
   const cloudModelOptions = useMemo(() => {
@@ -1001,6 +1052,11 @@ export default function TranscriptionModelPicker({
                         placeholder={field.placeholder}
                         className="h-8 text-sm"
                       />
+                    )}
+                    {field.helpKey && (
+                      <p className="text-[11px] leading-snug text-muted-foreground">
+                        {t(field.helpKey)}
+                      </p>
                     )}
                   </div>
                 ))}

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -303,8 +303,30 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return STREAMING_PROVIDERS[this.getStreamingProviderName()] || STREAMING_PROVIDERS[fallback];
   }
 
+  // Azure OpenAI (BYOK) streams dictation over the realtime WS protocol. Gated on
+  // the cloud transcription provider selection + presence of the three credentials.
+  isAzureStreamingTranscription() {
+    if (this.context !== "dictation") return false;
+    const s = getSettings();
+    return (
+      s.cloudTranscriptionProvider === "azure" &&
+      !!s.azureTranscriptionApiKey &&
+      !!s.azureTranscriptionEndpoint &&
+      !!s.azureTranscriptionDeployment
+    );
+  }
+
+  // Azure realtime rejects input audio below 24 kHz; everything else streams at
+  // 16 kHz. The browser resamples the mic to whatever the AudioContext requests.
+  getStreamingSampleRate() {
+    return this.isAzureStreamingTranscription() ? 24000 : 16000;
+  }
+
   getStreamingProviderName() {
     const s = getSettings();
+    if (this.isAzureStreamingTranscription()) {
+      return "openai-realtime";
+    }
     if (s.cloudTranscriptionProvider === "corti" && s.cloudTranscriptionMode === "byok") {
       return "corti";
     }
@@ -2304,6 +2326,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     const s = getSettings();
     if (s.useLocalWhisper) return false;
 
+    // Azure OpenAI (BYOK) streams dictation over the realtime WS, independent of
+    // OpenWhispr Cloud sign-in / streaming mode.
+    if (this.isAzureStreamingTranscription()) {
+      return true;
+    }
+
     // Corti (BYOK) streams over its own WSS — independent of OpenWhispr Cloud.
     if (s.cloudTranscriptionProvider === "corti" && s.cloudTranscriptionMode === "byok") {
       return !!(s.cortiClientId && s.cortiClientSecret);
@@ -2352,11 +2380,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             cortiTenant,
           } = getSettings();
           const res = await provider.warmup({
-            sampleRate: 16000,
+            sampleRate: this.getStreamingSampleRate(),
             language: warmupLang && warmupLang !== "auto" ? warmupLang : undefined,
             keyterms: this.getKeyterms(),
             model: cloudTranscriptionModel,
             mode: cloudTranscriptionMode === "byok" ? "byok" : "openwhispr",
+            azure: this.isAzureStreamingTranscription() ? true : undefined,
             environment: cortiEnvironment,
             tenant: cortiTenant,
           });
@@ -2426,13 +2455,24 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   }
 
   async getOrCreateAudioContext() {
+    const desiredRate = this.getStreamingSampleRate();
     if (this.persistentAudioContext && this.persistentAudioContext.state !== "closed") {
-      if (this.persistentAudioContext.state === "suspended") {
-        await this.persistentAudioContext.resume();
+      if (this.persistentAudioContext.sampleRate === desiredRate) {
+        if (this.persistentAudioContext.state === "suspended") {
+          await this.persistentAudioContext.resume();
+        }
+        return this.persistentAudioContext;
       }
-      return this.persistentAudioContext;
+      // Provider changed the required rate (e.g. Azure needs 24 kHz) — rebuild.
+      try {
+        await this.persistentAudioContext.close();
+      } catch (e) {
+        /* ignore */
+      }
+      this.persistentAudioContext = null;
+      this.workletModuleLoaded = false;
     }
-    this.persistentAudioContext = new AudioContext({ sampleRate: 16000 });
+    this.persistentAudioContext = new AudioContext({ sampleRate: desiredRate });
     this.workletModuleLoaded = false;
     return this.persistentAudioContext;
   }
@@ -2589,11 +2629,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           useLocalWhisper,
         } = getSettings();
         const res = await provider.start({
-          sampleRate: 16000,
+          sampleRate: this.getStreamingSampleRate(),
           language: preferredLang && preferredLang !== "auto" ? preferredLang : undefined,
           keyterms: this.getKeyterms(),
           model: cloudTranscriptionModel,
           mode: cloudTranscriptionMode === "byok" ? "byok" : "openwhispr",
+          azure: this.isAzureStreamingTranscription() ? true : undefined,
           environment: cortiEnvironment,
           tenant: cortiTenant,
         });

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -23,6 +23,7 @@ const SECRET_KEYS = [
   "BEDROCK_SECRET_ACCESS_KEY",
   "BEDROCK_SESSION_TOKEN",
   "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_TRANSCRIBE_API_KEY",
   "VERTEX_API_KEY",
 ];
 
@@ -57,6 +58,9 @@ const PERSISTED_KEYS = [
   "AZURE_OPENAI_ENDPOINT",
   "AZURE_OPENAI_DEPLOYMENT",
   "AZURE_OPENAI_API_VERSION",
+  "AZURE_OPENAI_TRANSCRIBE_ENDPOINT",
+  "AZURE_OPENAI_TRANSCRIBE_DEPLOYMENT",
+  "AZURE_OPENAI_TRANSCRIBE_API_VERSION",
   "VERTEX_PROJECT",
   "VERTEX_LOCATION",
 ];
@@ -419,6 +423,33 @@ class EnvironmentManager {
   }
   saveAzureApiVersion(value) {
     return this._saveKey("AZURE_OPENAI_API_VERSION", value);
+  }
+
+  // Azure OpenAI — streaming transcription (BYOK). Distinct from the enterprise
+  // reasoning Azure keys above so the two deployments don't clobber each other.
+  getAzureTranscribeKey() {
+    return this._getKey("AZURE_OPENAI_TRANSCRIBE_API_KEY");
+  }
+  saveAzureTranscribeKey(key) {
+    return this._saveKey("AZURE_OPENAI_TRANSCRIBE_API_KEY", key);
+  }
+  getAzureTranscribeEndpoint() {
+    return this._getKey("AZURE_OPENAI_TRANSCRIBE_ENDPOINT");
+  }
+  saveAzureTranscribeEndpoint(value) {
+    return this._saveKey("AZURE_OPENAI_TRANSCRIBE_ENDPOINT", value);
+  }
+  getAzureTranscribeDeployment() {
+    return this._getKey("AZURE_OPENAI_TRANSCRIBE_DEPLOYMENT");
+  }
+  saveAzureTranscribeDeployment(value) {
+    return this._saveKey("AZURE_OPENAI_TRANSCRIBE_DEPLOYMENT", value);
+  }
+  getAzureTranscribeApiVersion() {
+    return this._getKey("AZURE_OPENAI_TRANSCRIBE_API_VERSION");
+  }
+  saveAzureTranscribeApiVersion(value) {
+    return this._saveKey("AZURE_OPENAI_TRANSCRIBE_API_VERSION", value);
   }
 
   // Enterprise providers — GCP Vertex AI

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -55,6 +55,25 @@ const ALLOWED_MEETING_PROVIDERS = new Set([
   "corti-realtime",
 ]);
 
+// Azure OpenAI / AI Foundry realtime transcription config. The values are saved
+// from the in-app settings UI via environmentManager, which writes the secret to
+// safeStorage and the rest to .env — both loaded into process.env. Reading from
+// process.env here works immediately after save and on subsequent launches.
+const getAzureTranscribeConfig = () => {
+  const endpoint = (process.env.AZURE_OPENAI_TRANSCRIBE_ENDPOINT || "").trim();
+  const deployment = (process.env.AZURE_OPENAI_TRANSCRIBE_DEPLOYMENT || "").trim();
+  const apiKey = (process.env.AZURE_OPENAI_TRANSCRIBE_API_KEY || "").trim();
+  const apiVersion =
+    (process.env.AZURE_OPENAI_TRANSCRIBE_API_VERSION || "").trim() || "2025-04-01-preview";
+  return {
+    configured: !!(endpoint && deployment && apiKey),
+    endpoint,
+    deployment,
+    apiKey,
+    apiVersion,
+  };
+};
+
 // Meeting capture runs at 24 kHz (see meetingRecordingStore AudioContext); cloud
 // streaming providers must be told the true PCM rate or they misread the audio.
 const MEETING_STREAM_SAMPLE_RATE = 24000;
@@ -2800,6 +2819,30 @@ class IPCHandlers {
     ipcMain.handle("save-azure-api-version", async (event, value) => {
       return this.environmentManager.saveAzureApiVersion(value);
     });
+    ipcMain.handle("get-azure-transcribe-key", async () => {
+      return this.environmentManager.getAzureTranscribeKey();
+    });
+    ipcMain.handle("save-azure-transcribe-key", async (event, key) => {
+      return this.environmentManager.saveAzureTranscribeKey(key);
+    });
+    ipcMain.handle("get-azure-transcribe-endpoint", async () => {
+      return this.environmentManager.getAzureTranscribeEndpoint();
+    });
+    ipcMain.handle("save-azure-transcribe-endpoint", async (event, value) => {
+      return this.environmentManager.saveAzureTranscribeEndpoint(value);
+    });
+    ipcMain.handle("get-azure-transcribe-deployment", async () => {
+      return this.environmentManager.getAzureTranscribeDeployment();
+    });
+    ipcMain.handle("save-azure-transcribe-deployment", async (event, value) => {
+      return this.environmentManager.saveAzureTranscribeDeployment(value);
+    });
+    ipcMain.handle("get-azure-transcribe-api-version", async () => {
+      return this.environmentManager.getAzureTranscribeApiVersion();
+    });
+    ipcMain.handle("save-azure-transcribe-api-version", async (event, value) => {
+      return this.environmentManager.saveAzureTranscribeApiVersion(value);
+    });
     ipcMain.handle("get-vertex-project", async () => {
       return this.environmentManager.getVertexProject();
     });
@@ -5304,6 +5347,28 @@ class IPCHandlers {
       }
 
       const connectInner = async () => {
+        if (options.azure) {
+          const az = getAzureTranscribeConfig();
+          if (!az.configured) {
+            throw new Error(
+              "Azure transcription not configured. Add your endpoint, deployment and API key in Settings."
+            );
+          }
+          const streaming = new OpenAIRealtimeStreaming();
+          setupDictationCallbacks(streaming, event);
+          await streaming.connect({
+            apiKey: az.apiKey,
+            model: az.deployment,
+            endpoint: az.endpoint,
+            deployment: az.deployment,
+            apiVersion: az.apiVersion,
+            inputSampleRate: options.sampleRate || 24000,
+            preconfigured: false,
+          });
+          this._dictationStreaming = streaming;
+          return;
+        }
+
         const isCloud = options.mode !== "byok";
         const apiKey = await fetchRealtimeToken(event, { mode: options.mode });
         const streaming = new OpenAIRealtimeStreaming();

--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -23,6 +23,7 @@ class OpenAIRealtimeStreaming {
     this.isDisconnecting = false;
     this.audioBytesSent = 0;
     this.model = "gpt-4o-mini-transcribe";
+    this.sampleRate = SAMPLE_RATE;
     this.coldStartBuffer = [];
     this.coldStartBufferSize = 0;
     this.speechStartedAt = null;
@@ -33,7 +34,8 @@ class OpenAIRealtimeStreaming {
   }
 
   async connect(options = {}) {
-    const { apiKey, model, preconfigured } = options;
+    const { apiKey, model, preconfigured, endpoint, deployment, apiVersion, inputSampleRate } =
+      options;
     if (!apiKey) throw new Error("OpenAI API key is required");
 
     if (this.isConnected || this.isConnecting) {
@@ -44,6 +46,8 @@ class OpenAIRealtimeStreaming {
     this.isConnecting = true;
     this.model = model || "gpt-4o-mini-transcribe";
     this.preconfigured = !!preconfigured;
+    // Azure declares the deployment via URL; OpenAI declares the model in session config.
+    this.sampleRate = inputSampleRate || SAMPLE_RATE;
     this.completedSegments = [];
     this.currentPartial = "";
     this.audioBytesSent = 0;
@@ -51,8 +55,53 @@ class OpenAIRealtimeStreaming {
     this.coldStartBufferSize = 0;
     this.speechStartedAt = null;
 
-    const url = "wss://api.openai.com/v1/realtime?intent=transcription";
-    debugLogger.debug("OpenAI Realtime connecting", { model: this.model });
+    // Azure AI Foundry / Azure OpenAI exposes the same realtime protocol as OpenAI,
+    // but at a resource-scoped URL with a `deployment` query param and `api-key` auth.
+    const isAzure = !!endpoint;
+    let url;
+    let headers;
+    if (isAzure) {
+      // Accept a full base URL (https://res.openai.azure.com/openai/v1 or
+      // https://res.cognitiveservices.azure.com/openai/v1), wss://…, or a bare
+      // host. Normalize whatever the user pasted to the realtime WS endpoint.
+      let base = endpoint.trim().replace(/\/+$/, "");
+      if (/^https?:\/\//i.test(base)) {
+        base = base.replace(/^http/i, "ws");
+      } else if (!/^wss?:\/\//i.test(base)) {
+        base = `wss://${base}`;
+      }
+      // Drop a trailing /realtime the user may have included.
+      base = base.replace(/\/realtime$/i, "");
+      const version = apiVersion || "2025-04-01-preview";
+      const params = new URLSearchParams({
+        "api-version": version,
+        intent: "transcription",
+      });
+      // The realtime path depends on how much of the base the user supplied:
+      //   …/openai/v1 → append /realtime            (v1 GA surface)
+      //   …/openai    → append /realtime + deployment (classic surface)
+      //   bare host   → append /openai/v1/realtime   (v1 GA surface)
+      let realtimePath;
+      if (/\/openai\/v1$/i.test(base)) {
+        realtimePath = "/realtime";
+      } else if (/\/openai$/i.test(base)) {
+        realtimePath = "/realtime";
+        params.set("deployment", deployment || this.model);
+      } else {
+        realtimePath = "/openai/v1/realtime";
+      }
+      url = `${base}${realtimePath}?${params.toString()}`;
+      headers = { "api-key": apiKey };
+    } else {
+      url = "wss://api.openai.com/v1/realtime?intent=transcription";
+      headers = { Authorization: `Bearer ${apiKey}` };
+    }
+    debugLogger.debug("OpenAI Realtime connecting", {
+      model: this.model,
+      isAzure,
+      sampleRate: this.sampleRate,
+      url,
+    });
 
     return new Promise((resolve, reject) => {
       this.pendingResolve = resolve;
@@ -64,11 +113,7 @@ class OpenAIRealtimeStreaming {
         reject(new Error("OpenAI Realtime connection timeout"));
       }, WEBSOCKET_TIMEOUT_MS);
 
-      this.ws = new WebSocket(url, {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-        },
-      });
+      this.ws = new WebSocket(url, { headers });
 
       this.ws.on("open", () => {
         debugLogger.debug("OpenAI Realtime WebSocket opened");
@@ -143,7 +188,7 @@ class OpenAIRealtimeStreaming {
                   type: "transcription",
                   audio: {
                     input: {
-                      format: { type: "audio/pcm", rate: SAMPLE_RATE },
+                      format: { type: "audio/pcm", rate: this.sampleRate },
                       transcription: { model: this.model },
                       turn_detection: {
                         type: "server_vad",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Client-Secret",
       "environment": "Datenregion",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "Endpunkt-URL",
+      "deployment": "Bereitstellungsname",
+      "deploymentHelp": "Verwenden Sie den genauen Namen Ihrer Azure-OpenAI-Transkriptionsbereitstellung (z. B. gpt-4o-transcribe, gpt-4o-mini-transcribe oder whisper). Andere Foundry-Modelle werden nicht unterstützt.",
+      "apiVersion": "API-Version"
     }
   },
   "hooks": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Client Secret",
       "environment": "Data Region",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "Endpoint URL",
+      "deployment": "Deployment Name",
+      "deploymentHelp": "Use your exact Azure OpenAI transcription deployment name (e.g. gpt-4o-transcribe, gpt-4o-mini-transcribe, or whisper). Non-OpenAI Foundry models aren't supported.",
+      "apiVersion": "API Version"
     }
   },
   "hooks": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Secreto de cliente",
       "environment": "Región de datos",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "URL del endpoint",
+      "deployment": "Nombre de implementación",
+      "deploymentHelp": "Usa el nombre exacto de tu implementación de transcripción de Azure OpenAI (p. ej. gpt-4o-transcribe, gpt-4o-mini-transcribe o whisper). No se admiten modelos de Foundry que no sean de OpenAI.",
+      "apiVersion": "Versión de API"
     }
   },
   "hooks": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Secret client",
       "environment": "Région des données",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "URL du point de terminaison",
+      "deployment": "Nom du déploiement",
+      "deploymentHelp": "Utilisez le nom exact de votre déploiement de transcription Azure OpenAI (par ex. gpt-4o-transcribe, gpt-4o-mini-transcribe ou whisper). Les modèles Foundry non-OpenAI ne sont pas pris en charge.",
+      "apiVersion": "Version de l'API"
     }
   },
   "hooks": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Client secret",
       "environment": "Regione dei dati",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "URL endpoint",
+      "deployment": "Nome distribuzione",
+      "deploymentHelp": "Usa il nome esatto della tua distribuzione di trascrizione Azure OpenAI (ad es. gpt-4o-transcribe, gpt-4o-mini-transcribe o whisper). I modelli Foundry non OpenAI non sono supportati.",
+      "apiVersion": "Versione API"
     }
   },
   "hooks": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "クライアントシークレット",
       "environment": "データリージョン",
       "tenant": "テナント"
+    },
+    "azure": {
+      "endpoint": "エンドポイント URL",
+      "deployment": "デプロイ名",
+      "deploymentHelp": "Azure OpenAI 文字起こしデプロイの正確な名前（例: gpt-4o-transcribe、gpt-4o-mini-transcribe、whisper）を入力してください。OpenAI 以外の Foundry モデルはサポートされていません。",
+      "apiVersion": "API バージョン"
     }
   },
   "hooks": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -502,6 +502,12 @@
       "clientSecret": "Segredo do cliente",
       "environment": "Região de dados",
       "tenant": "Tenant"
+    },
+    "azure": {
+      "endpoint": "URL do endpoint",
+      "deployment": "Nome da implantação",
+      "deploymentHelp": "Use o nome exato da sua implantação de transcrição do Azure OpenAI (por ex. gpt-4o-transcribe, gpt-4o-mini-transcribe ou whisper). Modelos do Foundry que não sejam da OpenAI não são suportados.",
+      "apiVersion": "Versão da API"
     }
   },
   "hooks": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "Секрет клиента",
       "environment": "Регион данных",
       "tenant": "Тенант"
+    },
+    "azure": {
+      "endpoint": "URL конечной точки",
+      "deployment": "Имя развёртывания",
+      "deploymentHelp": "Укажите точное имя развёртывания транскрипции Azure OpenAI (например, gpt-4o-transcribe, gpt-4o-mini-transcribe или whisper). Модели Foundry, отличные от OpenAI, не поддерживаются.",
+      "apiVersion": "Версия API"
     }
   },
   "hooks": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "客户端密钥",
       "environment": "数据区域",
       "tenant": "租户"
+    },
+    "azure": {
+      "endpoint": "终结点 URL",
+      "deployment": "部署名称",
+      "deploymentHelp": "请输入你的 Azure OpenAI 转录部署的确切名称（例如 gpt-4o-transcribe、gpt-4o-mini-transcribe 或 whisper）。不支持非 OpenAI 的 Foundry 模型。",
+      "apiVersion": "API 版本"
     }
   },
   "hooks": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -523,6 +523,12 @@
       "clientSecret": "用戶端密鑰",
       "environment": "資料區域",
       "tenant": "租戶"
+    },
+    "azure": {
+      "endpoint": "端點 URL",
+      "deployment": "部署名稱",
+      "deploymentHelp": "請輸入你的 Azure OpenAI 轉錄部署的確切名稱（例如 gpt-4o-transcribe、gpt-4o-mini-transcribe 或 whisper）。不支援非 OpenAI 的 Foundry 模型。",
+      "apiVersion": "API 版本"
     }
   },
   "hooks": {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -218,6 +218,27 @@
           "streaming": true
         }
       ]
+    },
+    {
+      "id": "azure",
+      "name": "Azure OpenAI",
+      "baseUrl": "https://your-resource.openai.azure.com",
+      "models": [
+        {
+          "id": "gpt-4o-mini-transcribe",
+          "name": "GPT-4o Mini Transcribe",
+          "description": "Fast and accurate transcription",
+          "descriptionKey": "models.descriptions.transcription.openai_gpt_4o_mini_transcribe",
+          "streaming": true
+        },
+        {
+          "id": "gpt-4o-transcribe",
+          "name": "GPT-4o Transcribe",
+          "description": "Most accurate transcription",
+          "descriptionKey": "models.descriptions.transcription.openai_gpt_4o_transcribe",
+          "streaming": true
+        }
+      ]
     }
   ],
   "cloudProviders": [

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -577,6 +577,16 @@ export interface SettingsState
   setCortiEnvironment: (value: string) => void;
   setCortiTenant: (value: string) => void;
 
+  // Azure OpenAI streaming transcription (BYOK)
+  azureTranscriptionEndpoint: string;
+  azureTranscriptionDeployment: string;
+  azureTranscriptionApiVersion: string;
+  azureTranscriptionApiKey: string;
+  setAzureTranscriptionEndpoint: (value: string) => void;
+  setAzureTranscriptionDeployment: (value: string) => void;
+  setAzureTranscriptionApiVersion: (value: string) => void;
+  setAzureTranscriptionApiKey: (key: string) => void;
+
   // Enterprise providers
   bedrockAuthMode: string;
   bedrockRegion: string;
@@ -765,6 +775,7 @@ const SECRET_IPC_SAVERS = {
   bedrockSecretAccessKey: "saveBedrockSecretAccessKey",
   bedrockSessionToken: "saveBedrockSessionToken",
   azureApiKey: "saveAzureApiKey",
+  azureTranscriptionApiKey: "saveAzureTranscribeKey",
   vertexApiKey: "saveVertexApiKey",
 } as const;
 
@@ -806,6 +817,7 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
   "bedrockSecretAccessKey",
   "bedrockSessionToken",
   "azureApiKey",
+  "azureTranscriptionApiKey",
   "vertexApiKey",
 ] as const;
 
@@ -853,6 +865,9 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   cleanupCloudBaseUrl: readString("cleanupCloudBaseUrl", API_ENDPOINTS.OPENAI_BASE),
   cortiEnvironment: readString("cortiEnvironment", "us"),
   cortiTenant: readString("cortiTenant", "base"),
+  azureTranscriptionEndpoint: readString("azureTranscriptionEndpoint", ""),
+  azureTranscriptionDeployment: readString("azureTranscriptionDeployment", ""),
+  azureTranscriptionApiVersion: readString("azureTranscriptionApiVersion", "2025-04-01-preview"),
   customDictionary: readStringArray("customDictionary", []),
   snippets: (() => {
     try {
@@ -879,6 +894,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   mistralApiKey: "",
   cortiClientId: "",
   cortiClientSecret: "",
+  azureTranscriptionApiKey: "",
   customTranscriptionApiKey: "",
   cleanupCustomApiKey: "",
 
@@ -1299,6 +1315,28 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
   setCortiEnvironment: createStringSetter("cortiEnvironment"),
   setCortiTenant: createStringSetter("cortiTenant"),
+  setAzureTranscriptionEndpoint: (value: string) => {
+    if (isBrowser) localStorage.setItem("azureTranscriptionEndpoint", value);
+    set({ azureTranscriptionEndpoint: value });
+    window.electronAPI?.saveAzureTranscribeEndpoint?.(value);
+    debouncedPersistToEnv();
+  },
+  setAzureTranscriptionDeployment: (value: string) => {
+    if (isBrowser) localStorage.setItem("azureTranscriptionDeployment", value);
+    set({ azureTranscriptionDeployment: value });
+    window.electronAPI?.saveAzureTranscribeDeployment?.(value);
+    debouncedPersistToEnv();
+  },
+  setAzureTranscriptionApiVersion: (value: string) => {
+    if (isBrowser) localStorage.setItem("azureTranscriptionApiVersion", value);
+    set({ azureTranscriptionApiVersion: value });
+    window.electronAPI?.saveAzureTranscribeApiVersion?.(value);
+    debouncedPersistToEnv();
+  },
+  setAzureTranscriptionApiKey: (key: string) => {
+    set({ azureTranscriptionApiKey: key });
+    debouncedSaveSecret("azureTranscriptionApiKey", key);
+  },
   setCustomTranscriptionApiKey: (key: string) => {
     set({ customTranscriptionApiKey: key });
     debouncedSaveSecret("customTranscription", key);
@@ -1941,6 +1979,7 @@ export async function initializeSettings(): Promise<void> {
         bedrockSecretAccessKey,
         bedrockSessionToken,
         azureApiKey,
+        azureTranscriptionApiKey,
         vertexApiKey,
       ] = await Promise.all([
         window.electronAPI.getOpenAIKey?.(),
@@ -1957,6 +1996,7 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getBedrockSecretAccessKey?.(),
         window.electronAPI.getBedrockSessionToken?.(),
         window.electronAPI.getAzureApiKey?.(),
+        window.electronAPI.getAzureTranscribeKey?.(),
         window.electronAPI.getVertexApiKey?.(),
       ]);
 
@@ -1975,6 +2015,7 @@ export async function initializeSettings(): Promise<void> {
         bedrockSecretAccessKey: bedrockSecretAccessKey || "",
         bedrockSessionToken: bedrockSessionToken || "",
         azureApiKey: azureApiKey || "",
+        azureTranscriptionApiKey: azureTranscriptionApiKey || "",
         vertexApiKey: vertexApiKey || "",
       });
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1035,6 +1035,14 @@ declare global {
       saveAzureDeployment?: (value: string) => Promise<void>;
       getAzureApiVersion?: () => Promise<string | null>;
       saveAzureApiVersion?: (value: string) => Promise<void>;
+      getAzureTranscribeKey?: () => Promise<string | null>;
+      saveAzureTranscribeKey?: (key: string) => Promise<void>;
+      getAzureTranscribeEndpoint?: () => Promise<string | null>;
+      saveAzureTranscribeEndpoint?: (value: string) => Promise<void>;
+      getAzureTranscribeDeployment?: () => Promise<string | null>;
+      saveAzureTranscribeDeployment?: (value: string) => Promise<void>;
+      getAzureTranscribeApiVersion?: () => Promise<string | null>;
+      saveAzureTranscribeApiVersion?: (value: string) => Promise<void>;
       getVertexProject?: () => Promise<string | null>;
       saveVertexProject?: (value: string) => Promise<void>;
       getVertexLocation?: () => Promise<string | null>;


### PR DESCRIPTION
## Summary

Adds a bring-your-own-key **Azure OpenAI** cloud transcription provider that streams dictation over the OpenAI **realtime WebSocket** protocol exposed by Azure OpenAI / AI Foundry resources. Today, Azure/Foundry users fall back to the slower batch upload path; this gives them the same low latency as the existing OpenAI streaming path.

## Why

`OpenAIRealtimeStreaming` was hardcoded to `wss://api.openai.com/v1/realtime`, so dictation streaming only worked with OpenAI directly. Azure exposes the identical realtime protocol at a resource-scoped URL with `api-key` auth, so we can reuse the same client with a generic URL builder.

## What changed

- **`openaiRealtimeStreaming.js`** — generic Azure realtime URL builder that normalizes whatever endpoint form the user pastes and targets the correct surface:
  - `…/openai/v1` (or bare host) → GA `…/openai/v1/realtime`
  - `…/openai` → preview `…/openai/realtime` with a `deployment` param
  - `http(s)`→`ws(s)`, trailing `/realtime` tolerated, `intent=transcription`
  - `api-key` auth header; configurable input sample rate.
  - **The OpenAI (non-Azure) path is unchanged — the Azure branch is gated entirely on `endpoint` being present.**
- **`audioManager.js`** — gate Azure streaming on the cloud provider selection + presence of the three credentials; stream at **24 kHz** (Azure realtime rejects input below 24 kHz) via a rate-aware `AudioContext`; everything else continues at 16 kHz.
- **`ipcHandlers.js` / `environment.js` / `preload.js`** — persist & load the Azure transcribe endpoint, deployment and api-version (`.env`) and API key (`safeStorage`), plus a dedicated dictation connect branch. Kept separate from the existing enterprise Azure **reasoning** keys so the two deployments don't clobber each other.
- **settings store / types / model registry / `TranscriptionModelPicker`** — new "Azure OpenAI" transcription tab with endpoint, deployment, api-version and key fields.

## Scope

This targets **Azure OpenAI transcription deployments** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `whisper`). Non-OpenAI Foundry speech-to-text (Voice Live API / Azure AI Speech / `mai-transcribe`) uses a different endpoint, auth and message schema and is intentionally out of scope; the deployment field help text states the supported deployments, and a wrong/non-transcribe deployment surfaces a connection error rather than silently degrading.

## Validation

- Assumptions cross-checked against Microsoft Learn (realtime WS URL forms for GA vs preview, `api-key` auth for non-browser clients, `session.type: transcription` schema, ≥24 kHz PCM16).
- Verified end-to-end against a live Azure AI Foundry endpoint: correct WS URL, 24 kHz capture, accurate transcription, low latency.
- `tsc --noEmit` clean, `eslint` clean, `i18n:check` consistent across all 10 locales, renderer build passes.

## Backward compatibility

No change for existing OpenAI / OpenWhispr Cloud / Corti users — all new behavior is gated behind selecting the Azure provider and supplying credentials.

## Related issues

- Related to #581 (realtime streaming hardcodes `wss://api.openai.com` and ignores custom transcription endpoints) — this PR removes that hardcoding for the **Azure** path. The generic custom OpenAI-compatible proxy case in #581 is a separate slice and is not addressed here.
- Complements #131 (Azure AI Foundry models) on the transcription side.
