### PR TITLE
fix: snippet triggers containing Turkish İ and dotless ı never match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- **Snippets now match triggers containing Turkish İ and ı.** Trigger matching used `toLowerCase()`, whose lowercase form of İ (U+0130) is "i" plus a combining dot, so a snippet like "İmza" never matched the transcript — and the regex `/i` flag case-folds neither İ nor dotless ı (U+0131). Triggers and matches are now folded to a canonical key, the pattern matches İ/ı explicitly, and the transcript is NFC-normalized, so "imza", "İmza", "İMZA" — and "Işık"/"IŞIK" for an "ışık" trigger — all expand the same snippet.
+
 ### Transcription
 
 - **Azure AI Foundry / Azure OpenAI speech-to-text.** The custom transcription provider now recognizes Azure endpoints (`*.cognitiveservices.azure.com`, `*.openai.azure.com`, `*.services.ai.azure.com`) and builds the deployment-style URL Azure requires (`/openai/deployments/{model}/audio/transcriptions?api-version=...`) instead of the plain OpenAI `{base}/audio/transcriptions` shape, which returned `404 DeploymentNotFound`. Auth now uses Azure's `api-key` header on Azure hosts. Enter your resource endpoint as the URL and your exact deployment name in the Model field; `api-version` defaults to a transcribe-capable preview and can be overridden by appending `?api-version=...` to the endpoint.

