### PR TITLE
fix(ui): commit API key draft on click-outside instead of discarding it

### DIFF
--- a/src/components/ui/ApiKeyInput.tsx
+++ b/src/components/ui/ApiKeyInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, X, KeyRound } from "lucide-react";
 import { Input } from "./input";
@@ -54,14 +54,14 @@ export default function ApiKeyInput({
     setIsEditing(true);
   };
 
-  const save = () => {
+  const save = useCallback(() => {
     try {
       setApiKey(draft.trim());
     } catch (err) {
       logger.warn("Failed to save API key", { error: (err as Error).message }, "settings");
     }
     setIsEditing(false);
-  };
+  }, [draft, setApiKey]);
 
   const cancel = () => {
     setDraft("");
@@ -79,15 +79,17 @@ export default function ApiKeyInput({
     }
   };
 
+  // Commit the draft instead of discarding it — users paste a key and click
+  // the next field expecting it to stick (Escape or ✕ still cancels).
   useEffect(() => {
     if (!isEditing) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current?.contains(e.target as Node)) return;
-      cancel();
+      save();
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isEditing]);
+  }, [isEditing, save]);
 
   return (
     <div className={className}>


### PR DESCRIPTION
## Problem

Users reported their Corti client ID and client secret being cleared out right after typing them in during onboarding — especially those who continued without an account (they're the only cohort forced into BYOK, so they're the ones typing credentials by hand).

Root cause: `ApiKeyInput` keeps typed input in a local draft that only commits on Enter or the ✓ button. Any `mousedown` outside the field cancelled the draft, so the natural flow — paste client ID → click the client secret field — silently discarded the value and the field reverted to the empty "Add" placeholder. Validation reads the settings store, which never received the value, so "Use Corti" / Continue stayed disabled.

This affected every provider using `ApiKeyInput` (OpenAI, Groq, xAI, Mistral, custom), in both onboarding and Settings — Corti was just the most exposed since it has two adjacent credential fields.

## Fix

Click-outside now commits the draft instead of discarding it. Escape and the ✕ button remain explicit cancels. `save` is wrapped in `useCallback` so the document listener always sees the current draft.

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- `prettier --check` ✅