### PR TITLE
fix(transcription): reload local GPU model on wake from sleep

### DIFF
--- a/main.js
+++ b/main.js
@@ -318,6 +318,8 @@ let ipcHandlers = null;
 let cliBridge = null;
 let globeKeyAlertShown = false;
 let authBridgeServer = null;
+const WHISPER_WAKE_REWARM_DELAY_MS = 3000;
+let wakeRewarmTimer = null;
 
 function parseAuthBridgePort() {
   const raw = (process.env.OPENWHISPR_AUTH_BRIDGE_PORT || "").trim();
@@ -932,6 +934,14 @@ async function startApp() {
     if (googleCalendarManager) {
       googleCalendarManager.onWakeFromSleep();
     }
+    // Sleep evicts the local GPU model from VRAM; reload it once the driver settles. See #766.
+    if (wakeRewarmTimer) clearTimeout(wakeRewarmTimer);
+    wakeRewarmTimer = setTimeout(() => {
+      wakeRewarmTimer = null;
+      whisperManager?.onWakeFromSleep().catch((err) => {
+        debugLogger.debug("whisper wake re-warm error (non-fatal)", { error: err.message });
+      });
+    }, WHISPER_WAKE_REWARM_DELAY_MS);
   });
 
   // Non-blocking server pre-warming
