### PR TITLE
Add com.openwhispr.App D-Bus endpoint for global shortcuts on Linux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,14 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - Converts Electron hotkey format to Hyprland bind format (`MODS, key`)
   - Only active on Linux + Wayland + Hyprland (detected via `HYPRLAND_INSTANCE_SIGNATURE`)
   - D-Bus transport: `@homebridge/dbus-native` (pure JavaScript, no native addons)
+- **dbusToggleService.js**: Compositor-agnostic owner of the `com.openwhispr.App`
+  session-bus service and its no-arg methods (`Toggle`, `ToggleAgent`,
+  `ToggleMeeting`, `ToggleVoiceAgent`). Started once per Linux session by
+  `hotkeyManager.ensureDbusEndpoint()`; `gnomeShortcut.js`/`hyprlandShortcut.js`
+  are keybinding registrars that `dbus-send` to it. Single source of truth for the
+  D-Bus interface — no gsettings/compositor logic. D-Bus transport:
+  `@homebridge/dbus-native`. Claims the name with `DO_NOT_QUEUE`; if another owner
+  holds it, logs and returns failure so callers fall through to normal detection.
 - **kdeShortcut.js**: KDE Wayland global shortcut integration
   - Uses D-Bus to communicate with KGlobalAccel for global hotkey registration
   - Registers hotkeys via `setShortcut`/`doRegister` D-Bus calls on the KGlobalAccel interface
@@ -496,7 +504,7 @@ On GNOME Wayland, Electron's `globalShortcut` API doesn't work due to Wayland's 
 
 1. `main.js` enables `GlobalShortcutsPortal` feature flag for Wayland
 2. `hotkeyManager.js` detects GNOME + Wayland and initializes `GnomeShortcutManager`
-3. `gnomeShortcut.js` creates D-Bus service at `com.openwhispr.App`
+3. `gnomeShortcut.js` registers gsettings keybindings that `dbus-send` to the shared `com.openwhispr.App` endpoint (owned by `dbusToggleService.js`)
 4. Shortcuts registered via `gsettings` as custom GNOME keybindings
 5. GNOME triggers `dbus-send` command which calls the D-Bus `Toggle()` method
 
@@ -526,7 +534,7 @@ On Hyprland (wlroots Wayland compositor), Electron's `globalShortcut` API and th
 
 1. `main.js` enables `GlobalShortcutsPortal` feature flag for Wayland (fallback)
 2. `hotkeyManager.js` detects Hyprland + Wayland and initializes `HyprlandShortcutManager`
-3. `hyprlandShortcut.js` creates D-Bus service at `com.openwhispr.App` (same as GNOME)
+3. `hyprlandShortcut.js` registers `hyprctl` binds that `dbus-send` to the shared `com.openwhispr.App` endpoint (owned by `dbusToggleService.js`, same as GNOME)
 4. Shortcuts registered via `hyprctl keyword bind` (runtime keybinding)
 5. Hyprland triggers `dbus-send` command which calls the D-Bus `Toggle()` method
 
@@ -551,6 +559,47 @@ On Hyprland (wlroots Wayland compositor), Electron's `globalShortcut` API and th
 
 - Push-to-talk not supported (Hyprland `bind` fires a single exec, not key-down/key-up)
 - Requires `hyprctl` on PATH (ships with Hyprland)
+
+### 15a. D-Bus endpoint (`com.openwhispr.App`) — universal on Linux
+
+The `com.openwhispr.App` D-Bus service is **desktop-agnostic** and started **once on
+every Linux session** (X11 + all Wayland compositors) by
+`hotkeyManager.ensureDbusEndpoint()`, so `dbus-send` binds work everywhere. It's
+owned by a single shared `DBusToggleService` (`src/helpers/dbusToggleService.js`),
+transport `@homebridge/dbus-native`.
+
+The bus is _just the endpoint_ — it does not decide the shortcut mechanism. Each
+desktop layers its own keybinding auto-registration on top, all routing through
+this same service:
+
+| Desktop                  | Auto-registration                                                 | Uses the bus?                            |
+| ------------------------ | ----------------------------------------------------------------- | ---------------------------------------- |
+| GNOME                    | gsettings custom-keybinding whose command is `dbus-send …Toggle*` | yes                                      |
+| Hyprland                 | `hyprctl keyword bind … dbus-send`                                | yes                                      |
+| wlroots (Sway/river/dwl) | none — user binds keys manually to `dbus-send`                    | yes (only mechanism)                     |
+| KDE                      | KGlobalAccel (native `org.kde.kglobalaccel`)                      | no (bus also available for manual binds) |
+| X11 / other              | Electron `globalShortcut`                                         | no (bus also available for manual binds) |
+
+**Behavior**:
+
+1. `initializeHotkey()` calls `ensureDbusEndpoint()` first on any Linux session,
+   bringing up the shared service (wired with the dictation callback).
+2. `GnomeShortcutManager` / `HyprlandShortcutManager` are keybinding registrars
+   only (gsettings / hyprctl); they no longer own a bus and require the shared
+   endpoint to be up.
+3. `main.js` calls `hotkeyManager.setDbusToggleCallbacks()` to wire
+   agent/voiceAgent/meeting to the shared endpoint whenever it exists.
+   `registerSlot()` additively wires secondary-slot callbacks before the
+   DE-specific registration.
+4. `useDbus` means the endpoint is the **primary** mechanism (wlroots only, via
+   `shouldAutoUseDbus()`) — it is **not** set merely because the endpoint is up,
+   otherwise `isUsingNativeShortcut()` would force tap-to-talk on X11 and break
+   push-to-talk. `isUsingNativeShortcut()` = `useGnome||useHyprland||useKDE||useDbus`.
+
+**Name ownership**: `requestName` is called with `DO_NOT_QUEUE`. Any reply other
+than `PRIMARY_OWNER`/`ALREADY_OWNER` (e.g. another instance holds it) is treated as
+failure — it logs and returns false so callers fall through to normal detection
+(the single-instance lock in `main.js` makes this unreachable in a normal install).
 
 ### 16. Meeting Detection (Event-Driven)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,6 +596,28 @@ this same service:
    otherwise `isUsingNativeShortcut()` would force tap-to-talk on X11 and break
    push-to-talk. `isUsingNativeShortcut()` = `useGnome||useHyprland||useKDE||useDbus`.
 
+**D-Bus methods** (service `com.openwhispr.App`, path `/com/openwhispr/App`,
+interface `com.openwhispr.App`):
+
+- Momentary (tap-to-toggle): `Toggle` (dictation), `ToggleAgent`, `ToggleMeeting`,
+  `ToggleVoiceAgent`.
+- Push-to-talk pair: `StartDictation` (key press) / `StopDictation` (key release),
+  wired in `main.js` to `windowManager.startWindowsPushToTalk()` /
+  `handleWindowsPushKeyUp()` — the same primitives the native key listener uses.
+
+Push-to-talk needs a compositor that can bind key release (Sway `bindsym
+--release`, Hyprland `bindr`); GNOME/KDE native shortcuts are press-only.
+
+Example Sway bindings:
+
+```
+# Tap-to-toggle dictation
+bindsym Super+r exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.Toggle
+# Push-to-talk: hold to talk, release to stop
+bindsym Super+grave           exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.StartDictation
+bindsym --release Super+grave exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.StopDictation
+```
+
 **Name ownership**: `requestName` is called with `DO_NOT_QUEUE`. Any reply other
 than `PRIMARY_OWNER`/`ALREADY_OWNER` (e.g. another instance holds it) is treated as
 failure — it logs and returns false so callers fall through to normal detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,14 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - Converts Electron hotkey format to Hyprland bind format (`MODS, key`)
   - Only active on Linux + Wayland + Hyprland (detected via `HYPRLAND_INSTANCE_SIGNATURE`)
   - D-Bus transport: `@homebridge/dbus-native` (pure JavaScript, no native addons)
+- **dbusToggleService.js**: Compositor-agnostic owner of the `com.openwhispr.App`
+  session-bus service and its no-arg methods (`Toggle`, `ToggleAgent`,
+  `ToggleMeeting`, `ToggleVoiceAgent`). Started once per Linux session by
+  `hotkeyManager.ensureDbusEndpoint()`; `gnomeShortcut.js`/`hyprlandShortcut.js`
+  are keybinding registrars that `dbus-send` to it. Single source of truth for the
+  D-Bus interface — no gsettings/compositor logic. D-Bus transport:
+  `@homebridge/dbus-native`. Claims the name with `DO_NOT_QUEUE`; if another owner
+  holds it, logs and returns failure so callers fall through to normal detection.
 - **kdeShortcut.js**: KDE Wayland global shortcut integration
   - Uses D-Bus to communicate with KGlobalAccel for global hotkey registration
   - Registers hotkeys via `setShortcut`/`doRegister` D-Bus calls on the KGlobalAccel interface
@@ -482,7 +490,7 @@ On GNOME Wayland, Electron's `globalShortcut` API doesn't work due to Wayland's 
 
 1. `main.js` enables `GlobalShortcutsPortal` feature flag for Wayland
 2. `hotkeyManager.js` detects GNOME + Wayland and initializes `GnomeShortcutManager`
-3. `gnomeShortcut.js` creates D-Bus service at `com.openwhispr.App`
+3. `gnomeShortcut.js` registers gsettings keybindings that `dbus-send` to the shared `com.openwhispr.App` endpoint (owned by `dbusToggleService.js`)
 4. Shortcuts registered via `gsettings` as custom GNOME keybindings
 5. GNOME triggers `dbus-send` command which calls the D-Bus `Toggle()` method
 
@@ -512,7 +520,7 @@ On Hyprland (wlroots Wayland compositor), Electron's `globalShortcut` API and th
 
 1. `main.js` enables `GlobalShortcutsPortal` feature flag for Wayland (fallback)
 2. `hotkeyManager.js` detects Hyprland + Wayland and initializes `HyprlandShortcutManager`
