### PR TITLE
fix(cleanup): stop dictation cleanup from answering transcribed questions

### DIFF
--- a/src/config/agentDetection.ts
+++ b/src/config/agentDetection.ts
@@ -25,43 +25,97 @@ function maxEditsForLength(len: number): number {
   return 2;
 }
 
+const WAKE_WORDS = new Set(["hey", "hi", "ok", "okay", "yo"]);
+
+function normalizeWords(transcript: string): string[] {
+  return transcript
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.replace(/^[("'[\]]+|[)"'[\].,!?;:]+$/g, "").toLowerCase())
+    .filter(Boolean);
+}
+
+function nameKey(agentName: string): string {
+  return agentName.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function matchesExactName(candidate: string, key: string): boolean {
+  return candidate === key;
+}
+
+function matchesFuzzyName(candidate: string, key: string): boolean {
+  const maxEdits = maxEditsForLength(key.length);
+  if (maxEdits === 0) return false;
+  if (Math.abs(candidate.length - key.length) > maxEdits) return false;
+  return levenshteinDistance(candidate, key) <= maxEdits;
+}
+
+function matchesNameToken(candidate: string, key: string, allowFuzzy: boolean): boolean {
+  if (matchesExactName(candidate, key)) return true;
+  return allowFuzzy && matchesFuzzyName(candidate, key);
+}
+
+function consumeAgentName(
+  words: string[],
+  startIdx: number,
+  key: string,
+  allowFuzzy: boolean
+): number | null {
+  if (startIdx >= words.length) return null;
+
+  const first = words[startIdx];
+  if (matchesNameToken(first, key, allowFuzzy)) return startIdx + 1;
+
+  if (startIdx + 1 < words.length) {
+    const combined = first + words[startIdx + 1];
+    if (matchesExactName(combined, key)) return startIdx + 2;
+    if (allowFuzzy && matchesFuzzyName(combined, key)) return startIdx + 2;
+  }
+
+  return null;
+}
+
+function scanAddressingSegment(words: string[], segmentStart: number, key: string): boolean {
+  let index = segmentStart;
+  let usedWake = false;
+
+  if (index < words.length && WAKE_WORDS.has(words[index])) {
+    usedWake = true;
+    index++;
+  }
+
+  const nameEnd = consumeAgentName(words, index, key, usedWake);
+  if (nameEnd === null) return false;
+
+  // Wake-word invocations are explicit enough on their own.
+  if (usedWake) return true;
+
+  // Name-first invocations must include a command after the name.
+  return nameEnd < words.length;
+}
+
+// Voice Agent routing requires the agent to be addressed, not merely mentioned.
+// Fuzzy matching is limited to wake-word invocations so STT mishearings still work
+// without treating unrelated words ("whisper", "area", …) as wake words.
 export function detectAgentName(transcript: string, agentName: string): boolean {
   const name = agentName.trim();
   if (!name || name.length < 2) return false;
 
+  const text = transcript.trim();
+  if (!text) return false;
+
+  const key = nameKey(name);
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (new RegExp(`\\b${escaped}\\b`, "i").test(transcript)) return true;
+  const wakePattern = new RegExp(
+    `(^|[.!?]\\s+)(?:hey|hi|ok(?:ay)?|yo)\\s+${escaped}\\b`,
+    "i"
+  );
+  if (wakePattern.test(text)) return true;
 
-  const nameLower = name.toLowerCase().replace(/\s+/g, "");
-  const words = transcript
-    .split(/\s+/)
-    .map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase())
-    .filter(Boolean);
-
-  for (let i = 0; i < words.length - 1; i++) {
-    if (words[i] + words[i + 1] === nameLower) return true;
-  }
-
-  const maxEdits = maxEditsForLength(nameLower.length);
-  if (maxEdits === 0) return false;
-
-  for (const word of words) {
-    if (
-      Math.abs(word.length - nameLower.length) <= maxEdits &&
-      levenshteinDistance(word, nameLower) <= maxEdits
-    ) {
-      return true;
-    }
-  }
-
-  for (let i = 0; i < words.length - 1; i++) {
-    const combined = words[i] + words[i + 1];
-    if (
-      Math.abs(combined.length - nameLower.length) <= maxEdits &&
-      levenshteinDistance(combined, nameLower) <= maxEdits
-    ) {
-      return true;
-    }
+  for (const segment of text.split(/(?<=[.!?])\s+/)) {
+    const words = normalizeWords(segment);
+    if (words.length === 0) continue;
+    if (scanAddressingSegment(words, 0, key)) return true;
   }
 
   return false;

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -47,6 +47,33 @@ function dictationAgentReachable(settings) {
   });
 }
 
+function buildCleanupReasoningConfig(settings, agentName) {
+  return {
+    disableThinking: settings.cleanupDisableThinking,
+    temperature: 0.3,
+    promptMode: "cleanup",
+    systemPrompt: resolvePrompt("cleanup", {
+      agentName,
+      language: settings.preferredLanguage,
+      customDictionary: getDictionaryHintWords(settings),
+      uiLanguage: settings.uiLanguage,
+    }),
+  };
+}
+
+function buildCloudCleanupReasonOpts(settings, agentName, extra = {}) {
+  const config = buildCleanupReasoningConfig(settings, agentName);
+  return {
+    agentName,
+    customDictionary: getDictionaryHintWords(settings),
+    systemPrompt: config.systemPrompt,
+    promptMode: "cleanup",
+    language: settings.preferredLanguage || "auto",
+    locale: settings.uiLanguage || "en",
+    ...extra,
+  };
+}
+
 function resolveReasoningRoute(text, settings, agentName, voiceAgentRequested) {
   const cleanupReachable =
     !!settings.useCleanupModel && (!!settings.cleanupModel?.trim() || isCloudCleanupMode());
@@ -84,6 +111,7 @@ function resolveReasoningRoute(text, settings, agentName, voiceAgentRequested) {
             ? settings.dictationAgentCustomApiKey || undefined
             : undefined,
         disableThinking: settings.dictationAgentDisableThinking,
+        promptMode: "agent",
         systemPrompt: resolvePrompt("dictationAgent", {
           agentName,
           language: settings.preferredLanguage,
@@ -96,7 +124,7 @@ function resolveReasoningRoute(text, settings, agentName, voiceAgentRequested) {
   if (kind === "cleanup") {
     return {
       kind: "cleanup",
-      config: { disableThinking: settings.cleanupDisableThinking },
+      config: buildCleanupReasoningConfig(settings, agentName),
     };
   }
   return { kind: "skip" };
@@ -1574,21 +1602,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           if (reasoned) processedText = reasoned;
         } else if (route.kind === "cleanup" && cleanupCloudMode === "openwhispr") {
           const reasonResult = await withSessionRefresh(async () => {
-            const res = await window.electronAPI.cloudReason(processedText, {
-              agentName,
-              customDictionary: getDictionaryHintWords(settings),
-              customPrompt: this.getCustomPrompt(),
-              language: settings.preferredLanguage || "auto",
-              locale: settings.uiLanguage || "en",
-              sttProvider: result.sttProvider,
-              sttModel: result.sttModel,
-              sttProcessingMs: result.sttProcessingMs,
-              sttWordCount: result.sttWordCount,
-              sttLanguage: result.sttLanguage,
-              audioDurationMs: result.audioDurationMs,
-              audioSizeBytes,
-              audioFormat,
-            });
+            const res = await window.electronAPI.cloudReason(
+              processedText,
+              buildCloudCleanupReasonOpts(settings, agentName, {
+                sttProvider: result.sttProvider,
+                sttModel: result.sttModel,
+                sttProcessingMs: result.sttProcessingMs,
+                sttWordCount: result.sttWordCount,
+                sttLanguage: result.sttLanguage,
+                audioDurationMs: result.audioDurationMs,
+                audioSizeBytes,
+                audioFormat,
+              })
+            );
             if (!res.success) {
               const err = new Error(res.error || "Cloud reasoning failed");
               err.code = res.code;
@@ -2995,21 +3021,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           );
         } else if (route.kind === "cleanup" && cleanupCloudMode === "openwhispr") {
           const reasonResult = await withSessionRefresh(async () => {
-            const res = await window.electronAPI.cloudReason(finalText, {
-              agentName,
-              customDictionary: getDictionaryHintWords(stSettings),
-              customPrompt: this.getCustomPrompt(),
-              language: stSettings.preferredLanguage || "auto",
-              locale: stSettings.uiLanguage || "en",
-              sttProvider: this.getStreamingProviderName(),
-              sttModel: streamingSttModel,
-              sttProcessingMs: streamingSttProcessingMs,
-              sttWordCount: streamingSttWordCount,
-              sttLanguage: streamingSttLanguage,
-              audioDurationMs: durationSeconds ? Math.round(durationSeconds * 1000) : undefined,
-              audioSizeBytes: streamingAudioBytesSent || undefined,
-              audioFormat: "linear16",
-            });
+            const res = await window.electronAPI.cloudReason(
+              finalText,
+              buildCloudCleanupReasonOpts(stSettings, agentName, {
+                sttProvider: this.getStreamingProviderName(),
+                sttModel: streamingSttModel,
+                sttProcessingMs: streamingSttProcessingMs,
+                sttWordCount: streamingSttWordCount,
+                sttLanguage: streamingSttLanguage,
+                audioDurationMs: durationSeconds ? Math.round(durationSeconds * 1000) : undefined,
+                audioSizeBytes: streamingAudioBytesSent || undefined,
+                audioFormat: "linear16",
+              })
+            );
             if (!res.success) {
               const err = new Error(res.error || "Cloud reasoning failed");
               err.code = res.code;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5994,6 +5994,7 @@ class IPCHandlers {
             customDictionary: opts.customDictionary,
             customPrompt: opts.customPrompt,
             systemPrompt: opts.systemPrompt,
+            promptMode: opts.promptMode,
             language: opts.language,
             locale: opts.locale,
             sessionId: this.sessionId,

--- a/src/services/BaseReasoningService.ts
+++ b/src/services/BaseReasoningService.ts
@@ -7,6 +7,7 @@ export interface ReasoningConfig {
   temperature?: number;
   contextSize?: number;
   systemPrompt?: string;
+  promptMode?: "cleanup" | "agent";
   lanUrl?: string;
   baseUrl?: string;
   customApiKey?: string;

--- a/src/services/ai/inferenceProviders/openwhispr.ts
+++ b/src/services/ai/inferenceProviders/openwhispr.ts
@@ -18,6 +18,7 @@ export const openwhisprProvider: InferenceProvider = {
         customDictionary: ctx.getCustomDictionary(),
         customPrompt,
         systemPrompt: config.systemPrompt,
+        promptMode: config.promptMode,
         language: ctx.getPreferredLanguage(),
         locale: ctx.getUiLanguage(),
       });

--- a/src/services/localReasoningBridge.js
+++ b/src/services/localReasoningBridge.js
@@ -33,7 +33,7 @@ class LocalReasoningService {
     try {
       const inferenceConfig = {
         maxTokens: config.maxTokens || this.calculateMaxTokens(text.length),
-        temperature: config.temperature || 0.7,
+        temperature: config.temperature ?? 0.3,
         topK: config.topK || 40,
         topP: config.topP || 0.9,
         repeatPenalty: config.repeatPenalty || 1.1,

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1163,6 +1163,7 @@ declare global {
           customDictionary?: string[];
           customPrompt?: string;
           systemPrompt?: string;
+          promptMode?: "cleanup" | "agent";
           language?: string;
           locale?: string;
         }

--- a/test/config/agentDetection.test.js
+++ b/test/config/agentDetection.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/config/agentDetection.ts");
+
+test("detects wake-word invocations", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(
+    detectAgentName("Hey Whispr, what is the keyboard shortcut?", "Whispr"),
+    true
+  );
+  assert.equal(
+    detectAgentName("Here is my draft. Hey Whispr, shorten it.", "Whispr"),
+    true
+  );
+});
+
+test("detects name-first commands at the start of a segment", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("Whispr rewrite this paragraph", "Whispr"), true);
+  assert.equal(detectAgentName("Whispr, make this more professional", "Whispr"), true);
+});
+
+test("does not route cleanup when the agent name is only mentioned", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(
+    detectAgentName("What is the keyboard shortcut key to perform an action?", "Whispr"),
+    false
+  );
+  assert.equal(detectAgentName("I met Sarah yesterday at the office", "Sarah"), false);
+  assert.equal(detectAgentName("Tell Sarah I said hi", "Sarah"), false);
+  assert.equal(detectAgentName("I need to whisper this quietly", "Whispr"), false);
+});
+
+test("does not fuzzy-match unrelated words without a wake word", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("The area was flooded yesterday", "Aria"), false);
+});


### PR DESCRIPTION
## Summary

- Tighten Voice Agent wake-word detection so cleanup dictation is not routed through the agent prompt when the agent name is merely mentioned in the transcript.
- Always pass an explicit cleanup system prompt and `promptMode: "cleanup"` on cloud cleanup requests so the API does not re-route to agent mode.
- Lower the default local llama cleanup temperature from 0.7 to 0.3 to match cloud cleanup and improve instruction following.

Fixes #890

## Problem

Dictation Cleanup sometimes answered dictated questions (for example returning a keyboard shortcut or model name) instead of polishing and returning the spoken text. That happened when cleanup was mis-routed to the Voice Agent path, when OpenWhispr Cloud re-evaluated agent routing server-side, or when local models ignored the cleanup prompt at high temperature.

## Changes

- `src/config/agentDetection.ts`: require wake-word or name-at-start + command; limit fuzzy matching to wake-word invocations
- `src/helpers/audioManager.js`: build explicit cleanup reasoning config and cloud cleanup opts
- `src/helpers/ipcHandlers.js`, `src/services/ai/inferenceProviders/openwhispr.ts`, `src/types/electron.ts`: forward `promptMode`
- `src/services/localReasoningBridge.js`: default temperature 0.3
- `test/config/agentDetection.test.js`: regression coverage

## Test plan

- [x] `node --test test/config/agentDetection.test.js test/helpers/dictationRouting.test.js` (16/16 pass)
- [ ] Dictate a question with Dictation Cleanup enabled (local model) — output should be the cleaned question, not an answer
- [ ] Dictate text that mentions your agent name without addressing it — should stay on cleanup, not agent
- [ ] Dictate `Hey {agentName}, summarize this` — should still route to Voice Agent
