### PR TITLE
fix: reject empty recordings on retry, restore push-to-talk under compositor shortcuts

### DIFF
--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -376,13 +376,17 @@ class HotkeyManager extends EventEmitter {
    * raw key-down/key-up events. Only the dictation slot supports push-to-talk;
    * every other slot is tap-to-toggle. Globe/mouse hotkeys are macOS-only.
    * Each slot may bind several hotkeys, so we evaluate every one.
+   * When a compositor backend (GNOME/KDE/Hyprland) owns the hotkeys, tap slots are
+   * delivered over D-Bus and watching them here would double-fire; push-to-talk
+   * still needs the raw key events that compositor shortcuts cannot provide.
    */
-  getNativeListenerKeys(activationMode) {
+  getNativeListenerKeys(activationMode, compositorOwnsHotkeys = false) {
     const keys = [];
     for (const [slotName, slot] of this.slots) {
       for (const hotkey of slot.hotkeys ?? []) {
         if (!hotkey || isGlobeLikeHotkey(hotkey) || isMouseButtonHotkey(hotkey)) continue;
         const pushToTalk = slotName === "dictation" && activationMode === "push";
+        if (compositorOwnsHotkeys && !pushToTalk) continue;
         if (pushToTalk || isModifierOnlyHotkey(hotkey) || isRightSideModifier(hotkey)) {
           keys.push(hotkey);
         }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -39,6 +39,7 @@ const {
   isSpeakerLocked,
 } = require("./speakerAssignmentPolicy");
 const { downsample24kTo16k, pcm16ToWav } = require("../utils/audioUtils");
+const { isEmptyRecording } = require("./recordingGuard");
 const postMigrationDetector = require("./postMigrationDetector");
 const {
   DEFAULT_EXPECTED_SPEAKER_COUNT,
@@ -4265,6 +4266,11 @@ class IPCHandlers {
     ipcMain.handle("retry-transcription", async (event, id, settings) => {
       const buffer = this.audioStorageManager.getAudioBuffer(id);
       if (!buffer) return { success: false, error: "Audio file not found" };
+      // Header-only blobs stored by older builds fail every backend with a
+      // confusing "corrupted or unsupported" error; reject them clearly here.
+      if (isEmptyRecording(buffer.length)) {
+        return { success: false, error: "Recording contains no audio" };
+      }
       try {
         let result;
         const preferredLanguage = settings?.preferredLanguage;

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -529,11 +529,12 @@ class WindowManager {
   reconcileNativeKeyListeners() {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     if (this.hotkeyManager.isInListeningMode()) return;
-    // GNOME/KDE/Hyprland deliver hotkeys via D-Bus native shortcuts; the low-level
-    // listener would be redundant there and could double-fire, so watch nothing.
-    const keys = this.hotkeyManager.isUsingNativeShortcut()
-      ? []
-      : this.hotkeyManager.getNativeListenerKeys(this.getActivationMode());
+    // GNOME/KDE/Hyprland deliver tap hotkeys via D-Bus native shortcuts, but their
+    // single-trigger events cannot drive push-to-talk, which needs the listener.
+    const keys = this.hotkeyManager.getNativeListenerKeys(
+      this.getActivationMode(),
+      this.hotkeyManager.isUsingNativeShortcut()
+    );
     if (process.platform === "win32" && this.windowsKeyManager) {
       this.windowsKeyManager.setKeys(keys);
     } else if (process.platform === "linux" && this.linuxKeyManager) {

--- a/test/helpers/nativeListenerKeys.test.js
+++ b/test/helpers/nativeListenerKeys.test.js
@@ -108,3 +108,18 @@ test("translation slot conflicts are detected and it is never push-enabled", () 
   const mgr2 = makeManager({ translation: "Control+Alt" });
   assert.deepEqual(mgr2.getNativeListenerKeys("tap"), ["Control+Alt"]);
 });
+
+test("compositor-owned tap hotkeys are not watched (D-Bus delivers them)", () => {
+  const mgr = makeManager({ dictation: "Control+Super", agent: "Alt+Super" });
+  assert.deepEqual(mgr.getNativeListenerKeys("tap", true), []);
+});
+
+test("push mode keeps the dictation key watched when the compositor owns hotkeys", () => {
+  const mgr = makeManager({ dictation: "Control+Super", agent: "Alt+Super" });
+  assert.deepEqual(mgr.getNativeListenerKeys("push", true), ["Control+Super"]);
+});
+
+test("push mode with a compositor watches a regular dictation key too", () => {
+  const mgr = makeManager({ dictation: "Insert", voiceAgent: "Control+Alt" });
+  assert.deepEqual(mgr.getNativeListenerKeys("push", true), ["Insert"]);
+});

--- a/test/helpers/recordingGuard.test.js
+++ b/test/helpers/recordingGuard.test.js
@@ -44,3 +44,9 @@ test("MIN_AUDIO_BYTES is 256", async () => {
   const { MIN_AUDIO_BYTES } = await load();
   assert.equal(MIN_AUDIO_BYTES, 256);
 });
+
+test("stays loadable via require() for the main-process retry guard", () => {
+  const { isEmptyRecording, MIN_AUDIO_BYTES } = require("../../src/helpers/recordingGuard.js");
+  assert.equal(isEmptyRecording(MIN_AUDIO_BYTES - 1), true);
+  assert.equal(isEmptyRecording(MIN_AUDIO_BYTES), false);
+});


### PR DESCRIPTION
## Summary

The double-trigger behind #864 left a lasting scar: header-only recordings (~110 bytes) saved to history by older builds fail every Retry/Recover with the same confusing "Audio file might be corrupted or unsupported", because the `retry-transcription` handler in `ipcHandlers.js` ships the stored buffer to a backend with no validation. The handler now rejects buffers smaller than `MIN_AUDIO_BYTES` (reusing `isEmptyRecording` from `recordingGuard.js`) and returns a clear "Recording contains no audio" instead.

The `reconcileNativeKeyListeners` gate from #1001 also turned out to kill push-to-talk on KDE/GNOME/Hyprland: it blanks the native key listener whenever the compositor owns the hotkeys, but in push mode the compositor callback intentionally early-returns to defer to that same listener, so holding the hotkey did nothing at all. `getNativeListenerKeys` now takes a `compositorOwnsHotkeys` flag and keeps just the dictation key watched in push mode; tap slots stay compositor-delivered, so the original double-trigger cannot come back. Verified on KDE Plasma Wayland (Fedora 44): tap unchanged, hold works again.

Fixes #864 #847

## Changes

- src/helpers/ipcHandlers.js: reject stored audio buffers smaller than MIN_AUDIO_BYTES in the retry-transcription handler instead of sending them to a backend
- src/helpers/hotkeyManager.js: getNativeListenerKeys takes a compositorOwnsHotkeys flag and keeps only the push-to-talk dictation key when a compositor delivers hotkeys
- src/helpers/windowManager.js: reconcileNativeKeyListeners passes isUsingNativeShortcut() instead of blanking all keys
- test/helpers/recordingGuard.test.js: add a require() interop test for the main-process guard
- test/helpers/nativeListenerKeys.test.js: add compositor carve-out cases

Supersedes #872.
