### PR TITLE
fix(linux): stop overlay focus theft on wlroots (Sway)

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -10,13 +10,29 @@ const isKDEWayland =
   process.env.XDG_SESSION_TYPE === "wayland" &&
   /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "");
 
+// wlroots compositors (Sway, Hyprland, river, …). Our overlays are created with
+// focusable:false, which makes Electron map them as override-redirect XWayland
+// windows. wlroots' XWayland focuses override-redirect windows on map *unless*
+// their _NET_WM_WINDOW_TYPE is in its no-focus set (notification, tooltip,
+// utility, splash, menus). TOOLBAR/NORMAL are NOT in that set, so the overlays
+// steal focus on wlroots — but not on GNOME/KDE, whose WMs honor focusable:false
+// directly. So on wlroots we map the non-interactive overlays as "notification".
+const isWlrootsWayland =
+  process.platform === "linux" &&
+  process.env.XDG_SESSION_TYPE === "wayland" &&
+  (/sway|hyprland|wayfire|river|dwl|labwc/i.test(process.env.XDG_CURRENT_DESKTOP || "") ||
+    !!process.env.SWAYSOCK ||
+    !!process.env.HYPRLAND_INSTANCE_SIGNATURE);
+
 const MAIN_OVERLAY_TYPE =
   process.platform === "darwin"
     ? "panel"
     : process.platform === "linux"
-      ? isGnomeWayland || isKDEWayland
-        ? "normal"
-        : "toolbar"
+      ? isWlrootsWayland
+        ? "notification"
+        : isGnomeWayland || isKDEWayland
+          ? "normal"
+          : "toolbar"
       : "normal";
 
 const FLOATING_OVERLAY_TYPE =
@@ -27,6 +43,13 @@ const FLOATING_OVERLAY_TYPE =
         ? "normal"
         : "toolbar"
       : "normal";
+
+// Type for non-interactive, never-focus overlays (transcription preview, meeting
+// notification). On wlroots, "notification" keeps the override-redirect window
+// from stealing focus (see isWlrootsWayland above); elsewhere it matches the
+// regular floating overlay type. NOT used for the agent overlay, which needs
+// keyboard focus for chat input.
+const NOFOCUS_OVERLAY_TYPE = isWlrootsWayland ? "notification" : FLOATING_OVERLAY_TYPE;
 
 const WINDOW_SIZES = {
   BASE: { width: 96, height: 96 },
@@ -117,7 +140,7 @@ const NOTIFICATION_WINDOW_CONFIG = {
     sandbox: true,
   },
   visibleOnAllWorkspaces: process.platform !== "win32",
-  type: FLOATING_OVERLAY_TYPE,
+  type: NOFOCUS_OVERLAY_TYPE,
 };
 
 const TRANSCRIPTION_PREVIEW_SIZE_LIMITS = {
@@ -148,7 +171,7 @@ const TRANSCRIPTION_PREVIEW_CONFIG = {
     sandbox: true,
   },
   visibleOnAllWorkspaces: process.platform !== "win32",
-  type: FLOATING_OVERLAY_TYPE,
+  type: NOFOCUS_OVERLAY_TYPE,
 };
 
 class WindowPositionUtil {

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -10,25 +10,30 @@ const isKDEWayland =
   process.env.XDG_SESSION_TYPE === "wayland" &&
   /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "");
 
