### PR TITLE
fix: preserve rich clipboard formats on restore

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -621,10 +621,7 @@ class ClipboardManager {
       if (html) data.html = html;
     }
 
-    if (
-      typeof clipboard.readRTF === "function" &&
-      (formats.includes("text/rtf") || formats.includes("public.rtf"))
-    ) {
+    if (formats.includes("text/rtf") || formats.includes("public.rtf")) {
       const rtf = clipboard.readRTF();
       if (rtf) data.rtf = rtf;
     }
@@ -651,9 +648,7 @@ class ClipboardManager {
     if (original.type === "formats") {
       clipboard.write(original.data);
     } else if (original.type === "image") {
-      if (!original.data.isEmpty()) clipboard.writeImage(original.data);
-    } else if (original.type === "html") {
-      clipboard.write({ text: original.text, html: original.html });
+      clipboard.writeImage(original.data);
     } else {
       clipboard.writeText(original.data);
     }

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -611,18 +611,46 @@ class ClipboardManager {
 
   _saveClipboard() {
     const formats = clipboard.availableFormats();
-    if (formats.some((f) => f.startsWith("image/"))) {
-      return { type: "image", data: clipboard.readImage() };
-    } else if (formats.includes("text/html")) {
-      return { type: "html", text: clipboard.readText(), html: clipboard.readHTML() };
-    } else {
-      return { type: "text", data: clipboard.readText() };
+    const data = {};
+
+    const text = clipboard.readText();
+    if (text) data.text = text;
+
+    if (formats.includes("text/html")) {
+      const html = clipboard.readHTML();
+      if (html) data.html = html;
     }
+
+    if (
+      typeof clipboard.readRTF === "function" &&
+      (formats.includes("text/rtf") || formats.includes("public.rtf"))
+    ) {
+      const rtf = clipboard.readRTF();
+      if (rtf) data.rtf = rtf;
+    }
+
+    if (formats.some((f) => f.startsWith("image/"))) {
+      const image = clipboard.readImage();
+      if (image && !image.isEmpty()) data.image = image;
+    }
+
+    const keys = Object.keys(data);
+    if (keys.length === 1 && keys[0] === "image") {
+      return { type: "image", data: data.image };
+    }
+    if (keys.length === 1 && keys[0] === "text") {
+      return { type: "text", data: data.text };
+    }
+    if (keys.length > 0) return { type: "formats", data };
+
+    return { type: "text", data: text };
   }
 
   _restoreClipboard(original) {
     if (!original) return;
-    if (original.type === "image") {
+    if (original.type === "formats") {
+      clipboard.write(original.data);
+    } else if (original.type === "image") {
       if (!original.data.isEmpty()) clipboard.writeImage(original.data);
     } else if (original.type === "html") {
       clipboard.write({ text: original.text, html: original.html });

--- a/test/helpers/clipboardRestore.test.js
+++ b/test/helpers/clipboardRestore.test.js
@@ -5,7 +5,10 @@ const Module = require("node:module");
 const fakeClipboard = {
   text: "",
   html: "",
+  rtf: "",
+  image: null,
   formats: ["text/plain"],
+  writes: [],
   availableFormats() {
     return this.formats;
   },
@@ -14,19 +17,45 @@ const fakeClipboard = {
   },
   writeText(text) {
     this.text = text;
+    this.html = "";
+    this.rtf = "";
+    this.image = null;
+    this.formats = ["text/plain"];
+    this.writes.push(["writeText", text]);
   },
   readHTML() {
     return this.html;
   },
+  readRTF() {
+    return this.rtf;
+  },
   write(payload) {
-    this.text = payload.text;
-    this.html = payload.html;
+    this.text = payload.text || "";
+    this.html = payload.html || "";
+    this.rtf = payload.rtf || "";
+    this.image = payload.image || null;
+    this.formats = [];
+    if (Object.hasOwn(payload, "text")) this.formats.push("text/plain");
+    if (Object.hasOwn(payload, "html")) this.formats.push("text/html");
+    if (Object.hasOwn(payload, "rtf")) this.formats.push("text/rtf");
+    if (Object.hasOwn(payload, "image")) this.formats.push("image/png");
+    this.writes.push(["write", payload]);
   },
   readImage() {
-    return { isEmpty: () => true };
+    return this.image || emptyImage;
   },
-  writeImage() {},
+  writeImage(image) {
+    this.text = "";
+    this.html = "";
+    this.rtf = "";
+    this.image = image;
+    this.formats = image && !image.isEmpty() ? ["image/png"] : [];
+    this.writes.push(["writeImage", image]);
+  },
 };
+
+const emptyImage = { isEmpty: () => true };
+const nonEmptyImage = { isEmpty: () => false };
 
 const originalLoad = Module._load;
 Module._load = function loadWithElectronMock(request, parent, isMain) {
@@ -44,11 +73,47 @@ Module._load = function loadWithElectronMock(request, parent, isMain) {
 const ClipboardManager = require("../../src/helpers/clipboard");
 Module._load = originalLoad;
 
-function resetClipboard() {
-  fakeClipboard.text = "";
-  fakeClipboard.html = "";
-  fakeClipboard.formats = ["text/plain"];
+function resetClipboard({
+  text = "",
+  html = "",
+  rtf = "",
+  image = null,
+  formats = ["text/plain"],
+} = {}) {
+  fakeClipboard.text = text;
+  fakeClipboard.html = html;
+  fakeClipboard.rtf = rtf;
+  fakeClipboard.image = image;
+  fakeClipboard.formats = formats;
+  fakeClipboard.writes = [];
 }
+
+test("restore preserves rich clipboard formats atomically", () => {
+  resetClipboard({
+    formats: ["text/html", "text/rtf", "text/plain", "image/png"],
+    text: "plain before",
+    html: "<b>html before</b>",
+    rtf: "{\\rtf1 before}",
+    image: nonEmptyImage,
+  });
+  const manager = new ClipboardManager();
+
+  const snapshot = manager._saveClipboard();
+  fakeClipboard.writeText("dictated text");
+  manager._restoreClipboard(snapshot);
+
+  assert.deepEqual([...fakeClipboard.availableFormats()].sort(), [
+    "image/png",
+    "text/html",
+    "text/plain",
+    "text/rtf",
+  ]);
+  assert.equal(fakeClipboard.text, "plain before");
+  assert.equal(fakeClipboard.html, "<b>html before</b>");
+  assert.equal(fakeClipboard.rtf, "{\\rtf1 before}");
+  assert.equal(fakeClipboard.image, nonEmptyImage);
+  assert.equal(fakeClipboard.writes.at(-1)[0], "write");
+});
 
 test("restore runs when clipboard still contains the pasted text", async () => {
   resetClipboard();


### PR DESCRIPTION
## Summary
- Preserve rich clipboard representations together when restoring the pre-dictation clipboard.
- Snapshot Electron-supported text, HTML, RTF, and image data and restore multi-format payloads with `clipboard.write(...)`.
- Add focused regression coverage for image + HTML + RTF + plain text restoration.

Fixes #834

## Verification
- `mise x node@24.15.0 -- node --test test/helpers/clipboardRestore.test.js` -> 4 pass, 0 fail
- `mise x node@24.15.0 -- npm run lint` -> passed; emitted an existing module-type warning from `src/eslint.config.js`
- `mise x node@24.15.0 -- npm run typecheck` -> passed
- `git diff --check upstream/main...HEAD` -> clean

## Caveats
- `npm run quality-check` was not used as the PR proof because it reports unrelated pre-existing Prettier warnings in untouched helper files.
- I did not run a full desktop dictation smoke test; this change is covered by the focused clipboard restore regression test.
