### PR TITLE
fix(media): don't pause media for a recording that already ended

### DIFF
--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -44,7 +44,9 @@ export const useAudioRecording = (toast, options = {}) => {
         ? await audioManagerRef.current.startStreamingRecording()
         : await audioManagerRef.current.startRecording();
 
-      if (didStart) {
+      // A quick tap can end the recording inside the start call itself (deferred
+      // streaming stop) — don't pause media for a recording that already ended. See #1060.
+      if (didStart && audioManagerRef.current.getState().isRecording) {
         if (getSettings().pauseMediaOnDictation) {
           window.electronAPI?.pauseMediaPlayback?.();
         }


### PR DESCRIPTION
## Summary

With "pause media on dictation" enabled and streaming active, a quick press-and-release before the WebSocket connect finished left media paused permanently. The stop gets deferred (`stopRequestedDuringStreamingStart`) and runs to completion **inside** `startStreamingRecording`, so by the time `performStartRecording` sees `didStart === true`, the recording is already over — it then paused media with nothing left to resume it, re-registered the Escape cancel hotkey (leaving it hijacked until the next recording), and played the start cue after the stop cue.

The fix gates the post-start side effects on the recording still being active: `didStart && audioManagerRef.current.getState().isRecording`. Every successful-start path returns with `isRecording === true` (batch sets it in `startRecording`, streaming at session setup, and the no-API fallback lands in batch), while the deferred-stop path resets it in `stopStreamingRecording` before the start call returns — so the guard only skips side effects when the recording already ended. It also covers the narrower batch window where a stop lands during the preview worklet setup await.

Fixes #1060

## Changes

- src/hooks/useAudioRecording.js: in `performStartRecording`, skip pause-media / cancel-hotkey / start-cue when the recording already ended inside the start call.

## Testing

- `npx eslint src/hooks/useAudioRecording.js` — clean
- `node --test test/helpers/*.test.js` — 142 tests, 0 failures