### PR TITLE
fix(clipboard): use main-process write for clipboard-only mode

### DIFF
--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -160,7 +160,12 @@ export const useAudioRecording = (toast, options = {}) => {
               "streaming"
             );
           } else if (keepTranscriptionInClipboard) {
-            await navigator.clipboard.writeText(result.text);
+            // Route through the main process (write-clipboard IPC) rather than the
+            // renderer Clipboard API: navigator.clipboard.writeText requires the
+            // window to be focused, which it isn't during dictation, so on native
+            // Wayland (e.g. Sway) the write is silently rejected. The main-process
+            // path uses wl-copy and works regardless of focus.
+            await window.electronAPI?.writeClipboard?.(result.text);
           }
 
           audioManagerRef.current.saveTranscription(result.text, result.rawText ?? result.text, {


### PR DESCRIPTION
When auto-paste is disabled, the transcription was written via the renderer's navigator.clipboard.writeText. The async Clipboard API requires the document to be focused, but the OpenWhispr window isn't focused during dictation, so in Wayland (e.g. Sway) the write is silently rejected and the clipboard ends up empty.

Route through the existing write-clipboard IPC instead, which uses wl-copy in the main process and works regardless of which window is focused. Harmless on X11/macOS/Windows, where it falls back to Electron's clipboard.writeText.

Note: I only tested on Linux/NixOS on Sway but this works