### PR TITLE
fix(cleanup): stop dictation cleanup from answering transcribed questions

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -96,7 +96,16 @@ function resolveReasoningRoute(text, settings, agentName, voiceAgentRequested) {
   if (kind === "cleanup") {
     return {
       kind: "cleanup",
-      config: { disableThinking: settings.cleanupDisableThinking },
+      config: {
+        disableThinking: settings.cleanupDisableThinking,
+        temperature: 0.3,
+        systemPrompt: resolvePrompt("cleanup", {
+          agentName,
+          language: settings.preferredLanguage,
+          customDictionary: getDictionaryHintWords(settings),
+          uiLanguage: settings.uiLanguage,
+        }),
+      },
     };
   }
   return { kind: "skip" };
@@ -1577,7 +1586,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             const res = await window.electronAPI.cloudReason(processedText, {
               agentName,
               customDictionary: getDictionaryHintWords(settings),
-              customPrompt: this.getCustomPrompt(),
+              systemPrompt: route.config.systemPrompt,
               language: settings.preferredLanguage || "auto",
               locale: settings.uiLanguage || "en",
               sttProvider: result.sttProvider,
@@ -1637,10 +1646,6 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   getCustomDictionaryArray() {
     return getSettings().customDictionary;
-  }
-
-  getCustomPrompt() {
-    return getSettings().customPrompts.cleanup || undefined;
   }
 
   getKeyterms() {
@@ -2998,7 +3003,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             const res = await window.electronAPI.cloudReason(finalText, {
               agentName,
               customDictionary: getDictionaryHintWords(stSettings),
-              customPrompt: this.getCustomPrompt(),
+              systemPrompt: route.config.systemPrompt,
               language: stSettings.preferredLanguage || "auto",
               locale: stSettings.uiLanguage || "en",
               sttProvider: this.getStreamingProviderName(),

--- a/src/services/localReasoningBridge.js
+++ b/src/services/localReasoningBridge.js
@@ -33,7 +33,7 @@ class LocalReasoningService {
     try {
       const inferenceConfig = {
         maxTokens: config.maxTokens || this.calculateMaxTokens(text.length),
-        temperature: config.temperature || 0.7,
+        temperature: config.temperature ?? 0.3,
         topK: config.topK || 40,
         topP: config.topP || 0.9,
         repeatPenalty: config.repeatPenalty || 1.1,


### PR DESCRIPTION
## Summary

Dictated questions sometimes come back *answered* instead of cleaned up (#890). Two causes; this PR fixes the first and documents a deterministic repro for the second.

**Cause 1 (fixed here): cleanup requests are under-specified.** The cleanup route's config carried only `disableThinking` — no system prompt (left to per-provider fallbacks; the cloud path only sent the custom-prompt override) and local llama inference defaulted to temperature 0.7, where models follow the cleanup instructions poorly. The route now always carries the resolved cleanup prompt and temperature 0.3.

Verified against the bundled llama-server + gpt-oss-20b with the exact question from #890: with the cleanup prompt attached the question is echoed verbatim (6/6 trials at both 0.7 and 0.3); with an empty or agent system prompt the model answers it ("Ctrl+S saves, Ctrl+C copies…").

**Cause 2 (out of scope, repro below): agent-name mention mis-routing.** `detectAgentName()` returns true for a mere *mention* of the agent name — or a fuzzy 2-edit near-miss across adjacent words ("open whisper" ≈ "openwhispr") — routing the dictation to the agent, whose prompt answers questions by design. With default settings (signed in, dictation agent enabled) this fires on every dictation that mentions the agent's name. Deliberately not changed here; I'll create a separate issue for it but repro script below.

<details>
<summary>Repro script for cause 2 (save anywhere, run from repo root with Node 24)</summary>

```js
// node path/to/issue-890-repro.mjs   (from the openwhispr repo root)
import { pathToFileURL } from "node:url";

const root = pathToFileURL(process.cwd() + "/");
const { detectAgentName } = await import(new URL("src/config/agentDetection.ts", root));
const { resolveDictationRouteKind } = await import(
  new URL("src/helpers/dictationRouting.js", root)
);

// Reflects default settings for a signed-in user: useCleanupModel=true,
// useDictationAgent=true, dictationAgentMode="openwhispr".
const routeFor = (agentInvoked) =>
  resolveDictationRouteKind({
    cleanupReachable: true,
    agentReachable: true,
    agentInvoked,
    voiceAgentRequested: false,
  });

const cases = [
  // Legitimate invocations — must stay on the agent route.
  { agent: "OpenWhispr", text: "Hey OpenWhispr, summarize this paragraph", want: "agent" },
  { agent: "Whispr", text: "Whispr, make this more professional", want: "agent" },

  // Mere mentions — the speaker is talking ABOUT the agent, not TO it.
  { agent: "OpenWhispr", text: "Add a note about OpenWhispr settings", want: "cleanup" },
  { agent: "OpenWhispr", text: "The open whisper docs need an update", want: "cleanup" }, // fuzzy: 1 edit
  { agent: "Sarah", text: "Tell Sarah I said hi", want: "cleanup" },

  // The literal #890 sentence — stays on cleanup, where this PR's fix applies.
  { agent: "Whispr", text: "What is the keyboard shortcut key to perform an action?", want: "cleanup" },
];

let misroutes = 0;
for (const { agent, text, want } of cases) {
  const route = routeFor(detectAgentName(text, agent));
  const ok = route === want;
  if (!ok) misroutes++;
  console.log(
    `${ok ? "  ok    " : "MISROUTE"}  agent="${agent}"  route=${route} (want ${want})  "${text}"`
  );
}
console.log(`\n${misroutes} mention-only transcript(s) mis-routed to the dictation agent.`);
```

Current output: 3 MISROUTE lines — mention-only transcripts land on the agent route.

</details>

## Test plan

- [x] `node --test test/helpers/dictationRouting.test.js` (12/12 pass)
- [x] Dictate a question with local cleanup enabled — output is the cleaned question, not an answer
- [x] Dictate with a custom cleanup prompt set — custom prompt still honored (resolved via `resolvePrompt`)

Fixes #890