-3. `hyprlandShortcut.js` creates D-Bus service at `com.openwhispr.App` (same as GNOME)
+3. `hyprlandShortcut.js` registers `hyprctl` binds that `dbus-send` to the shared `com.openwhispr.App` endpoint (owned by `dbusToggleService.js`, same as GNOME)
 4. Shortcuts registered via `hyprctl keyword bind` (runtime keybinding)
 5. Hyprland triggers `dbus-send` command which calls the D-Bus `Toggle()` method
 
@@ -537,6 +545,47 @@ On Hyprland (wlroots Wayland compositor), Electron's `globalShortcut` API and th
 
 - Push-to-talk not supported (Hyprland `bind` fires a single exec, not key-down/key-up)
 - Requires `hyprctl` on PATH (ships with Hyprland)
+
+### 15a. D-Bus endpoint (`com.openwhispr.App`) — universal on Linux
+
+The `com.openwhispr.App` D-Bus service is **desktop-agnostic** and started **once on
+every Linux session** (X11 + all Wayland compositors) by
+`hotkeyManager.ensureDbusEndpoint()`, so `dbus-send` binds work everywhere. It's
+owned by a single shared `DBusToggleService` (`src/helpers/dbusToggleService.js`),
+transport `@homebridge/dbus-native`.
+
+The bus is _just the endpoint_ — it does not decide the shortcut mechanism. Each
+desktop layers its own keybinding auto-registration on top, all routing through
+this same service:
+
+| Desktop                  | Auto-registration                                                 | Uses the bus?                            |
+| ------------------------ | ----------------------------------------------------------------- | ---------------------------------------- |
+| GNOME                    | gsettings custom-keybinding whose command is `dbus-send …Toggle*` | yes                                      |
+| Hyprland                 | `hyprctl keyword bind … dbus-send`                                | yes                                      |
+| wlroots (Sway/river/dwl) | none — user binds keys manually to `dbus-send`                    | yes (only mechanism)                     |
+| KDE                      | KGlobalAccel (native `org.kde.kglobalaccel`)                      | no (bus also available for manual binds) |
+| X11 / other              | Electron `globalShortcut`                                         | no (bus also available for manual binds) |
+
+**Behavior**:
+
+1. `initializeHotkey()` calls `ensureDbusEndpoint()` first on any Linux session,
+   bringing up the shared service (wired with the dictation callback).
+2. `GnomeShortcutManager` / `HyprlandShortcutManager` are keybinding registrars
+   only (gsettings / hyprctl); they no longer own a bus and require the shared
+   endpoint to be up.
+3. `main.js` calls `hotkeyManager.setDbusToggleCallbacks()` to wire
+   agent/voiceAgent/meeting to the shared endpoint whenever it exists.
+   `registerSlot()` additively wires secondary-slot callbacks before the
+   DE-specific registration.
+4. `useDbus` means the endpoint is the **primary** mechanism (wlroots only, via
+   `shouldAutoUseDbus()`) — it is **not** set merely because the endpoint is up,
+   otherwise `isUsingNativeShortcut()` would force tap-to-talk on X11 and break
+   push-to-talk. `isUsingNativeShortcut()` = `useGnome||useHyprland||useKDE||useDbus`.
+
+**Name ownership**: `requestName` is called with `DO_NOT_QUEUE`. Any reply other
+than `PRIMARY_OWNER`/`ALREADY_OWNER` (e.g. another instance holds it) is treated as
+failure — it logs and returns false so callers fall through to normal detection
+(the single-instance lock in `main.js` makes this unreachable in a normal install).
 
 ### 16. Meeting Detection (Event-Driven)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,6 +582,28 @@ this same service:
    otherwise `isUsingNativeShortcut()` would force tap-to-talk on X11 and break
    push-to-talk. `isUsingNativeShortcut()` = `useGnome||useHyprland||useKDE||useDbus`.
 
+**D-Bus methods** (service `com.openwhispr.App`, path `/com/openwhispr/App`,
+interface `com.openwhispr.App`):
+
+- Momentary (tap-to-toggle): `Toggle` (dictation), `ToggleAgent`, `ToggleMeeting`,
+  `ToggleVoiceAgent`.
+- Push-to-talk pair: `StartDictation` (key press) / `StopDictation` (key release),
+  wired in `main.js` to `windowManager.startWindowsPushToTalk()` /
+  `handleWindowsPushKeyUp()` — the same primitives the native key listener uses.
+
+Push-to-talk needs a compositor that can bind key release (Sway `bindsym
+--release`, Hyprland `bindr`); GNOME/KDE native shortcuts are press-only.
+
+Example Sway bindings:
+
+```
+# Tap-to-toggle dictation
+bindsym Super+r exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.Toggle
+# Push-to-talk: hold to talk, release to stop
+bindsym Super+grave           exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.StartDictation
+bindsym --release Super+grave exec dbus-send --session --type=method_call --dest=com.openwhispr.App /com/openwhispr/App com.openwhispr.App.StopDictation
+```
+
 **Name ownership**: `requestName` is called with `DO_NOT_QUEUE`. Any reply other
 than `PRIMARY_OWNER`/`ALREADY_OWNER` (e.g. another instance holds it) is treated as
 failure — it logs and returns false so callers fall through to normal detection

--- a/main.js
+++ b/main.js
@@ -933,6 +933,16 @@ async function startApp() {
     meetingDetectionEngine?.startManualMeeting();
   };
 
