### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -33,7 +33,7 @@ type CloudModelOption = {
   invertInDark?: boolean;
 };
 
-const CLOUD_PROVIDER_IDS = ["openai", "anthropic", "gemini", "groq", "custom"];
+const CLOUD_PROVIDER_IDS = ["openai", "anthropic", "gemini", "groq", "custom", "litellm"];
 
 interface ReasoningModelSelectorProps {
   reasoningModel: string;
@@ -331,7 +331,9 @@ export default function ReasoningModelSelector({
     name:
       id === "custom"
         ? t("reasoning.custom.providerName")
-        : REASONING_PROVIDERS[id as keyof typeof REASONING_PROVIDERS]?.name || id,
+        : id === "litellm"
+          ? "LiteLLM"
+          : REASONING_PROVIDERS[id as keyof typeof REASONING_PROVIDERS]?.name || id,
   }));
 
   const localProviders = useMemo<LocalProvider[]>(() => {
@@ -365,7 +367,7 @@ export default function ReasoningModelSelector({
 
   const selectedCloudModels = useMemo<CloudModelOption[]>(() => {
     if (selectedCloudProvider === "openai") return openaiModelOptions;
-    if (selectedCloudProvider === "custom") return [];
+    if (selectedCloudProvider === "custom" || selectedCloudProvider === "litellm") return [];
 
     const provider = REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
     if (!provider?.models) return [];
@@ -425,7 +427,7 @@ export default function ReasoningModelSelector({
       window.electronAPI?.llamaServerStop?.();
       setLocalReasoningProvider(selectedCloudProvider);
 
-      if (selectedCloudProvider === "custom") return;
+      if (selectedCloudProvider === "custom" || selectedCloudProvider === "litellm") return;
 
       const provider =
         REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
@@ -452,7 +454,7 @@ export default function ReasoningModelSelector({
     setSelectedCloudProvider(provider);
     setLocalReasoningProvider(provider);
 
-    if (provider === "custom") return;
+    if (provider === "custom" || provider === "litellm") return;
 
     const providerData = REASONING_PROVIDERS[provider as keyof typeof REASONING_PROVIDERS];
     if (providerData?.models?.length > 0) {
@@ -516,7 +518,7 @@ export default function ReasoningModelSelector({
           />
 
           <div>
-            {selectedCloudProvider === "custom" ? (
+            {selectedCloudProvider === "custom" || selectedCloudProvider === "litellm" ? (
               <OpenAICompatiblePanel
                 baseUrl={cloudReasoningBaseUrl}
                 setBaseUrl={setCloudReasoningBaseUrl}
@@ -524,7 +526,8 @@ export default function ReasoningModelSelector({
                 setApiKey={setCustomReasoningApiKey || (() => {})}
                 model={reasoningModel}
                 setModel={setReasoningModel}
-                defaultBaseUrl={API_ENDPOINTS.OPENAI_BASE}
+                defaultBaseUrl={selectedCloudProvider === "litellm" ? "http://localhost:4000/v1" : API_ENDPOINTS.OPENAI_BASE}
+                baseUrlPlaceholder={selectedCloudProvider === "litellm" ? "http://localhost:4000/v1" : undefined}
               />
             ) : (
               <>

--- a/src/components/chat/useChatStreaming.ts
+++ b/src/components/chat/useChatStreaming.ts
@@ -99,7 +99,7 @@ export function useChatStreaming({
       const isLanAgent = chatAgentMode === "self-hosted" && !!settings.chatAgentRemoteUrl;
       const isCustomAgent =
         chatAgentMode === "providers" && settings.chatAgentProvider === "custom";
-      const isLocalProvider = !["openai", "groq", "custom", "anthropic", "gemini"].includes(
+      const isLocalProvider = !["openai", "groq", "custom", "anthropic", "gemini", "litellm"].includes(
         settings.chatAgentProvider
       );
       const localModelCanUseTool =

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -62,9 +62,9 @@ class ReasoningService extends BaseReasoningService {
   }
 
   private async getApiKey(
-    provider: "openai" | "anthropic" | "gemini" | "groq" | "custom"
+    provider: "openai" | "anthropic" | "gemini" | "groq" | "custom" | "litellm"
   ): Promise<string> {
-    if (provider === "custom") {
+    if (provider === "custom" || provider === "litellm") {
       let customKey = "";
       try {
         customKey = (await window.electronAPI?.getCleanupCustomKey?.()) || "";
@@ -335,7 +335,7 @@ class ReasoningService extends BaseReasoningService {
     provider: string,
     config: ReasoningConfig & { systemPrompt: string }
   ): AsyncGenerator<string, void, unknown> {
-    const cloudProviders = ["openai", "groq", "gemini", "anthropic", "custom"];
+    const cloudProviders = ["openai", "groq", "gemini", "anthropic", "custom", "litellm"];
     const isLocalProvider = !cloudProviders.includes(provider);
 
     const settings = getSettings();
@@ -356,8 +356,8 @@ class ReasoningService extends BaseReasoningService {
       }
       endpoint = `http://127.0.0.1:${serverResult.port}/v1/chat/completions`;
     } else {
-      const providerKey = provider as "openai" | "groq" | "gemini" | "anthropic" | "custom";
-      const overrideKey = providerKey === "custom" ? config.customApiKey?.trim() : "";
+      const providerKey = provider as "openai" | "groq" | "gemini" | "anthropic" | "custom" | "litellm";
+      const overrideKey = providerKey === "custom" || providerKey === "litellm" ? config.customApiKey?.trim() : "";
       apiKey = overrideKey || (await this.getApiKey(providerKey));
 
       switch (providerKey) {
@@ -369,6 +369,7 @@ class ReasoningService extends BaseReasoningService {
           break;
         case "openai":
         case "custom":
+        case "litellm":
           endpoint = buildApiUrl(
             config.baseUrl?.trim() || getConfiguredOpenAIBase(),
             "/chat/completions"
@@ -538,7 +539,7 @@ class ReasoningService extends BaseReasoningService {
       );
     }
 
-    const cloudProviders = ["openai", "groq", "gemini", "anthropic", "custom"];
+    const cloudProviders = ["openai", "groq", "gemini", "anthropic", "custom", "litellm"];
     const isLocalProvider = !cloudProviders.includes(provider);
 
     const settings = getSettings();
@@ -567,11 +568,11 @@ class ReasoningService extends BaseReasoningService {
       }
       baseURL = `http://127.0.0.1:${serverResult.port}/v1`;
     } else {
-      const providerKey = provider as "openai" | "groq" | "gemini" | "anthropic" | "custom";
-      const overrideKey = providerKey === "custom" ? config.customApiKey?.trim() : "";
+      const providerKey = provider as "openai" | "groq" | "gemini" | "anthropic" | "custom" | "litellm";
+      const overrideKey = providerKey === "custom" || providerKey === "litellm" ? config.customApiKey?.trim() : "";
       apiKey = overrideKey || (await this.getApiKey(providerKey));
       baseURL =
-        provider === "custom" ? config.baseUrl?.trim() || getConfiguredOpenAIBase() : undefined;
+        provider === "custom" || provider === "litellm" ? config.baseUrl?.trim() || getConfiguredOpenAIBase() : undefined;
     }
     const apiConfig = getOpenAiApiConfig(model);
 
@@ -880,7 +881,7 @@ class ReasoningService extends BaseReasoningService {
   }
 
   clearApiKeyCache(
-    provider?: "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "custom"
+    provider?: "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "custom" | "litellm"
   ): void {
     if (provider) {
       if (provider !== "custom") {

--- a/src/services/ai/inferenceProviders/index.ts
+++ b/src/services/ai/inferenceProviders/index.ts
@@ -7,6 +7,7 @@ import { enterpriseProvider } from "./enterprise";
 import { openwhisprProvider } from "./openwhispr";
 import { lanProvider } from "./lan";
 import { openaiProvider } from "./openai";
+import { litellmProvider } from "./litellm";
 
 export const PROVIDER_REGISTRY: Readonly<Record<string, InferenceProvider>> = Object.freeze({
   openai: openaiProvider,
@@ -20,6 +21,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, InferenceProvider>> = Ob
   vertex: enterpriseProvider,
   openwhispr: openwhisprProvider,
   lan: lanProvider,
+  litellm: litellmProvider,
 });
 
 export type { InferenceProvider, ProviderContext, ProviderCallParams } from "./types";

--- a/src/services/ai/inferenceProviders/litellm.ts
+++ b/src/services/ai/inferenceProviders/litellm.ts
@@ -1,0 +1,14 @@
+import type { InferenceProvider } from "./types";
+import { buildApiUrl } from "../../../config/constants";
+import logger from "../../../utils/logger";
+
+export const litellmProvider: InferenceProvider = {
+  id: "litellm",
+  async call({ text, model, agentName, config, ctx }) {
+    logger.logReasoning("LITELLM_START", { model, agentName });
+    const apiKey = await ctx.getApiKey("litellm");
+    const baseUrl = config.baseUrl?.trim() || "http://localhost:4000/v1";
+    const endpoint = buildApiUrl(baseUrl, "/chat/completions");
+    return ctx.callChatCompletionsApi(endpoint, apiKey, model, text, agentName, config, "LiteLLM");
+  },
+};

--- a/src/services/ai/providers.ts
+++ b/src/services/ai/providers.ts
@@ -26,6 +26,7 @@ export function getAIModel(
     case "gemini":
       return createGoogleGenerativeAI({ apiKey })(model);
     case "custom":
+    case "litellm":
       return createOpenAI({ apiKey, baseURL })(model);
     case "local":
       return createOpenAI({ apiKey: "no-key", baseURL }).chat(model);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -810,7 +810,7 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
 ] as const;
 
 function invalidateApiKeyCaches(
-  provider?: "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "custom"
+  provider?: "openai" | "anthropic" | "gemini" | "groq" | "mistral" | "custom" | "litellm"
 ) {
   if (provider) {
     if (_ReasoningService) {


### PR DESCRIPTION
## Summary

- Add LiteLLM as a first-class AI inference provider, giving users access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Cohere, Mistral, and more) through a single proxy interface.
- LiteLLM appears as a named provider in the provider selector with the OpenAI-compatible panel for base URL and API key configuration, defaulting to `http://localhost:4000/v1`.

## Motivation

OpenWhispr currently supports 5 cloud providers (OpenAI, Anthropic, Gemini, Groq, plus a generic "Custom" endpoint). Users who want providers not directly supported (Bedrock, Azure OpenAI, Mistral, Cohere, Together AI, etc.) must use the generic Custom provider and manually configure everything.

[LiteLLM](https://github.com/BerriAI/litellm) is an AI gateway that proxies 100+ LLM providers through a single OpenAI-compatible endpoint. With this PR, users can:
1. Run `litellm --model anthropic/claude-sonnet-4-6` (or deploy the proxy server)
2. Select "LiteLLM" as the provider in OpenWhispr settings
3. Access any of 100+ models with automatic provider routing, load balancing, and cost tracking


## Changes

- `src/services/ai/inferenceProviders/litellm.ts` - new `litellmProvider` implementing `InferenceProvider` (follows the Groq provider pattern)
- `src/services/ai/inferenceProviders/index.ts` - registered `litellm` in `PROVIDER_REGISTRY`
- `src/services/ai/providers.ts` - added `litellm` case to AI SDK factory (reuses `createOpenAI` with custom `baseURL`)
- `src/services/ReasoningService.ts` - added `litellm` to cloud provider lists, API key handling, and endpoint resolution
- `src/components/ReasoningModelSelector.tsx` - added to `CLOUD_PROVIDER_IDS`, renders `OpenAICompatiblePanel` with LiteLLM-specific defaults
- `src/components/chat/useChatStreaming.ts` - added `litellm` to cloud provider detection
- `src/stores/settingsStore.ts` - added `litellm` to provider type union

## Tests

**1. TypeScript type check:**
```
$ npx tsc --noEmit --pretty
# No errors
```

**2. Prettier format check:**
```
$ npx prettier --check src/services/ai/inferenceProviders/litellm.ts src/services/ai/inferenceProviders/index.ts src/services/ai/providers.ts
All matched files use Prettier code style!
```

## Implementation details

- The LiteLLM provider delegates to `ctx.callChatCompletionsApi()` (same pattern as Groq) - the shared context handles request formatting, retries, and response parsing.
- Uses `createOpenAI({ apiKey, baseURL })` from `@ai-sdk/openai` in the AI SDK factory since LiteLLM proxy exposes an OpenAI-compatible API.
- The `OpenAICompatiblePanel` renders with `defaultBaseUrl="http://localhost:4000/v1"` for LiteLLM, so users see the correct default proxy URL.
- Model names are free-text (like Custom) since available models depend on the user's LiteLLM proxy configuration. The proxy auto-discovers models via `/v1/models`.

## Risk / Compatibility

- Additive only. Existing providers untouched.
- No new npm dependencies - reuses existing `@ai-sdk/openai` and the shared `callChatCompletionsApi` infrastructure.
- LiteLLM provider reuses the same API key and base URL storage as the Custom provider (via `OpenAICompatiblePanel`).

## Example usage

1. Start a LiteLLM proxy:
```bash
pip install litellm
litellm --model anthropic/claude-sonnet-4-6
```

2. In OpenWhispr Settings > AI Models:
   - Select **LiteLLM** as the provider
   - Base URL: `http://localhost:4000/v1` (default)
   - API Key: your LiteLLM proxy master key (or leave empty for keyless local proxy)
   - Model: `anthropic/claude-sonnet-4-6`
