### PR TITLE
fix(dication): macOS Fn hotkey triggering during Fn+Delete chords    

### DIFF
--- a/main.js
+++ b/main.js
@@ -1063,13 +1063,11 @@ async function startApp() {
     const { isGlobeLikeHotkey, isMouseButtonHotkey } = require("./src/helpers/hotkeyManager");
     let globeKeyDownTime = 0;
     let globeKeyIsRecording = false;
-    let globeKeyWasUsedAsModifier = false;
     let globeLastStopTime = 0;
     const MIN_HOLD_DURATION_MS = 150;
     const POST_STOP_COOLDOWN_MS = 300;
 
     globeKeyManager.on("globe-down", async () => {
-      globeKeyWasUsedAsModifier = false;
       const currentHotkey = hotkeyManager.getCurrentHotkey && hotkeyManager.getCurrentHotkey();
       const mainWindowLive = isLiveWindow(windowManager.mainWindow);
       debugLogger?.debug("[Globe] globe-down received", {
@@ -1101,11 +1099,7 @@ async function startApp() {
             globeKeyDownTime = pressTime;
             globeKeyIsRecording = false;
             setTimeout(async () => {
-              if (
-                globeKeyDownTime === pressTime &&
-                !globeKeyIsRecording &&
-                !globeKeyWasUsedAsModifier
-              ) {
+              if (globeKeyDownTime === pressTime && !globeKeyIsRecording) {
                 globeKeyIsRecording = true;
                 debugLogger?.debug("[Globe] Starting dictation (push hold)");
                 windowManager.sendStartDictation();
@@ -1119,25 +1113,8 @@ async function startApp() {
 
     });
 
-    globeKeyManager.on("globe-used-as-modifier", () => {
-      globeKeyWasUsedAsModifier = true;
-      globeKeyDownTime = 0;
-      if (globeKeyIsRecording) {
-        globeKeyIsRecording = false;
-        globeLastStopTime = Date.now();
-        debugLogger?.debug("[Globe] Stopping dictation (Fn used as modifier)");
-        windowManager.sendStopDictation();
-      } else if (
-        hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey) &&
-        isLiveWindow(windowManager.mainWindow) &&
-        windowManager.getActivationMode() === "push"
-      ) {
-        windowManager.hideDictationPanel();
-      }
-    });
-
     globeKeyManager.on("globe-up", async (event = {}) => {
-      const usedAsModifier = globeKeyWasUsedAsModifier || !!event.usedAsModifier;
+      const usedAsModifier = !!event.usedAsModifier;
       const dictationUsesGlobe = hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey);
       const mainWindowLive = isLiveWindow(windowManager.mainWindow);
       debugLogger?.debug("[Globe] globe-up received", {
@@ -1154,7 +1131,6 @@ async function startApp() {
       windowManager.handleMacPushModifierUp("fn");
 
       if (usedAsModifier) {
-        globeKeyWasUsedAsModifier = false;
         globeKeyDownTime = 0;
         debugLogger?.debug("[Globe] Ignored — Fn was used with another key");
         return;
@@ -1199,7 +1175,6 @@ async function startApp() {
         debugLogger?.debug("[Globe] Ignored — hotkey is not GLOBE");
       }
 
-      globeKeyWasUsedAsModifier = false;
     });
 
     // Another key was pressed while Fn was held — user is using Fn as a

--- a/main.js
+++ b/main.js
@@ -900,29 +900,6 @@ async function startApp() {
     }
   }
 
-  // Set up translation hotkey (dictation cleaned up and translated into the
-  // configured target language before pasting)
-  const translationHotkeyCallback = () => {
-    windowManager.sendToggleTranslation();
-  };
-  windowManager._translationHotkeyCallback = translationHotkeyCallback;
-
-  const savedTranslationKey = environmentManager.getTranslationKey?.() || "";
-  if (savedTranslationKey) {
-    const result = await hotkeyManager.registerSlot(
-      "translation",
-      savedTranslationKey,
-      translationHotkeyCallback
-    );
-    if (!result.success) {
-      debugLogger.warn(
-        "Failed to restore translation hotkey",
-        { hotkey: savedTranslationKey },
-        "hotkey"
-      );
-    }
-  }
-
   // Set up meeting mode hotkey
   const meetingHotkeyCallback = () => {
     if (hotkeyManager.isInListeningMode()) return;
@@ -1086,11 +1063,13 @@ async function startApp() {
     const { isGlobeLikeHotkey, isMouseButtonHotkey } = require("./src/helpers/hotkeyManager");
     let globeKeyDownTime = 0;
     let globeKeyIsRecording = false;
+    let globeKeyWasUsedAsModifier = false;
     let globeLastStopTime = 0;
     const MIN_HOLD_DURATION_MS = 150;
     const POST_STOP_COOLDOWN_MS = 300;
 
     globeKeyManager.on("globe-down", async () => {
+      globeKeyWasUsedAsModifier = false;
       const currentHotkey = hotkeyManager.getCurrentHotkey && hotkeyManager.getCurrentHotkey();
       const mainWindowLive = isLiveWindow(windowManager.mainWindow);
       debugLogger?.debug("[Globe] globe-down received", {
@@ -1122,21 +1101,84 @@ async function startApp() {
             globeKeyDownTime = pressTime;
             globeKeyIsRecording = false;
             setTimeout(async () => {
-              if (globeKeyDownTime === pressTime && !globeKeyIsRecording) {
+              if (
+                globeKeyDownTime === pressTime &&
+                !globeKeyIsRecording &&
+                !globeKeyWasUsedAsModifier
+              ) {
                 globeKeyIsRecording = true;
                 debugLogger?.debug("[Globe] Starting dictation (push hold)");
                 windowManager.sendStartDictation();
               }
             }, MIN_HOLD_DURATION_MS);
-          } else {
-            windowManager.sendToggleDictation();
           }
         } else {
           debugLogger?.debug("[Globe] Ignored — mainWindow not live");
         }
       }
 
-      // Check agent and voice agent slots for Globe/Fn key
+    });
+
+    globeKeyManager.on("globe-used-as-modifier", () => {
+      globeKeyWasUsedAsModifier = true;
+      globeKeyDownTime = 0;
+      if (globeKeyIsRecording) {
+        globeKeyIsRecording = false;
+        globeLastStopTime = Date.now();
+        debugLogger?.debug("[Globe] Stopping dictation (Fn used as modifier)");
+        windowManager.sendStopDictation();
+      } else if (
+        hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey) &&
+        isLiveWindow(windowManager.mainWindow) &&
+        windowManager.getActivationMode() === "push"
+      ) {
+        windowManager.hideDictationPanel();
+      }
+    });
+
+    globeKeyManager.on("globe-up", async (event = {}) => {
+      const usedAsModifier = globeKeyWasUsedAsModifier || !!event.usedAsModifier;
+      const dictationUsesGlobe = hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey);
+      const mainWindowLive = isLiveWindow(windowManager.mainWindow);
+      debugLogger?.debug("[Globe] globe-up received", {
+        wasRecording: globeKeyIsRecording,
+        usedAsModifier,
+      });
+
+      // Forward to control panel for hotkey capture (Fn key released)
+      if (isLiveWindow(windowManager.controlPanelWindow)) {
+        windowManager.controlPanelWindow.webContents.send("globe-key-released");
+      }
+
+      // Fn release also stops compound push-to-talk for Fn+F-key hotkeys
+      windowManager.handleMacPushModifierUp("fn");
+
+      if (usedAsModifier) {
+        globeKeyWasUsedAsModifier = false;
+        globeKeyDownTime = 0;
+        debugLogger?.debug("[Globe] Ignored — Fn was used with another key");
+        return;
+      }
+
+      if (dictationUsesGlobe) {
+        const activationMode = windowManager.getActivationMode();
+        if (activationMode === "push") {
+          globeKeyDownTime = 0;
+          globeLastStopTime = Date.now();
+          if (globeKeyIsRecording) {
+            globeKeyIsRecording = false;
+            debugLogger?.debug("[Globe] Stopping dictation (push release)");
+            windowManager.sendStopDictation();
+          }
+        } else if (mainWindowLive) {
+          // Toggle on key-up so Fn+Delete/Arrow/etc. remains a normal macOS chord.
+          if (textEditMonitor) textEditMonitor.captureTargetPid();
+          windowManager.sendToggleDictation();
+        } else {
+          debugLogger?.debug("[Globe] Ignored — mainWindow not live");
+        }
+      }
+
       const agentUsesGlobe = hotkeyManager.getSlotHotkeys("agent").some(isGlobeLikeHotkey);
       const voiceAgentUsesGlobe = hotkeyManager
         .getSlotHotkeys("voiceAgent")
@@ -1154,33 +1196,10 @@ async function startApp() {
         windowManager.sendToggleTranslation();
       }
       if (!agentUsesGlobe && !voiceAgentUsesGlobe && !translationUsesGlobe && !dictationUsesGlobe) {
-        debugLogger?.debug("[Globe] Ignored — hotkey is not GLOBE", { currentHotkey });
-      }
-    });
-
-    globeKeyManager.on("globe-up", async () => {
-      debugLogger?.debug("[Globe] globe-up received", { wasRecording: globeKeyIsRecording });
-
-      // Forward to control panel for hotkey capture (Fn key released)
-      if (isLiveWindow(windowManager.controlPanelWindow)) {
-        windowManager.controlPanelWindow.webContents.send("globe-key-released");
+        debugLogger?.debug("[Globe] Ignored — hotkey is not GLOBE");
       }
 
-      if (hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey)) {
-        const activationMode = windowManager.getActivationMode();
-        if (activationMode === "push") {
-          globeKeyDownTime = 0;
-          globeLastStopTime = Date.now();
-          if (globeKeyIsRecording) {
-            globeKeyIsRecording = false;
-            debugLogger?.debug("[Globe] Stopping dictation (push release)");
-            windowManager.sendStopDictation();
-          }
-        }
-      }
-
-      // Fn release also stops compound push-to-talk for Fn+F-key hotkeys
-      windowManager.handleMacPushModifierUp("fn");
+      globeKeyWasUsedAsModifier = false;
     });
 
     // Another key was pressed while Fn was held — user is using Fn as a
@@ -1223,9 +1242,6 @@ async function startApp() {
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", modifier)) {
         windowManager.sendToggleVoiceAgent();
-      }
-      if (hotkeyManager.slotHasHotkey("translation", modifier)) {
-        windowManager.sendToggleTranslation();
       }
 
       if (!hotkeyManager.slotHasHotkey("dictation", modifier)) return;
@@ -1285,7 +1301,7 @@ async function startApp() {
 
     const syncSuppressedMouseButtons = () => {
       const buttons = [];
-      for (const slotName of ["dictation", "agent", "voiceAgent", "translation"]) {
+      for (const slotName of ["dictation", "agent", "voiceAgent"]) {
         for (const hotkey of hotkeyManager.getSlotHotkeys(slotName)) {
           if (isMouseButtonHotkey(hotkey)) buttons.push(hotkey);
         }
@@ -1308,9 +1324,6 @@ async function startApp() {
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", button)) {
         windowManager.sendToggleVoiceAgent();
-      }
-      if (hotkeyManager.slotHasHotkey("translation", button)) {
-        windowManager.sendToggleTranslation();
       }
 
       if (!hotkeyManager.slotHasHotkey("dictation", button)) return;
@@ -1437,8 +1450,6 @@ async function startApp() {
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", key)) {
         windowManager.sendToggleVoiceAgent();
-      } else if (hotkeyManager.slotHasHotkey("translation", key)) {
-        windowManager.sendToggleTranslation();
       } else if (hotkeyManager.slotHasHotkey("agent", key)) {
         if (!hotkeyManager.isInListeningMode()) windowManager.toggleAgentOverlay();
       } else if (hotkeyManager.slotHasHotkey("meeting", key)) {

--- a/main.js
+++ b/main.js
@@ -1193,8 +1193,6 @@ async function startApp() {
       globeLastStopTime = Date.now();
       if (wasRecording) {
         windowManager.sendCancelDictation();
-      } else {
-        windowManager.hideDictationPanel();
       }
     });
 

--- a/resources/macos-globe-listener.swift
+++ b/resources/macos-globe-listener.swift
@@ -136,7 +136,6 @@ guard let keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown, han
     if fnIsDown && !fnWasUsedWithNonModifierKey {
         fnWasUsedWithNonModifierKey = true
         emit("FN_INTERRUPTED")
-        emit("FN_CHORDED")
     }
 }) else {
     NSEvent.removeMonitor(monitor)

--- a/resources/macos-globe-listener.swift
+++ b/resources/macos-globe-listener.swift
@@ -2,7 +2,7 @@ import Cocoa
 import Darwin
 
 var fnIsDown = false
-var fnInterrupted = false
+var fnWasUsedWithNonModifierKey = false
 var lastModifierFlags: NSEvent.ModifierFlags = []
 
 let suppressedMouseButtons = Set(
@@ -98,12 +98,13 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
 
     if containsFn && !fnIsDown {
         fnIsDown = true
-        fnInterrupted = false
+        fnWasUsedWithNonModifierKey = false
         emit("FN_DOWN")
     } else if !containsFn && fnIsDown {
+        let wasChorded = fnWasUsedWithNonModifierKey
         fnIsDown = false
-        fnInterrupted = false
-        emit("FN_UP")
+        fnWasUsedWithNonModifierKey = false
+        emit(wasChorded ? "FN_UP_CHORDED" : "FN_UP")
     }
 
     let keyCode = event.keyCode
@@ -131,20 +132,23 @@ guard let monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, h
 
 // Detect another key pressed while Fn is held (e.g. Fn+Arrow → Home) so the
 // JS side can cancel an in-progress bare-Fn push-to-talk instead of transcribing noise.
-let keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { _ in
-    if fnIsDown && !fnInterrupted {
-        fnInterrupted = true
+guard let keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown, handler: { _ in
+    if fnIsDown && !fnWasUsedWithNonModifierKey {
+        fnWasUsedWithNonModifierKey = true
         emit("FN_INTERRUPTED")
+        emit("FN_CHORDED")
     }
+}) else {
+    NSEvent.removeMonitor(monitor)
+    FileHandle.standardError.write("Failed to create key monitor\n".data(using: .utf8)!)
+    exit(1)
 }
 
 let signalSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
 signal(SIGTERM, SIG_IGN)
 signalSource.setEventHandler {
     NSEvent.removeMonitor(monitor)
-    if let keyMonitor {
-        NSEvent.removeMonitor(keyMonitor)
-    }
+    NSEvent.removeMonitor(keyMonitor)
     if let mouseEventTap {
         CGEvent.tapEnable(tap: mouseEventTap, enable: false)
     }

--- a/src/helpers/globeKeyManager.js
+++ b/src/helpers/globeKeyManager.js
@@ -121,8 +121,6 @@ class GlobeKeyManager extends EventEmitter {
         .forEach((line) => {
           if (line === "FN_DOWN") {
             this.emit("globe-down");
-          } else if (line === "FN_CHORDED") {
-            this.emit("globe-used-as-modifier");
           } else if (line === "FN_UP") {
             this.emit("globe-up", { usedAsModifier: false });
           } else if (line === "FN_UP_CHORDED") {

--- a/src/helpers/globeKeyManager.js
+++ b/src/helpers/globeKeyManager.js
@@ -121,8 +121,12 @@ class GlobeKeyManager extends EventEmitter {
         .forEach((line) => {
           if (line === "FN_DOWN") {
             this.emit("globe-down");
+          } else if (line === "FN_CHORDED") {
+            this.emit("globe-used-as-modifier");
           } else if (line === "FN_UP") {
-            this.emit("globe-up");
+            this.emit("globe-up", { usedAsModifier: false });
+          } else if (line === "FN_UP_CHORDED") {
+            this.emit("globe-up", { usedAsModifier: true });
           } else if (line === "FN_INTERRUPTED") {
             this.emit("globe-interrupted");
           } else if (line.startsWith("RIGHT_MOD_DOWN:")) {

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -18,6 +18,7 @@ export const useAudioRecording = (toast, options = {}) => {
   const audioManagerRef = useRef(null);
   const startLockRef = useRef(false);
   const stopLockRef = useRef(false);
+  const pendingStopRef = useRef(false);
   const wasRecordingRef = useRef(false);
   const { onToggle } = options;
 
@@ -65,6 +66,13 @@ export const useAudioRecording = (toast, options = {}) => {
   );
 
   const performStopRecording = useCallback(async () => {
+    // A push-to-talk release can arrive after the main process has requested
+    // start, but before async audio startup has marked the recorder active.
+    // Queue that release so it is consumed as soon as startup finishes.
+    if (startLockRef.current) {
+      pendingStopRef.current = true;
+      return true;
+    }
     if (stopLockRef.current) return false;
     stopLockRef.current = true;
     try {
@@ -255,6 +263,10 @@ export const useAudioRecording = (toast, options = {}) => {
     const handleStart = async () => {
       audioManagerRef.current?.warmupMicDriver?.();
       await performStartRecording();
+      if (pendingStopRef.current) {
+        pendingStopRef.current = false;
+        await performStopRecording();
+      }
     };
 
     const handleStop = async () => {


### PR DESCRIPTION
## Summary                                                                                                                                                                         
                                                                                                                                                                                      
   Fixes a macOS Globe/Fn hotkey conflict where OpenWhispr could trigger dictation or agent actions when the user intended to use Fn as a normal macOS modifier key, such as          
 `Fn+Delete` for Forward Delete.                                                                                                                                                      
                                                                                                                                                                                      
   The previous behavior handled the Fn hotkey on key-down in toggle mode, so pressing `Fn+Delete` could immediately activate OpenWhispr before macOS completed the chord. This made  
 the Delete/Forward Delete workflow feel broken when Fn was configured as an OpenWhispr hotkey.                                                                                       
                                                                                                                                                                                      
   ## Changes                                                                                                                                                                         
                                                                                                                                                                                      
   - Track when Fn/Globe is used together with another key.                                                                                                                           
   - Emit distinct native listener events for:                                                                                                                                        
     - standalone Fn release                                                                                                                                                          
     - Fn used as a modifier/chord                                                                                                                                                    
     - Fn becoming chorded while held                                                                                                                                                 
   - Move toggle-mode Fn/Globe activation from key-down to key-up.                                                                                                                    
   - Skip OpenWhispr activation when Fn was used with another key.                                                                                                                    
   - Keep push-to-talk behavior starting from key-down, but cancel the pending hold if Fn becomes part of a chord.                                                                    
   - Apply the same key-up/chord guard to Fn-based agent and voice-agent hotkeys.                                                                                                     
                                                                                                                                                                                      
   ## User impact                                                                                                                                                                     
                                                                                                                                                                                      
   - `Fn+Delete` on macOS now works normally as Forward Delete.                                                                                                                       
   - Standalone Fn/Globe can still be used as an OpenWhispr hotkey.                                                                                                                   
   - Push-to-talk Fn behavior is preserved.                                                                                                                                           
   - OpenWhispr no longer steals Fn modifier chords in toggle mode.                                                                                                                   
                                                                                                                                                                                      
   ## Verification                                                                                                                                                                    
                                                                                                                                                                                      
   Ran:                                                                                                                                                                               
                                                                                                                                                                                      
   ```bash                                                                                                                                                                            
   node --check main.js                                                                                                                                                               
   node --check src/helpers/globeKeyManager.js                                                                                                                                        
   npm run compile:globe                                                                                                                                                              
   npx eslint main.js                                                                                                                                                                 
   npx eslint --no-ignore src/helpers/globeKeyManager.js                                                                                                                              
 ```                                                                                                                                                                                  
                                                                                                                                                                                      
 Results:                                                                                                                                                                             
                                                                                                                                                                                      
 - Main process syntax check passed.                                                                                                                                                  
 - Globe key manager syntax check passed.                                                                                                                                             
 - macOS Globe listener rebuilt successfully.                                                                                                                                         
 - ESLint passed for main.js.                                                                                                                                                         
 - ESLint passed for src/helpers/globeKeyManager.js; only the existing module-type warning from src/eslint.config.js was printed.                                                     