### PR TITLE
fix: crash on first "Install & Restart" click after an update

### DIFF
--- a/main.js
+++ b/main.js
@@ -1554,6 +1554,10 @@ if (gotSingleInstanceLock) {
   app.on("before-quit", (event) => {
     if (isShuttingDown) return;
     isShuttingDown = true;
+    if (updateManager && updateManager.isQuittingForUpdate) {
+      performSyncTeardown();
+      return;
+    }
     event.preventDefault();
     performSyncTeardown();
     sidecarRegistry.shutdownAll().finally(() => app.exit(0));

--- a/main.js
+++ b/main.js
@@ -1555,7 +1555,10 @@ if (gotSingleInstanceLock) {
     if (isShuttingDown) return;
     isShuttingDown = true;
     if (updateManager && updateManager.isQuittingForUpdate) {
+      // Quit must proceed for the installer to run, so no preventDefault;
+      // sidecar shutdown is best-effort (the reaper cleans up orphans on relaunch).
       performSyncTeardown();
+      sidecarRegistry.shutdownAll().catch(() => {});
       return;
     }
     event.preventDefault();

--- a/src/updater.js
+++ b/src/updater.js
@@ -9,6 +9,7 @@ class UpdateManager {
     this.lastUpdateInfo = null;
     this.isInstalling = false;
     this.isDownloading = false;
+    this.isQuittingForUpdate = false;
     this.eventListeners = [];
     this.updateCheckInterval = null;
     this.windowManager = null;
@@ -136,6 +137,18 @@ class UpdateManager {
         }
         this.notifyRenderers("update-downloaded", info);
       },
+      "before-quit-for-update": () => {
+        this.isQuittingForUpdate = true;
+        if (this.windowManager) {
+          this.windowManager.isQuitting = true;
+          if (this.windowManager.hotkeyManager) {
+            this.windowManager.hotkeyManager.unregisterAll();
+          } else {
+            const { globalShortcut } = require("electron");
+            globalShortcut.unregisterAll();
+          }
+        }
+      },
     };
 
     Object.entries(handlers).forEach(([event, handler]) => {
@@ -253,15 +266,6 @@ class UpdateManager {
 
       this.isInstalling = true;
       console.log("🔄 Installing update and restarting...");
-
-      const { app, BrowserWindow } = require("electron");
-
-      // Set windowManager.isQuitting before removing close listeners
-      app.emit("before-quit");
-      app.removeAllListeners("window-all-closed");
-      BrowserWindow.getAllWindows().forEach((win) => {
-        win.removeAllListeners("close");
-      });
 
       const isSilent = process.platform === "win32";
       autoUpdater.quitAndInstall(isSilent, true);

--- a/src/updater.js
+++ b/src/updater.js
@@ -10,6 +10,7 @@ class UpdateManager {
     this.isInstalling = false;
     this.isDownloading = false;
     this.isQuittingForUpdate = false;
+    this.handleBeforeQuitForUpdate = null;
     this.eventListeners = [];
     this.updateCheckInterval = null;
     this.windowManager = null;
@@ -137,24 +138,23 @@ class UpdateManager {
         }
         this.notifyRenderers("update-downloaded", info);
       },
-      "before-quit-for-update": () => {
-        this.isQuittingForUpdate = true;
-        if (this.windowManager) {
-          this.windowManager.isQuitting = true;
-          if (this.windowManager.hotkeyManager) {
-            this.windowManager.hotkeyManager.unregisterAll();
-          } else {
-            const { globalShortcut } = require("electron");
-            globalShortcut.unregisterAll();
-          }
-        }
-      },
     };
 
     Object.entries(handlers).forEach(([event, handler]) => {
       autoUpdater.on(event, handler);
       this.eventListeners.push({ event, handler });
     });
+
+    // electron-updater and Squirrel.Mac emit this on Electron's native
+    // autoUpdater (before any windows close), not on the electron-updater instance.
+    this.handleBeforeQuitForUpdate = () => {
+      this.isQuittingForUpdate = true;
+      if (this.windowManager) {
+        this.windowManager.isQuitting = true;
+        this.windowManager.hotkeyManager.unregisterAll();
+      }
+    };
+    require("electron").autoUpdater.on("before-quit-for-update", this.handleBeforeQuitForUpdate);
   }
 
   notifyRenderers(channel, data) {
@@ -338,6 +338,13 @@ class UpdateManager {
       autoUpdater.removeListener(event, handler);
     });
     this.eventListeners = [];
+    if (this.handleBeforeQuitForUpdate) {
+      require("electron").autoUpdater.removeListener(
+        "before-quit-for-update",
+        this.handleBeforeQuitForUpdate
+      );
+      this.handleBeforeQuitForUpdate = null;
+    }
   }
 }
 


### PR DESCRIPTION
`installUpdate()` called `app.emit("before-quit")` with no Event argument, causing `event.preventDefault()` to throw _TypeError_ in the `app.on("before-quit")` listener.

Instead of doing manual teardown and relying on the `removeAllListeners` workaround, it's now using Electron's dedicated [before-quit-for-update](https://www.electronjs.org/docs/latest/api/auto-updater#event-before-quit-for-update) event for pre-quit cleanup, and make the `before-quit` listener update-aware so `quitAndInstall()` can proceed without `preventDefault()` blocking it.

Here are the compressed trace logs of the error
```bash
> ./OpenWhispr-1.7.2-linux-x86_64.AppImage --log-level=debug 2>&1 | tee ~/openwhispr-session.log
◇ injected env (0) from ../../../tmp/.mount_OpenWhuhwbfu/resources/app.asar/.env // tip: ⌁ auth for agents [www.vestauth.com]
◇ injected env (6) from ../.config/open-whispr/.env // tip: ⌘ override existing { override: true }
[DEBUG] Debug logging enabled {
  logFile: '/home/idris/.config/open-whispr/logs/debug-2026-06-26T06-22-59-154Z.log'
}
✅ Update downloaded successfully: 1.7.3
📥 Download initiated successfully
[DEBUG][meeting] Process list refreshed { count: 617 }
🔄 Installing update and restarting...
❌ Update installation error: TypeError: Cannot read properties of undefined (reading 'preventDefault')
    at EventEmitter.<anonymous> (/tmp/.mount_OpenWhuhwbfu/resources/app.asar/main.js:1579:11)
    at EventEmitter.emit (node:events:520:35)
    at UpdateManager.installUpdate (/tmp/.mount_OpenWhuhwbfu/resources/app.asar/src/updater.js:257:11)
    at /tmp/.mount_OpenWhuhwbfu/resources/app.asar/src/helpers/ipcHandlers.js:6497:33
    at Session.<anonymous> (node:electron/js2c/browser_init:2:116478)
    at Session.emit (node:events:508:28)
Error occurred in handler for 'install-update': TypeError: Cannot read properties of undefined (reading 'preventDefault')
    at EventEmitter.<anonymous> (/tmp/.mount_OpenWhuhwbfu/resources/app.asar/main.js:1579:11)
    at EventEmitter.emit (node:events:520:35)
    at UpdateManager.installUpdate (/tmp/.mount_OpenWhuhwbfu/resources/app.asar/src/updater.js:257:11)
    at /tmp/.mount_OpenWhuhwbfu/resources/app.asar/src/helpers/ipcHandlers.js:6497:33
    at Session.<anonymous> (node:electron/js2c/browser_init:2:116478)
    at Session.emit (node:events:508:28)
```

fixes #1006