### PR TITLE
fix(media): resume playback when recording stops, not after transcription

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -3096,7 +3096,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         "streaming"
       );
     } else {
-      // Silence: still fire callback so media playback resumes.
+      // Silence: still fire callback to dismiss the preview and show the no-audio toast.
       this.onTranscriptionComplete?.({ success: true, text: "" });
     }
 

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -18,6 +18,7 @@ export const useAudioRecording = (toast, options = {}) => {
   const audioManagerRef = useRef(null);
   const startLockRef = useRef(false);
   const stopLockRef = useRef(false);
+  const wasRecordingRef = useRef(false);
   const { onToggle } = options;
 
   const performStartRecording = useCallback(async ({ voiceAgentRequested = false } = {}) => {
@@ -90,7 +91,14 @@ export const useAudioRecording = (toast, options = {}) => {
 
     audioManagerRef.current.setCallbacks({
       onStateChange: ({ isRecording, isProcessing, isStreaming }) => {
-        if (!isRecording) window.electronAPI?.unregisterCancelHotkey?.();
+        if (!isRecording) {
+          window.electronAPI?.unregisterCancelHotkey?.();
+          // Resume media the instant recording ends, not after transcription.
+          if (wasRecordingRef.current && getSettings().pauseMediaOnDictation) {
+            window.electronAPI?.resumeMediaPlayback?.();
+          }
+        }
+        wasRecordingRef.current = isRecording;
         setIsRecording(isRecording);
         setIsProcessing(isProcessing);
         setIsStreaming(isStreaming ?? false);
@@ -118,10 +126,6 @@ export const useAudioRecording = (toast, options = {}) => {
         setPartialTranscript(text);
       },
       onTranscriptionComplete: async (result) => {
-        if (getSettings().pauseMediaOnDictation) {
-          window.electronAPI?.resumeMediaPlayback?.();
-        }
-
         if (result.success) {
           const transcribedText = result.text?.trim();
 


### PR DESCRIPTION
## Summary

With "pause media on dictation" on, playback paused at record start but only resumed inside `onTranscriptionComplete`, so a long dictation left the music paused for the entire transcription (minutes). The fix moves the resume to the moment recording stops: it fires on the `isRecording` false edge in `onStateChange` (`src/hooks/useAudioRecording.js`), gated by a new `wasRecordingRef` so it runs once at the stop instant, and the late `onTranscriptionComplete` resume is removed. Music comes back on button release while transcription keeps running in the background. That edge is the one point every stop path passes through (normal stop, streaming stop, cancel, empty-recording drop, connection-loss auto-stop), and `mediaPlayer.resumeMedia()` is idempotent, so the remaining defensive resume calls stay safe.

Fixes #947

## Changes

- src/hooks/useAudioRecording.js: resume media on the recording-stopped edge in `onStateChange` via a new `wasRecordingRef`; drop the resume from `onTranscriptionComplete`.
- src/helpers/audioManager.js: update the stale silence-path comment that referred to the removed resume.
