### PR TITLE
feat(sidebar): collapsible sidebar with hover-to-peek reveal

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,7 +1,15 @@
 import React, { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
-import { Download, RefreshCw, Loader2, AlertTriangle, Zap, ChevronLeft } from "lucide-react";
+import {
+  Download,
+  RefreshCw,
+  Loader2,
+  AlertTriangle,
+  Zap,
+  ChevronLeft,
+  PanelLeftOpen,
+} from "lucide-react";
 import UpgradePrompt from "./UpgradePrompt";
 import PostMigrationOnboarding from "./PostMigrationOnboarding";
 import { ConfirmDialog, AlertDialog } from "./ui/dialog";
@@ -87,6 +95,9 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   const showDiscarded = useShowDiscarded();
   const [showCloudMigrationBanner, setShowCloudMigrationBanner] = useState(false);
   const [activeView, setActiveView] = useState<ControlPanelView>("home");
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => localStorage.getItem("sidebarCollapsed") === "true"
+  );
   const isMeetingMode = useIsMeetingMode();
   const isNarrowWindow = useIsNarrowWindow();
   const activeNoteId = useActiveNoteId();
@@ -389,6 +400,14 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
 
   const handleExitMeetingMode = useCallback(() => {
     window.electronAPI?.restoreFromMeetingMode?.();
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem("sidebarCollapsed", String(next));
+      return next;
+    });
   }, []);
 
   const copyToClipboard = useCallback(
@@ -737,11 +756,12 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
       <div className="flex flex-1 overflow-hidden">
         <div
           className="shrink-0 overflow-hidden transition-[width] duration-300 ease-out"
-          style={{ width: isSidePanelLayout ? 0 : undefined }}
+          style={{ width: isSidePanelLayout || sidebarCollapsed ? 0 : undefined }}
         >
           <ControlPanelSidebar
             activeView={activeView}
             onViewChange={setActiveView}
+            onToggleCollapse={toggleSidebar}
             onOpenSearch={() => setShowSearch(true)}
             onOpenSettings={() => {
               setSettingsSection(undefined);
@@ -786,7 +806,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
           >
             {isSidePanelLayout && (
               <div
-                className={platform === "darwin" ? "ml-[84px] mt-[16px]" : "ml-2"}
+                className={platform === "darwin" ? "ml-21 mt-4" : "ml-2"}
                 style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
               >
                 <Button
@@ -798,6 +818,23 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                   <ChevronLeft size={14} strokeWidth={1.8} />
                   {t("controlPanel.backToNotes")}
                 </Button>
+              </div>
+            )}
+            {sidebarCollapsed && !isSidePanelLayout && (
+              <div
+                className={platform === "darwin" ? "ml-21 mt-4" : "ml-2"}
+                style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+              >
+                <button
+                  onClick={toggleSidebar}
+                  aria-label={t("sidebar.expand")}
+                  className="group flex items-center justify-center h-7 w-7 rounded-md outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+                >
+                  <PanelLeftOpen
+                    size={15}
+                    className="text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
+                  />
+                </button>
               </div>
             )}
             <div className="flex-1" />

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -756,12 +756,13 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
       <div className="flex flex-1 overflow-hidden">
         <div
           className="shrink-0 overflow-hidden transition-[width] duration-300 ease-out"
-          style={{ width: isSidePanelLayout || sidebarCollapsed ? 0 : undefined }}
+          style={{ width: isSidePanelLayout ? 0 : undefined }}
         >
           <ControlPanelSidebar
             activeView={activeView}
             onViewChange={setActiveView}
             onToggleCollapse={toggleSidebar}
+            collapsed={sidebarCollapsed}
             onOpenSearch={() => setShowSearch(true)}
             onOpenSettings={() => {
               setSettingsSection(undefined);
@@ -820,9 +821,9 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                 </Button>
               </div>
             )}
-            {sidebarCollapsed && !isSidePanelLayout && (
+            {sidebarCollapsed && !isSidePanelLayout && platform === "darwin" && (
               <div
-                className={platform === "darwin" ? "ml-21 mt-4" : "ml-2"}
+                className="ml-5 mt-4"
                 style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
               >
                 <button

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,7 +1,16 @@
 import React, { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
-import { Download, RefreshCw, Loader2, AlertTriangle, Zap, ChevronLeft } from "lucide-react";
+import {
+  Download,
+  RefreshCw,
+  Loader2,
+  AlertTriangle,
+  Zap,
+  ChevronLeft,
+  PanelLeftOpen,
+  PanelLeftClose,
+} from "lucide-react";
 import UpgradePrompt from "./UpgradePrompt";
 import PostMigrationOnboarding from "./PostMigrationOnboarding";
 import { ConfirmDialog, AlertDialog } from "./ui/dialog";
@@ -12,6 +21,7 @@ import { useUpdater } from "../hooks/useUpdater";
 import { useSettings } from "../hooks/useSettings";
 import { useAuth } from "../hooks/useAuth";
 import { useUsage } from "../hooks/useUsage";
+import { useCollapsibleSidebar } from "../hooks/useCollapsibleSidebar";
 import {
   useTranscriptions,
   useShowDiscarded,
@@ -54,6 +64,11 @@ import { WORKSPACES_ENABLED } from "../lib/features";
 
 const platform = getCachedPlatform();
 
+const SIDEBAR_WIDTH_PX = 192;
+
+const toggleIconClass =
+  "text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150";
+
 const SettingsModal = React.lazy(() => import("./SettingsModal"));
 const ReferralModal = React.lazy(() => import("./ReferralModal"));
 const PersonalNotesView = React.lazy(() => import("./notes/PersonalNotesView"));
@@ -89,6 +104,14 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   const showDiscarded = useShowDiscarded();
   const [showCloudMigrationBanner, setShowCloudMigrationBanner] = useState(false);
   const [activeView, setActiveView] = useState<ControlPanelView>("home");
+  const {
+    collapsed: sidebarCollapsed,
+    peek: sidebarPeek,
+    toggle: toggleSidebar,
+    showPeek: showSidebarPeek,
+    hidePeek: hideSidebarPeek,
+    leaveToggle: leaveSidebarToggle,
+  } = useCollapsibleSidebar();
   const isMeetingMode = useIsMeetingMode();
   const isNarrowWindow = useIsNarrowWindow();
   const activeNoteId = useActiveNoteId();
@@ -807,10 +830,25 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
         </Suspense>
       )}
 
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden relative">
         <div
-          className="shrink-0 overflow-hidden transition-[width] duration-300 ease-out"
-          style={{ width: isSidePanelLayout ? 0 : undefined }}
+          className="shrink-0 transition-[width] duration-300 ease-out"
+          style={{ width: sidebarCollapsed || isSidePanelLayout ? 0 : SIDEBAR_WIDTH_PX }}
+        />
+        <div
+          className={`absolute inset-y-0 left-0 z-30 transition-transform duration-300 ease-out${
+            sidebarCollapsed && sidebarPeek && !isSidePanelLayout
+              ? " shadow-[10px_0_40px_-18px_rgba(0,0,0,0.2)]"
+              : ""
+          }`}
+          style={{
+            transform:
+              !isSidePanelLayout && (!sidebarCollapsed || sidebarPeek)
+                ? "translateX(0)"
+                : "translateX(-100%)",
+          }}
+          onMouseEnter={sidebarCollapsed ? showSidebarPeek : undefined}
+          onMouseLeave={sidebarCollapsed ? hideSidebarPeek : undefined}
         >
           <ControlPanelSidebar
             activeView={activeView}
@@ -1032,6 +1070,28 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
             )}
           </div>
         </main>
+        {!isSidePanelLayout && (
+          <div
+            className={`absolute z-40 flex h-10 items-center ${
+              platform === "darwin" ? "left-21 top-2" : "left-2 top-0"
+            }`}
+            style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+            onMouseEnter={sidebarCollapsed ? showSidebarPeek : undefined}
+            onMouseLeave={sidebarCollapsed ? leaveSidebarToggle : undefined}
+          >
+            <button
+              onClick={toggleSidebar}
+              aria-label={sidebarCollapsed ? t("sidebar.expand") : t("sidebar.collapse")}
+              className="group flex items-center justify-center h-7 w-7 rounded-md outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            >
+              {sidebarCollapsed ? (
+                <PanelLeftOpen size={15} className={toggleIconClass} />
+              ) : (
+                <PanelLeftClose size={15} className={toggleIconClass} />
+              )}
+            </button>
+          </div>
+        )}
       </div>
       <BackgroundActionToastListener />
     </div>

--- a/src/components/ControlPanelSidebar.tsx
+++ b/src/components/ControlPanelSidebar.tsx
@@ -14,6 +14,7 @@ import {
   X,
   Search,
   PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react";
 import logoIcon from "../assets/icon.png";
 import { useTranslation } from "react-i18next";
@@ -27,6 +28,13 @@ import { useWorkspace } from "../hooks/useWorkspace";
 import { WORKSPACES_ENABLED } from "../lib/features";
 
 const platform = getCachedPlatform();
+
+const rowIconClass =
+  "shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150";
+const rowLabelClass =
+  "text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150";
+const rowButtonClass =
+  "group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150";
 
 export type ControlPanelView =
   | "home"
@@ -53,6 +61,7 @@ interface ControlPanelSidebarProps {
   usageLoaded?: boolean;
   updateAction?: React.ReactNode;
   onToggleCollapse?: () => void;
+  collapsed?: boolean;
 }
 
 export default function ControlPanelSidebar({
@@ -72,6 +81,7 @@ export default function ControlPanelSidebar({
   usageLoaded,
   updateAction,
   onToggleCollapse,
+  collapsed,
 }: ControlPanelSidebarProps) {
   const { t } = useTranslation();
   const [upgradeDismissed, setUpgradeDismissed] = useState(
@@ -103,27 +113,37 @@ export default function ControlPanelSidebar({
   ];
 
   return (
-    <div className="w-48 h-full shrink-0 border-r border-border/15 dark:border-white/6 flex flex-col bg-surface-1/60 dark:bg-surface-1">
+    <div
+      className={cn(
+        "h-full shrink-0 border-r border-border/15 dark:border-white/6 flex flex-col overflow-hidden bg-surface-1/60 dark:bg-surface-1 transition-[width] duration-300 ease-out",
+        collapsed ? "w-16" : "w-48"
+      )}
+    >
       <div
-        className="w-full h-10 shrink-0 flex items-center justify-end px-2"
+        className="w-full h-10 shrink-0 flex items-center"
         style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
       >
-        {onToggleCollapse && (
-          <button
-            onClick={onToggleCollapse}
-            aria-label={t("sidebar.collapse")}
-            className="group flex items-center justify-center h-7 w-7 rounded-md outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+        {onToggleCollapse && (!collapsed || platform !== "darwin") && (
+          <div
+            className={platform === "darwin" ? "ml-21 mt-4" : "ml-2"}
             style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
           >
-            <PanelLeftClose
-              size={15}
-              className="text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-            />
-          </button>
+            <button
+              onClick={onToggleCollapse}
+              aria-label={collapsed ? t("sidebar.expand") : t("sidebar.collapse")}
+              className="group flex items-center justify-center h-7 w-7 rounded-md outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            >
+              {collapsed ? (
+                <PanelLeftOpen size={15} className={rowIconClass} />
+              ) : (
+                <PanelLeftClose size={15} className={rowIconClass} />
+              )}
+            </button>
+          </div>
         )}
       </div>
 
-      {WORKSPACES_ENABLED && isSignedIn && (
+      {WORKSPACES_ENABLED && isSignedIn && !collapsed && (
         <div className="px-2 pt-1 pb-1">
           <WorkspaceSwitcher userName={userName} />
         </div>
@@ -131,23 +151,34 @@ export default function ControlPanelSidebar({
 
       {onOpenSearch && (
         <div className="px-2 pt-2 pb-1">
-          <button
-            onClick={onOpenSearch}
-            className="group flex items-center w-full h-7 px-2.5 rounded-md border border-border/70 dark:border-white/25 bg-transparent hover:bg-foreground/5 dark:hover:bg-white/5 transition-colors gap-2 outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
-          >
-            <Search size={11} className="text-muted-foreground/50 shrink-0" />
-            <span className="flex-1 text-[11px] text-left text-muted-foreground/50">
-              {t("commandSearch.shortPlaceholder")}
-            </span>
-            <div className="flex items-center gap-0.5 shrink-0">
-              <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
-                {platform === "darwin" ? "⌘" : "Ctrl"}
-              </kbd>
-              <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
-                K
-              </kbd>
-            </div>
-          </button>
+          {collapsed ? (
+            <button
+              onClick={onOpenSearch}
+              aria-label={t("commandSearch.shortPlaceholder")}
+              title={t("commandSearch.shortPlaceholder")}
+              className={rowButtonClass}
+            >
+              <Search size={15} className={rowIconClass} />
+            </button>
+          ) : (
+            <button
+              onClick={onOpenSearch}
+              className="group flex items-center w-full h-7 px-2.5 rounded-md border border-border/70 dark:border-white/25 bg-transparent hover:bg-foreground/5 dark:hover:bg-white/5 transition-colors gap-2 outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
+            >
+              <Search size={11} className="text-muted-foreground/50 shrink-0" />
+              <span className="flex-1 text-[11px] text-left text-muted-foreground/50">
+                {t("commandSearch.shortPlaceholder")}
+              </span>
+              <div className="flex items-center gap-0.5 shrink-0">
+                <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
+                  {platform === "darwin" ? "⌘" : "Ctrl"}
+                </kbd>
+                <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
+                  K
+                </kbd>
+              </div>
+            </button>
+          )}
         </div>
       )}
 
@@ -160,6 +191,7 @@ export default function ControlPanelSidebar({
             <button
               key={item.id}
               onClick={() => onViewChange(item.id)}
+              title={collapsed ? item.label : undefined}
               className={cn(
                 "group relative flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md outline-none transition-colors duration-150 text-left",
                 "focus-visible:ring-1 focus-visible:ring-primary/30",
@@ -177,16 +209,18 @@ export default function ControlPanelSidebar({
                     : "text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/55 dark:group-hover:text-foreground/70"
                 )}
               />
-              <span
-                className={cn(
-                  "text-xs transition-colors duration-150",
-                  isActive
-                    ? "text-foreground font-medium"
-                    : "text-foreground/80 group-hover:text-foreground dark:text-foreground/75 dark:group-hover:text-foreground/90"
-                )}
-              >
-                {item.label}
-              </span>
+              {!collapsed && (
+                <span
+                  className={cn(
+                    "text-xs transition-colors duration-150",
+                    isActive
+                      ? "text-foreground font-medium"
+                      : "text-foreground/80 group-hover:text-foreground dark:text-foreground/75 dark:group-hover:text-foreground/90"
+                  )}
+                >
+                  {item.label}
+                </span>
+              )}
             </button>
           );
         })}
@@ -194,7 +228,7 @@ export default function ControlPanelSidebar({
 
       <div className="flex-1" />
 
-      {showLimitBanner && (
+      {showLimitBanner && !collapsed && (
         <div className="px-2 pb-2">
           <div className="rounded-lg border border-destructive/25 bg-destructive/5 dark:bg-destructive/10 p-3">
             <div className="flex flex-col items-center text-center">
@@ -216,7 +250,7 @@ export default function ControlPanelSidebar({
         </div>
       )}
 
-      {showUpgradeBanner && (
+      {showUpgradeBanner && !collapsed && (
         <div className="px-2 pb-2">
           <div className="relative rounded-lg border border-primary/20 bg-primary/5 dark:bg-primary/10 p-3">
             <button
@@ -249,7 +283,7 @@ export default function ControlPanelSidebar({
       )}
 
       <div className="px-2 pb-2 space-y-0.5">
-        {updateAction && (
+        {updateAction && !collapsed && (
           <div className="px-1 pb-1" style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
             {updateAction}
           </div>
@@ -259,15 +293,11 @@ export default function ControlPanelSidebar({
           <button
             onClick={onOpenReferrals}
             aria-label={t("sidebar.referral")}
-            className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            title={collapsed ? t("sidebar.referral") : undefined}
+            className={rowButtonClass}
           >
-            <Gift
-              size={15}
-              className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-            />
-            <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-              {t("sidebar.referral")}
-            </span>
+            <Gift size={15} className={rowIconClass} />
+            {!collapsed && <span className={rowLabelClass}>{t("sidebar.referral")}</span>}
           </button>
         )}
 
@@ -277,45 +307,43 @@ export default function ControlPanelSidebar({
             aria-label={
               activeWorkspace ? t("sidebar.inviteTeammate") : t("sidebar.createWorkspace")
             }
-            className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            title={
+              collapsed
+                ? activeWorkspace
+                  ? t("sidebar.inviteTeammate")
+                  : t("sidebar.createWorkspace")
+                : undefined
+            }
+            className={rowButtonClass}
           >
-            <UserPlus
-              size={15}
-              className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-            />
-            <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-              {activeWorkspace ? t("sidebar.inviteTeammate") : t("sidebar.createWorkspace")}
-            </span>
+            <UserPlus size={15} className={rowIconClass} />
+            {!collapsed && (
+              <span className={rowLabelClass}>
+                {activeWorkspace ? t("sidebar.inviteTeammate") : t("sidebar.createWorkspace")}
+              </span>
+            )}
           </button>
         )}
 
         <button
           onClick={onOpenSettings}
           aria-label={t("sidebar.settings")}
-          className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+          title={collapsed ? t("sidebar.settings") : undefined}
+          className={rowButtonClass}
         >
-          <Settings
-            size={15}
-            className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-          />
-          <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-            {t("sidebar.settings")}
-          </span>
+          <Settings size={15} className={rowIconClass} />
+          {!collapsed && <span className={rowLabelClass}>{t("sidebar.settings")}</span>}
         </button>
 
         <SupportDropdown
           trigger={
             <button
               aria-label={t("sidebar.support")}
-              className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+              title={collapsed ? t("sidebar.support") : undefined}
+              className={rowButtonClass}
             >
-              <HelpCircle
-                size={15}
-                className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-              />
-              <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-                {t("sidebar.support")}
-              </span>
+              <HelpCircle size={15} className={rowIconClass} />
+              {!collapsed && <span className={rowLabelClass}>{t("sidebar.support")}</span>}
             </button>
           }
         />
@@ -328,24 +356,26 @@ export default function ControlPanelSidebar({
           ) : (
             <UserCircle size={18} className="shrink-0 text-foreground/50 dark:text-foreground/45" />
           )}
-          <div className="flex-1 min-w-0">
-            {isSignedIn && (userName || userEmail) ? (
-              <>
-                <p className="text-xs text-foreground/80 dark:text-foreground/80 truncate leading-tight">
-                  {userName || t("sidebar.defaultUser")}
-                </p>
-                {userEmail && (
-                  <p className="text-xs text-foreground/55 dark:text-foreground/55 truncate leading-tight">
-                    {userEmail}
+          {!collapsed && (
+            <div className="flex-1 min-w-0">
+              {isSignedIn && (userName || userEmail) ? (
+                <>
+                  <p className="text-xs text-foreground/80 dark:text-foreground/80 truncate leading-tight">
+                    {userName || t("sidebar.defaultUser")}
                   </p>
-                )}
-              </>
-            ) : authLoaded && !isSignedIn ? (
-              <p className="text-xs text-foreground/45 dark:text-foreground/55">
-                {t("sidebar.notSignedIn")}
-              </p>
-            ) : null}
-          </div>
+                  {userEmail && (
+                    <p className="text-xs text-foreground/55 dark:text-foreground/55 truncate leading-tight">
+                      {userEmail}
+                    </p>
+                  )}
+                </>
+              ) : authLoaded && !isSignedIn ? (
+                <p className="text-xs text-foreground/45 dark:text-foreground/55">
+                  {t("sidebar.notSignedIn")}
+                </p>
+              ) : null}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/ControlPanelSidebar.tsx
+++ b/src/components/ControlPanelSidebar.tsx
@@ -13,6 +13,7 @@ import {
   UserPlus,
   X,
   Search,
+  PanelLeftClose,
 } from "lucide-react";
 import logoIcon from "../assets/icon.png";
 import { useTranslation } from "react-i18next";
@@ -51,6 +52,7 @@ interface ControlPanelSidebarProps {
   isProUser?: boolean;
   usageLoaded?: boolean;
   updateAction?: React.ReactNode;
+  onToggleCollapse?: () => void;
 }
 
 export default function ControlPanelSidebar({
@@ -69,6 +71,7 @@ export default function ControlPanelSidebar({
   isProUser,
   usageLoaded,
   updateAction,
+  onToggleCollapse,
 }: ControlPanelSidebarProps) {
   const { t } = useTranslation();
   const [upgradeDismissed, setUpgradeDismissed] = useState(
@@ -102,9 +105,23 @@ export default function ControlPanelSidebar({
   return (
     <div className="w-48 h-full shrink-0 border-r border-border/15 dark:border-white/6 flex flex-col bg-surface-1/60 dark:bg-surface-1">
       <div
-        className="w-full h-10 shrink-0"
+        className="w-full h-10 shrink-0 flex items-center justify-end px-2"
         style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-      />
+      >
+        {onToggleCollapse && (
+          <button
+            onClick={onToggleCollapse}
+            aria-label={t("sidebar.collapse")}
+            className="group flex items-center justify-center h-7 w-7 rounded-md outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+          >
+            <PanelLeftClose
+              size={15}
+              className="text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
+            />
+          </button>
+        )}
+      </div>
 
       {WORKSPACES_ENABLED && isSignedIn && (
         <div className="px-2 pt-1 pb-1">

--- a/src/components/ControlPanelSidebar.tsx
+++ b/src/components/ControlPanelSidebar.tsx
@@ -35,6 +35,10 @@ const rowLabelClass =
   "text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150";
 const rowButtonClass =
   "group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150";
+const railButtonClass =
+  "group flex items-center justify-center w-full h-8 rounded-lg outline-none hover:bg-foreground/5 dark:hover:bg-white/5 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150";
+const islandClass =
+  "ml-2 w-12 flex flex-col gap-0.5 rounded-2xl border border-border/60 dark:border-white/10 bg-surface-2 dark:bg-surface-2 p-1.5 shadow-[var(--shadow-card-hover-subtle)]";
 
 export type ControlPanelView =
   | "home"
@@ -115,8 +119,10 @@ export default function ControlPanelSidebar({
   return (
     <div
       className={cn(
-        "h-full shrink-0 border-r border-border/15 dark:border-white/6 flex flex-col overflow-hidden bg-surface-1/60 dark:bg-surface-1 transition-[width] duration-300 ease-out",
-        collapsed ? "w-16" : "w-48"
+        "h-full shrink-0 flex flex-col transition-all duration-300 ease-out",
+        collapsed
+          ? "w-16"
+          : "w-48 overflow-hidden border-r border-border/15 dark:border-white/6 bg-surface-1/60 dark:bg-surface-1"
       )}
     >
       <div
@@ -149,82 +155,85 @@ export default function ControlPanelSidebar({
         </div>
       )}
 
-      {onOpenSearch && (
-        <div className="px-2 pt-2 pb-1">
-          {collapsed ? (
+      <div className={collapsed ? cn(islandClass, "mt-1") : undefined}>
+        {onOpenSearch &&
+          (collapsed ? (
             <button
               onClick={onOpenSearch}
               aria-label={t("commandSearch.shortPlaceholder")}
               title={t("commandSearch.shortPlaceholder")}
-              className={rowButtonClass}
+              className={railButtonClass}
             >
               <Search size={15} className={rowIconClass} />
             </button>
           ) : (
-            <button
-              onClick={onOpenSearch}
-              className="group flex items-center w-full h-7 px-2.5 rounded-md border border-border/70 dark:border-white/25 bg-transparent hover:bg-foreground/5 dark:hover:bg-white/5 transition-colors gap-2 outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
-            >
-              <Search size={11} className="text-muted-foreground/50 shrink-0" />
-              <span className="flex-1 text-[11px] text-left text-muted-foreground/50">
-                {t("commandSearch.shortPlaceholder")}
-              </span>
-              <div className="flex items-center gap-0.5 shrink-0">
-                <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
-                  {platform === "darwin" ? "⌘" : "Ctrl"}
-                </kbd>
-                <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
-                  K
-                </kbd>
-              </div>
-            </button>
-          )}
-        </div>
-      )}
-
-      <nav className="flex flex-col gap-0.5 px-2 pt-2 pb-2">
-        {navItems.map((item) => {
-          const Icon = item.icon;
-          const isActive = activeView === item.id;
-
-          return (
-            <button
-              key={item.id}
-              onClick={() => onViewChange(item.id)}
-              title={collapsed ? item.label : undefined}
-              className={cn(
-                "group relative flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md outline-none transition-colors duration-150 text-left",
-                "focus-visible:ring-1 focus-visible:ring-primary/30",
-                isActive
-                  ? "bg-primary/8 dark:bg-primary/10"
-                  : "hover:bg-foreground/4 dark:hover:bg-white/4 active:bg-foreground/6"
-              )}
-            >
-              <Icon
-                size={15}
-                className={cn(
-                  "shrink-0 transition-colors duration-150",
-                  isActive
-                    ? "text-primary"
-                    : "text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/55 dark:group-hover:text-foreground/70"
-                )}
-              />
-              {!collapsed && (
-                <span
-                  className={cn(
-                    "text-xs transition-colors duration-150",
-                    isActive
-                      ? "text-foreground font-medium"
-                      : "text-foreground/80 group-hover:text-foreground dark:text-foreground/75 dark:group-hover:text-foreground/90"
-                  )}
-                >
-                  {item.label}
+            <div className="px-2 pt-2 pb-1">
+              <button
+                onClick={onOpenSearch}
+                className="group flex items-center w-full h-7 px-2.5 rounded-md border border-border/70 dark:border-white/25 bg-transparent hover:bg-foreground/5 dark:hover:bg-white/5 transition-colors gap-2 outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
+              >
+                <Search size={11} className="text-muted-foreground/50 shrink-0" />
+                <span className="flex-1 text-[11px] text-left text-muted-foreground/50">
+                  {t("commandSearch.shortPlaceholder")}
                 </span>
-              )}
-            </button>
-          );
-        })}
-      </nav>
+                <div className="flex items-center gap-0.5 shrink-0">
+                  <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
+                    {platform === "darwin" ? "⌘" : "Ctrl"}
+                  </kbd>
+                  <kbd className="text-[10px] px-1 py-px rounded border border-border/30 dark:border-white/8 bg-muted/40 text-muted-foreground/40 font-mono leading-tight">
+                    K
+                  </kbd>
+                </div>
+              </button>
+            </div>
+          ))}
+
+        <nav className={cn("flex flex-col gap-0.5", !collapsed && "px-2 pt-2 pb-2")}>
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = activeView === item.id;
+
+            return (
+              <button
+                key={item.id}
+                onClick={() => onViewChange(item.id)}
+                title={collapsed ? item.label : undefined}
+                className={cn(
+                  "group relative flex items-center w-full h-8 outline-none transition-colors duration-150 focus-visible:ring-1 focus-visible:ring-primary/30",
+                  collapsed ? "justify-center rounded-lg" : "gap-2.5 px-2.5 rounded-md text-left",
+                  isActive
+                    ? "bg-primary/8 dark:bg-primary/10"
+                    : collapsed
+                      ? "hover:bg-foreground/5 dark:hover:bg-white/5"
+                      : "hover:bg-foreground/4 dark:hover:bg-white/4 active:bg-foreground/6"
+                )}
+              >
+                <Icon
+                  size={15}
+                  className={cn(
+                    "shrink-0 transition-colors duration-150",
+                    isActive
+                      ? "text-primary"
+                      : "text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/55 dark:group-hover:text-foreground/70"
+                  )}
+                />
+                {!collapsed && (
+                  <span
+                    className={cn(
+                      "text-xs transition-colors duration-150",
+                      isActive
+                        ? "text-foreground font-medium"
+                        : "text-foreground/80 group-hover:text-foreground dark:text-foreground/75 dark:group-hover:text-foreground/90"
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
 
       <div className="flex-1" />
 
@@ -282,7 +291,7 @@ export default function ControlPanelSidebar({
         </div>
       )}
 
-      <div className="px-2 pb-2 space-y-0.5">
+      <div className={collapsed ? cn(islandClass, "mb-2") : "px-2 pb-2 space-y-0.5"}>
         {updateAction && !collapsed && (
           <div className="px-1 pb-1" style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
             {updateAction}
@@ -294,7 +303,7 @@ export default function ControlPanelSidebar({
             onClick={onOpenReferrals}
             aria-label={t("sidebar.referral")}
             title={collapsed ? t("sidebar.referral") : undefined}
-            className={rowButtonClass}
+            className={collapsed ? railButtonClass : rowButtonClass}
           >
             <Gift size={15} className={rowIconClass} />
             {!collapsed && <span className={rowLabelClass}>{t("sidebar.referral")}</span>}
@@ -314,7 +323,7 @@ export default function ControlPanelSidebar({
                   : t("sidebar.createWorkspace")
                 : undefined
             }
-            className={rowButtonClass}
+            className={collapsed ? railButtonClass : rowButtonClass}
           >
             <UserPlus size={15} className={rowIconClass} />
             {!collapsed && (
@@ -329,7 +338,7 @@ export default function ControlPanelSidebar({
           onClick={onOpenSettings}
           aria-label={t("sidebar.settings")}
           title={collapsed ? t("sidebar.settings") : undefined}
-          className={rowButtonClass}
+          className={collapsed ? railButtonClass : rowButtonClass}
         >
           <Settings size={15} className={rowIconClass} />
           {!collapsed && <span className={rowLabelClass}>{t("sidebar.settings")}</span>}
@@ -340,7 +349,7 @@ export default function ControlPanelSidebar({
             <button
               aria-label={t("sidebar.support")}
               title={collapsed ? t("sidebar.support") : undefined}
-              className={rowButtonClass}
+              className={collapsed ? railButtonClass : rowButtonClass}
             >
               <HelpCircle size={15} className={rowIconClass} />
               {!collapsed && <span className={rowLabelClass}>{t("sidebar.support")}</span>}
@@ -348,9 +357,14 @@ export default function ControlPanelSidebar({
           }
         />
 
-        <div className="mx-1 h-px bg-border/10 dark:bg-white/6 my-1.5!" />
+        {!collapsed && <div className="mx-1 h-px bg-border/10 dark:bg-white/6 my-1.5!" />}
 
-        <div className="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md">
+        <div
+          className={cn(
+            "flex items-center rounded-md",
+            collapsed ? "justify-center py-1" : "gap-2.5 px-2.5 py-1.5"
+          )}
+        >
           {userImage ? (
             <img src={userImage} alt="" className="w-6 h-6 rounded-full shrink-0 object-cover" />
           ) : (

--- a/src/components/ControlPanelSidebar.tsx
+++ b/src/components/ControlPanelSidebar.tsx
@@ -27,8 +27,20 @@ import { WORKSPACES_ENABLED } from "../lib/features";
 
 const platform = getCachedPlatform();
 
+const rowIconClass =
+  "shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150";
+const rowLabelClass =
+  "text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150";
+const rowButtonClass =
+  "group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150";
+
 export type ControlPanelView =
-  "home" | "chat" | "personal-notes" | "dictionary" | "upload" | "integrations";
+  | "home"
+  | "chat"
+  | "personal-notes"
+  | "dictionary"
+  | "upload"
+  | "integrations";
 
 interface ControlPanelSidebarProps {
   activeView: ControlPanelView;
@@ -237,15 +249,10 @@ export default function ControlPanelSidebar({
           <button
             onClick={onOpenReferrals}
             aria-label={t("sidebar.referral")}
-            className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            className={rowButtonClass}
           >
-            <Gift
-              size={15}
-              className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-            />
-            <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-              {t("sidebar.referral")}
-            </span>
+            <Gift size={15} className={rowIconClass} />
+            <span className={rowLabelClass}>{t("sidebar.referral")}</span>
           </button>
         )}
 
@@ -255,13 +262,10 @@ export default function ControlPanelSidebar({
             aria-label={
               activeWorkspace ? t("sidebar.inviteTeammate") : t("sidebar.createWorkspace")
             }
-            className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+            className={rowButtonClass}
           >
-            <UserPlus
-              size={15}
-              className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-            />
-            <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
+            <UserPlus size={15} className={rowIconClass} />
+            <span className={rowLabelClass}>
               {activeWorkspace ? t("sidebar.inviteTeammate") : t("sidebar.createWorkspace")}
             </span>
           </button>
@@ -270,30 +274,17 @@ export default function ControlPanelSidebar({
         <button
           onClick={onOpenSettings}
           aria-label={t("sidebar.settings")}
-          className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
+          className={rowButtonClass}
         >
-          <Settings
-            size={15}
-            className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-          />
-          <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-            {t("sidebar.settings")}
-          </span>
+          <Settings size={15} className={rowIconClass} />
+          <span className={rowLabelClass}>{t("sidebar.settings")}</span>
         </button>
 
         <SupportDropdown
           trigger={
-            <button
-              aria-label={t("sidebar.support")}
-              className="group flex items-center gap-2.5 w-full h-8 px-2.5 rounded-md text-left outline-none hover:bg-foreground/4 dark:hover:bg-white/4 focus-visible:ring-1 focus-visible:ring-primary/30 transition-colors duration-150"
-            >
-              <HelpCircle
-                size={15}
-                className="shrink-0 text-foreground/60 group-hover:text-foreground/75 dark:text-foreground/50 dark:group-hover:text-foreground/65 transition-colors duration-150"
-              />
-              <span className="text-xs text-foreground/80 group-hover:text-foreground dark:text-foreground/70 dark:group-hover:text-foreground/85 transition-colors duration-150">
-                {t("sidebar.support")}
-              </span>
+            <button aria-label={t("sidebar.support")} className={rowButtonClass}>
+              <HelpCircle size={15} className={rowIconClass} />
+              <span className={rowLabelClass}>{t("sidebar.support")}</span>
             </button>
           }
         />

--- a/src/hooks/useCollapsibleSidebar.ts
+++ b/src/hooks/useCollapsibleSidebar.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const PEEK_CLOSE_DELAY_MS = 120;
+
+export function useCollapsibleSidebar() {
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem("sidebarCollapsed") === "true"
+  );
+  const [peek, setPeek] = useState(false);
+  const peekTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const suppressPeek = useRef(false);
+
+  const toggle = useCallback(() => {
+    clearTimeout(peekTimer.current);
+    setPeek(false);
+    const next = !collapsed;
+    suppressPeek.current = next;
+    localStorage.setItem("sidebarCollapsed", String(next));
+    setCollapsed(next);
+  }, [collapsed]);
+
+  const showPeek = useCallback(() => {
+    if (suppressPeek.current) return;
+    clearTimeout(peekTimer.current);
+    setPeek(true);
+  }, []);
+
+  const hidePeek = useCallback(() => {
+    clearTimeout(peekTimer.current);
+    peekTimer.current = setTimeout(() => setPeek(false), PEEK_CLOSE_DELAY_MS);
+  }, []);
+
+  const leaveToggle = useCallback(() => {
+    suppressPeek.current = false;
+    hidePeek();
+  }, [hidePeek]);
+
+  useEffect(() => () => clearTimeout(peekTimer.current), []);
+
+  return { collapsed, peek, toggle, showPeek, hidePeek, leaveToggle };
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2318,7 +2318,9 @@
     "notSignedIn": "Nicht angemeldet",
     "chat": "Chat",
     "inviteTeammate": "Teammitglied einladen",
-    "createWorkspace": "Workspace erstellen"
+    "createWorkspace": "Workspace erstellen",
+    "collapse": "Seitenleiste einklappen",
+    "expand": "Seitenleiste ausklappen"
   },
   "chat": {
     "newChat": "Neuer Chat",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2430,7 +2430,9 @@
     "notSignedIn": "Nicht angemeldet",
     "chat": "Chat",
     "inviteTeammate": "Teammitglied einladen",
-    "createWorkspace": "Workspace erstellen"
+    "createWorkspace": "Workspace erstellen",
+    "collapse": "Seitenleiste einklappen",
+    "expand": "Seitenleiste ausklappen"
   },
   "chat": {
     "newChat": "Neuer Chat",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2039,7 +2039,9 @@
     "notSignedIn": "Not signed in",
     "chat": "Chat",
     "inviteTeammate": "Invite teammate",
-    "createWorkspace": "Create workspace"
+    "createWorkspace": "Create workspace",
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar"
   },
   "workspaces": {
     "switcher": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2116,7 +2116,9 @@
     "notSignedIn": "Not signed in",
     "chat": "Chat",
     "inviteTeammate": "Invite teammate",
-    "createWorkspace": "Create workspace"
+    "createWorkspace": "Create workspace",
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar"
   },
   "workspaces": {
     "switcher": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2366,7 +2366,9 @@
     "notSignedIn": "Sin sesión iniciada",
     "chat": "Chat",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "Contraer barra lateral",
+    "expand": "Expandir barra lateral"
   },
   "chat": {
     "newChat": "Nuevo chat",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2478,7 +2478,9 @@
     "notSignedIn": "Sin sesión iniciada",
     "chat": "Chat",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "Contraer barra lateral",
+    "expand": "Expandir barra lateral"
   },
   "chat": {
     "newChat": "Nuevo chat",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1999,7 +1999,9 @@
     "notSignedIn": "Non connecté",
     "chat": "Chat",
     "inviteTeammate": "Inviter un coéquipier",
-    "createWorkspace": "Créer un espace de travail"
+    "createWorkspace": "Créer un espace de travail",
+    "collapse": "Réduire la barre latérale",
+    "expand": "Développer la barre latérale"
   },
   "chat": {
     "newChat": "Nouveau chat",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2076,7 +2076,9 @@
     "notSignedIn": "Non connecté",
     "chat": "Chat",
     "inviteTeammate": "Inviter un coéquipier",
-    "createWorkspace": "Créer un espace de travail"
+    "createWorkspace": "Créer un espace de travail",
+    "collapse": "Réduire la barre latérale",
+    "expand": "Développer la barre latérale"
   },
   "chat": {
     "newChat": "Nouveau chat",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2318,7 +2318,9 @@
     "notSignedIn": "Non hai effettuato l'accesso",
     "chat": "Chat",
     "inviteTeammate": "Inviter un coéquipier",
-    "createWorkspace": "Créer un espace de travail"
+    "createWorkspace": "Créer un espace de travail",
+    "collapse": "Comprimi barra laterale",
+    "expand": "Espandi barra laterale"
   },
   "chat": {
     "newChat": "Nuova chat",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2430,7 +2430,9 @@
     "notSignedIn": "Non hai effettuato l'accesso",
     "chat": "Chat",
     "inviteTeammate": "Inviter un coéquipier",
-    "createWorkspace": "Créer un espace de travail"
+    "createWorkspace": "Créer un espace de travail",
+    "collapse": "Comprimi barra laterale",
+    "expand": "Espandi barra laterale"
   },
   "chat": {
     "newChat": "Nuova chat",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2318,7 +2318,9 @@
     "notSignedIn": "未サインイン",
     "chat": "チャット",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "サイドバーを折りたたむ",
+    "expand": "サイドバーを展開"
   },
   "chat": {
     "newChat": "新しいチャット",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2430,7 +2430,9 @@
     "notSignedIn": "未サインイン",
     "chat": "チャット",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "サイドバーを折りたたむ",
+    "expand": "サイドバーを展開"
   },
   "chat": {
     "newChat": "新しいチャット",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2318,7 +2318,9 @@
     "notSignedIn": "Não conectado",
     "chat": "Chat",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "Recolher barra lateral",
+    "expand": "Expandir barra lateral"
   },
   "chat": {
     "newChat": "Novo chat",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2430,7 +2430,9 @@
     "notSignedIn": "Não conectado",
     "chat": "Chat",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "Recolher barra lateral",
+    "expand": "Expandir barra lateral"
   },
   "chat": {
     "newChat": "Novo chat",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2322,7 +2322,9 @@
     "notSignedIn": "Не авторизован",
     "chat": "Чат",
     "inviteTeammate": "Teammitglied einladen",
-    "createWorkspace": "Workspace erstellen"
+    "createWorkspace": "Workspace erstellen",
+    "collapse": "Свернуть боковую панель",
+    "expand": "Развернуть боковую панель"
   },
   "chat": {
     "newChat": "Новый чат",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2434,7 +2434,9 @@
     "notSignedIn": "Не авторизован",
     "chat": "Чат",
     "inviteTeammate": "Teammitglied einladen",
-    "createWorkspace": "Workspace erstellen"
+    "createWorkspace": "Workspace erstellen",
+    "collapse": "Свернуть боковую панель",
+    "expand": "Развернуть боковую панель"
   },
   "chat": {
     "newChat": "Новый чат",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2313,7 +2313,9 @@
     "notSignedIn": "未登录",
     "chat": "聊天",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "折叠侧边栏",
+    "expand": "展开侧边栏"
   },
   "chat": {
     "newChat": "新对话",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2425,7 +2425,9 @@
     "notSignedIn": "未登录",
     "chat": "聊天",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "折叠侧边栏",
+    "expand": "展开侧边栏"
   },
   "chat": {
     "newChat": "新对话",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2313,7 +2313,9 @@
     "notSignedIn": "尚未登入",
     "chat": "聊天",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "收合側邊欄",
+    "expand": "展開側邊欄"
   },
   "chat": {
     "newChat": "新對話",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2425,7 +2425,9 @@
     "notSignedIn": "尚未登入",
     "chat": "聊天",
     "inviteTeammate": "Invitar compañero",
-    "createWorkspace": "Crear espacio de trabajo"
+    "createWorkspace": "Crear espacio de trabajo",
+    "collapse": "收合側邊欄",
+    "expand": "展開側邊欄"
   },
   "chat": {
     "newChat": "新對話",


### PR DESCRIPTION
## Summary

Adds a collapsible control-panel sidebar. Clicking the toggle fully hides the sidebar (slides it out); while hidden, **hovering the toggle icon peeks the sidebar back in** as an overlay over the content so you can navigate quickly, and it slides away when you move off.

## Behaviour

- **Toggle never moves** — a single control absolutely positioned next to the window controls (aligned with the macOS traffic lights); it only swaps its glyph while the sidebar slides underneath it.
- **Peek is an overlay** — a spacer reserves width only when the sidebar is *pinned* open, so a hover-peek floats over the content without reflowing it (the icon and content stay put).
- **Hover intent** — a short close delay bridges the cursor gap between the icon and the sidebar; an explicit collapse suppresses the peek until the pointer leaves the toggle, so it doesn't immediately reopen.
- Collapsed state persists across restarts (`localStorage`); disabled in meeting/side-panel mode.

## Implementation

- Collapse + peek logic extracted into a focused `useCollapsibleSidebar` hook (`src/hooks/`), keeping `ControlPanel` lean.
- Sidebar reverts to its normal full layout; the four footer buttons were de-duplicated behind shared class constants.
- `sidebar.collapse` / `sidebar.expand` strings added across all 10 locales.

## Verification

- `tsc --noEmit`, eslint, and prettier all clean on the changed files.
- Rebased onto latest `main`.