@@ -1561,6 +1571,10 @@ if (gotSingleInstanceLock) {
 }
 
 function performSyncTeardown() {
+  if (wakeRewarmTimer) {
+    clearTimeout(wakeRewarmTimer);
+    wakeRewarmTimer = null;
+  }
   if (authBridgeServer) {
     authBridgeServer.close();
     authBridgeServer = null;

--- a/src/helpers/whisper.js
+++ b/src/helpers/whisper.js
@@ -30,6 +30,13 @@ function getValidModelNames() {
   return Object.keys(modelRegistryData.whisperModels);
 }
 
+function shouldRewarmOnWake({ isRemote, useCuda, modelName, transcribing, rewarmInFlight }) {
+  // Only re-warm a running local CUDA whisper-server: sleep evicts its model from
+  // VRAM. Skip remote/CPU servers, and skip while a transcription (already warming
+  // the server) or another re-warm is in flight. See #766.
+  return !isRemote && !!useCuda && !!modelName && !transcribing && !rewarmInFlight;
+}
+
 class WhisperManager {
   constructor() {
     this.cachedFFmpegPath = null;
@@ -40,6 +47,8 @@ class WhisperManager {
     this.serverManager = new WhisperServerManager();
     this.currentServerModel = null;
     this.cachedVadModelPath = undefined;
+    this._transcribing = false;
+    this._rewarmInFlight = false;
   }
 
   getModelsDir() {
@@ -235,6 +244,40 @@ class WhisperManager {
     this.currentServerModel = null;
   }
 
+  async onWakeFromSleep() {
+    const sm = this.serverManager;
+    const modelName = this.currentServerModel;
+    if (
+      !shouldRewarmOnWake({
+        isRemote: sm.isRemote,
+        useCuda: sm.useCuda,
+        modelName,
+        transcribing: this._transcribing,
+        rewarmInFlight: this._rewarmInFlight,
+      })
+    ) {
+      return false;
+    }
+
+    // Replay the last start options (VAD, threads) so the reloaded server matches the
+    // signature the next dictation will use; a bare start would otherwise be rejected
+    // by start()'s no-op guard and reload the model on the first dictation. See #766.
+    const options = { ...sm.lastStartOptions, useCuda: true };
+    this._rewarmInFlight = true;
+    try {
+      debugLogger.info("Re-warming whisper-server after wake from sleep", { model: modelName });
+      await this.stopServer();
+      const result = await this.startServer(modelName, options);
+      if (!result?.success) {
+        debugLogger.warn("whisper-server wake re-warm failed", { reason: result?.reason });
+        return false;
+      }
+      return true;
+    } finally {
+      this._rewarmInFlight = false;
+    }
+  }
+
   getServerStatus() {
     return this.serverManager.getStatus();
   }
@@ -286,6 +329,16 @@ class WhisperManager {
   }
 
   async transcribeViaServer(audioBlob, model, language, initialPrompt = null, options = {}) {
+    // Mark the server busy so a wake re-warm doesn't kill an in-flight dictation. See #766.
+    this._transcribing = true;
+    try {
+      return await this._runServerTranscription(audioBlob, model, language, initialPrompt, options);
+    } finally {
+      this._transcribing = false;
+    }
+  }
+
+  async _runServerTranscription(audioBlob, model, language, initialPrompt = null, options = {}) {
     debugLogger.info("Transcription mode: SERVER", { model, language: language || "auto" });
     const modelPath = this.getModelPath(model);
 
@@ -770,3 +823,4 @@ class WhisperManager {
 }
 
 module.exports = WhisperManager;
+module.exports.shouldRewarmOnWake = shouldRewarmOnWake;

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -176,6 +176,7 @@ class WhisperServerManager extends EventEmitter {
     this.useCuda = false;
     this.vadSignature = "vad:off";
     this.threadSignature = "threads:default";
+    this.lastStartOptions = {};
   }
 
   getFFmpegPath() {
@@ -371,6 +372,10 @@ class WhisperServerManager extends EventEmitter {
 
   async start(modelPath, options = {}) {
     if (this.startupPromise) return this.startupPromise;
+
+    // Remember the options so a wake re-warm can reload with the same VAD/thread
+    // signature and survive start()'s no-op guard on the next dictation. See #766.
+    this.lastStartOptions = { ...options };
 
     const threadResolution = resolveWhisperThreads(options);
     const nextThreadSignature = getThreadSignature(threadResolution);

--- a/test/helpers/whisperWakeRewarm.test.js
+++ b/test/helpers/whisperWakeRewarm.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { shouldRewarmOnWake } = require("../../src/helpers/whisper");
+
+const base = {
+  isRemote: false,
+  useCuda: true,
+  modelName: "large",
+  transcribing: false,
+  rewarmInFlight: false,
+};
+
+test("re-warms a running local CUDA whisper-server after wake", () => {
+  assert.equal(shouldRewarmOnWake(base), true);
+});
+
+test("skips CPU whisper-server (model survives sleep in RAM)", () => {
+  assert.equal(shouldRewarmOnWake({ ...base, useCuda: false }), false);
+});
+
+test("skips a remote whisper-server", () => {
+  assert.equal(shouldRewarmOnWake({ ...base, isRemote: true }), false);
+});
+
+test("skips when no server model is active", () => {
+  assert.equal(shouldRewarmOnWake({ ...base, modelName: null }), false);
+});
+
+test("skips while a transcription is already warming the server", () => {
+  assert.equal(shouldRewarmOnWake({ ...base, transcribing: true }), false);
+});
+
+test("skips while another wake re-warm is already in flight", () => {
+  assert.equal(shouldRewarmOnWake({ ...base, rewarmInFlight: true }), false);
+});


### PR DESCRIPTION
## Summary

The literal ask in #766 (keep the model in VRAM while idle) is already how it works: the local whisper-server holds the model resident the whole time it sits idle. The real problem, surfaced later in the thread, is sleep. On Windows the GPU powers down during S3 sleep and the model is evicted from VRAM; the whisper-server process survives but its CUDA context is dead, and since `start()` in `whisperServer.js` short-circuits when the server is already up with the same model, nothing reloads it. So the first dictation after waking pays the full model reload and clips the opening words.

This hooks the existing `powerMonitor` "resume" handler in `main.js`. A few seconds after wake (enough for the NVIDIA driver to reinitialize) it calls a new `whisperManager.onWakeFromSleep()`, which restarts the local server so the model is back in VRAM before the user dictates. It only fires for a running local CUDA server (remote and CPU servers keep their model across sleep, and Parakeet is CPU only), replays the last `start()` options so the reloaded server keeps the VAD/thread signature the next dictation expects, and skips when a transcription or another re-warm is already in flight.

Fixes #766

## Changes

- src/helpers/whisper.js: add `onWakeFromSleep()` to restart a running local CUDA whisper-server, replaying the last start options; add the `shouldRewarmOnWake()` gate; track `_transcribing` and `_rewarmInFlight`; wrap `transcribeViaServer` so it flags in-flight work around the extracted `_runServerTranscription`.
- src/helpers/whisperServer.js: remember the last `start()` options so the wake reload matches the next dictation's VAD/thread signature.
- main.js: on `powerMonitor` "resume", schedule a debounced, delayed `onWakeFromSleep()` and clear the timer on teardown.
- test/helpers/whisperWakeRewarm.test.js: unit tests for the `shouldRewarmOnWake()` gate.