--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -11,18 +11,34 @@ interface SnippetMatcher {
 let cachedSnippets: Snippet[] | null = null;
 let cachedMatcher: SnippetMatcher | null = null;
 
+// The regex /i flag can't case-fold Turkish İ (U+0130) or dotless ı
+// (U+0131), and İ's toLowerCase() form is two code units ("i" + U+0307), so
+// triggers like "İmza" never matched. Folding İ to a plain "i" gives Map
+// keys a canonical form, and matching İ/ı explicitly in the pattern lets the
+// regex find them in the transcript.
+function foldCapitalIDot(value: string): string {
+  return value.replace(/İ/g, "i");
+}
+
 function buildMatcher(snippets: Snippet[]): SnippetMatcher | null {
   const replacements = new Map<string, string>();
   for (const { trigger, replacement } of snippets) {
-    const key = trigger.trim().toLowerCase();
-    if (key) replacements.set(key, replacement);
+    const folded = foldCapitalIDot(trigger.trim().normalize("NFC"));
+    const key = folded.toLowerCase();
+    if (!key) continue;
+    replacements.set(key, replacement);
+    // An uppercase I in the trigger may mean Turkish ı as well as English i,
+    // so register both readings; an explicit trigger wins over a variant.
+    const dotlessKey = folded.replace(/I/g, "ı").toLowerCase();
+    if (!replacements.has(dotlessKey)) replacements.set(dotlessKey, replacement);
   }
   if (replacements.size === 0) return null;
 
   // Longest-first so "investor ask" wins over a shorter "ask" trigger.
   const escaped = [...replacements.keys()]
     .sort((a, b) => b.length - a.length)
-    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .map((t) => t.replace(/i/g, "[iİ]").replace(/ı/g, "[ıI]"));
   // Unicode-aware word boundaries — triggers never match inside a word.
   const regex = new RegExp(
     `(?<=^|[\\s\\p{P}\\p{S}])(?:${escaped.join("|")})(?=$|[\\s\\p{P}\\p{S}])`,
@@ -44,7 +60,16 @@ export function expandSnippets(text: string, snippets: Snippet[]): string {
   }
   if (!cachedMatcher) return text;
   const { regex, replacements } = cachedMatcher;
-  return text.replace(regex, (match) => replacements.get(match.toLowerCase()) ?? match);
+  // NFC so a decomposed "I" + U+0307 in the transcript recombines into İ.
+  return text.normalize("NFC").replace(regex, (match) => {
+    const folded = foldCapitalIDot(match);
+    return (
+      replacements.get(folded.toLowerCase()) ??
+      // An uppercase I can be capital dotless ı as well as English i.
+      replacements.get(folded.replace(/I/g, "ı").toLowerCase()) ??
+      match
+    );
+  });
 }
 
 /**

--- a/test/utils/snippets.test.js
+++ b/test/utils/snippets.test.js
@@ -1,0 +1,77 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { expandSnippets } = require("../../src/utils/snippets.ts");
+
+test("expands a trigger containing Turkish capital İ", () => {
+  const snippets = [{ trigger: "İmza", replacement: "Best regards,\nUmut" }];
+  assert.equal(expandSnippets("İmza", snippets), "Best regards,\nUmut");
+});
+
+test("İ trigger matches every casing the transcript may use", () => {
+  const snippets = [{ trigger: "İmza", replacement: "Best regards,\nUmut" }];
+  for (const spoken of ["imza", "İmza", "İMZA", "Imza"]) {
+    assert.equal(
+      expandSnippets(`Meeting is over. ${spoken} please.`, snippets),
+      "Meeting is over. Best regards,\nUmut please.",
+      `expected "${spoken}" to expand`
+    );
+  }
+});
+
+test("lowercase trigger matches capital İ in the transcript", () => {
+  const snippets = [{ trigger: "imza", replacement: "Best regards,\nUmut" }];
+  assert.equal(expandSnippets("İmza goes here", snippets), "Best regards,\nUmut goes here");
+  assert.equal(expandSnippets("İMZA goes here", snippets), "Best regards,\nUmut goes here");
+});
+
+test("dotless ı trigger matches capital I in the transcript", () => {
+  const snippets = [{ trigger: "ışık", replacement: "LIGHT" }];
+  for (const spoken of ["ışık", "Işık", "IŞIK"]) {
+    assert.equal(
+      expandSnippets(`${spoken} on`, snippets),
+      "LIGHT on",
+      `expected "${spoken}" to expand`
+    );
+  }
+});
+
+test("trigger saved with capital I matches both Turkish and English readings", () => {
+  const snippets = [{ trigger: "Işık", replacement: "LIGHT" }];
+  for (const spoken of ["ışık", "Işık", "IŞIK", "işık"]) {
+    assert.equal(
+      expandSnippets(`${spoken} on`, snippets),
+      "LIGHT on",
+      `expected "${spoken}" to expand`
+    );
+  }
+});
+
+test("all-caps English trigger with capital I still matches", () => {
+  const snippets = [{ trigger: "IBAN", replacement: "TR00 0000 0000" }];
+  assert.equal(expandSnippets("iban please", snippets), "TR00 0000 0000 please");
+  assert.equal(expandSnippets("IBAN please", snippets), "TR00 0000 0000 please");
+  assert.equal(expandSnippets("İBAN please", snippets), "TR00 0000 0000 please");
+});
+
+test("decomposed İ (capital I + combining dot above) still matches", () => {
+  const snippets = [{ trigger: "İmza", replacement: "Best regards,\nUmut" }];
+  assert.equal(expandSnippets("İmza done".normalize("NFD"), snippets), "Best regards,\nUmut done");
+});
+
+test("İ still respects word boundaries", () => {
+  const snippets = [{ trigger: "İmza", replacement: "SIGNATURE" }];
+  assert.equal(expandSnippets("imzalar are ready", snippets), "imzalar are ready");
+  assert.equal(expandSnippets("(İmza) is required", snippets), "(SIGNATURE) is required");
+});
+
+test("plain ASCII triggers still fold case both ways", () => {
+  const snippets = [{ trigger: "Signoff", replacement: "Regards" }];
+  assert.equal(expandSnippets("SIGNOFF now", snippets), "Regards now");
+  assert.equal(expandSnippets("signoff now", snippets), "Regards now");
+});
+
+test("multiple occurrences and unmatched text are preserved", () => {
+  const snippets = [{ trigger: "İmza", replacement: "X" }];
+  assert.equal(expandSnippets("İmza and imza, done", snippets), "X and X, done");
+});


### PR DESCRIPTION
## Problem

Snippet trigger matching used `toLowerCase()` for the lookup keys and the regex `/i` flag for matching, and neither handles the Turkish dotted/dotless I pair:

- `"İ".toLowerCase()` (U+0130) produces **two** code units — `"i"` + U+0307 combining dot — so a trigger saved as `İmza` produced a Map key that could never equal any regex match.
- The `/i` flag's simple case folding maps neither `İ` (U+0130) nor `ı` (U+0131): `/i/iu.test("İ")` and `/ı/iu.test("I")` are both `false`.

Result: any snippet whose trigger contains `İ` or `ı` (or is spoken with one) silently never expands.

## Fix

- Fold `İ` → `i` before lowercasing, giving Map keys a canonical form.
- A capital `I` in a trigger is ambiguous (English `i` vs Turkish `ı`), so both readings are registered as keys; an explicit trigger always wins over a generated variant.
- The compiled pattern matches `İ`/`ı` explicitly via `[iİ]` / `[ıI]` character classes.
- The transcript is NFC-normalized so a decomposed `I` + U+0307 recombines into `İ` before matching.
- Lookup falls back to the `I` → `ı` reading, since JS `toLowerCase()` maps `I` to `i` (`"IŞIK".toLowerCase()` is `"işik"`, not `"ışık"`).

Deliberately avoids `toLocaleLowerCase("tr")`, which would fix Turkish triggers but break English ones (`I` → `ı` everywhere).

## Tests

`test/utils/snippets.test.js`: covers `İmza`/`imza`/`İMZA`/`Imza`, `ışık`/`Işık`/`IŞIK`, an all-caps English trigger (`IBAN`), NFD input, word boundaries, and plain-ASCII regression cases. All 10 pass; existing tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)