+  // When the shared D-Bus endpoint is active, ensure every method (ToggleAgent/
+  // ToggleVoiceAgent/ToggleMeeting/ToggleTranslation) is live even if the user
+  // configured no in-app hotkey for them. No-op when the D-Bus endpoint isn't in use.
+  hotkeyManager.setDbusToggleCallbacks({
+    agent: agentHotkeyCallback,
+    voiceAgent: voiceAgentHotkeyCallback,
+    meeting: meetingHotkeyCallback,
+    translation: translationHotkeyCallback,
+  });
+
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";
   if (savedMeetingKey) {
     const result = await hotkeyManager.registerSlot(

--- a/main.js
+++ b/main.js
@@ -933,14 +933,31 @@ async function startApp() {
     meetingDetectionEngine?.startManualMeeting();
   };
 
+  // Push-to-talk over D-Bus: StartDictation on key press, StopDictation on key
+  // release (bind both in the compositor, e.g. Sway `bindsym` + `bindsym
+  // --release`). Reuses the native-listener PTT primitives, which show the panel,
+  // start after a short hold, and stop/hide on release; capture the target PID on
+  // start so paste can refocus.
+  const startDictationCallback = () => {
+    if (hotkeyManager.isInListeningMode()) return;
+    if (textEditMonitor) textEditMonitor.captureTargetPid();
+    windowManager.startWindowsPushToTalk();
+  };
+  const stopDictationCallback = () => {
+    windowManager.handleWindowsPushKeyUp();
+  };
+
   // When the shared D-Bus endpoint is active, ensure every method (ToggleAgent/
-  // ToggleVoiceAgent/ToggleMeeting/ToggleTranslation) is live even if the user
-  // configured no in-app hotkey for them. No-op when the D-Bus endpoint isn't in use.
+  // ToggleVoiceAgent/ToggleMeeting/ToggleTranslation + the StartDictation/StopDictation
+  // PTT pair) is live even if the user configured no in-app hotkey for them. No-op when
+  // the D-Bus endpoint isn't in use.
   hotkeyManager.setDbusToggleCallbacks({
     agent: agentHotkeyCallback,
     voiceAgent: voiceAgentHotkeyCallback,
     meeting: meetingHotkeyCallback,
     translation: translationHotkeyCallback,
+    startDictation: startDictationCallback,
+    stopDictation: stopDictationCallback,
   });
 
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";

--- a/main.js
+++ b/main.js
@@ -898,13 +898,30 @@ async function startApp() {
     meetingDetectionEngine?.startManualMeeting();
   };
 
+  // Push-to-talk over D-Bus: StartDictation on key press, StopDictation on key
+  // release (bind both in the compositor, e.g. Sway `bindsym` + `bindsym
+  // --release`). Reuses the native-listener PTT primitives, which show the panel,
+  // start after a short hold, and stop/hide on release; capture the target PID on
+  // start so paste can refocus.
+  const startDictationCallback = () => {
+    if (hotkeyManager.isInListeningMode()) return;
+    if (textEditMonitor) textEditMonitor.captureTargetPid();
+    windowManager.startWindowsPushToTalk();
+  };
+  const stopDictationCallback = () => {
+    windowManager.handleWindowsPushKeyUp();
+  };
+
   // When the shared D-Bus endpoint is active, ensure every method (ToggleAgent/
-  // ToggleVoiceAgent/ToggleMeeting) is live even if the user configured no in-app
-  // hotkey for them. No-op when the D-Bus endpoint isn't in use.
+  // ToggleVoiceAgent/ToggleMeeting + the StartDictation/StopDictation PTT pair) is
+  // live even if the user configured no in-app hotkey for them. No-op when the
+  // D-Bus endpoint isn't in use.
   hotkeyManager.setDbusToggleCallbacks({
     agent: agentHotkeyCallback,
     voiceAgent: voiceAgentHotkeyCallback,
     meeting: meetingHotkeyCallback,
+    startDictation: startDictationCallback,
+    stopDictation: stopDictationCallback,
   });
 
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";

--- a/main.js
+++ b/main.js
@@ -898,6 +898,15 @@ async function startApp() {
     meetingDetectionEngine?.startManualMeeting();
   };
 
+  // When the shared D-Bus endpoint is active, ensure every method (ToggleAgent/
+  // ToggleVoiceAgent/ToggleMeeting) is live even if the user configured no in-app
+  // hotkey for them. No-op when the D-Bus endpoint isn't in use.
+  hotkeyManager.setDbusToggleCallbacks({
+    agent: agentHotkeyCallback,
+    voiceAgent: voiceAgentHotkeyCallback,
+    meeting: meetingHotkeyCallback,
+  });
+
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";
   if (savedMeetingKey) {
     const result = await hotkeyManager.registerSlot(

--- a/src/helpers/dbusToggleService.js
+++ b/src/helpers/dbusToggleService.js
@@ -1,0 +1,167 @@
+const debugLogger = require("./debugLogger");
+
+const DBUS_SERVICE_NAME = "com.openwhispr.App";
+const DBUS_OBJECT_PATH = "/com/openwhispr/App";
+const DBUS_INTERFACE = "com.openwhispr.App";
+
+// @homebridge/dbus-native is a lower-level binding than dbus-next and does not
+// export named enums, so use the numeric RequestName flags/replies from the
+// D-Bus spec directly.
+// https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-request-name
+const DBUS_NAME_FLAG_DO_NOT_QUEUE = 0x4;
+const DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER = 1;
+const DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER = 4;
+
+let dbus = null;
+
+function getDBus() {
+  if (dbus) return dbus;
+  try {
+    dbus = require("@homebridge/dbus-native");
+    return dbus;
+  } catch (err) {
+    debugLogger.log("[DBusToggleService] Failed to load dbus-native:", err.message);
+    return null;
+  }
+}
+
+// Owns the com.openwhispr.App session-bus service and its no-arg methods.
+// Toggle/ToggleAgent/ToggleMeeting/ToggleVoiceAgent/ToggleTranslation are momentary
+// (tap-to-toggle) for compositors that only fire on key press.
+// Compositor-agnostic: the GNOME integration and the auto-enabled endpoint on
+// wlroots Wayland (e.g. Sway) both route key events to these via dbus-send.
+// Callbacks may be supplied up front to start() or attached later via the setters;
+// the exported methods read them live, so a setter takes effect immediately.
+class DBusToggleService {
+  constructor() {
+    this.bus = null;
+    this._callbacks = {
+      dictation: null,
+      agent: null,
+      meeting: null,
+      voiceAgent: null,
+      translation: null,
+    };
+  }
+
+  async start(callbacks = {}) {
+    const dbusModule = getDBus();
+    if (!dbusModule) {
+      return false;
+    }
+
+    Object.assign(this._callbacks, callbacks);
+
+    try {
+      this.bus = dbusModule.sessionBus();
+      // Without a listener, async socket errors (e.g. a stale
+      // DBUS_SESSION_BUS_ADDRESS) crash the process as an unhandled "error"
+      // event — sessionBus() returns before connecting.
+      this.bus.connection.on("error", (err) => {
+        debugLogger.log("[DBusToggleService] D-Bus connection error:", err.message);
+      });
+
+      // DO_NOT_QUEUE so a losing request fails fast instead of silently sitting
+      // in the queue and reporting success. Anything other than becoming (or
+      // already being) the primary owner means another instance holds the name.
+      const reply = await this._requestName();
+      if (
+        reply !== DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER &&
+        reply !== DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER
+      ) {
+        debugLogger.log(
+          `[DBusToggleService] Could not claim ${DBUS_SERVICE_NAME} (reply ${reply}); falling back to normal detection`
+        );
+        this.close();
+        return false;
+      }
+
+      this.bus.exportInterface(this._buildImpl(), DBUS_OBJECT_PATH, this._interfaceDesc());
+
+      debugLogger.log("[DBusToggleService] D-Bus service initialized successfully");
+      return true;
+    } catch (err) {
+      debugLogger.log("[DBusToggleService] Failed to initialize D-Bus service:", err.message);
+      this.close();
+      return false;
+    }
+  }
+
+  _requestName() {
+    return new Promise((resolve, reject) => {
+      this.bus.requestName(DBUS_SERVICE_NAME, DBUS_NAME_FLAG_DO_NOT_QUEUE, (err, retCode) => {
+        if (err) reject(err);
+        else resolve(retCode);
+      });
+    });
+  }
+
+  _buildImpl() {
+    return {
+      Toggle: () => {
+        if (this._callbacks.dictation) this._callbacks.dictation();
+      },
+      ToggleAgent: () => {
+        if (this._callbacks.agent) this._callbacks.agent();
+      },
+      ToggleMeeting: () => {
+        if (this._callbacks.meeting) this._callbacks.meeting();
+      },
+      ToggleVoiceAgent: () => {
+        if (this._callbacks.voiceAgent) this._callbacks.voiceAgent();
+      },
+      ToggleTranslation: () => {
+        if (this._callbacks.translation) this._callbacks.translation();
+      },
+    };
+  }
+
+  _interfaceDesc() {
+    return {
+      name: DBUS_INTERFACE,
+      methods: {
+        Toggle: ["", ""],
+        ToggleAgent: ["", ""],
+        ToggleMeeting: ["", ""],
+        ToggleVoiceAgent: ["", ""],
+        ToggleTranslation: ["", ""],
+      },
+    };
+  }
+
+  setDictationCallback(callback) {
+    this._callbacks.dictation = callback || null;
+  }
+
+  setAgentCallback(callback) {
+    this._callbacks.agent = callback || null;
+  }
+
+  setMeetingCallback(callback) {
+    this._callbacks.meeting = callback || null;
+  }
+
+  setVoiceAgentCallback(callback) {
+    this._callbacks.voiceAgent = callback || null;
+  }
+
+  setTranslationCallback(callback) {
+    this._callbacks.translation = callback || null;
+  }
+
+  close() {
+    if (this.bus) {
+      try {
+        this.bus.connection.end();
+      } catch {
+        // Connection already gone.
+      }
+      this.bus = null;
+    }
+  }
+}
+
+module.exports = DBusToggleService;
+module.exports.DBUS_SERVICE_NAME = DBUS_SERVICE_NAME;
+module.exports.DBUS_OBJECT_PATH = DBUS_OBJECT_PATH;
+module.exports.DBUS_INTERFACE = DBUS_INTERFACE;

--- a/src/helpers/dbusToggleService.js
+++ b/src/helpers/dbusToggleService.js
@@ -27,7 +27,9 @@ function getDBus() {
 
 // Owns the com.openwhispr.App session-bus service and its no-arg methods.
 // Toggle/ToggleAgent/ToggleMeeting/ToggleVoiceAgent/ToggleTranslation are momentary
-// (tap-to-toggle) for compositors that only fire on key press.
+// (tap-to-toggle) for compositors that only fire on key press. StartDictation/StopDictation
+// are a press/release pair for push-to-talk: bind key-press → StartDictation and
+// key-release → StopDictation (e.g. Sway `bindsym` + `bindsym --release`).
 // Compositor-agnostic: the GNOME integration and the auto-enabled endpoint on
 // wlroots Wayland (e.g. Sway) both route key events to these via dbus-send.
 // Callbacks may be supplied up front to start() or attached later via the setters;
@@ -41,6 +43,8 @@ class DBusToggleService {
       meeting: null,
       voiceAgent: null,
       translation: null,
+      startDictation: null,
+      stopDictation: null,
     };
   }
 
@@ -113,6 +117,13 @@ class DBusToggleService {
       ToggleTranslation: () => {
         if (this._callbacks.translation) this._callbacks.translation();
       },
+      // Push-to-talk: bind key-press → StartDictation, key-release → StopDictation.
+      StartDictation: () => {
+        if (this._callbacks.startDictation) this._callbacks.startDictation();
+      },
+      StopDictation: () => {
+        if (this._callbacks.stopDictation) this._callbacks.stopDictation();
+      },
     };
   }
 
@@ -125,6 +136,8 @@ class DBusToggleService {
         ToggleMeeting: ["", ""],
         ToggleVoiceAgent: ["", ""],
         ToggleTranslation: ["", ""],
+        StartDictation: ["", ""],
+        StopDictation: ["", ""],
       },
     };
   }
@@ -147,6 +160,14 @@ class DBusToggleService {
 
   setTranslationCallback(callback) {
     this._callbacks.translation = callback || null;
+  }
+
+  setStartDictationCallback(callback) {
+    this._callbacks.startDictation = callback || null;
+  }
+
+  setStopDictationCallback(callback) {
+    this._callbacks.stopDictation = callback || null;
   }
 
   close() {

--- a/src/helpers/dbusToggleService.js
+++ b/src/helpers/dbusToggleService.js
@@ -1,0 +1,158 @@
+const debugLogger = require("./debugLogger");
+
+const DBUS_SERVICE_NAME = "com.openwhispr.App";
+const DBUS_OBJECT_PATH = "/com/openwhispr/App";
+const DBUS_INTERFACE = "com.openwhispr.App";
+
+// @homebridge/dbus-native is a lower-level binding than dbus-next and does not
+// export named enums, so use the numeric RequestName flags/replies from the
+// D-Bus spec directly.
+// https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-request-name
+const DBUS_NAME_FLAG_DO_NOT_QUEUE = 0x4;
+const DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER = 1;
+const DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER = 4;
+
+let dbus = null;
+
+function getDBus() {
+  if (dbus) return dbus;
+  try {
+    dbus = require("@homebridge/dbus-native");
+    return dbus;
+  } catch (err) {
+    debugLogger.log("[DBusToggleService] Failed to load dbus-native:", err.message);
+    return null;
+  }
+}
+
+// Owns the com.openwhispr.App session-bus service and its no-arg methods.
+// Toggle/ToggleAgent/ToggleMeeting/ToggleVoiceAgent are momentary (tap-to-toggle)
+// for compositors that only fire on key press.
+// Compositor-agnostic: the GNOME integration and the auto-enabled endpoint on
+// wlroots Wayland (e.g. Sway) both route key events to these via dbus-send.
+// Callbacks may be supplied up front to start() or attached later via the setters;
+// the exported methods read them live, so a setter takes effect immediately.
+class DBusToggleService {
+  constructor() {
+    this.bus = null;
+    this._callbacks = {
+      dictation: null,
+      agent: null,
+      meeting: null,
+      voiceAgent: null,
+    };
+  }
+
+  async start(callbacks = {}) {
+    const dbusModule = getDBus();
+    if (!dbusModule) {
+      return false;
+    }
+
+    Object.assign(this._callbacks, callbacks);
+
+    try {
+      this.bus = dbusModule.sessionBus();
+      // Without a listener, async socket errors (e.g. a stale
+      // DBUS_SESSION_BUS_ADDRESS) crash the process as an unhandled "error"
+      // event — sessionBus() returns before connecting.
+      this.bus.connection.on("error", (err) => {
+        debugLogger.log("[DBusToggleService] D-Bus connection error:", err.message);
+      });
+
+      // DO_NOT_QUEUE so a losing request fails fast instead of silently sitting
+      // in the queue and reporting success. Anything other than becoming (or
+      // already being) the primary owner means another instance holds the name.
+      const reply = await this._requestName();
+      if (
+        reply !== DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER &&
+        reply !== DBUS_REQUEST_NAME_REPLY_ALREADY_OWNER
+      ) {
+        debugLogger.log(
+          `[DBusToggleService] Could not claim ${DBUS_SERVICE_NAME} (reply ${reply}); falling back to normal detection`
+        );
+        this.close();
+        return false;
+      }
+
+      this.bus.exportInterface(this._buildImpl(), DBUS_OBJECT_PATH, this._interfaceDesc());
+
+      debugLogger.log("[DBusToggleService] D-Bus service initialized successfully");
+      return true;
+    } catch (err) {
+      debugLogger.log("[DBusToggleService] Failed to initialize D-Bus service:", err.message);
+      this.close();
+      return false;
+    }
+  }
+
+  _requestName() {
+    return new Promise((resolve, reject) => {
+      this.bus.requestName(DBUS_SERVICE_NAME, DBUS_NAME_FLAG_DO_NOT_QUEUE, (err, retCode) => {
+        if (err) reject(err);
+        else resolve(retCode);
+      });
+    });
+  }
+
+  _buildImpl() {
+    return {
+      Toggle: () => {
+        if (this._callbacks.dictation) this._callbacks.dictation();
+      },
+      ToggleAgent: () => {
+        if (this._callbacks.agent) this._callbacks.agent();
+      },
+      ToggleMeeting: () => {
+        if (this._callbacks.meeting) this._callbacks.meeting();
+      },
+      ToggleVoiceAgent: () => {
+        if (this._callbacks.voiceAgent) this._callbacks.voiceAgent();
+      },
+    };
+  }
+
+  _interfaceDesc() {
+    return {
+      name: DBUS_INTERFACE,
+      methods: {
+        Toggle: ["", ""],
+        ToggleAgent: ["", ""],
+        ToggleMeeting: ["", ""],
+        ToggleVoiceAgent: ["", ""],
+      },
+    };
+  }
+
+  setDictationCallback(callback) {
+    this._callbacks.dictation = callback || null;
+  }
+
+  setAgentCallback(callback) {
+    this._callbacks.agent = callback || null;
+  }
+
+  setMeetingCallback(callback) {
+    this._callbacks.meeting = callback || null;
+  }
+
+  setVoiceAgentCallback(callback) {
+    this._callbacks.voiceAgent = callback || null;
+  }
+
+  close() {
+    if (this.bus) {
+      try {
+        this.bus.connection.end();
+      } catch {
+        // Connection already gone.
+      }
+      this.bus = null;
+    }
+  }
+}
+
+module.exports = DBusToggleService;
+module.exports.DBUS_SERVICE_NAME = DBUS_SERVICE_NAME;
+module.exports.DBUS_OBJECT_PATH = DBUS_OBJECT_PATH;
+module.exports.DBUS_INTERFACE = DBUS_INTERFACE;

--- a/src/helpers/dbusToggleService.js
+++ b/src/helpers/dbusToggleService.js
@@ -27,7 +27,9 @@ function getDBus() {
 
 // Owns the com.openwhispr.App session-bus service and its no-arg methods.
 // Toggle/ToggleAgent/ToggleMeeting/ToggleVoiceAgent are momentary (tap-to-toggle)
-// for compositors that only fire on key press.
+// for compositors that only fire on key press. StartDictation/StopDictation are a
+// press/release pair for push-to-talk: bind key-press → StartDictation and
+// key-release → StopDictation (e.g. Sway `bindsym` + `bindsym --release`).
 // Compositor-agnostic: the GNOME integration and the auto-enabled endpoint on
 // wlroots Wayland (e.g. Sway) both route key events to these via dbus-send.
 // Callbacks may be supplied up front to start() or attached later via the setters;
@@ -40,6 +42,8 @@ class DBusToggleService {
       agent: null,
       meeting: null,
       voiceAgent: null,
+      startDictation: null,
+      stopDictation: null,
     };
   }
 
@@ -109,6 +113,13 @@ class DBusToggleService {
       ToggleVoiceAgent: () => {
         if (this._callbacks.voiceAgent) this._callbacks.voiceAgent();
       },
+      // Push-to-talk: bind key-press → StartDictation, key-release → StopDictation.
+      StartDictation: () => {
+        if (this._callbacks.startDictation) this._callbacks.startDictation();
+      },
+      StopDictation: () => {
+        if (this._callbacks.stopDictation) this._callbacks.stopDictation();
+      },
     };
   }
 
@@ -120,6 +131,8 @@ class DBusToggleService {
         ToggleAgent: ["", ""],
         ToggleMeeting: ["", ""],
         ToggleVoiceAgent: ["", ""],
+        StartDictation: ["", ""],
+        StopDictation: ["", ""],
       },
     };
   }