-// wlroots compositors (Sway, Hyprland, river, …). Our overlays are created with
-// focusable:false, which makes Electron map them as override-redirect XWayland
-// windows. wlroots' XWayland focuses override-redirect windows on map *unless*
-// their _NET_WM_WINDOW_TYPE is in its no-focus set (notification, tooltip,
-// utility, splash, menus). TOOLBAR/NORMAL are NOT in that set, so the overlays
-// steal focus on wlroots — but not on GNOME/KDE, whose WMs honor focusable:false
-// directly. So on wlroots we map the non-interactive overlays as "notification".
-const isWlrootsWayland =
+// Compositors that need the "notification" window type to stop overlays from
+// stealing focus. Our overlays are created with focusable:false, which makes
+// Electron map them as override-redirect XWayland windows. wlroots' XWayland
+// focuses override-redirect windows on map *unless* their _NET_WM_WINDOW_TYPE is
+// in its no-focus set (notification, tooltip, utility, splash, menus).
+// TOOLBAR/NORMAL are NOT in that set, so the overlays steal focus on wlroots —
+// but not on GNOME/KDE, whose WMs honor focusable:false directly.
+//
+// This is an explicit allowlist rather than "all wlroots compositors" on
+// purpose: mapping the interactive overlays (preview copy/dismiss, meeting
+// start/dismiss) as "notification" keeps their clicks working on Sway, but on
+// Hyprland the same type makes those buttons unclickable. So we only enable the
+// remap on compositors confirmed to keep clicks working. Sway is the first;
+// add more here as they're verified.
+const isNoFocusOverlayCompositor =
   process.platform === "linux" &&
   process.env.XDG_SESSION_TYPE === "wayland" &&
-  (/sway|hyprland|wayfire|river|dwl|labwc/i.test(process.env.XDG_CURRENT_DESKTOP || "") ||
-    !!process.env.SWAYSOCK ||
-    !!process.env.HYPRLAND_INSTANCE_SIGNATURE);
+  (/sway/i.test(process.env.XDG_CURRENT_DESKTOP || "") || !!process.env.SWAYSOCK);
 
 const MAIN_OVERLAY_TYPE =
   process.platform === "darwin"
     ? "panel"
     : process.platform === "linux"
-      ? isWlrootsWayland
+      ? isNoFocusOverlayCompositor
         ? "notification"
         : isGnomeWayland || isKDEWayland
           ? "normal"
@@ -45,11 +50,13 @@ const FLOATING_OVERLAY_TYPE =
       : "normal";
 
 // Type for non-interactive, never-focus overlays (transcription preview, meeting
-// notification). On wlroots, "notification" keeps the override-redirect window
-// from stealing focus (see isWlrootsWayland above); elsewhere it matches the
-// regular floating overlay type. NOT used for the agent overlay, which needs
-// keyboard focus for chat input.
-const NOFOCUS_OVERLAY_TYPE = isWlrootsWayland ? "notification" : FLOATING_OVERLAY_TYPE;
+// notification). On the allowlisted compositors (see isNoFocusOverlayCompositor
+// above), "notification" keeps the override-redirect window from stealing focus;
+// elsewhere it matches the regular floating overlay type. NOT used for the agent
+// overlay, which needs keyboard focus for chat input.
+const NOFOCUS_OVERLAY_TYPE = isNoFocusOverlayCompositor
+  ? "notification"
+  : FLOATING_OVERLAY_TYPE;
 
 const WINDOW_SIZES = {
   BASE: { width: 96, height: 96 },


### PR DESCRIPTION
On wlroots compositors the dictation/preview/notification overlays steal focus on map. Root cause: the overlays are created focusable:false, which makes Electron map them as override-redirect XWayland windows. wlroots' XWayland focuses override-redirect windows on map unless their _NET_WM_WINDOW_TYPE is in its no-focus set (notification/tooltip/utility/splash/menus) — and the overlays are TOOLBAR/NORMAL, which are not. Mutter/KWin honor focusable:false directly, so GNOME/KDE never had the bug; forcing XWayland (the prior fix) doesn't help here because it's already XWayland.

Map the non-interactive overlays (dictation mic, transcription preview, meeting notification) as type "notification" on wlroots, which is in wlroots' no-focus set — clicks still work, keyboard focus isn't grabbed. GNOME/KDE keep their existing types (no regression). The agent overlay is left focus-capable since it needs keyboard input for chat.

Verified against xprop on Sway: preview was override-redirect + TOOLBAR (focus stolen); no_focus rules and get_tree don't apply to override-redirect windows.

Fixes the focus stealing on Sway for me at least and should fix https://github.com/OpenWhispr/openwhispr/issues/719
