### PR TITLE
Fix macOS clipboard restore delay

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -54,7 +54,7 @@ const PASTE_DELAYS = {
 };
 
 const RESTORE_DELAYS = {
-  darwin: 2000,
+  darwin: 450,
   win32_nircmd: 500,
   win32_pwsh: 500,
   linux: 800,

--- a/test/helpers/clipboardRestore.test.js
+++ b/test/helpers/clipboardRestore.test.js
@@ -1,6 +1,8 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+const childProcess = require("node:child_process");
 
 const fakeClipboard = {
   text: "",
@@ -28,21 +30,47 @@ const fakeClipboard = {
   writeImage() {},
 };
 
-const originalLoad = Module._load;
-Module._load = function loadWithElectronMock(request, parent, isMain) {
-  if (request === "electron") {
-    return {
-      clipboard: fakeClipboard,
-      systemPreferences: {
-        isTrustedAccessibilityClient: () => true,
-      },
-    };
-  }
-  return originalLoad.call(this, request, parent, isMain);
-};
+const clipboardModulePath = require.resolve("../../src/helpers/clipboard");
 
-const ClipboardManager = require("../../src/helpers/clipboard");
-Module._load = originalLoad;
+const originalLoad = Module._load;
+
+function loadClipboardManager({ spawn } = {}) {
+  delete require.cache[clipboardModulePath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        clipboard: fakeClipboard,
+        systemPreferences: {
+          isTrustedAccessibilityClient: () => true,
+        },
+      };
+    }
+    if (request === "child_process" && spawn) {
+      return { ...childProcess, spawn };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../../src/helpers/clipboard");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const ClipboardManager = loadClipboardManager();
+
+function createSuccessfulSpawn(calls) {
+  return function successfulSpawn(command, args = []) {
+    calls.push({ command, args });
+    const pasteProcess = new EventEmitter();
+    pasteProcess.stderr = new EventEmitter();
+    pasteProcess.stdout = new EventEmitter();
+    process.nextTick(() => pasteProcess.emit("close", 0));
+    return pasteProcess;
+  };
+}
 
 function resetClipboard() {
   fakeClipboard.text = "";
@@ -103,4 +131,66 @@ test("pasteText waits for prior clipboard restoration before starting the next p
   releaseFirstRestore();
   await secondPaste;
   assert.deepEqual(events, ["start:first", "end:first", "start:second", "end:second"]);
+});
+
+test("pasteMacOS restores clipboard after the short macOS delay on successful fast paste", async () => {
+  const spawnCalls = [];
+  const TestClipboardManager = loadClipboardManager({
+    spawn: createSuccessfulSpawn(spawnCalls),
+  });
+  const manager = new TestClipboardManager();
+  const originalClipboard = { type: "text", data: "previous clipboard" };
+  let restoreCall;
+
+  manager.resolveFastPasteBinary = () => "/tmp/openwhispr-fast-paste";
+  manager._restoreClipboardAfterDelay = (original, options) => {
+    restoreCall = { original, options };
+    return Promise.resolve();
+  };
+
+  const result = await manager.pasteMacOS(originalClipboard, {
+    expectedClipboardText: "dictated text",
+    fromStreaming: true,
+  });
+  await result.restoreComplete;
+
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].command, "/tmp/openwhispr-fast-paste");
+  assert.equal(restoreCall.original, originalClipboard);
+  assert.deepEqual(restoreCall.options, {
+    delayMs: 450,
+    expectedText: "dictated text",
+  });
+});
+
+test("pasteMacOSWithOsascript fallback uses the short macOS restore delay", async () => {
+  const spawnCalls = [];
+  const TestClipboardManager = loadClipboardManager({
+    spawn: createSuccessfulSpawn(spawnCalls),
+  });
+  const manager = new TestClipboardManager();
+  const originalClipboard = { type: "text", data: "previous clipboard" };
+  let restoreCall;
+
+  manager._restoreClipboardAfterDelay = (original, options) => {
+    restoreCall = { original, options };
+    return Promise.resolve();
+  };
+
+  const result = await manager.pasteMacOSWithOsascript(originalClipboard, {
+    expectedClipboardText: "dictated text",
+  });
+  await result.restoreComplete;
+
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].command, "osascript");
+  assert.deepEqual(spawnCalls[0].args, [
+    "-e",
+    'tell application "System Events" to key code 9 using command down',
+  ]);
+  assert.equal(restoreCall.original, originalClipboard);
+  assert.deepEqual(restoreCall.options, {
+    delayMs: 450,
+    expectedText: "dictated text",
+  });
 });


### PR DESCRIPTION
## Summary

- Restore the macOS clipboard after 450ms instead of 2000ms after a successful paste.
- Add coverage for both the fast-paste path and the osascript fallback to keep the shared macOS restore delay at 450ms.

## Why

Fixes #1023.

OpenWhispr 1.7.3 increased the macOS clipboard restore delay to 2000ms. That leaves the dictated text on the clipboard for longer after paste, which can cause follow-up paste behavior to use the dictated text rather than the user's previous clipboard content. This restores the shorter macOS delay while keeping the existing expected-text guard that avoids overwriting a newer user clipboard write.

## Tests

- `mise x node@24 -- node --test test/helpers/clipboardRestore.test.js` passed, 5/5.
- `mise x node@24 -- npm run lint` passed.
- `mise x node@24 -- npm run typecheck` passed.
- `mise x node@24 -- npx prettier --check src/helpers/clipboard.js test/helpers/clipboardRestore.test.js` passed.
- `git diff --check upstream/main` passed.
- `mise x node@24 -- npm run format:check` ran but failed on existing unrelated formatting issues in `helpers/audioManager.js`, `helpers/speakerEmbeddings.js`, and `helpers/textEditMonitor.js`; the two changed files pass Prettier directly.

## Scope / non-goals

- Scope is limited to the macOS clipboard restore delay and focused unit coverage for the macOS paste success paths.
- No changes to Windows or Linux clipboard timing.
- No changes to paste behavior beyond the restore delay value.

## Caveats

- I did not run a manual macOS dictation smoke test.
- PR #1020 also touches `src/helpers/clipboard.js` and `test/helpers/clipboardRestore.test.js` for #834 rich clipboard restoration. This PR fixes a separate #1023 timing regression; if #1020 lands first, I will rebase this branch before requesting review.