@@ -138,6 +151,14 @@ class DBusToggleService {
 
   setVoiceAgentCallback(callback) {
     this._callbacks.voiceAgent = callback || null;
+  }
+
+  setStartDictationCallback(callback) {
+    this._callbacks.startDictation = callback || null;
+  }
+
+  setStopDictationCallback(callback) {
+    this._callbacks.stopDictation = callback || null;
   }
 
   close() {

--- a/src/helpers/gnomeShortcut.js
+++ b/src/helpers/gnomeShortcut.js
@@ -1,9 +1,8 @@
 const { execFileSync } = require("child_process");
 const debugLogger = require("./debugLogger");
+const DBusToggleService = require("./dbusToggleService");
 
-const DBUS_SERVICE_NAME = "com.openwhispr.App";
-const DBUS_OBJECT_PATH = "/com/openwhispr/App";
-const DBUS_INTERFACE = "com.openwhispr.App";
+const { DBUS_SERVICE_NAME, DBUS_OBJECT_PATH, DBUS_INTERFACE } = DBusToggleService;
 
 // Per-slot gsettings paths and display names
 const SLOT_CONFIG = {
@@ -65,19 +64,6 @@ const ELECTRON_TO_GNOME_KEY_MAP = {
   right: "Right",
 };
 
-let dbus = null;
-
-function getDBus() {
-  if (dbus) return dbus;
-  try {
-    dbus = require("@homebridge/dbus-native");
-    return dbus;
-  } catch (err) {
-    debugLogger.log("[GnomeShortcut] Failed to load dbus-native:", err.message);
-    return null;
-  }
-}
-
 function getSlotConfig(slotName) {
   const config = SLOT_CONFIG[slotName];
   if (!config) {
@@ -86,14 +72,12 @@ function getSlotConfig(slotName) {
   return config;
 }
 
+// Registers global shortcuts as GNOME gsettings custom-keybindings whose command
+// dbus-sends to the shared com.openwhispr.App endpoint (owned by hotkeyManager's
+// DBusToggleService). This class only does gsettings — callback wiring to the bus
+// lives in hotkeyManager.
 class GnomeShortcutManager {
   constructor() {
-    this.bus = null;
-    this.dictationCallback = null;
-    this.agentCallback = null;
-    this.meetingCallback = null;
-    this.voiceAgentCallback = null;
-    this.translationCallback = null;
     // Track which slots have been registered in gsettings
     this.registeredSlots = new Set();
   }
@@ -109,101 +93,6 @@ class GnomeShortcutManager {
 
   static isWayland() {
     return process.env.XDG_SESSION_TYPE === "wayland";
-  }
-
-  /**
-   * Set or update the agent callback after initial D-Bus service initialisation.
-   * This supports the case where the dictation hotkey is set up first and the
-   * agent callback is only available later (after agent window creation).
-   */
-  setAgentCallback(callback) {
-    this.agentCallback = callback;
-    debugLogger.log("[GnomeShortcut] Agent callback registered");
-  }
-
-  setMeetingCallback(callback) {
-    this.meetingCallback = callback;
-    debugLogger.log("[GnomeShortcut] Meeting callback registered");
-  }
-
-  setVoiceAgentCallback(callback) {
-    this.voiceAgentCallback = callback;
-    debugLogger.log("[GnomeShortcut] Voice agent callback registered");
-  }
-
-  setTranslationCallback(callback) {
-    this.translationCallback = callback;
-    debugLogger.log("[GnomeShortcut] Translation callback registered");
-  }
-
-  async initDBusService(dictationCallback) {
-    this.dictationCallback = dictationCallback;
-
-    const dbusModule = getDBus();
-    if (!dbusModule) {
-      return false;
-    }
-
-    try {
-      this.bus = dbusModule.sessionBus();
-      // Without a listener, async socket errors (e.g. a stale
-      // DBUS_SESSION_BUS_ADDRESS) crash the process as an unhandled
-      // "error" event — sessionBus() returns before connecting.
-      this.bus.connection.on("error", (err) => {
-        debugLogger.log("[GnomeShortcut] D-Bus connection error:", err.message);
-      });
-      this.bus.requestName(DBUS_SERVICE_NAME, 0);
-      this.bus.exportInterface(
-        {
-          Toggle: () => {
-            if (this.dictationCallback) {
-              this.dictationCallback();
-            }
-          },
-          ToggleAgent: () => {
-            if (this.agentCallback) {
-              this.agentCallback();
-            }
-          },
-          ToggleMeeting: () => {
-            if (this.meetingCallback) {
-              this.meetingCallback();
-            }
-          },
-          ToggleVoiceAgent: () => {
-            if (this.voiceAgentCallback) {
-              this.voiceAgentCallback();
-            }
-          },
-          ToggleTranslation: () => {
-            if (this.translationCallback) {
-              this.translationCallback();
-            }
-          },
-        },
-        DBUS_OBJECT_PATH,
-        {
-          name: DBUS_INTERFACE,
-          methods: {
-            Toggle: ["", ""],
-            ToggleAgent: ["", ""],
-            ToggleMeeting: ["", ""],
-            ToggleVoiceAgent: ["", ""],
-            ToggleTranslation: ["", ""],
-          },
-        }
-      );
-
-      debugLogger.log("[GnomeShortcut] D-Bus service initialized successfully");
-      return true;
-    } catch (err) {
-      debugLogger.log("[GnomeShortcut] Failed to initialize D-Bus service:", err.message);
-      if (this.bus) {
-        this.bus.connection.end();
-        this.bus = null;
-      }
-      return false;
-    }
   }
 
   static isValidShortcut(shortcut) {
@@ -492,12 +381,9 @@ class GnomeShortcutManager {
     return modifiers + gnomeKey;
   }
 
-  close() {
-    if (this.bus) {
-      this.bus.connection.end();
-      this.bus = null;
-    }
-  }
+  // The shared D-Bus endpoint is owned/closed by hotkeyManager; nothing to tear
+  // down here beyond the gsettings keybindings (removed via unregisterKeybinding).
+  close() {}
 }
 
 module.exports = GnomeShortcutManager;

--- a/src/helpers/gnomeShortcut.js
+++ b/src/helpers/gnomeShortcut.js
@@ -1,9 +1,8 @@
 const { execFileSync } = require("child_process");
 const debugLogger = require("./debugLogger");
+const DBusToggleService = require("./dbusToggleService");
 
-const DBUS_SERVICE_NAME = "com.openwhispr.App";
-const DBUS_OBJECT_PATH = "/com/openwhispr/App";
-const DBUS_INTERFACE = "com.openwhispr.App";
+const { DBUS_SERVICE_NAME, DBUS_OBJECT_PATH, DBUS_INTERFACE } = DBusToggleService;
 
 // Per-slot gsettings paths and display names
 const SLOT_CONFIG = {
@@ -61,19 +60,6 @@ const ELECTRON_TO_GNOME_KEY_MAP = {
   right: "Right",
 };
 
-let dbus = null;
-
-function getDBus() {
-  if (dbus) return dbus;
-  try {
-    dbus = require("@homebridge/dbus-native");
-    return dbus;
-  } catch (err) {
-    debugLogger.log("[GnomeShortcut] Failed to load dbus-native:", err.message);
-    return null;
-  }
-}
-
 function getSlotConfig(slotName) {
   const config = SLOT_CONFIG[slotName];
   if (!config) {
@@ -82,13 +68,12 @@ function getSlotConfig(slotName) {
   return config;
 }
 
+// Registers global shortcuts as GNOME gsettings custom-keybindings whose command
+// dbus-sends to the shared com.openwhispr.App endpoint (owned by hotkeyManager's
+// DBusToggleService). This class only does gsettings — callback wiring to the bus
+// lives in hotkeyManager.
 class GnomeShortcutManager {
   constructor() {
-    this.bus = null;
-    this.dictationCallback = null;
-    this.agentCallback = null;
-    this.meetingCallback = null;
-    this.voiceAgentCallback = null;
     // Track which slots have been registered in gsettings
     this.registeredSlots = new Set();
   }
@@ -104,90 +89,6 @@ class GnomeShortcutManager {
 
   static isWayland() {
     return process.env.XDG_SESSION_TYPE === "wayland";
-  }
-
-  /**
-   * Set or update the agent callback after initial D-Bus service initialisation.
-   * This supports the case where the dictation hotkey is set up first and the
-   * agent callback is only available later (after agent window creation).
-   */
-  setAgentCallback(callback) {
-    this.agentCallback = callback;
-    debugLogger.log("[GnomeShortcut] Agent callback registered");
-  }
-
-  setMeetingCallback(callback) {
-    this.meetingCallback = callback;
-    debugLogger.log("[GnomeShortcut] Meeting callback registered");
-  }
-
-  setVoiceAgentCallback(callback) {
-    this.voiceAgentCallback = callback;
-    debugLogger.log("[GnomeShortcut] Voice agent callback registered");
-  }
-
-  async initDBusService(dictationCallback) {
-    this.dictationCallback = dictationCallback;
-
-    const dbusModule = getDBus();
-    if (!dbusModule) {
-      return false;
-    }
-
-    try {
-      this.bus = dbusModule.sessionBus();
-      // Without a listener, async socket errors (e.g. a stale
-      // DBUS_SESSION_BUS_ADDRESS) crash the process as an unhandled
-      // "error" event — sessionBus() returns before connecting.
-      this.bus.connection.on("error", (err) => {
-        debugLogger.log("[GnomeShortcut] D-Bus connection error:", err.message);
-      });
-      this.bus.requestName(DBUS_SERVICE_NAME, 0);
-      this.bus.exportInterface(
-        {
-          Toggle: () => {
-            if (this.dictationCallback) {
-              this.dictationCallback();
-            }
-          },
-          ToggleAgent: () => {
-            if (this.agentCallback) {
-              this.agentCallback();
-            }
-          },
-          ToggleMeeting: () => {
-            if (this.meetingCallback) {
-              this.meetingCallback();
-            }
-          },
-          ToggleVoiceAgent: () => {
-            if (this.voiceAgentCallback) {
-              this.voiceAgentCallback();
-            }
-          },
-        },
-        DBUS_OBJECT_PATH,
-        {
-          name: DBUS_INTERFACE,
-          methods: {
-            Toggle: ["", ""],
-            ToggleAgent: ["", ""],
-            ToggleMeeting: ["", ""],
-            ToggleVoiceAgent: ["", ""],
-          },
-        }
-      );
-
-      debugLogger.log("[GnomeShortcut] D-Bus service initialized successfully");
-      return true;
-    } catch (err) {
-      debugLogger.log("[GnomeShortcut] Failed to initialize D-Bus service:", err.message);
-      if (this.bus) {
-        this.bus.connection.end();
-        this.bus = null;
-      }
-      return false;
-    }
   }
 
   static isValidShortcut(shortcut) {
@@ -475,12 +376,9 @@ class GnomeShortcutManager {
     return modifiers + gnomeKey;
   }
 
-  close() {
-    if (this.bus) {
-      this.bus.connection.end();
-      this.bus = null;
-    }
-  }
+  // The shared D-Bus endpoint is owned/closed by hotkeyManager; nothing to tear
+  // down here beyond the gsettings keybindings (removed via unregisterKeybinding).
+  close() {}
 }
 
 module.exports = GnomeShortcutManager;

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -4,6 +4,7 @@ const debugLogger = require("./debugLogger");
 const GnomeShortcutManager = require("./gnomeShortcut");
 const HyprlandShortcutManager = require("./hyprlandShortcut");
 const KDEShortcutManager = require("./kdeShortcut");
+const DBusToggleService = require("./dbusToggleService");
 const { i18nMain } = require("./i18nMain");
 const { parseHotkeyList } = require("./hotkeyList");
 
@@ -16,9 +17,10 @@ const FALLBACK_HOTKEYS = ["F8", "F9", "Control+Shift+Space"];
 // Default hotkey for dictation if no saved value exists
 const DEFAULT_HOTKEY = "Control+Super";
 
-// Slots routed through GNOME native gsettings (not globalShortcut).
-// Temporary slots like "cancel" stay on globalShortcut.
-const GNOME_NATIVE_SLOTS = new Set(["agent", "meeting", "voiceAgent", "translation"]);
+// Slots exposed via the shared com.openwhispr.App D-Bus toggle endpoint
+// (ToggleAgent/ToggleMeeting/ToggleVoiceAgent/ToggleTranslation) and auto-registered
+// on top by the GNOME gsettings path. Temporary slots like "cancel" stay on globalShortcut.
+const DBUS_TOGGLE_SLOTS = new Set(["agent", "meeting", "voiceAgent", "translation"]);
 
 // KDE registration failure reasons — reuse existing i18n keys
 const KDE_FAILURE_REASONS = {
@@ -96,6 +98,10 @@ class HotkeyManager extends EventEmitter {
     this.useHyprland = false;
     this.kdeManager = null;
     this.useKDE = false;
+    // Shared com.openwhispr.App bus owner (all Linux sessions). useDbus means the
+    // endpoint is the *primary* mechanism (wlroots), not merely that it's up.
+    this.dbusToggleService = null;
+    this.useDbus = false;
   }
 
   // Ensure a slot exists and return it (slots always use the list shape).
@@ -197,16 +203,45 @@ class HotkeyManager extends EventEmitter {
     const hotkey = hotkeys[0];
     if (
       hotkeys.length > 1 &&
-      ((this.useGnome && GNOME_NATIVE_SLOTS.has(slotName)) ||
-        (this.useKDE && slotName !== "cancel"))
+      ((this.useGnome && DBUS_TOGGLE_SLOTS.has(slotName)) || (this.useKDE && slotName !== "cancel"))
     ) {
       debugLogger.log(
         `[HotkeyManager] Slot "${slotName}" has ${hotkeys.length} hotkeys but this Linux desktop backend only applies the primary ("${hotkey}")`
       );
     }
 
+    // Always wire secondary-slot callbacks to the shared D-Bus endpoint (present on
+    // any Linux session), so `dbus-send …Toggle{Agent,Meeting,VoiceAgent,Translation}`
+    // works regardless of desktop. The desktop-specific auto-registration below layers
+    // on top of this.
+    if (this.dbusToggleService && DBUS_TOGGLE_SLOTS.has(slotName)) {
+      if (slotName === "agent") {
+        this.dbusToggleService.setAgentCallback(callback);
+      } else if (slotName === "meeting") {
+        this.dbusToggleService.setMeetingCallback(callback);
+      } else if (slotName === "voiceAgent") {
+        this.dbusToggleService.setVoiceAgentCallback(callback);
+      } else if (slotName === "translation") {
+        this.dbusToggleService.setTranslationCallback(callback);
+      }
+    }
+
+    // wlroots primary (useDbus): the shared-endpoint wiring above is the whole
+    // registration — the user binds keys externally, so there's no compositor bind.
+    if (this.useDbus && DBUS_TOGGLE_SLOTS.has(slotName)) {
+      const slot = this._ensureSlot(slotName);
+      slot.hotkeys = [hotkey];
+      slot.callback = callback;
+      slot.accelerators = [];
+      this.slots.set(slotName, slot);
+      debugLogger.log(
+        `[HotkeyManager] D-Bus slot "${slotName}" callback wired (no compositor bind)`
+      );
+      return { success: true, hotkey };
+    }
+
     // On GNOME (X11 or Wayland), route named slots through native gsettings
-    if (this.useGnome && this.gnomeManager && GNOME_NATIVE_SLOTS.has(slotName)) {
+    if (this.useGnome && this.gnomeManager && DBUS_TOGGLE_SLOTS.has(slotName)) {
       const gnomeHotkey = GnomeShortcutManager.convertToGnomeFormat(hotkey);
       if (!gnomeHotkey) {
         debugLogger.log(
@@ -220,16 +255,8 @@ class HotkeyManager extends EventEmitter {
 
       this.unregisterSlot(slotName);
 
-      if (slotName === "agent") {
-        this.gnomeManager.setAgentCallback(callback);
-      } else if (slotName === "meeting") {
-        this.gnomeManager.setMeetingCallback(callback);
-      } else if (slotName === "voiceAgent") {
-        this.gnomeManager.setVoiceAgentCallback(callback);
-      } else if (slotName === "translation") {
-        this.gnomeManager.setTranslationCallback(callback);
-      }
-
+      // Callbacks are wired to the shared endpoint above; GNOME only registers the
+      // gsettings keybinding (whose command dbus-sends to that endpoint).
       const success = await this.gnomeManager.registerKeybinding(gnomeHotkey, slotName);
       if (!success) {
         debugLogger.log(
@@ -312,7 +339,7 @@ class HotkeyManager extends EventEmitter {
     }
 
     // On GNOME, native slots are managed via gsettings, not globalShortcut
-    if (this.useGnome && this.gnomeManager && GNOME_NATIVE_SLOTS.has(slotName)) {
+    if (this.useGnome && this.gnomeManager && DBUS_TOGGLE_SLOTS.has(slotName)) {
       this.gnomeManager.unregisterKeybinding(slotName).catch((err) => {
         debugLogger.warn(
           `[HotkeyManager] Error unregistering GNOME keybinding for slot "${slotName}":`,
@@ -622,20 +649,85 @@ class HotkeyManager extends EventEmitter {
     });
   }
 
+  // wlroots (Sway/river/dwl) Wayland with no native global-shortcut integration:
+  // globalShortcut can't register global hotkeys at all. GNOME, KDE, and Hyprland
+  // have their own native paths, so they're excluded and left to handle themselves.
+  // X11 is excluded because globalShortcut works there. On wlroots the user binds
+  // keys to dbus-send the Toggle*/Start/StopDictation methods on the shared endpoint.
+  static shouldAutoUseDbus() {
+    if (process.platform !== "linux" || !GnomeShortcutManager.isWayland()) {
+      return false;
+    }
+    return (
+      !GnomeShortcutManager.isGnome() &&
+      !KDEShortcutManager.isKDE() &&
+      !HyprlandShortcutManager.isHyprland()
+    );
+  }
+
+  // Bring up the single shared com.openwhispr.App bus owner. This is only the
+  // D-Bus *endpoint* — it does not decide the shortcut mechanism (that's
+  // useGnome/useHyprland/useKDE/useDbus). The compositor-specific managers (GNOME
+  // gsettings, Hyprland hyprctl) register keybindings that route through this same
+  // service. Idempotent; returns whether the endpoint is up.
+  async ensureDbusEndpoint(callback) {
+    if (process.platform !== "linux") {
+      return false;
+    }
+    if (this.dbusToggleService) {
+      // A later initializeHotkey may carry a fresh dictation callback; adopt it so
+      // the already-running endpoint doesn't keep calling a stale one.
+      this.dbusToggleService.setDictationCallback(callback);
+      this.hotkeyCallback = callback;
+      return true;
+    }
+
+    try {
+      const service = new DBusToggleService();
+      const dbusOk = await service.start({ dictation: callback });
+      if (dbusOk) {
+        this.dbusToggleService = service;
+        this.hotkeyCallback = callback;
+        debugLogger.log("[HotkeyManager] Shared com.openwhispr.App D-Bus endpoint active");
+        return true;
+      }
+      service.close();
+    } catch (err) {
+      debugLogger.log("[HotkeyManager] D-Bus endpoint init failed:", err.message);
+    }
+
+    this.dbusToggleService = null;
+    return false;
+  }
+
+  // Attach callbacks to the shared D-Bus interface, so the methods work on any DE
+  // even when the user has no in-app hotkey configured for them (they bind keys
+  // externally). No-op unless the shared endpoint is up.
+  setDbusToggleCallbacks({ agent, voiceAgent, meeting, translation } = {}) {
+    if (!this.dbusToggleService) {
+      return;
+    }
+    if (agent) this.dbusToggleService.setAgentCallback(agent);
+    if (voiceAgent) this.dbusToggleService.setVoiceAgentCallback(voiceAgent);
+    if (meeting) this.dbusToggleService.setMeetingCallback(meeting);
+    if (translation) this.dbusToggleService.setTranslationCallback(translation);
+  }
+
   async initializeGnomeShortcuts(callback) {
     if (process.platform !== "linux" || !GnomeShortcutManager.isGnome()) {
+      return false;
+    }
+    // GNOME registers gsettings keybindings whose command dbus-sends to the shared
+    // endpoint, so it can only work if that endpoint is up.
+    if (!this.dbusToggleService) {
       return false;
     }
 
     try {
       this.gnomeManager = new GnomeShortcutManager();
-
-      const dbusOk = await this.gnomeManager.initDBusService(callback);
-      if (dbusOk) {
-        this.useGnome = true;
-        this.hotkeyCallback = callback;
-        return true;
-      }
+      this.useGnome = true;
+      this.hotkeyCallback = callback;
+      return true;
     } catch (err) {
       debugLogger.log("[HotkeyManager] GNOME shortcut init failed:", err.message);
       this.gnomeManager = null;
@@ -692,16 +784,18 @@ class HotkeyManager extends EventEmitter {
         return false;
       }
 
+      // Hyprland binds `hyprctl keyword bind … dbus-send …`, so it needs the shared
+      // endpoint to be up.
+      if (!this.dbusToggleService) {
+        debugLogger.log("[HotkeyManager] Hyprland detected but D-Bus endpoint unavailable");
+        return false;
+      }
+
       try {
         this.hyprlandManager = new HyprlandShortcutManager();
-
-        const dbusOk = await this.hyprlandManager.initDBusService(callback);
-        debugLogger.log("[HotkeyManager] Hyprland D-Bus init result:", dbusOk);
-        if (dbusOk) {
-          this.useHyprland = true;
-          this.hotkeyCallback = callback;
-          return true;
-        }
+        this.useHyprland = true;
+        this.hotkeyCallback = callback;
+        return true;
       } catch (err) {
         debugLogger.log("[HotkeyManager] Hyprland shortcut init failed:", err.message);
         this.hyprlandManager = null;
@@ -719,6 +813,30 @@ class HotkeyManager extends EventEmitter {
 
     this.mainWindow = mainWindow;
     this.hotkeyCallback = callback;
+
+    // Bring up the shared com.openwhispr.App endpoint on every Linux session so
+    // dbus-send binds work regardless of desktop. The desktop paths below layer
+    // their own auto-registration (gsettings/hyprctl/KGlobalAccel/globalShortcut)
+    // on top and route through this same bus.
+    if (process.platform === "linux") {
+      await this.ensureDbusEndpoint(callback);
+    }
+
+    // wlroots (Sway/river/dwl) with no native global-shortcut integration: the
+    // D-Bus endpoint IS the mechanism — the user binds keys to dbus-send the
+    // Toggle*/Start/StopDictation methods. useDbus drives isUsingNativeShortcut()
+    // (forces tap-to-talk); only set it here, never merely because the endpoint is
+    // up — otherwise X11 would lose push-to-talk.
+    if (process.platform === "linux" && HotkeyManager.shouldAutoUseDbus()) {
+      if (this.dbusToggleService) {
+        this.useDbus = true;
+        this.isInitialized = true;
+        return;
+      }
+      debugLogger.log(
+        "[HotkeyManager] D-Bus endpoint unavailable on wlroots; continuing with normal detection"
+      );
+    }
 
     // Try GNOME native shortcuts on any GNOME session (X11 or Wayland).
     // On Wayland: required (globalShortcut/XGrabKey doesn't work globally).
@@ -1299,6 +1417,11 @@ class HotkeyManager extends EventEmitter {
       this.hyprlandManager = null;
       this.useHyprland = false;
     }
+    if (this.dbusToggleService) {
+      this.dbusToggleService.close();
+      this.dbusToggleService = null;
+      this.useDbus = false;
+    }
     for (const slotName of this.slots.keys()) {
       const slot = this.slots.get(slotName);
       if (slot) {
@@ -1327,7 +1450,9 @@ class HotkeyManager extends EventEmitter {
   }
 
   isUsingNativeShortcut() {
-    return this.useGnome || this.useHyprland || this.useKDE;
+    // The D-Bus endpoint drives dictation via a single dbus-send Toggle (no
+    // key-up), so it must force tap-to-talk like the other native paths.
+    return this.useGnome || this.useHyprland || this.useKDE || this.useDbus;
   }
 
   isHotkeyRegistered(hotkey) {

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -702,8 +702,17 @@ class HotkeyManager extends EventEmitter {
 
   // Attach callbacks to the shared D-Bus interface, so the methods work on any DE
   // even when the user has no in-app hotkey configured for them (they bind keys
-  // externally). No-op unless the shared endpoint is up.
-  setDbusToggleCallbacks({ agent, voiceAgent, meeting, translation } = {}) {
+  // externally). agent/voiceAgent/meeting/translation drive the momentary Toggle*
+  // methods; startDictation/stopDictation drive the push-to-talk pair (StartDictation/
+  // StopDictation). No-op unless the shared endpoint is up.
+  setDbusToggleCallbacks({
+    agent,
+    voiceAgent,
+    meeting,
+    translation,
+    startDictation,
+    stopDictation,
+  } = {}) {
     if (!this.dbusToggleService) {
       return;
     }
@@ -711,6 +720,8 @@ class HotkeyManager extends EventEmitter {
     if (voiceAgent) this.dbusToggleService.setVoiceAgentCallback(voiceAgent);
     if (meeting) this.dbusToggleService.setMeetingCallback(meeting);
     if (translation) this.dbusToggleService.setTranslationCallback(translation);
+    if (startDictation) this.dbusToggleService.setStartDictationCallback(startDictation);
+    if (stopDictation) this.dbusToggleService.setStopDictationCallback(stopDictation);
   }
 
   async initializeGnomeShortcuts(callback) {

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -4,6 +4,7 @@ const debugLogger = require("./debugLogger");
 const GnomeShortcutManager = require("./gnomeShortcut");
 const HyprlandShortcutManager = require("./hyprlandShortcut");
 const KDEShortcutManager = require("./kdeShortcut");
+const DBusToggleService = require("./dbusToggleService");
 const { i18nMain } = require("./i18nMain");
 const { parseHotkeyList } = require("./hotkeyList");
 
@@ -16,9 +17,10 @@ const FALLBACK_HOTKEYS = ["F8", "F9", "Control+Shift+Space"];
 // Default hotkey for dictation if no saved value exists
 const DEFAULT_HOTKEY = "Control+Super";
 
-// Slots routed through GNOME native gsettings (not globalShortcut).
-// Temporary slots like "cancel" stay on globalShortcut.
-const GNOME_NATIVE_SLOTS = new Set(["agent", "meeting", "voiceAgent"]);
+// Slots exposed via the shared com.openwhispr.App D-Bus toggle endpoint
+// (ToggleAgent/ToggleMeeting/ToggleVoiceAgent) and auto-registered on top by the
+// GNOME gsettings path. Temporary slots like "cancel" stay on globalShortcut.
+const DBUS_TOGGLE_SLOTS = new Set(["agent", "meeting", "voiceAgent"]);
 
 // KDE registration failure reasons — reuse existing i18n keys
 const KDE_FAILURE_REASONS = {
@@ -96,6 +98,10 @@ class HotkeyManager extends EventEmitter {
     this.useHyprland = false;
     this.kdeManager = null;
     this.useKDE = false;
+    // Shared com.openwhispr.App bus owner (all Linux sessions). useDbus means the
+    // endpoint is the *primary* mechanism (wlroots), not merely that it's up.
+    this.dbusToggleService = null;
+    this.useDbus = false;
   }
 
   // Ensure a slot exists and return it (slots always use the list shape).
@@ -197,16 +203,43 @@ class HotkeyManager extends EventEmitter {
     const hotkey = hotkeys[0];
     if (
       hotkeys.length > 1 &&
-      ((this.useGnome && GNOME_NATIVE_SLOTS.has(slotName)) ||
-        (this.useKDE && slotName !== "cancel"))
+      ((this.useGnome && DBUS_TOGGLE_SLOTS.has(slotName)) || (this.useKDE && slotName !== "cancel"))
     ) {
       debugLogger.log(
         `[HotkeyManager] Slot "${slotName}" has ${hotkeys.length} hotkeys but this Linux desktop backend only applies the primary ("${hotkey}")`
       );
     }
 
+    // Always wire secondary-slot callbacks to the shared D-Bus endpoint (present on
+    // any Linux session), so `dbus-send …Toggle{Agent,Meeting,VoiceAgent}` works
+    // regardless of desktop. The desktop-specific auto-registration below layers on
+    // top of this.
+    if (this.dbusToggleService && DBUS_TOGGLE_SLOTS.has(slotName)) {
+      if (slotName === "agent") {
+        this.dbusToggleService.setAgentCallback(callback);
+      } else if (slotName === "meeting") {
+        this.dbusToggleService.setMeetingCallback(callback);
+      } else if (slotName === "voiceAgent") {
+        this.dbusToggleService.setVoiceAgentCallback(callback);
+      }
+    }
+
+    // wlroots primary (useDbus): the shared-endpoint wiring above is the whole
+    // registration — the user binds keys externally, so there's no compositor bind.
+    if (this.useDbus && DBUS_TOGGLE_SLOTS.has(slotName)) {
+      const slot = this._ensureSlot(slotName);
+      slot.hotkeys = [hotkey];
+      slot.callback = callback;
+      slot.accelerators = [];
+      this.slots.set(slotName, slot);
+      debugLogger.log(
+        `[HotkeyManager] D-Bus slot "${slotName}" callback wired (no compositor bind)`
+      );
+      return { success: true, hotkey };
+    }
+
     // On GNOME (X11 or Wayland), route named slots through native gsettings
-    if (this.useGnome && this.gnomeManager && GNOME_NATIVE_SLOTS.has(slotName)) {
+    if (this.useGnome && this.gnomeManager && DBUS_TOGGLE_SLOTS.has(slotName)) {
       const gnomeHotkey = GnomeShortcutManager.convertToGnomeFormat(hotkey);
       if (!gnomeHotkey) {
         debugLogger.log(
@@ -220,14 +253,8 @@ class HotkeyManager extends EventEmitter {
 
       this.unregisterSlot(slotName);
 
-      if (slotName === "agent") {
-        this.gnomeManager.setAgentCallback(callback);
-      } else if (slotName === "meeting") {
-        this.gnomeManager.setMeetingCallback(callback);
-      } else if (slotName === "voiceAgent") {
-        this.gnomeManager.setVoiceAgentCallback(callback);
-      }
-
+      // Callbacks are wired to the shared endpoint above; GNOME only registers the
+      // gsettings keybinding (whose command dbus-sends to that endpoint).
       const success = await this.gnomeManager.registerKeybinding(gnomeHotkey, slotName);
       if (!success) {
         debugLogger.log(
@@ -310,7 +337,7 @@ class HotkeyManager extends EventEmitter {
     }
 
     // On GNOME, native slots are managed via gsettings, not globalShortcut
-    if (this.useGnome && this.gnomeManager && GNOME_NATIVE_SLOTS.has(slotName)) {
+    if (this.useGnome && this.gnomeManager && DBUS_TOGGLE_SLOTS.has(slotName)) {
       this.gnomeManager.unregisterKeybinding(slotName).catch((err) => {
         debugLogger.warn(
           `[HotkeyManager] Error unregistering GNOME keybinding for slot "${slotName}":`,
@@ -620,20 +647,84 @@ class HotkeyManager extends EventEmitter {
     });
   }
 
+  // wlroots (Sway/river/dwl) Wayland with no native global-shortcut integration:
+  // globalShortcut can't register global hotkeys at all. GNOME, KDE, and Hyprland
+  // have their own native paths, so they're excluded and left to handle themselves.
+  // X11 is excluded because globalShortcut works there. On wlroots the user binds
+  // keys to dbus-send the Toggle*/Start/StopDictation methods on the shared endpoint.
+  static shouldAutoUseDbus() {
+    if (process.platform !== "linux" || !GnomeShortcutManager.isWayland()) {
+      return false;
+    }
+    return (
+      !GnomeShortcutManager.isGnome() &&
+      !KDEShortcutManager.isKDE() &&
+      !HyprlandShortcutManager.isHyprland()
+    );
+  }
+
+  // Bring up the single shared com.openwhispr.App bus owner. This is only the
+  // D-Bus *endpoint* — it does not decide the shortcut mechanism (that's
+  // useGnome/useHyprland/useKDE/useDbus). The compositor-specific managers (GNOME
+  // gsettings, Hyprland hyprctl) register keybindings that route through this same
+  // service. Idempotent; returns whether the endpoint is up.
+  async ensureDbusEndpoint(callback) {
+    if (process.platform !== "linux") {
+      return false;
+    }
+    if (this.dbusToggleService) {
+      // A later initializeHotkey may carry a fresh dictation callback; adopt it so
+      // the already-running endpoint doesn't keep calling a stale one.
+      this.dbusToggleService.setDictationCallback(callback);
+      this.hotkeyCallback = callback;
+      return true;
+    }
+
+    try {
+      const service = new DBusToggleService();
+      const dbusOk = await service.start({ dictation: callback });
+      if (dbusOk) {
+        this.dbusToggleService = service;
+        this.hotkeyCallback = callback;
+        debugLogger.log("[HotkeyManager] Shared com.openwhispr.App D-Bus endpoint active");
+        return true;
+      }
+      service.close();
+    } catch (err) {
+      debugLogger.log("[HotkeyManager] D-Bus endpoint init failed:", err.message);
+    }
+
+    this.dbusToggleService = null;
+    return false;
+  }
+
+  // Attach callbacks to the shared D-Bus interface, so the methods work on any DE
+  // even when the user has no in-app hotkey configured for them (they bind keys
+  // externally). No-op unless the shared endpoint is up.
+  setDbusToggleCallbacks({ agent, voiceAgent, meeting } = {}) {
+    if (!this.dbusToggleService) {
+      return;
+    }
+    if (agent) this.dbusToggleService.setAgentCallback(agent);
+    if (voiceAgent) this.dbusToggleService.setVoiceAgentCallback(voiceAgent);
+    if (meeting) this.dbusToggleService.setMeetingCallback(meeting);
+  }
+
   async initializeGnomeShortcuts(callback) {
     if (process.platform !== "linux" || !GnomeShortcutManager.isGnome()) {
+      return false;
+    }
+    // GNOME registers gsettings keybindings whose command dbus-sends to the shared
+    // endpoint, so it can only work if that endpoint is up.
+    if (!this.dbusToggleService) {
       return false;
     }
 
     try {
       this.gnomeManager = new GnomeShortcutManager();
-
-      const dbusOk = await this.gnomeManager.initDBusService(callback);
-      if (dbusOk) {
-        this.useGnome = true;
-        this.hotkeyCallback = callback;
-        return true;
-      }
+      this.useGnome = true;
+      this.hotkeyCallback = callback;
+      return true;
     } catch (err) {
       debugLogger.log("[HotkeyManager] GNOME shortcut init failed:", err.message);
       this.gnomeManager = null;
@@ -690,16 +781,18 @@ class HotkeyManager extends EventEmitter {
         return false;
       }
 
+      // Hyprland binds `hyprctl keyword bind … dbus-send …`, so it needs the shared
+      // endpoint to be up.
+      if (!this.dbusToggleService) {
+        debugLogger.log("[HotkeyManager] Hyprland detected but D-Bus endpoint unavailable");
+        return false;
+      }
+
       try {
         this.hyprlandManager = new HyprlandShortcutManager();
-
-        const dbusOk = await this.hyprlandManager.initDBusService(callback);
-        debugLogger.log("[HotkeyManager] Hyprland D-Bus init result:", dbusOk);
-        if (dbusOk) {
-          this.useHyprland = true;
-          this.hotkeyCallback = callback;
-          return true;
-        }
+        this.useHyprland = true;
+        this.hotkeyCallback = callback;
+        return true;
       } catch (err) {
         debugLogger.log("[HotkeyManager] Hyprland shortcut init failed:", err.message);
         this.hyprlandManager = null;
@@ -717,6 +810,30 @@ class HotkeyManager extends EventEmitter {
 
     this.mainWindow = mainWindow;
     this.hotkeyCallback = callback;
+
+    // Bring up the shared com.openwhispr.App endpoint on every Linux session so
+    // dbus-send binds work regardless of desktop. The desktop paths below layer
+    // their own auto-registration (gsettings/hyprctl/KGlobalAccel/globalShortcut)
+    // on top and route through this same bus.
+    if (process.platform === "linux") {
+      await this.ensureDbusEndpoint(callback);
+    }
+
+    // wlroots (Sway/river/dwl) with no native global-shortcut integration: the
+    // D-Bus endpoint IS the mechanism — the user binds keys to dbus-send the
+    // Toggle*/Start/StopDictation methods. useDbus drives isUsingNativeShortcut()
+    // (forces tap-to-talk); only set it here, never merely because the endpoint is
+    // up — otherwise X11 would lose push-to-talk.
+    if (process.platform === "linux" && HotkeyManager.shouldAutoUseDbus()) {
+      if (this.dbusToggleService) {
+        this.useDbus = true;
+        this.isInitialized = true;
+        return;
+      }
+      debugLogger.log(
+        "[HotkeyManager] D-Bus endpoint unavailable on wlroots; continuing with normal detection"
+      );
+    }
 
     // Try GNOME native shortcuts on any GNOME session (X11 or Wayland).
     // On Wayland: required (globalShortcut/XGrabKey doesn't work globally).
@@ -1297,6 +1414,11 @@ class HotkeyManager extends EventEmitter {
       this.hyprlandManager = null;
       this.useHyprland = false;
     }
+    if (this.dbusToggleService) {
+      this.dbusToggleService.close();
+      this.dbusToggleService = null;
+      this.useDbus = false;
+    }
     for (const slotName of this.slots.keys()) {
       const slot = this.slots.get(slotName);
       if (slot) {
@@ -1325,7 +1447,9 @@ class HotkeyManager extends EventEmitter {
   }
 
   isUsingNativeShortcut() {
-    return this.useGnome || this.useHyprland || this.useKDE;
+    // The D-Bus endpoint drives dictation via a single dbus-send Toggle (no
+    // key-up), so it must force tap-to-talk like the other native paths.
+    return this.useGnome || this.useHyprland || this.useKDE || this.useDbus;
   }
 
   isHotkeyRegistered(hotkey) {

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -700,14 +700,18 @@ class HotkeyManager extends EventEmitter {
 
   // Attach callbacks to the shared D-Bus interface, so the methods work on any DE
   // even when the user has no in-app hotkey configured for them (they bind keys
-  // externally). No-op unless the shared endpoint is up.
-  setDbusToggleCallbacks({ agent, voiceAgent, meeting } = {}) {
+  // externally). agent/voiceAgent/meeting drive the momentary Toggle* methods;
+  // startDictation/stopDictation drive the push-to-talk pair (StartDictation/
+  // StopDictation). No-op unless the shared endpoint is up.
+  setDbusToggleCallbacks({ agent, voiceAgent, meeting, startDictation, stopDictation } = {}) {
     if (!this.dbusToggleService) {
       return;
     }
     if (agent) this.dbusToggleService.setAgentCallback(agent);
     if (voiceAgent) this.dbusToggleService.setVoiceAgentCallback(voiceAgent);
     if (meeting) this.dbusToggleService.setMeetingCallback(meeting);
+    if (startDictation) this.dbusToggleService.setStartDictationCallback(startDictation);
+    if (stopDictation) this.dbusToggleService.setStopDictationCallback(stopDictation);
   }
 
   async initializeGnomeShortcuts(callback) {

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -79,23 +79,11 @@ function getBindsFilePath() {
   return path.join(getHyprConfigDir(), BINDS_FILENAME);
 }
 
-let dbus = null;
-
-function getDBus() {
-  if (dbus) return dbus;
-  try {
-    dbus = require("@homebridge/dbus-native");
-    return dbus;
-  } catch (err) {
-    debugLogger.log("[HyprlandShortcut] Failed to load dbus-native:", err.message);
-    return null;
-  }
-}
-
+// Registers a global shortcut via `hyprctl keyword bind … dbus-send …` targeting
+// the shared com.openwhispr.App endpoint (owned by hotkeyManager's DBusToggleService).
+// This class only does hyprctl — it does not own a bus.
 class HyprlandShortcutManager {
   constructor() {
-    this.bus = null;
-    this.callback = null;
     this.isRegistered = false;
     this.currentBinding = null; // Store the current Hyprland bind string for unbinding
   }
@@ -125,56 +113,6 @@ class HyprlandShortcutManager {
       execFileSync("hyprctl", ["version"], { stdio: "pipe", timeout: 3000 });
       return true;
     } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Initialize a D-Bus service to receive Toggle() calls from Hyprland keybindings.
-   * Reuses the same D-Bus service name/path as the GNOME integration.
-   */
-  async initDBusService(callback) {
-    this.callback = callback;
-
-    const dbusModule = getDBus();
-    if (!dbusModule) {
-      return false;
-    }
-
-    try {
-      this.bus = dbusModule.sessionBus();
-      // Without a listener, async socket errors (e.g. a stale
-      // DBUS_SESSION_BUS_ADDRESS) crash the process as an unhandled
-      // "error" event — sessionBus() returns before connecting.
-      this.bus.connection.on("error", (err) => {
-        debugLogger.log("[HyprlandShortcut] D-Bus connection error:", err.message);
-      });
-      this.bus.requestName(DBUS_SERVICE_NAME, 0);
-      this.bus.exportInterface(
-        {
-          Toggle: () => {
-            if (this.callback) {
-              this.callback();
-            }
-          },
-        },
-        DBUS_OBJECT_PATH,
-        {
-          name: DBUS_INTERFACE,
-          methods: {
-            Toggle: ["", ""],
-          },
-        }
-      );
-
-      debugLogger.log("[HyprlandShortcut] D-Bus service initialized successfully");
-      return true;
-    } catch (err) {
-      debugLogger.log("[HyprlandShortcut] Failed to initialize D-Bus service:", err.message);
-      if (this.bus) {
-        this.bus.connection.end();
-        this.bus = null;
-      }
       return false;
     }
   }
@@ -461,15 +399,9 @@ class HyprlandShortcutManager {
     return true;
   }
 
-  /**
-   * Clean up D-Bus connection.
-   */
-  close() {
-    if (this.bus) {
-      this.bus.connection.end();
-      this.bus = null;
-    }
-  }
+  // The shared D-Bus endpoint is owned/closed by hotkeyManager; the hyprctl bind
+  // is removed via unregisterKeybinding(). Nothing to tear down here.
+  close() {}
 }
 
 module.exports = HyprlandShortcutManager;


### PR DESCRIPTION
Adds a `com.openwhispr.App` session D-Bus endpoint for global shortcuts on Linux, since Electron's `globalShortcut` can't register hotkeys on many Wayland compositors (e.g. Sway). GNOME already drove shortcuts through this D-Bus interface; this extracts it into one shared, compositor-agnostic service and makes it available everywhere.

- **`dbusToggleService.js`** (new): single owner of `com.openwhispr.App` and its methods — `Toggle`/`ToggleAgent`/`ToggleMeeting`/`ToggleVoiceAgent` (tap) plus `StartDictation`/`StopDictation` (push-to-talk).
- **Universal on Linux:** the endpoint starts on every session (X11 + Wayland). Each desktop layers its own keybinding auto-registration on top and routes through it — GNOME gsettings, Hyprland hyprctl, wlroots manual `dbus-send` binds; KDE/X11 keep their native mechanism with the bus additionally available.
- **`gnomeShortcut.js` / `hyprlandShortcut.js`:** reduced to keybinding registrars (Hyprland's duplicate bus/interface removed).
- Having the bus up does **not** force tap-to-talk — X11 keeps `globalShortcut` + push-to-talk.
- Push-to-talk needs a compositor that can bind key release (Sway `bindsym --release`, Hyprland `bindr`).
- Docs: `CLAUDE.md` §15a.
