### PR TITLE
fix(linux): fall back to --no-sandbox when user namespaces are restricted

### DIFF
--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -6,13 +6,16 @@
 //
 // 1. Strips non-target platform/arch binaries from onnxruntime-node
 //    (saves 150–180 MB per build).
-// 2. Wraps the Linux binary in a shell script that forces XWayland and
-//    reads user flags from ~/.config/open-whispr-flags.conf.
+// 2. Wraps the Linux binary in a shell script that forces XWayland, reads
+//    user flags from ~/.config/open-whispr-flags.conf, and falls back to
+//    --no-sandbox where the Chromium sandbox cannot work (AppImage/tar.gz
+//    on distros that restrict unprivileged user namespaces).
 
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const { Arch } = require("app-builder-lib");
+const { buildLinuxWrapperScript } = require("./lib/linux-launcher");
 
 // ---------------------------------------------------------------------------
 // macOS resource binary signing
@@ -172,31 +175,7 @@ function wrapLinuxBinary(context) {
 
   fs.renameSync(binaryPath, realBinaryPath);
 
-  const wrapper = `#!/bin/bash
-# OpenWhispr launcher
-# User flags: ~/.config/${binaryName}-flags.conf (one per line, # = comment)
-
-HERE="$(dirname "$(readlink -f "\${BASH_SOURCE[0]}")")"
-FLAGS=()
-
-# Wayland: forces XWayland (overlay positioning requires X11)
-if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-  FLAGS+=(--ozone-platform=x11)
-fi
-
-# User flags
-FLAGS_FILE="\${XDG_CONFIG_HOME:-$HOME/.config}/${binaryName}-flags.conf"
-if [ -f "$FLAGS_FILE" ]; then
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
-    FLAGS+=("$line")
-  done < "$FLAGS_FILE"
-fi
-
-exec -a "$0" "$HERE/${binaryName}-app" "\${FLAGS[@]}" "$@"
-`;
-
-  fs.writeFileSync(binaryPath, wrapper, { mode: 0o755 });
+  fs.writeFileSync(binaryPath, buildLinuxWrapperScript(binaryName), { mode: 0o755 });
 }
 
 function verifyMeetingAecHelper(context) {

--- a/scripts/lib/linux-launcher.js
+++ b/scripts/lib/linux-launcher.js
@@ -1,0 +1,40 @@
+function buildLinuxWrapperScript(binaryName) {
+  if (typeof binaryName !== "string" || !/^[A-Za-z0-9._-]+$/.test(binaryName)) {
+    throw new Error(`Invalid Linux executable name: ${JSON.stringify(binaryName)}`);
+  }
+
+  return `#!/bin/bash
+# OpenWhispr launcher
+# User flags: ~/.config/${binaryName}-flags.conf (one per line, # = comment)
+
+HERE="$(dirname "$(readlink -f "\${BASH_SOURCE[0]}")")"
+FLAGS=()
+
+# Wayland: forces XWayland (overlay positioning requires X11)
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+  FLAGS+=(--ozone-platform=x11)
+fi
+
+# Chromium needs unprivileged user namespaces (restricted since Ubuntu 23.10)
+# or a root-owned setuid chrome-sandbox; with neither it aborts at launch.
+if ! { [ "$(stat -c %u "$HERE/chrome-sandbox" 2>/dev/null)" = "0" ] && [ -u "$HERE/chrome-sandbox" ] && [ -x "$HERE/chrome-sandbox" ]; }; then
+  if command -v unshare >/dev/null 2>&1 && ! unshare --user --map-root-user true >/dev/null 2>&1; then
+    echo "${binaryName}: user namespaces are restricted, starting with --no-sandbox" >&2
+    FLAGS+=(--no-sandbox)
+  fi
+fi
+
+# User flags
+FLAGS_FILE="\${XDG_CONFIG_HOME:-$HOME/.config}/${binaryName}-flags.conf"
+if [ -f "$FLAGS_FILE" ]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    FLAGS+=("$line")
+  done < "$FLAGS_FILE"
+fi
+
+exec -a "$0" "$HERE/${binaryName}-app" "\${FLAGS[@]}" "$@"
+`;
+}
+
+module.exports = { buildLinuxWrapperScript };

--- a/test/helpers/linuxLauncherSandbox.test.js
+++ b/test/helpers/linuxLauncherSandbox.test.js
@@ -1,0 +1,140 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const cp = require("child_process");
+
+const { buildLinuxWrapperScript } = require("../../scripts/lib/linux-launcher.js");
+
+const isLinux = process.platform === "linux";
+const BINARY_NAME = "open-whispr";
+
+function setupLauncher() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "linux-launcher-test-"));
+  const appDir = path.join(tmp, "app");
+  const stubBin = path.join(tmp, "stub-bin");
+  const argsFile = path.join(tmp, "args.txt");
+  fs.mkdirSync(appDir);
+  fs.mkdirSync(stubBin);
+
+  const wrapperPath = path.join(appDir, BINARY_NAME);
+  fs.writeFileSync(wrapperPath, buildLinuxWrapperScript(BINARY_NAME), { mode: 0o755 });
+
+  fs.writeFileSync(
+    path.join(appDir, `${BINARY_NAME}-app`),
+    `#!/bin/bash\nprintf '%s\\n' "$@" > "${argsFile}"\n`,
+    { mode: 0o755 }
+  );
+
+  fs.writeFileSync(path.join(stubBin, "unshare"), '#!/bin/bash\nexit "${STUB_UNSHARE_EXIT:-0}"\n', {
+    mode: 0o755,
+  });
+
+  return { tmp, appDir, stubBin, argsFile, wrapperPath };
+}
+
+function runLauncher(ctx, { unshareExit = 0, env = {}, args = [] } = {}) {
+  return cp.spawnSync(ctx.wrapperPath, args, {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${ctx.stubBin}:${process.env.PATH}`,
+      XDG_SESSION_TYPE: "x11",
+      XDG_CONFIG_HOME: path.join(ctx.tmp, "xdg"),
+      STUB_UNSHARE_EXIT: String(unshareExit),
+      ...env,
+    },
+  });
+}
+
+function launchedArgs(ctx) {
+  return fs.readFileSync(ctx.argsFile, "utf8").split("\n").filter(Boolean);
+}
+
+test(
+  "appends --no-sandbox before user args when chrome-sandbox is not setuid root and the userns probe fails",
+  { skip: !isLinux },
+  () => {
+    const ctx = setupLauncher();
+    const res = runLauncher(ctx, { unshareExit: 1, args: ["--user-arg"] });
+
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stderr, /--no-sandbox/);
+    assert.deepEqual(launchedArgs(ctx), ["--no-sandbox", "--user-arg"]);
+  }
+);
+
+test("keeps the sandbox when user namespaces are available", { skip: !isLinux }, () => {
+  const ctx = setupLauncher();
+  const res = runLauncher(ctx, { unshareExit: 0 });
+
+  assert.equal(res.status, 0, res.stderr);
+  assert.deepEqual(launchedArgs(ctx), []);
+});
+
+test(
+  "keeps the sandbox when chrome-sandbox is setuid root even if the userns probe fails",
+  { skip: !isLinux },
+  () => {
+    const ctx = setupLauncher();
+    const sandboxPath = path.join(ctx.appDir, "chrome-sandbox");
+    fs.writeFileSync(sandboxPath, "#!/bin/bash\n", { mode: 0o755 });
+    fs.chmodSync(sandboxPath, 0o4755);
+    fs.writeFileSync(path.join(ctx.stubBin, "stat"), "#!/bin/bash\necho 0\n", { mode: 0o755 });
+
+    const res = runLauncher(ctx, { unshareExit: 1 });
+
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(launchedArgs(ctx), []);
+  }
+);
+
+test("keeps the sandbox when unshare is unavailable", { skip: !isLinux }, () => {
+  const ctx = setupLauncher();
+  const isolatedBin = path.join(ctx.tmp, "isolated-bin");
+  fs.mkdirSync(isolatedBin);
+  for (const tool of ["dirname", "readlink", "stat"]) {
+    const realPath = cp
+      .execFileSync("/bin/bash", ["-c", `command -v ${tool}`], { encoding: "utf8" })
+      .trim();
+    fs.symlinkSync(realPath, path.join(isolatedBin, tool));
+  }
+
+  const res = runLauncher(ctx, { env: { PATH: isolatedBin } });
+
+  assert.equal(res.status, 0, res.stderr);
+  assert.deepEqual(launchedArgs(ctx), []);
+});
+
+test(
+  "orders the XWayland flag, the sandbox fallback, and flags-file entries before user args",
+  { skip: !isLinux },
+  () => {
+    const ctx = setupLauncher();
+    const xdgDir = path.join(ctx.tmp, "xdg");
+    fs.mkdirSync(xdgDir);
+    fs.writeFileSync(path.join(xdgDir, `${BINARY_NAME}-flags.conf`), "# comment\n--from-conf\n");
+
+    const res = runLauncher(ctx, {
+      unshareExit: 1,
+      env: { XDG_SESSION_TYPE: "wayland" },
+      args: ["--user-arg"],
+    });
+
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(launchedArgs(ctx), [
+      "--ozone-platform=x11",
+      "--no-sandbox",
+      "--from-conf",
+      "--user-arg",
+    ]);
+  }
+);
+
+test("rejects executable names that could break out of the generated script", () => {
+  assert.throws(() => buildLinuxWrapperScript('bad"; rm -rf /'), /Invalid Linux executable name/);
+  assert.throws(() => buildLinuxWrapperScript("name with spaces"), /Invalid Linux executable name/);
+  assert.throws(() => buildLinuxWrapperScript(""), /Invalid Linux executable name/);
+  assert.throws(() => buildLinuxWrapperScript(undefined), /Invalid Linux executable name/);
+});


### PR DESCRIPTION
## Summary

Ubuntu 23.10+ enables `kernel.apparmor_restrict_unprivileged_userns=1` by default, which denies the user namespaces Chromium's sandbox needs to any process without an AppArmor profile. Electron then falls back to the setuid `chrome-sandbox` helper, which inside an AppImage FUSE mount can never be root-owned with mode 4755, so the app aborts at launch (electron/electron#41066). deb/rpm installs are unaffected because `after-install.sh` already sets the SUID bit.

The launcher script generated by `wrapLinuxBinary` in `scripts/afterPack.js` now checks at startup: if `chrome-sandbox` next to the binary is not setuid root and `unshare --user --map-root-user true` fails, it starts with `--no-sandbox` and prints a notice to stderr. This is the same probe electron-builder ships in AppRun since 26.9 (electron-userland/electron-builder#9590), which we don't get on 26.4 with the default AppImage toolset. The uid mapping in the probe matters: on Ubuntu 24.04 namespace creation succeeds but capabilities inside are denied, so a plain `unshare --user` reports the sandbox as usable when it isn't. This also covers tar.gz, while deb/rpm and distros with working namespaces keep the sandbox.

Fixes #1033

## Changes

- scripts/lib/linux-launcher.js: new module that generates the Linux launcher script (template moved out of afterPack.js), adding the sandbox fallback and executable name validation
- scripts/afterPack.js: wrapLinuxBinary now builds the wrapper via the new module
- test/helpers/linuxLauncherSandbox.test.js: tests for the fallback (failing probe, working namespaces, setuid helper present, unshare missing, flag ordering, name validation)
