### PR TITLE
feat(sync): re-sync on window focus and a 5-minute interval

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -384,14 +384,17 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
         syncService.requestSyncAll("focus");
       }
     };
+    const onOnline = () => syncService.requestSyncAll("online");
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("online", onOnline);
 
     const interval = setInterval(() => syncService.requestSyncAll("interval"), 5 * 60 * 1000);
 
     return () => {
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", onOnline);
       clearInterval(interval);
     };
   }, []);
@@ -440,7 +443,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
             const result = await window.electronAPI.deleteTranscription(id);
             if (result.success) {
               removeFromStore(id);
-              syncService.syncAll().catch(console.error);
+              syncService.requestSyncAll("manual");
             } else {
               showAlertDialog({
                 title: t("controlPanel.history.couldNotDeleteTitle"),
@@ -469,7 +472,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
           const result = await window.electronAPI.clearTranscriptions();
           if (result.success) {
             clearStore();
-            syncService.syncAll().catch(console.error);
+            syncService.requestSyncAll("manual");
             toast({
               title: t("controlPanel.history.clearAllSuccess"),
               variant: "success",

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -375,7 +375,25 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   }, [toast, t]);
 
   useEffect(() => {
-    syncService.syncAll().catch(console.error);
+    // Keep syncing during a long session, not just once at launch.
+    syncService.requestSyncAll("mount");
+
+    const onFocus = () => syncService.requestSyncAll("focus");
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        syncService.requestSyncAll("focus");
+      }
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const interval = setInterval(() => syncService.requestSyncAll("interval"), 5 * 60 * 1000);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+      clearInterval(interval);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -3372,7 +3372,7 @@ EOF`,
                             setCloudBackupEnabled(v);
                             if (v) {
                               startMigration().catch(console.error);
-                              syncService.syncAll().catch(console.error);
+                              syncService.requestSyncAll("manual");
                             }
                           }}
                         />

--- a/src/hooks/useFolderManagement.ts
+++ b/src/hooks/useFolderManagement.ts
@@ -208,7 +208,7 @@ export function useFolderManagement(): UseFolderManagementReturn {
           const personalFolder = findDefaultFolder(items);
           if (personalFolder) setActiveFolderId(personalFolder.id);
         }
-        syncService.syncAll().catch(console.error);
+        syncService.requestSyncAll("manual");
       } else if (result.error) {
         toast({
           title: t("notes.folders.couldNotDelete"),

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -37,6 +37,7 @@ function normalizeTimestamp(value: string | null | undefined): string {
 
 class SyncService {
   private syncing = false;
+  private syncAllPending = false;
   private dictionaryDirty = false;
   private snippetsDirty = false;
   private pushTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -51,7 +52,13 @@ class SyncService {
   }
 
   async syncAll(): Promise<void> {
-    if (this.syncing || !this.canSync()) return;
+    if (!this.canSync()) return;
+    // A pass already running may have synced past the data this request covers,
+    // so flag a re-run instead of dropping it.
+    if (this.syncing) {
+      this.syncAllPending = true;
+      return;
+    }
     this.syncing = true;
     try {
       await this.syncFolders();
@@ -69,20 +76,27 @@ class SyncService {
         await this.syncSnippets();
       } while (this.snippetsDirty);
       localStorage.setItem("lastSyncedAt", new Date().toISOString());
+      this.lastSyncAllAt = Date.now();
     } catch (err) {
       console.error("Sync failed:", err);
     } finally {
       this.syncing = false;
     }
+    if (this.syncAllPending) {
+      this.syncAllPending = false;
+      await this.syncAll();
+    }
   }
 
-  requestSyncAll(reason: "mount" | "focus" | "interval" | "manual"): void {
+  requestSyncAll(reason: "mount" | "focus" | "interval" | "online" | "manual"): void {
     if (!this.canSync()) return;
-    if (reason !== "manual" && Date.now() - this.lastSyncAllAt < AUTO_SYNC_THROTTLE_MS) {
+    if (
+      reason !== "manual" &&
+      (this.syncing || Date.now() - this.lastSyncAllAt < AUTO_SYNC_THROTTLE_MS)
+    ) {
       return;
     }
-    this.lastSyncAllAt = Date.now();
-    void this.syncAll().catch(console.error);
+    void this.syncAll();
   }
 
   async syncDictionaryNow(): Promise<void> {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -21,6 +21,8 @@ const BATCH_SIZE = 50;
 const TRANSCRIPTION_BATCH_SIZE = 100;
 const DICTIONARY_BATCH_SIZE = 200;
 const SNIPPET_BATCH_SIZE = 200;
+// Skip a redundant syncAll() if focus + interval fire close together.
+const AUTO_SYNC_THROTTLE_MS = 20000;
 
 // SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
 // the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
@@ -38,6 +40,7 @@ class SyncService {
   private dictionaryDirty = false;
   private snippetsDirty = false;
   private pushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private lastSyncAllAt = 0;
 
   canSync(): boolean {
     return (
@@ -71,6 +74,15 @@ class SyncService {
     } finally {
       this.syncing = false;
     }
+  }
+
+  requestSyncAll(reason: "mount" | "focus" | "interval" | "manual"): void {
+    if (!this.canSync()) return;
+    if (reason !== "manual" && Date.now() - this.lastSyncAllAt < AUTO_SYNC_THROTTLE_MS) {
+      return;
+    }
+    this.lastSyncAllAt = Date.now();
+    void this.syncAll().catch(console.error);
   }
 
   async syncDictionaryNow(): Promise<void> {


### PR DESCRIPTION
## Summary

The desktop app only ran a full syncAll() once, when ControlPanel mounts (app launch). During a long-lived session it never re-pulled, so dictionary, snippet, and note changes made on other devices (e.g. mobile) wouldn't appear on desktop until the app was restarted or some unrelated action (transcription/folder delete) happened to trigger a sync.

This adds ambient re-sync triggers that mirror mobile's foreground behavior: on window focus / tab becoming visible, and on a 5-minute interval. A new throttled entry point (requestSyncAll) prevents these triggers from stacking redundant passes, and leaves the existing canSync() gating and syncing mutex fully intact — so sync semantics are unchanged, only its cadence improves.