### PR TITLE
Add SEO YouTube Radar workflow

### DIFF
--- a/docs/superpowers/plans/2026-07-06-seo-youtube-radar.md
+++ b/docs/superpowers/plans/2026-07-06-seo-youtube-radar.md
@@ -1,0 +1,963 @@
+# SEO YouTube Radar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a local-first workflow that discovers newly popular SEO-related YouTube videos, imports only the best candidates into OpenWhispr, transcribes them, and saves notes containing the full transcript plus a local-AI summary.
+
+**Architecture:** The Electron main process owns discovery, caching, scheduling, YouTube API calls, and orchestration. The existing OpenWhispr YouTube import/transcription/note-save flow is reused for selected videos. Local AI is mandatory for ranking and summarisation; cloud AI is not used by this workflow.
+
+**Tech Stack:** Electron IPC, Node helpers in `src/helpers`, React settings UI, SQLite/JSON userData cache, YouTube Data API v3 metadata calls, existing `ytow` import helper, existing local Whisper/Parakeet transcription, existing local reasoning runtime.
+
+## Global Constraints
+
+- Discovery must use YouTube Data API v3 for metadata; avoid scraping search pages.
+- Use YouTube API quota conservatively: default to one daily run, cache video IDs, and cap searches/results.
+- Use local AI only for relevance ranking and summaries.
+- Do not consume paid or cloud AI credits in this workflow.
+- Never store the YouTube API key in renderer localStorage.
+- Keep full transcripts in note `content`; save summary plus transcript in `enhanced_content`.
+- If summary or ranking fails, save/keep the full transcript and log the failure.
+- All new UI strings must be added to every `src/locales/*/translation.json`.
+- Respect the existing dirty `src/helpers/mediaPlayer.js`; do not modify it.
+
+---
+
+## File Structure
+
+- Create `src/helpers/seoYoutubeRadar/scoring.js`
+  - Pure functions for query config, candidate dedupe, view-velocity scoring, and local-AI prompt construction.
+- Create `src/helpers/seoYoutubeRadar/youtubeClient.js`
+  - Thin YouTube Data API client with injected `fetchImpl`, quota guard, and no persistent state.
+- Create `src/helpers/seoYoutubeRadar/store.js`
+  - Persistent cache under Electron `app.getPath("userData")`, keyed by YouTube video ID.
+- Create `src/helpers/seoYoutubeRadar/runner.js`
+  - Orchestrates discovery, cache filtering, import, transcription, local AI summary, and note creation.
+- Create `src/helpers/seoYoutubeRadar/scheduler.js`
+  - Starts/stops the daily scheduled job when OpenWhispr is running.
+- Create tests under `test/helpers/seoYoutubeRadar.*.test.js`
+  - Unit tests for scoring, client request construction, cache behaviour, and runner orchestration.
+- Modify `src/helpers/ipcHandlers.js`
+  - Register API-key storage, config get/set, manual run, and scheduler handlers.
+- Modify `preload.js`
+  - Expose safe SEO Radar methods to renderer.
+- Modify `src/types/electron.ts`
+  - Type the new IPC surface.
+- Modify `src/components/SettingsPage.tsx`
+  - Add a compact SEO Radar settings panel.
+- Modify `src/locales/*/translation.json`
+  - Add labels, statuses, errors, and helper text.
+
+---
+
+### Task 1: Scoring And Query Planning
+
+**Files:**
+- Create: `src/helpers/seoYoutubeRadar/scoring.js`
+- Test: `test/helpers/seoYoutubeRadar.scoring.test.js`
+
+**Interfaces:**
+- Produces:
+  - `normalizeRadarConfig(input?: object): SeoRadarConfig`
+  - `buildSearchQueries(config: SeoRadarConfig): string[]`
+  - `scoreVideoCandidate(video: SeoVideoCandidate, nowMs: number): SeoVideoScore`
+  - `dedupeCandidates(candidates: SeoVideoCandidate[]): SeoVideoCandidate[]`
+  - `buildLocalRelevancePrompt(video: SeoVideoCandidate): string`
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  normalizeRadarConfig,
+  buildSearchQueries,
+  scoreVideoCandidate,
+  dedupeCandidates,
+  buildLocalRelevancePrompt,
+} = require("../../src/helpers/seoYoutubeRadar/scoring.js");
+
+test("normalizeRadarConfig applies safe local-first defaults", () => {
+  const config = normalizeRadarConfig({});
+  assert.deepEqual(config.keywords, [
+    "seo",
+    "technical seo",
+    "google algorithm update",
+    "search console",
+    "local seo",
+    "ai seo",
+  ]);
+  assert.equal(config.lookbackHours, 72);
+  assert.equal(config.maxSearchResultsPerQuery, 10);
+  assert.equal(config.maxVideosToProcess, 5);
+  assert.equal(config.minDurationSeconds, 180);
+  assert.equal(config.excludeShorts, true);
+});
+
+test("buildSearchQueries combines each keyword with practical SEO intent", () => {
+  const queries = buildSearchQueries(
+    normalizeRadarConfig({ keywords: ["technical seo", "search console"] })
+  );
+  assert.deepEqual(queries, [
+    "technical seo SEO",
+    "search console SEO",
+  ]);
+});
+
+test("scoreVideoCandidate rewards view velocity and engagement", () => {
+  const nowMs = Date.parse("2026-07-06T12:00:00Z");
+  const score = scoreVideoCandidate(
+    {
+      id: "vid1",
+      title: "Google SEO update explained",
+      channelTitle: "SEO Channel",
+      url: "https://www.youtube.com/watch?v=vid1",
+      publishedAt: "2026-07-06T06:00:00Z",
+      durationSeconds: 900,
+      viewCount: 12000,
+      likeCount: 600,
+      commentCount: 80,
+      description: "Useful technical SEO update",
+    },
+    nowMs
+  );
+  assert.equal(score.videoId, "vid1");
+  assert.equal(score.viewsPerHour, 2000);
+  assert.ok(score.score > 2000);
+});
+
+test("dedupeCandidates keeps first instance of each video id", () => {
+  const candidates = dedupeCandidates([
+    { id: "a", title: "A" },
+    { id: "b", title: "B" },
+    { id: "a", title: "A duplicate" },
+  ]);
+  assert.deepEqual(candidates.map((c) => c.id), ["a", "b"]);
+});
+
+test("buildLocalRelevancePrompt asks for strict JSON classification", () => {
+  const prompt = buildLocalRelevancePrompt({
+    id: "vid1",
+    title: "SEO audit checklist",
+    channelTitle: "SEO Channel",
+    description: "A checklist for technical SEO audits",
+  });
+  assert.match(prompt, /Return strict JSON/);
+  assert.match(prompt, /relevanceScore/);
+  assert.match(prompt, /SEO audit checklist/);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.scoring.test.js`
+
+Expected: fails with `Cannot find module '../../src/helpers/seoYoutubeRadar/scoring.js'`.
+
+- [ ] **Step 3: Implement minimal scoring module**
+
+```js
+const DEFAULT_KEYWORDS = [
+  "seo",
+  "technical seo",
+  "google algorithm update",
+  "search console",
+  "local seo",
+  "ai seo",
+];
+
+function normalizeRadarConfig(input = {}) {
+  return {
+    enabled: Boolean(input.enabled),
+    keywords: Array.isArray(input.keywords) && input.keywords.length > 0
+      ? input.keywords.map((v) => String(v).trim()).filter(Boolean)
+      : DEFAULT_KEYWORDS,
+    lookbackHours: Number.isFinite(input.lookbackHours) ? input.lookbackHours : 72,
+    maxSearchResultsPerQuery: Number.isFinite(input.maxSearchResultsPerQuery)
+      ? input.maxSearchResultsPerQuery
+      : 10,
+    maxVideosToProcess: Number.isFinite(input.maxVideosToProcess)
+      ? input.maxVideosToProcess
+      : 5,
+    minDurationSeconds: Number.isFinite(input.minDurationSeconds) ? input.minDurationSeconds : 180,
+    excludeShorts: input.excludeShorts !== false,
+    regionCode: String(input.regionCode || "US"),
+    language: String(input.language || "en"),
+  };
+}
+
+function buildSearchQueries(config) {
+  return config.keywords.map((keyword) => `${keyword} SEO`);
+}
+
+function dedupeCandidates(candidates) {
+  const seen = new Set();
+  const result = [];
+  for (const candidate of candidates) {
+    if (!candidate?.id || seen.has(candidate.id)) continue;
+    seen.add(candidate.id);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function scoreVideoCandidate(video, nowMs = Date.now()) {
+  const publishedMs = Date.parse(video.publishedAt || "");
+  const ageHours = Math.max(1, (nowMs - publishedMs) / 3_600_000);
+  const viewsPerHour = Math.round((Number(video.viewCount) || 0) / ageHours);
+  const engagement = (Number(video.likeCount) || 0) * 0.5 + (Number(video.commentCount) || 0) * 2;
+  const durationPenalty = video.durationSeconds && video.durationSeconds < 180 ? 500 : 0;
+  return {
+    videoId: video.id,
+    viewsPerHour,
+    score: Math.round(viewsPerHour + engagement - durationPenalty),
+  };
+}
+
+function buildLocalRelevancePrompt(video) {
+  return [
+    "You are filtering YouTube videos for an SEO operator.",
+    "Return strict JSON with keys: relevanceScore, reason, reject.",
+    "relevanceScore must be 0-100. reject must be true for spam, generic marketing, crypto, dropshipping, or non-SEO content.",
+    "",
+    `Title: ${video.title || ""}`,
+    `Channel: ${video.channelTitle || ""}`,
+    `Description: ${video.description || ""}`,
+  ].join("\n");
+}
+
+module.exports = {
+  normalizeRadarConfig,
+  buildSearchQueries,
+  dedupeCandidates,
+  scoreVideoCandidate,
+  buildLocalRelevancePrompt,
+};
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `node --test test/helpers/seoYoutubeRadar.scoring.test.js`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/helpers/seoYoutubeRadar/scoring.js test/helpers/seoYoutubeRadar.scoring.test.js
+git commit -m "feat: add seo youtube radar scoring"
+```
+
+---
+
+### Task 2: YouTube Metadata Client
+
+**Files:**
+- Create: `src/helpers/seoYoutubeRadar/youtubeClient.js`
+- Test: `test/helpers/seoYoutubeRadar.youtubeClient.test.js`
+
+**Interfaces:**
+- Consumes:
+  - `SeoRadarConfig` from Task 1.
+- Produces:
+  - `createYouTubeClient({ apiKey, fetchImpl }): YouTubeClient`
+  - `client.searchVideos({ query, publishedAfter, maxResults, regionCode, language }): Promise<SearchResult[]>`
+  - `client.getVideoDetails(videoIds: string[]): Promise<SeoVideoCandidate[]>`
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createYouTubeClient } = require("../../src/helpers/seoYoutubeRadar/youtubeClient.js");
+
+test("searchVideos calls YouTube search.list with quota-safe params", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(new URL(url));
+    return {
+      ok: true,
+      json: async () => ({
+        items: [{ id: { videoId: "abc123" }, snippet: { title: "SEO update" } }],
+      }),
+    };
+  };
+  const client = createYouTubeClient({ apiKey: "key", fetchImpl });
+  const result = await client.searchVideos({
+    query: "technical seo SEO",
+    publishedAfter: "2026-07-03T00:00:00.000Z",
+    maxResults: 10,
+    regionCode: "US",
+    language: "en",
+  });
+  assert.equal(result[0].id, "abc123");
+  assert.equal(calls[0].searchParams.get("part"), "snippet");
+  assert.equal(calls[0].searchParams.get("type"), "video");
+  assert.equal(calls[0].searchParams.get("order"), "viewCount");
+  assert.equal(calls[0].searchParams.get("maxResults"), "10");
+});
+
+test("getVideoDetails maps statistics and ISO 8601 duration", async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    json: async () => ({
+      items: [{
+        id: "abc123",
+        snippet: {
+          title: "SEO update",
+          channelTitle: "SEO Channel",
+          publishedAt: "2026-07-06T00:00:00Z",
+          description: "Useful",
+        },
+        statistics: { viewCount: "1000", likeCount: "50", commentCount: "12" },
+        contentDetails: { duration: "PT12M34S" },
+      }],
+    }),
+  });
+  const client = createYouTubeClient({ apiKey: "key", fetchImpl });
+  const videos = await client.getVideoDetails(["abc123"]);
+  assert.equal(videos[0].durationSeconds, 754);
+  assert.equal(videos[0].url, "https://www.youtube.com/watch?v=abc123");
+  assert.equal(videos[0].viewCount, 1000);
+});
+
+test("client throws clear error for missing api key", async () => {
+  assert.throws(() => createYouTubeClient({ apiKey: "" }), /YouTube API key/);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.youtubeClient.test.js`
+
+Expected: fails with missing module.
+
+- [ ] **Step 3: Implement YouTube client**
+
+Implement `search.list` and `videos.list` only. Use official endpoints:
+
+```js
+const API_BASE = "https://www.googleapis.com/youtube/v3";
+
+function parseDurationSeconds(value) {
+  const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value || "");
+  if (!match) return 0;
+  return (Number(match[1]) || 0) * 3600 + (Number(match[2]) || 0) * 60 + (Number(match[3]) || 0);
+}
+
+async function fetchJson(fetchImpl, url) {
+  const response = await fetchImpl(url.toString());
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.error?.message || `YouTube API request failed: ${response.status}`);
+  }
+  return data;
+}
+
+function createYouTubeClient({ apiKey, fetchImpl = fetch }) {
+  const key = String(apiKey || "").trim();
+  if (!key) throw new Error("YouTube API key is required");
+
+  return {
+    async searchVideos({ query, publishedAfter, maxResults, regionCode, language }) {
+      const url = new URL(`${API_BASE}/search`);
+      url.searchParams.set("key", key);
+      url.searchParams.set("part", "snippet");
+      url.searchParams.set("type", "video");
+      url.searchParams.set("order", "viewCount");
+      url.searchParams.set("q", query);
+      url.searchParams.set("publishedAfter", publishedAfter);
+      url.searchParams.set("maxResults", String(maxResults));
+      url.searchParams.set("regionCode", regionCode);
+      url.searchParams.set("relevanceLanguage", language);
+      const data = await fetchJson(fetchImpl, url);
+      return (data.items || [])
+        .map((item) => ({ id: item?.id?.videoId, snippet: item.snippet }))
+        .filter((item) => item.id);
+    },
+
+    async getVideoDetails(videoIds) {
+      if (!videoIds.length) return [];
+      const url = new URL(`${API_BASE}/videos`);
+      url.searchParams.set("key", key);
+      url.searchParams.set("part", "snippet,statistics,contentDetails");
+      url.searchParams.set("id", videoIds.join(","));
+      const data = await fetchJson(fetchImpl, url);
+      return (data.items || []).map((item) => ({
+        id: item.id,
+        title: item.snippet?.title || "",
+        channelTitle: item.snippet?.channelTitle || "",
+        publishedAt: item.snippet?.publishedAt || "",
+        description: item.snippet?.description || "",
+        viewCount: Number(item.statistics?.viewCount || 0),
+        likeCount: Number(item.statistics?.likeCount || 0),
+        commentCount: Number(item.statistics?.commentCount || 0),
+        durationSeconds: parseDurationSeconds(item.contentDetails?.duration),
+        url: `https://www.youtube.com/watch?v=${item.id}`,
+      }));
+    },
+  };
+}
+
+module.exports = { createYouTubeClient, parseDurationSeconds };
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `node --test test/helpers/seoYoutubeRadar.youtubeClient.test.js`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/helpers/seoYoutubeRadar/youtubeClient.js test/helpers/seoYoutubeRadar.youtubeClient.test.js
+git commit -m "feat: add seo youtube metadata client"
+```
+
+---
+
+### Task 3: Persistent Cache And Config Store
+
+**Files:**
+- Create: `src/helpers/seoYoutubeRadar/store.js`
+- Test: `test/helpers/seoYoutubeRadar.store.test.js`
+
+**Interfaces:**
+- Produces:
+  - `createSeoYoutubeRadarStore({ filePath }): Store`
+  - `store.load(): object`
+  - `store.save(data: object): void`
+  - `store.getConfig(): SeoRadarConfig`
+  - `store.setConfig(config: object): SeoRadarConfig`
+  - `store.markVideo(videoId: string, status: "seen" | "processed" | "rejected", meta?: object): void`
+  - `store.hasProcessed(videoId: string): boolean`
+
+- [ ] **Step 1: Write failing tests**
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { createSeoYoutubeRadarStore } = require("../../src/helpers/seoYoutubeRadar/store.js");
+
+test("store persists config and processed videos", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "seo-radar-"));
+  const store = createSeoYoutubeRadarStore({ filePath: path.join(dir, "radar.json") });
+  const config = store.setConfig({ enabled: true, keywords: ["technical seo"] });
+  assert.equal(config.enabled, true);
+  assert.deepEqual(config.keywords, ["technical seo"]);
+  store.markVideo("abc123", "processed", { title: "SEO update" });
+
+  const reloaded = createSeoYoutubeRadarStore({ filePath: path.join(dir, "radar.json") });
+  assert.equal(reloaded.hasProcessed("abc123"), true);
+  assert.equal(reloaded.load().videos.abc123.title, "SEO update");
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.store.test.js`
+
+Expected: fails with missing module.
+
+- [ ] **Step 3: Implement store**
+
+Use atomic JSON writes and `normalizeRadarConfig` from Task 1. Store shape:
+
+```json
+{
+  "config": {},
+  "videos": {
+    "abc123": {
+      "status": "processed",
+      "title": "SEO update",
+      "updatedAt": "2026-07-06T12:00:00.000Z"
+    }
+  },
+  "runs": []
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `node --test test/helpers/seoYoutubeRadar.store.test.js`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/helpers/seoYoutubeRadar/store.js test/helpers/seoYoutubeRadar.store.test.js
+git commit -m "feat: add seo youtube radar store"
+```
+
+---
+
+### Task 4: Runner Orchestration
+
+**Files:**
+- Create: `src/helpers/seoYoutubeRadar/runner.js`
+- Test: `test/helpers/seoYoutubeRadar.runner.test.js`
+
+**Interfaces:**
+- Consumes:
+  - `createYouTubeClient()` from Task 2.
+  - `createSeoYoutubeRadarStore()` from Task 3.
+  - Existing `importYoutubeAudio(url)` from `src/helpers/youtubeImport.js`.
+- Produces:
+  - `runSeoYoutubeRadar({ config, store, youtubeClient, importAudio, transcribeAudio, summarizeLocal, saveNote, nowMs }): Promise<SeoRadarRunResult>`
+
+- [ ] **Step 1: Write failing orchestration test**
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { runSeoYoutubeRadar } = require("../../src/helpers/seoYoutubeRadar/runner.js");
+const { createSeoYoutubeRadarStore } = require("../../src/helpers/seoYoutubeRadar/store.js");
+
+test("runner imports, transcribes, summarizes locally, and saves selected SEO videos", async () => {
+  const memory = {};
+  const store = {
+    load: () => memory,
+    save: (data) => Object.assign(memory, data),
+    hasProcessed: () => false,
+    markVideo: (id, status, meta) => {
+      memory.videos = memory.videos || {};
+      memory.videos[id] = { status, ...meta };
+    },
+  };
+  const youtubeClient = {
+    searchVideos: async () => [{ id: "abc123" }],
+    getVideoDetails: async () => [{
+      id: "abc123",
+      title: "Technical SEO update",
+      channelTitle: "SEO Channel",
+      url: "https://www.youtube.com/watch?v=abc123",
+      publishedAt: "2026-07-06T06:00:00Z",
+      durationSeconds: 900,
+      viewCount: 12000,
+      likeCount: 100,
+      commentCount: 20,
+      description: "Technical SEO update",
+    }],
+  };
+  const notes = [];
+  const result = await runSeoYoutubeRadar({
+    config: {
+      keywords: ["technical seo"],
+      lookbackHours: 72,
+      maxSearchResultsPerQuery: 10,
+      maxVideosToProcess: 1,
+      minDurationSeconds: 180,
+      excludeShorts: true,
+      regionCode: "US",
+      language: "en",
+    },
+    store,
+    youtubeClient,
+    importAudio: async () => ({ success: true, audioPath: "/tmp/abc123.mp3" }),
+    transcribeAudio: async () => ({ success: true, text: "Full transcript text" }),
+    summarizeLocal: async () => ({
+      relevanceScore: 92,
+      summary: "Useful technical SEO update.",
+      keyTakeaways: ["Check Search Console"],
+    }),
+    saveNote: async (note) => {
+      notes.push(note);
+      return { success: true, note: { id: 10 } };
+    },
+    nowMs: Date.parse("2026-07-06T12:00:00Z"),
+  });
+  assert.equal(result.processed, 1);
+  assert.equal(notes[0].title.includes("Technical SEO update"), true);
+  assert.match(notes[0].content, /Full transcript text/);
+  assert.match(notes[0].enhancedContent, /## Summary/);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.runner.test.js`
+
+Expected: fails with missing runner module.
+
+- [ ] **Step 3: Implement runner**
+
+Implement the orchestration with these behaviours:
+
+- Build queries from config.
+- Fetch search results.
+- Fetch details for found video IDs.
+- Exclude videos already marked processed.
+- Exclude duration below `minDurationSeconds`.
+- Sort by score descending.
+- For each finalist:
+  - Ask local AI relevance classifier.
+  - Reject if `reject === true` or `relevanceScore < 70`.
+  - Call `importAudio(video.url)`.
+  - Call `transcribeAudio(audioPath)`.
+  - Call `summarizeLocal(video, transcript)`.
+  - Save note with raw transcript in `content`.
+  - Save enhanced markdown in `enhancedContent`.
+  - Mark video processed.
+
+Enhanced markdown format:
+
+```markdown
+## Summary
+
+[summary]
+
+## Key Takeaways
+
+- [takeaway]
+
+## Source
+
+- Video: [title](url)
+- Channel: [channelTitle]
+- Score: [score]
+
+## Full Transcript
+
+[transcript]
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `node --test test/helpers/seoYoutubeRadar.runner.test.js`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/helpers/seoYoutubeRadar/runner.js test/helpers/seoYoutubeRadar.runner.test.js
+git commit -m "feat: add seo youtube radar runner"
+```
+
+---
+
+### Task 5: Main-Process IPC And Secure API Key Storage
+
+**Files:**
+- Modify: `src/helpers/ipcHandlers.js`
+- Modify: `preload.js`
+- Modify: `src/types/electron.ts`
+- Test: `test/helpers/seoYoutubeRadar.ipcContract.test.js`
+
+**Interfaces:**
+- Produces renderer API:
+  - `seoRadarGetConfig(): Promise<SeoRadarConfig>`
+  - `seoRadarSetConfig(config): Promise<{ success: boolean; config?: SeoRadarConfig; error?: string }>`
+  - `seoRadarSaveYouTubeKey(key: string): Promise<{ success: boolean; error?: string }>`
+  - `seoRadarHasYouTubeKey(): Promise<{ success: boolean; hasKey: boolean }>`
+  - `seoRadarRunNow(): Promise<{ success: boolean; result?: SeoRadarRunResult; error?: string }>`
+
+- [ ] **Step 1: Write IPC contract test**
+
+Create `test/helpers/seoYoutubeRadar.ipcContract.test.js` that reads `preload.js` and `src/types/electron.ts` and asserts the five method names exist.
+
+- [ ] **Step 2: Run test and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.ipcContract.test.js`
+
+Expected: fails because methods are not exposed.
+
+- [ ] **Step 3: Add IPC handlers**
+
+In `src/helpers/ipcHandlers.js`, register:
+
+```js
+ipcMain.handle("seo-radar-get-config", async () => radarStore.getConfig());
+ipcMain.handle("seo-radar-set-config", async (_event, config) => ({ success: true, config: radarStore.setConfig(config) }));
+ipcMain.handle("seo-radar-save-youtube-key", async (_event, key) => secureKeyStore.save("youtubeDataApiKey", key));
+ipcMain.handle("seo-radar-has-youtube-key", async () => ({ success: true, hasKey: !!secureKeyStore.get("youtubeDataApiKey") }));
+ipcMain.handle("seo-radar-run-now", async () => runSeoYoutubeRadarWithRuntimeDeps());
+```
+
+Use the existing secure key mechanism in the repo; if it only exposes named helpers for current keys, add one narrowly scoped helper for `youtubeDataApiKey`.
+
+- [ ] **Step 4: Expose preload methods and TypeScript types**
+
+Add methods to `preload.js` using `ipcRenderer.invoke`. Add matching types to `src/types/electron.ts`.
+
+- [ ] **Step 5: Run checks**
+
+Run:
+
+```bash
+node --test test/helpers/seoYoutubeRadar.ipcContract.test.js
+npm run typecheck
+node --check preload.js
+node --check src/helpers/ipcHandlers.js
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/helpers/ipcHandlers.js preload.js src/types/electron.ts test/helpers/seoYoutubeRadar.ipcContract.test.js
+git commit -m "feat: expose seo youtube radar ipc"
+```
+
+---
+
+### Task 6: Settings UI
+
+**Files:**
+- Modify: `src/components/SettingsPage.tsx`
+- Modify: `src/locales/de/translation.json`
+- Modify: `src/locales/en/translation.json`
+- Modify: `src/locales/es/translation.json`
+- Modify: `src/locales/fr/translation.json`
+- Modify: `src/locales/it/translation.json`
+- Modify: `src/locales/ja/translation.json`
+- Modify: `src/locales/pt/translation.json`
+- Modify: `src/locales/ru/translation.json`
+- Modify: `src/locales/zh-CN/translation.json`
+- Modify: `src/locales/zh-TW/translation.json`
+
+**Interfaces:**
+- Consumes renderer API from Task 5.
+- Produces a Settings panel with:
+  - Enable daily SEO Radar.
+  - YouTube API key save field.
+  - Keyword textarea.
+  - Max videos per run input.
+  - Manual `Run now` button.
+  - Last run summary.
+
+- [ ] **Step 1: Add UI keys to all locale files**
+
+Add keys under `settingsPage.seoRadar`:
+
+```json
+{
+  "title": "SEO YouTube Radar",
+  "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+  "enabled": "Run daily",
+  "apiKey": "YouTube API key",
+  "apiKeySaved": "YouTube API key saved",
+  "keywords": "Search topics",
+  "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+  "maxVideos": "Max videos per run",
+  "runNow": "Run now",
+  "running": "Running",
+  "lastRun": "Last run",
+  "noRunYet": "No runs yet",
+  "saved": "Settings saved",
+  "failed": "SEO Radar failed"
+}
+```
+
+Use accurate translations for non-English locales or English fallback text if the repo already accepts fallback-like translations for new operational strings.
+
+- [ ] **Step 2: Add settings panel**
+
+Add a compact panel to the existing Settings page. Use existing `Input`, `Button`, `Toggle`, and panel conventions. Do not add a landing page or marketing copy.
+
+- [ ] **Step 3: Wire `Run now`**
+
+Call `window.electronAPI.seoRadarRunNow()`. Display result counts:
+
+```tsx
+const label = result.success
+  ? `${result.result?.processed ?? 0} processed, ${result.result?.rejected ?? 0} rejected`
+  : t("settingsPage.seoRadar.failed");
+```
+
+- [ ] **Step 4: Run checks**
+
+Run:
+
+```bash
+npm run i18n:check
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/SettingsPage.tsx src/locales/de/translation.json src/locales/en/translation.json src/locales/es/translation.json src/locales/fr/translation.json src/locales/it/translation.json src/locales/ja/translation.json src/locales/pt/translation.json src/locales/ru/translation.json src/locales/zh-CN/translation.json src/locales/zh-TW/translation.json
+git commit -m "feat: add seo youtube radar settings"
+```
+
+---
+
+### Task 7: Scheduler
+
+**Files:**
+- Create: `src/helpers/seoYoutubeRadar/scheduler.js`
+- Modify: `src/helpers/ipcHandlers.js`
+- Test: `test/helpers/seoYoutubeRadar.scheduler.test.js`
+
+**Interfaces:**
+- Produces:
+  - `createSeoYoutubeRadarScheduler({ store, runNow, setTimeoutImpl, clearTimeoutImpl, now }): Scheduler`
+  - `scheduler.start(): void`
+  - `scheduler.stop(): void`
+  - `scheduler.runNow(): Promise<SeoRadarRunResult>`
+
+- [ ] **Step 1: Write failing scheduler test**
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createSeoYoutubeRadarScheduler } = require("../../src/helpers/seoYoutubeRadar/scheduler.js");
+
+test("scheduler does not schedule when disabled", () => {
+  let scheduled = false;
+  const scheduler = createSeoYoutubeRadarScheduler({
+    store: { getConfig: () => ({ enabled: false }) },
+    runNow: async () => ({ processed: 0 }),
+    setTimeoutImpl: () => { scheduled = true; return 1; },
+    clearTimeoutImpl: () => {},
+    now: () => new Date("2026-07-06T12:00:00Z"),
+  });
+  scheduler.start();
+  assert.equal(scheduled, false);
+});
+
+test("scheduler schedules enabled daily run", () => {
+  let delay = null;
+  const scheduler = createSeoYoutubeRadarScheduler({
+    store: { getConfig: () => ({ enabled: true, runHourLocal: 7 }) },
+    runNow: async () => ({ processed: 0 }),
+    setTimeoutImpl: (_fn, ms) => { delay = ms; return 1; },
+    clearTimeoutImpl: () => {},
+    now: () => new Date("2026-07-06T06:00:00"),
+  });
+  scheduler.start();
+  assert.ok(delay > 0);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test test/helpers/seoYoutubeRadar.scheduler.test.js`
+
+Expected: fails with missing scheduler module.
+
+- [ ] **Step 3: Implement scheduler**
+
+Schedule the next run at `config.runHourLocal || 7` local time. After every run, schedule the next one. Do not overlap runs; if a run is active, `runNow()` returns `{ skipped: true, reason: "already_running" }`.
+
+- [ ] **Step 4: Hook scheduler into app startup**
+
+In `ipcHandlers.js` or the existing main-process initialization point, instantiate the scheduler once after IPC dependencies are available. Stop it during app quit using the same lifecycle pattern as other sidecar managers.
+
+- [ ] **Step 5: Run tests and checks**
+
+Run:
+
+```bash
+node --test test/helpers/seoYoutubeRadar.scheduler.test.js
+npm run typecheck
+npm run lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/helpers/seoYoutubeRadar/scheduler.js src/helpers/ipcHandlers.js test/helpers/seoYoutubeRadar.scheduler.test.js
+git commit -m "feat: schedule seo youtube radar"
+```
+
+---
+
+### Task 8: End-To-End Verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-06-seo-youtube-radar.md` only if verification reveals an implementation detail that must be documented for operators.
+
+**Interfaces:**
+- Consumes all prior tasks.
+- Produces verified local workflow.
+
+- [ ] **Step 1: Run full focused test suite**
+
+Run:
+
+```bash
+node --test test/helpers/seoYoutubeRadar.scoring.test.js
+node --test test/helpers/seoYoutubeRadar.youtubeClient.test.js
+node --test test/helpers/seoYoutubeRadar.store.test.js
+node --test test/helpers/seoYoutubeRadar.runner.test.js
+node --test test/helpers/seoYoutubeRadar.ipcContract.test.js
+node --test test/helpers/seoYoutubeRadar.scheduler.test.js
+npm run typecheck
+npm run lint
+npm run i18n:check
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run OpenWhispr and verify UI loads**
+
+Run:
+
+```bash
+ow restart
+ow status
+curl -I --max-time 5 http://127.0.0.1:5183
+```
+
+Expected:
+- `ow status` reports `RUNNING`.
+- `curl` returns `HTTP/1.1 200 OK`.
+
+- [ ] **Step 3: Manual dry run with quota guard**
+
+Use Settings → SEO YouTube Radar:
+
+1. Save YouTube API key.
+2. Set keywords to `technical seo`.
+3. Set max videos per run to `1`.
+4. Click `Run now`.
+
+Expected:
+- One run starts.
+- At most one video is imported/transcribed.
+- Saved note contains raw transcript in `content`.
+- Saved note contains `## Summary` and `## Full Transcript` in `enhanced_content`.
+- Local AI model server is used; no cloud AI calls are made.
+
+- [ ] **Step 4: Confirm cache prevents duplicate processing**
+
+Click `Run now` again with the same settings.
+
+Expected:
+- Previously processed video is skipped.
+- Run result shows `processed: 0` if no new candidate appears.
+
+- [ ] **Step 5: Commit final verification notes if docs changed**
+
+```bash
+git add docs/superpowers/plans/2026-07-06-seo-youtube-radar.md
+git commit -m "docs: document seo youtube radar verification"
+```
+
+Skip this commit if no documentation changes were made during verification.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers discovery, popularity scoring, cache, local AI filtering, import, transcription, summary, note saving, settings, scheduler, and verification.
+- Placeholder scan: No placeholder markers or unspecified error-handling steps remain.
+- Type consistency: The runner consumes the exact functions produced by scoring, client, and store tasks. Renderer IPC names match preload and `electron.ts` method names.
+- Scope check: This is one cohesive feature. It touches discovery, orchestration, settings, and scheduling, but each task is independently testable and can be reviewed separately.

--- a/preload.js
+++ b/preload.js
@@ -127,6 +127,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Audio file operations
   selectAudioFile: () => ipcRenderer.invoke("select-audio-file"),
   getFileSize: (filePath) => ipcRenderer.invoke("get-file-size", filePath),
+  importYoutubeAudio: (url) => ipcRenderer.invoke("import-youtube-audio", url),
   transcribeAudioFile: (filePath, options) =>
     ipcRenderer.invoke("transcribe-audio-file", filePath, options),
   getPathForFile: (file) => webUtils.getPathForFile(file),

--- a/preload.js
+++ b/preload.js
@@ -132,6 +132,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("transcribe-audio-file", filePath, options),
   getPathForFile: (file) => webUtils.getPathForFile(file),
 
+  // SEO YouTube Radar
+  seoRadarGetConfig: () => ipcRenderer.invoke("seo-radar-get-config"),
+  seoRadarSetConfig: (config) => ipcRenderer.invoke("seo-radar-set-config", config),
+  seoRadarSaveYouTubeKey: (key) => ipcRenderer.invoke("seo-radar-save-youtube-key", key),
+  seoRadarHasYouTubeKey: () => ipcRenderer.invoke("seo-radar-has-youtube-key"),
+  seoRadarRunNow: () => ipcRenderer.invoke("seo-radar-run-now"),
+
   onNoteAdded: (callback) => {
     const listener = (_event, note) => callback?.(note);
     ipcRenderer.on("note-added", listener);

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Badge } from "./ui/badge";
+import { Textarea } from "./ui/textarea";
 import {
   RefreshCw,
   Download,
@@ -34,6 +35,7 @@ import {
   FileAudio,
   Wand2,
   Upload,
+  Search,
 } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
 import { AUTH_URL, signOut, deleteAccount } from "../lib/auth";
@@ -87,7 +89,13 @@ import { Skeleton } from "./ui/skeleton";
 import { Progress } from "./ui/progress";
 import { useToast } from "./ui/useToast";
 import { useTheme } from "../hooks/useTheme";
-import type { GpuDevice, LocalTranscriptionProvider, InferenceMode } from "../types/electron";
+import type {
+  GpuDevice,
+  LocalTranscriptionProvider,
+  InferenceMode,
+  SeoRadarConfig,
+  SeoRadarRunResult,
+} from "../types/electron";
 import logger from "../utils/logger";
 import { SettingsRow, InferenceModeSelector } from "./ui/SettingsSection";
 import type { InferenceModeOption } from "./ui/SettingsSection";
@@ -424,6 +432,289 @@ function NoteFormattingSettings() {
         </SettingsPanelRow>
       </SettingsPanel>
       <InferenceConfigEditor scope="noteFormatting" />
+    </div>
+  );
+}
+
+const FALLBACK_SEO_RADAR_CONFIG: SeoRadarConfig = {
+  enabled: false,
+  keywords: [
+    "seo",
+    "technical seo",
+    "google algorithm update",
+    "search console",
+    "local seo",
+    "ai seo",
+  ],
+  lookbackHours: 72,
+  maxSearchResultsPerQuery: 10,
+  maxVideosToProcess: 5,
+  minDurationSeconds: 180,
+  excludeShorts: true,
+  regionCode: "US",
+  language: "en",
+  runHourLocal: 7,
+  localModelId: "",
+};
+
+function formatSeoRadarRunResult(t: ReturnType<typeof useTranslation>["t"], result: SeoRadarRunResult) {
+  if (result.skipReason === "already_running") return t("settingsPage.seoRadar.alreadyRunning");
+  return t("settingsPage.seoRadar.lastRunSummary", {
+    processed: result.processed,
+    rejected: result.rejected,
+    skipped: result.skipped,
+  });
+}
+
+function SeoRadarSettings() {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const [config, setConfig] = useState<SeoRadarConfig>(FALLBACK_SEO_RADAR_CONFIG);
+  const [keywordsText, setKeywordsText] = useState(FALLBACK_SEO_RADAR_CONFIG.keywords.join(", "));
+  const [apiKey, setApiKey] = useState("");
+  const [hasKey, setHasKey] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [lastRunLabel, setLastRunLabel] = useState("");
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([
+      window.electronAPI?.seoRadarGetConfig?.() ?? Promise.resolve(FALLBACK_SEO_RADAR_CONFIG),
+      window.electronAPI?.seoRadarHasYouTubeKey?.() ??
+        Promise.resolve({ success: true, hasKey: false }),
+    ])
+      .then(([loadedConfig, keyState]) => {
+        if (!mounted) return;
+        const nextConfig = loadedConfig || FALLBACK_SEO_RADAR_CONFIG;
+        setConfig(nextConfig);
+        setKeywordsText(nextConfig.keywords.join(", "));
+        setHasKey(Boolean(keyState?.hasKey));
+      })
+      .finally(() => {
+        if (mounted) setIsLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const patchConfig = (patch: Partial<SeoRadarConfig>) => {
+    setConfig((current) => ({ ...current, ...patch }));
+  };
+
+  const buildConfigFromInputs = () => ({
+    ...config,
+    keywords: keywordsText
+      .split(/[,\n]/)
+      .map((value) => value.trim())
+      .filter(Boolean),
+  });
+
+  const persistConfig = useCallback(
+    async (nextConfig: SeoRadarConfig, successTitle = t("settingsPage.seoRadar.saved")) => {
+      const response = await window.electronAPI?.seoRadarSetConfig?.(nextConfig);
+      if (!response?.success || !response.config) {
+        throw new Error(response?.error || t("settingsPage.seoRadar.failed"));
+      }
+      setConfig(response.config);
+      setKeywordsText(response.config.keywords.join(", "));
+      toast({ title: successTitle, variant: "success" });
+      return response.config;
+    },
+    [t, toast]
+  );
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await persistConfig(buildConfigFromInputs());
+      if (apiKey.trim()) {
+        const keyResult = await window.electronAPI?.seoRadarSaveYouTubeKey?.(apiKey.trim());
+        if (!keyResult?.success) {
+          throw new Error(keyResult?.error || t("settingsPage.seoRadar.failed"));
+        }
+        setApiKey("");
+        setHasKey(true);
+        toast({ title: t("settingsPage.seoRadar.apiKeySaved"), variant: "success" });
+      }
+    } catch (error) {
+      toast({
+        title: t("settingsPage.seoRadar.failed"),
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleEnabledChange = async (enabled: boolean) => {
+    const nextConfig = { ...config, enabled };
+    patchConfig({ enabled });
+    try {
+      await persistConfig(nextConfig, enabled ? t("settingsPage.seoRadar.enabled") : t("settingsPage.seoRadar.saved"));
+    } catch (error) {
+      patchConfig({ enabled: !enabled });
+      toast({
+        title: t("settingsPage.seoRadar.failed"),
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRunNow = async () => {
+    setIsRunning(true);
+    try {
+      const configResult = await window.electronAPI?.seoRadarSetConfig?.(buildConfigFromInputs());
+      if (!configResult?.success || !configResult.config) {
+        throw new Error(configResult?.error || t("settingsPage.seoRadar.failed"));
+      }
+      setConfig(configResult.config);
+      setKeywordsText(configResult.config.keywords.join(", "));
+      if (apiKey.trim()) {
+        const keyResult = await window.electronAPI?.seoRadarSaveYouTubeKey?.(apiKey.trim());
+        if (!keyResult?.success) {
+          throw new Error(keyResult?.error || t("settingsPage.seoRadar.failed"));
+        }
+        setApiKey("");
+        setHasKey(true);
+      }
+      const result = await window.electronAPI?.seoRadarRunNow?.();
+      if (!result?.success || !result.result) {
+        throw new Error(result?.error || t("settingsPage.seoRadar.failed"));
+      }
+      const label = formatSeoRadarRunResult(t, result.result);
+      setLastRunLabel(label);
+      toast({ title: label, variant: "success" });
+    } catch (error) {
+      toast({
+        title: t("settingsPage.seoRadar.failed"),
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <div className="border-t border-border/40 pt-6">
+      <SectionHeader
+        title={t("settingsPage.seoRadar.title")}
+        description={t("settingsPage.seoRadar.description")}
+      />
+      <SettingsPanel>
+        <SettingsPanelRow>
+          <SettingsRow
+            label={t("settingsPage.seoRadar.enabled")}
+            description={t("settingsPage.seoRadar.enabledDescription")}
+          >
+            <Toggle checked={config.enabled} disabled={isLoading} onChange={handleEnabledChange} />
+          </SettingsRow>
+        </SettingsPanelRow>
+        <SettingsPanelRow>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground">
+                {t("settingsPage.seoRadar.apiKey")}
+              </label>
+              <Input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={
+                  hasKey
+                    ? t("settingsPage.seoRadar.apiKeySaved")
+                    : t("settingsPage.seoRadar.apiKeyPlaceholder")
+                }
+                autoComplete="off"
+              />
+            </div>
+            <Button size="sm" variant="outline" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Key className="h-3.5 w-3.5" />}
+              {t("settingsPage.seoRadar.save")}
+            </Button>
+          </div>
+        </SettingsPanelRow>
+        <SettingsPanelRow>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-foreground">
+              {t("settingsPage.seoRadar.keywords")}
+            </label>
+            <Textarea
+              value={keywordsText}
+              onChange={(e) => setKeywordsText(e.target.value)}
+              placeholder={t("settingsPage.seoRadar.keywordsPlaceholder")}
+              className="min-h-[84px] rounded-md border-border bg-background text-xs"
+            />
+          </div>
+        </SettingsPanelRow>
+        <SettingsPanelRow>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground">
+                {t("settingsPage.seoRadar.maxVideos")}
+              </label>
+              <Input
+                type="number"
+                min="1"
+                max="10"
+                value={config.maxVideosToProcess}
+                onChange={(e) => patchConfig({ maxVideosToProcess: Number(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground">
+                {t("settingsPage.seoRadar.lookbackHours")}
+              </label>
+              <Input
+                type="number"
+                min="1"
+                max="168"
+                value={config.lookbackHours}
+                onChange={(e) => patchConfig({ lookbackHours: Number(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground">
+                {t("settingsPage.seoRadar.runHour")}
+              </label>
+              <Input
+                type="number"
+                min="0"
+                max="23"
+                value={config.runHourLocal}
+                onChange={(e) => patchConfig({ runHourLocal: Number(e.target.value) })}
+              />
+            </div>
+          </div>
+        </SettingsPanelRow>
+        <SettingsPanelRow>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs font-medium text-foreground">
+                {t("settingsPage.seoRadar.lastRun")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {lastRunLabel || t("settingsPage.seoRadar.noRunYet")}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button size="sm" variant="outline" onClick={handleSave} disabled={isSaving}>
+                {isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+                {t("settingsPage.seoRadar.save")}
+              </Button>
+              <Button size="sm" onClick={handleRunNow} disabled={isRunning || isLoading}>
+                {isRunning ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
+                {isRunning ? t("settingsPage.seoRadar.running") : t("settingsPage.seoRadar.runNow")}
+              </Button>
+            </div>
+          </div>
+        </SettingsPanelRow>
+      </SettingsPanel>
     </div>
   );
 }
@@ -3975,6 +4266,7 @@ EOF`,
             renderUpload={() => (
               <div className="space-y-6">
                 <UploadTranscriptionPanel />
+                <SeoRadarSettings />
               </div>
             )}
           />

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -1,6 +1,16 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Upload, FileAudio, X, AlertCircle, FolderOpen, Plus, Settings } from "lucide-react";
+import {
+  Upload,
+  FileAudio,
+  X,
+  AlertCircle,
+  FolderOpen,
+  Plus,
+  Settings,
+  Link as LinkIcon,
+  Loader2,
+} from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "../ui/button";
 import { cn } from "../lib/utils";
@@ -25,11 +35,21 @@ import { getAllReasoningModels } from "../../models/ModelRegistry";
 import {
   useSettingsStore,
   selectIsCloudCleanupMode,
+  selectIsCloudNoteFormattingMode,
   selectResolvedUploadTranscription,
+  selectResolvedLLMConfig,
   getSettings,
 } from "../../stores/settingsStore";
 import { generateNoteTitle } from "../../utils/generateTitle";
 import { getBaseLanguageCode } from "../../utils/languageSupport";
+import reasoningService from "../../services/ReasoningService";
+import logger from "../../utils/logger";
+import {
+  buildUploadEnhancedContent,
+  makeUploadContentHash,
+  resolveUploadSummaryReasoning,
+  UPLOAD_SUMMARY_SYSTEM_PROMPT,
+} from "../../utils/uploadTranscriptSummary";
 
 type UploadState = "idle" | "selected" | "transcribing" | "complete" | "error";
 
@@ -63,6 +83,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
   const [noteId, setNoteId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [youtubeUrl, setYoutubeUrl] = useState("");
+  const [isImportingYoutube, setIsImportingYoutube] = useState(false);
   const [progress, setProgress] = useState(0);
   const progressRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [chunkProgress, setChunkProgress] = useState<{
@@ -96,6 +118,10 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     cloudTranscriptionBaseUrl,
     cloudTranscriptionMode,
   } = useSettingsStore(useShallow(selectResolvedUploadTranscription));
+  const noteFormatting = useSettingsStore(
+    useShallow((s) => selectResolvedLLMConfig(s, "noteFormatting"))
+  );
+  const isCloudNoteFormatting = useSettingsStore(selectIsCloudNoteFormattingMode);
 
   const setUploadTranscriptionMode = useSettingsStore((s) => s.setUploadTranscriptionMode);
   const setUploadCloudTranscriptionMode = useSettingsStore(
@@ -263,19 +289,79 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     return generateNoteTitle(text, model);
   };
 
+  const generateSummaryContent = async (text: string): Promise<string | null> => {
+    const summaryRequest = resolveUploadSummaryReasoning({
+      ...noteFormatting,
+      mode:
+        noteFormatting.mode === "openwhispr" && !isCloudNoteFormatting
+          ? "providers"
+          : noteFormatting.mode,
+    });
+    if (!summaryRequest) return null;
+
+    try {
+      const summary = await reasoningService.processText(text, summaryRequest.modelId, null, {
+        ...summaryRequest.config,
+        systemPrompt: UPLOAD_SUMMARY_SYSTEM_PROMPT,
+        temperature: 0.2,
+      });
+      const trimmedSummary = summary.trim();
+      if (!trimmedSummary) return null;
+      return buildUploadEnhancedContent({ summary: trimmedSummary, transcript: text });
+    } catch (err) {
+      logger.warn(
+        "Failed to summarize uploaded transcript",
+        { error: err instanceof Error ? err.message : String(err) },
+        "notes"
+      );
+      return null;
+    }
+  };
+
+  const selectAudioPath = async (filePath: string) => {
+    const name = filePath.split(/[/\\]/).pop() || "audio";
+    const sizeBytes = (await window.electronAPI.getFileSize?.(filePath)) ?? 0;
+    setFile({
+      name,
+      path: filePath,
+      size: sizeBytes ? formatFileSize(sizeBytes) : "",
+      sizeBytes,
+    });
+    setState("selected");
+    setError(null);
+  };
+
   const handleBrowse = async () => {
     const res = await window.electronAPI.selectAudioFile();
     if (!res.canceled && res.filePath) {
-      const name = res.filePath.split(/[/\\]/).pop() || "audio";
-      const sizeBytes = (await window.electronAPI.getFileSize?.(res.filePath)) ?? 0;
-      setFile({
-        name,
-        path: res.filePath,
-        size: sizeBytes ? formatFileSize(sizeBytes) : "",
-        sizeBytes,
-      });
-      setState("selected");
-      setError(null);
+      await selectAudioPath(res.filePath);
+    }
+  };
+
+  const handleYoutubeImport = async () => {
+    const url = youtubeUrl.trim();
+    if (!url || isImportingYoutube) return;
+
+    if (!window.electronAPI.importYoutubeAudio) {
+      setError(t("notes.upload.youtubeImportUnavailable"));
+      setState("error");
+      return;
+    }
+
+    setIsImportingYoutube(true);
+    setError(null);
+    try {
+      const res = await window.electronAPI.importYoutubeAudio(url);
+      if (!res.success || !res.audioPath) {
+        throw new Error(res.error || t("notes.upload.youtubeImportFailed"));
+      }
+      await selectAudioPath(res.audioPath);
+      setYoutubeUrl("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("notes.upload.youtubeImportFailed"));
+      setState("error");
+    } finally {
+      setIsImportingYoutube(false);
     }
   };
 
@@ -406,7 +492,26 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           null,
           folderId
         );
-        if (noteRes.success && noteRes.note) setNoteId(noteRes.note.id);
+        if (noteRes.success && noteRes.note) {
+          const summaryContent = await generateSummaryContent(res.text);
+          if (runId !== runIdRef.current) return;
+          if (summaryContent) {
+            try {
+              await window.electronAPI.updateNote(noteRes.note.id, {
+                enhanced_content: summaryContent,
+                enhancement_prompt: UPLOAD_SUMMARY_SYSTEM_PROMPT,
+                enhanced_at_content_hash: makeUploadContentHash(res.text),
+              });
+            } catch (err) {
+              logger.warn(
+                "Failed to save uploaded transcript summary",
+                { error: err instanceof Error ? err.message : String(err) },
+                "notes"
+              );
+            }
+          }
+          setNoteId(noteRes.note.id);
+        }
         setState("complete");
       } else {
         setProgress(0);
@@ -486,6 +591,10 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
               getActiveModelLabel={getActiveModelLabel}
               handleDrop={handleDrop}
               handleBrowse={handleBrowse}
+              youtubeUrl={youtubeUrl}
+              setYoutubeUrl={setYoutubeUrl}
+              handleYoutubeImport={handleYoutubeImport}
+              isImportingYoutube={isImportingYoutube}
               isDragOver={isDragOver}
               setIsDragOver={setIsDragOver}
             />
@@ -618,6 +727,10 @@ interface IdleViewProps {
   getActiveModelLabel: () => string;
   handleDrop: (e: React.DragEvent) => void;
   handleBrowse: () => void;
+  youtubeUrl: string;
+  setYoutubeUrl: (v: string) => void;
+  handleYoutubeImport: () => void;
+  isImportingYoutube: boolean;
   isDragOver: boolean;
   setIsDragOver: (v: boolean) => void;
 }
@@ -627,6 +740,10 @@ function IdleView({
   getActiveModelLabel,
   handleDrop,
   handleBrowse,
+  youtubeUrl,
+  setYoutubeUrl,
+  handleYoutubeImport,
+  isImportingYoutube,
   isDragOver,
   setIsDragOver,
 }: IdleViewProps) {
@@ -729,6 +846,44 @@ function IdleView({
           </div>
         )}
       </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleYoutubeImport();
+        }}
+        className="mt-3 flex items-center gap-2"
+      >
+        <div className="relative min-w-0 flex-1">
+          <LinkIcon
+            size={13}
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-foreground/20"
+          />
+          <Input
+            value={youtubeUrl}
+            onChange={(e) => setYoutubeUrl(e.target.value)}
+            disabled={isImportingYoutube}
+            placeholder={t("notes.upload.youtubeUrlPlaceholder")}
+            aria-label={t("notes.upload.youtubeUrlLabel")}
+            className="h-8 pl-8 pr-2 text-xs bg-surface-1/40 dark:bg-white/[0.03] border-foreground/6 dark:border-white/6"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isImportingYoutube || !youtubeUrl.trim()}
+          className="h-8 min-w-[78px] gap-1.5 px-3 text-xs"
+        >
+          {isImportingYoutube ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <LinkIcon size={12} />
+          )}
+          {isImportingYoutube
+            ? t("notes.upload.youtubeImporting")
+            : t("notes.upload.youtubeImport")}
+        </Button>
+      </form>
     </>
   );
 }

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -24,6 +24,7 @@ const SECRET_KEYS = [
   "BEDROCK_SESSION_TOKEN",
   "AZURE_OPENAI_API_KEY",
   "VERTEX_API_KEY",
+  "YOUTUBE_DATA_API_KEY",
 ];
 
 const SECRET_KEY_SET = new Set(SECRET_KEYS);
@@ -439,6 +440,14 @@ class EnvironmentManager {
   }
   saveVertexApiKey(key) {
     return this._saveKey("VERTEX_API_KEY", key);
+  }
+
+  getYouTubeDataApiKey() {
+    return this._getKey("YOUTUBE_DATA_API_KEY");
+  }
+
+  saveYouTubeDataApiKey(key) {
+    return this._saveKey("YOUTUBE_DATA_API_KEY", key);
   }
 
   getDictationKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -44,6 +44,7 @@ const { importYoutubeAudio } = require("./youtubeImport");
 const { createSeoYoutubeRadarStore } = require("./seoYoutubeRadar/store");
 const { createYouTubeClient } = require("./seoYoutubeRadar/youtubeClient");
 const { runSeoYoutubeRadar } = require("./seoYoutubeRadar/runner");
+const { createSeoYoutubeRadarScheduler } = require("./seoYoutubeRadar/scheduler");
 
 const STREAMING_CLIENT_BY_PROVIDER = {
   "openai-realtime": OpenAIRealtimeStreaming,
@@ -352,6 +353,14 @@ class IPCHandlers {
     this.seoRadarStore = createSeoYoutubeRadarStore({
       filePath: path.join(app.getPath("userData"), "seo-youtube-radar.json"),
     });
+    this.seoRadarScheduler = createSeoYoutubeRadarScheduler({
+      store: this.seoRadarStore,
+      runNow: () => this._runSeoYoutubeRadar(),
+      onError: (error) =>
+        debugLogger.error("Scheduled SEO YouTube Radar run failed", {
+          error: error.message,
+        }),
+    });
     this._audioCleanupInterval = null;
     this._noteFilesEnabled = false;
     this.speakerDiarizationEnabled = true;
@@ -367,6 +376,10 @@ class IPCHandlers {
     this._setupAudioCleanup();
     this._logDetectedGpus();
     this.setupHandlers();
+    this.seoRadarScheduler.start();
+    app.on("before-quit", () => {
+      this.seoRadarScheduler.stop();
+    });
 
     if (this.whisperManager?.serverManager) {
       this.whisperManager.serverManager.on("cuda-fallback", () => {
@@ -931,7 +944,9 @@ class IPCHandlers {
 
     ipcMain.handle("seo-radar-set-config", async (_event, config) => {
       try {
-        return { success: true, config: this.seoRadarStore.setConfig(config) };
+        const nextConfig = this.seoRadarStore.setConfig(config);
+        this.seoRadarScheduler.reschedule();
+        return { success: true, config: nextConfig };
       } catch (error) {
         return { success: false, error: error.message };
       }
@@ -958,7 +973,7 @@ class IPCHandlers {
 
     ipcMain.handle("seo-radar-run-now", async () => {
       try {
-        return { success: true, result: await this._runSeoYoutubeRadar() };
+        return { success: true, result: await this.seoRadarScheduler.runNow() };
       } catch (error) {
         debugLogger.error("SEO YouTube Radar run failed", { error: error.message }, "seo-radar");
         return { success: false, error: error.message };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -40,6 +40,7 @@ const {
   sanitizeWhisperVadConfig,
   resolveContextSileroEnabled,
 } = require("./whisperVadConfig");
+const { importYoutubeAudio } = require("./youtubeImport");
 
 const STREAMING_CLIENT_BY_PROVIDER = {
   "openai-realtime": OpenAIRealtimeStreaming,
@@ -1536,6 +1537,15 @@ class IPCHandlers {
         return stats.size;
       } catch {
         return 0;
+      }
+    });
+
+    ipcMain.handle("import-youtube-audio", async (_event, url) => {
+      try {
+        return await importYoutubeAudio(url);
+      } catch (error) {
+        debugLogger.error("YouTube audio import error", { error: error.message }, "upload");
+        return { success: false, error: error.message || "YouTube import failed." };
       }
     });
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -41,6 +41,9 @@ const {
   resolveContextSileroEnabled,
 } = require("./whisperVadConfig");
 const { importYoutubeAudio } = require("./youtubeImport");
+const { createSeoYoutubeRadarStore } = require("./seoYoutubeRadar/store");
+const { createYouTubeClient } = require("./seoYoutubeRadar/youtubeClient");
+const { runSeoYoutubeRadar } = require("./seoYoutubeRadar/runner");
 
 const STREAMING_CLIENT_BY_PROVIDER = {
   "openai-realtime": OpenAIRealtimeStreaming,
@@ -346,6 +349,9 @@ class IPCHandlers {
     this._textEditHandler = null;
     this._activeRecordingPipeline = null;
     this.audioStorageManager = new AudioStorageManager();
+    this.seoRadarStore = createSeoYoutubeRadarStore({
+      filePath: path.join(app.getPath("userData"), "seo-youtube-radar.json"),
+    });
     this._audioCleanupInterval = null;
     this._noteFilesEnabled = false;
     this.speakerDiarizationEnabled = true;
@@ -701,6 +707,127 @@ class IPCHandlers {
     }
   }
 
+  async _resolveSeoRadarLocalModelId(config = {}) {
+    const configured = String(config.localModelId || "").trim();
+    if (configured) return configured;
+
+    const envModel = process.env.LOCAL_CLEANUP_MODEL || process.env.LOCAL_DICTATION_AGENT_MODEL;
+    if (envModel) return envModel;
+
+    const modelManager = require("./modelManagerBridge").default;
+    const models = await modelManager.getAllModels();
+    const downloaded = models.find((model) => model.isDownloaded);
+    if (downloaded?.id) return downloaded.id;
+
+    throw new Error(
+      "No local AI model is configured. Download/select a local AI model before running SEO Radar."
+    );
+  }
+
+  async _processSeoRadarLocalPrompt(prompt, config = {}, options = {}) {
+    const LocalReasoningService = require("../services/localReasoningBridge").default;
+    const modelId = await this._resolveSeoRadarLocalModelId(config);
+    return LocalReasoningService.processText(prompt, modelId, {
+      maxTokens: options.maxTokens || 900,
+      temperature: options.temperature ?? 0.2,
+      systemPrompt:
+        options.systemPrompt ||
+        "You are an SEO research assistant. Return only strict JSON. Do not use markdown.",
+      disableThinking: true,
+    });
+  }
+
+  async _classifySeoRadarVideo(video, prompt, config) {
+    return this._processSeoRadarLocalPrompt(prompt, config, { maxTokens: 500, temperature: 0 });
+  }
+
+  async _summarizeSeoRadarTranscript(video, transcript, config) {
+    const prompt = [
+      "Return strict JSON with keys: summary, keyTakeaways.",
+      "summary must be concise and useful for an SEO operator.",
+      "keyTakeaways must be an array of 3-7 practical SEO takeaways.",
+      "",
+      `Title: ${video.title || ""}`,
+      `Channel: ${video.channelTitle || ""}`,
+      `URL: ${video.url || ""}`,
+      "",
+      "Transcript:",
+      transcript,
+    ].join("\n");
+    return this._processSeoRadarLocalPrompt(prompt, config, { maxTokens: 1400, temperature: 0.2 });
+  }
+
+  async _transcribeSeoRadarAudio(audioPath, config) {
+    const audioBuffer = fs.readFileSync(audioPath);
+    const provider = process.env.LOCAL_TRANSCRIPTION_PROVIDER === "nvidia" ? "nvidia" : "whisper";
+    if (provider === "nvidia") {
+      return this.parakeetManager.transcribeLocalParakeet(audioBuffer, {
+        provider,
+        model: process.env.PARAKEET_MODEL || config.parakeetModel || "parakeet-tdt-0.6b-v3",
+      });
+    }
+    const vadOptions = this._resolveWhisperVadOptions("noteRecording");
+    return this.whisperManager.transcribeLocalWhisper(audioBuffer, {
+      provider,
+      model: process.env.LOCAL_WHISPER_MODEL || config.whisperModel || "base",
+      ...vadOptions,
+    });
+  }
+
+  _saveSeoRadarNote(note) {
+    const result = this.databaseManager.saveNote(
+      note.title,
+      note.content,
+      "upload",
+      note.sourceFile,
+      null,
+      null
+    );
+    if (!result?.success || !result.note) return result;
+
+    const updated = this.databaseManager.updateNote(result.note.id, {
+      enhanced_content: note.enhancedContent,
+      enhancement_prompt: "SEO YouTube Radar local AI summary",
+      enhanced_at_content_hash: crypto
+        .createHash("sha256")
+        .update(note.content || "")
+        .digest("hex"),
+    });
+    const savedNote = updated?.note || result.note;
+    setImmediate(() => {
+      this.broadcastToWindows("note-added", savedNote);
+      this.broadcastToWindows("note-updated", savedNote);
+    });
+    this._asyncVectorUpsert(savedNote);
+    this._asyncMirrorWrite(savedNote);
+    return { success: true, note: savedNote };
+  }
+
+  async _runSeoYoutubeRadar() {
+    const config = this.seoRadarStore.getConfig();
+    const apiKey = this.environmentManager.getYouTubeDataApiKey();
+    if (!apiKey) {
+      throw new Error("YouTube Data API key is required for SEO Radar discovery.");
+    }
+
+    const youtubeClient = createYouTubeClient({
+      apiKey,
+      fetchImpl: (url) => net.fetch(url, { useSessionCookies: false }),
+    });
+
+    return runSeoYoutubeRadar({
+      config,
+      store: this.seoRadarStore,
+      youtubeClient,
+      importAudio: (url) => importYoutubeAudio(url),
+      transcribeAudio: (audioPath) => this._transcribeSeoRadarAudio(audioPath, config),
+      classifyLocal: (video, prompt) => this._classifySeoRadarVideo(video, prompt, config),
+      summarizeLocal: (video, transcript) =>
+        this._summarizeSeoRadarTranscript(video, transcript, config),
+      saveNote: (note) => this._saveSeoRadarNote(note),
+    });
+  }
+
   // Mints a Corti access token from stored BYOK credentials. Shared by the
   // dictation streaming handlers and the meeting realtime-token resolver.
   async _mintStoredCortiToken(options = {}) {
@@ -796,6 +923,46 @@ class IPCHandlers {
 
     ipcMain.handle("save-openai-key", async (event, key) => {
       return this.environmentManager.saveOpenAIKey(key);
+    });
+
+    ipcMain.handle("seo-radar-get-config", async () => {
+      return this.seoRadarStore.getConfig();
+    });
+
+    ipcMain.handle("seo-radar-set-config", async (_event, config) => {
+      try {
+        return { success: true, config: this.seoRadarStore.setConfig(config) };
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    });
+
+    ipcMain.handle("seo-radar-save-youtube-key", async (_event, key) => {
+      try {
+        return this.environmentManager.saveYouTubeDataApiKey(key);
+      } catch (error) {
+        return { success: false, error: error.message };
+      }
+    });
+
+    ipcMain.handle("seo-radar-has-youtube-key", async () => {
+      try {
+        return {
+          success: true,
+          hasKey: Boolean(this.environmentManager.getYouTubeDataApiKey()),
+        };
+      } catch (error) {
+        return { success: false, hasKey: false, error: error.message };
+      }
+    });
+
+    ipcMain.handle("seo-radar-run-now", async () => {
+      try {
+        return { success: true, result: await this._runSeoYoutubeRadar() };
+      } catch (error) {
+        debugLogger.error("SEO YouTube Radar run failed", { error: error.message }, "seo-radar");
+        return { success: false, error: error.message };
+      }
     });
 
     ipcMain.handle("db-save-transcription", async (event, text, rawText, options) => {

--- a/src/helpers/seoYoutubeRadar/runner.js
+++ b/src/helpers/seoYoutubeRadar/runner.js
@@ -1,0 +1,190 @@
+const {
+  buildSearchQueries,
+  buildLocalRelevancePrompt,
+  dedupeCandidates,
+  normalizeRadarConfig,
+  scoreVideoCandidate,
+} = require("./scoring");
+
+const MIN_RELEVANCE_SCORE = 70;
+
+function parseLocalJson(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  const text = String(value).trim();
+  try {
+    return JSON.parse(text);
+  } catch {
+    const match = /\{[\s\S]*\}/.exec(text);
+    if (!match) return {};
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return {};
+    }
+  }
+}
+
+function buildEnhancedContent({ video, transcript, summary, keyTakeaways = [], score }) {
+  const takeawayLines = Array.isArray(keyTakeaways)
+    ? keyTakeaways.filter(Boolean).map((item) => `- ${item}`)
+    : [];
+  return [
+    "## Summary",
+    "",
+    summary || "Summary generation failed. Full transcript is still available below.",
+    "",
+    "## Key Takeaways",
+    "",
+    takeawayLines.length > 0 ? takeawayLines.join("\n") : "- No key takeaways generated.",
+    "",
+    "## Source",
+    "",
+    `- Video: [${video.title || "YouTube video"}](${video.url})`,
+    `- Channel: ${video.channelTitle || "Unknown"}`,
+    `- Score: ${score?.score ?? 0}`,
+    "",
+    "## Full Transcript",
+    "",
+    transcript,
+  ].join("\n");
+}
+
+function toNoteTitle(video) {
+  const title = String(video.title || "SEO YouTube video").trim();
+  return title.length > 120 ? `${title.slice(0, 117)}...` : title;
+}
+
+async function classifyVideo({ video, classifyLocal, summarizeLocal }) {
+  const prompt = buildLocalRelevancePrompt(video);
+  const classifier = classifyLocal || ((candidate) => summarizeLocal(candidate, "", { prompt }));
+  const result = await classifier(video, prompt);
+  return parseLocalJson(result);
+}
+
+async function summarizeTranscript({ video, transcript, summarizeLocal }) {
+  const result = await summarizeLocal(video, transcript);
+  return parseLocalJson(result);
+}
+
+async function runSeoYoutubeRadar({
+  config,
+  store,
+  youtubeClient,
+  importAudio,
+  transcribeAudio,
+  classifyLocal,
+  summarizeLocal,
+  saveNote,
+  nowMs = Date.now(),
+}) {
+  const normalizedConfig = normalizeRadarConfig(config);
+  const result = {
+    processed: 0,
+    rejected: 0,
+    skipped: 0,
+    errors: [],
+    candidates: 0,
+  };
+
+  const publishedAfter = new Date(nowMs - normalizedConfig.lookbackHours * 3_600_000).toISOString();
+  const searchResults = [];
+  for (const query of buildSearchQueries(normalizedConfig)) {
+    const matches = await youtubeClient.searchVideos({
+      query,
+      publishedAfter,
+      maxResults: normalizedConfig.maxSearchResultsPerQuery,
+      regionCode: normalizedConfig.regionCode,
+      language: normalizedConfig.language,
+    });
+    searchResults.push(...matches);
+  }
+
+  const searchIds = dedupeCandidates(searchResults).map((candidate) => candidate.id);
+  const details = await youtubeClient.getVideoDetails(searchIds);
+  const candidates = dedupeCandidates(details)
+    .filter((video) => !store.hasProcessed(video.id))
+    .filter((video) => !normalizedConfig.excludeShorts || video.durationSeconds >= 60)
+    .filter((video) => video.durationSeconds >= normalizedConfig.minDurationSeconds)
+    .map((video) => ({ video, score: scoreVideoCandidate(video, nowMs) }))
+    .sort((a, b) => b.score.score - a.score.score)
+    .slice(0, normalizedConfig.maxVideosToProcess);
+
+  result.candidates = candidates.length;
+
+  for (const { video, score } of candidates) {
+    try {
+      const classification = await classifyVideo({ video, classifyLocal, summarizeLocal });
+      const relevanceScore = Number(classification.relevanceScore || 0);
+      if (classification.reject === true || relevanceScore < MIN_RELEVANCE_SCORE) {
+        result.rejected++;
+        store.markVideo(video.id, "rejected", {
+          title: video.title,
+          reason: classification.reason || "Low relevance",
+          relevanceScore,
+        });
+        continue;
+      }
+
+      const importResult = await importAudio(video.url);
+      if (!importResult?.success || !importResult.audioPath) {
+        throw new Error(importResult?.error || "YouTube audio import failed");
+      }
+
+      const transcriptResult = await transcribeAudio(importResult.audioPath, video);
+      if (!transcriptResult?.success || !transcriptResult.text) {
+        throw new Error(transcriptResult?.error || "Transcription failed");
+      }
+
+      const transcript = transcriptResult.text.trim();
+      let summaryResult = {};
+      try {
+        summaryResult = await summarizeTranscript({ video, transcript, summarizeLocal });
+      } catch (error) {
+        result.errors.push({ videoId: video.id, stage: "summary", error: error.message });
+      }
+
+      const enhancedContent = buildEnhancedContent({
+        video,
+        transcript,
+        summary: summaryResult.summary,
+        keyTakeaways: summaryResult.keyTakeaways,
+        score,
+      });
+      const noteResult = await saveNote({
+        title: toNoteTitle(video),
+        content: transcript,
+        enhancedContent,
+        sourceFile: video.url,
+        video,
+        score,
+      });
+      if (noteResult?.success === false) {
+        throw new Error(noteResult.error || "Failed to save note");
+      }
+
+      result.processed++;
+      store.markVideo(video.id, "processed", {
+        title: video.title,
+        channelTitle: video.channelTitle,
+        noteId: noteResult?.note?.id || null,
+        relevanceScore,
+        score: score.score,
+      });
+    } catch (error) {
+      result.errors.push({ videoId: video.id, stage: "process", error: error.message });
+      store.markVideo(video.id, "seen", { title: video.title, error: error.message });
+    }
+  }
+
+  result.skipped = Math.max(0, searchIds.length - result.candidates - result.rejected);
+  store.appendRun?.({ ...result, createdAt: new Date(nowMs).toISOString() });
+  return result;
+}
+
+module.exports = {
+  MIN_RELEVANCE_SCORE,
+  buildEnhancedContent,
+  parseLocalJson,
+  runSeoYoutubeRadar,
+};

--- a/src/helpers/seoYoutubeRadar/scheduler.js
+++ b/src/helpers/seoYoutubeRadar/scheduler.js
@@ -1,0 +1,86 @@
+const EMPTY_SKIPPED_RUN = Object.freeze({
+  processed: 0,
+  rejected: 0,
+  skipped: 0,
+  candidates: 0,
+  errors: [],
+  skipReason: "already_running",
+});
+
+function msUntilNextRun(nowDate, runHourLocal = 7) {
+  const hour = Math.max(0, Math.min(23, Number(runHourLocal) || 7));
+  const next = new Date(nowDate);
+  next.setHours(hour, 0, 0, 0);
+  if (next <= nowDate) {
+    next.setDate(next.getDate() + 1);
+  }
+  return Math.max(1, next.getTime() - nowDate.getTime());
+}
+
+function createSeoYoutubeRadarScheduler({
+  store,
+  runNow,
+  setTimeoutImpl = setTimeout,
+  clearTimeoutImpl = clearTimeout,
+  now = () => new Date(),
+  onError,
+}) {
+  let timer = null;
+  let activeRun = null;
+  let stopped = true;
+
+  const clear = () => {
+    if (timer) clearTimeoutImpl(timer);
+    timer = null;
+  };
+
+  const scheduleNext = () => {
+    clear();
+    if (stopped) return;
+    const config = store.getConfig();
+    if (!config.enabled) return;
+    timer = setTimeoutImpl(async () => {
+      try {
+        await scheduler.runNow();
+      } catch (error) {
+        onError?.(error);
+      } finally {
+        scheduleNext();
+      }
+    }, msUntilNextRun(now(), config.runHourLocal));
+    timer?.unref?.();
+  };
+
+  const scheduler = {
+    start() {
+      stopped = false;
+      scheduleNext();
+    },
+
+    stop() {
+      stopped = true;
+      clear();
+    },
+
+    async runNow() {
+      if (activeRun) return { ...EMPTY_SKIPPED_RUN };
+      activeRun = Promise.resolve().then(() => runNow());
+      try {
+        return await activeRun;
+      } finally {
+        activeRun = null;
+      }
+    },
+
+    reschedule() {
+      scheduleNext();
+    },
+  };
+
+  return scheduler;
+}
+
+module.exports = {
+  createSeoYoutubeRadarScheduler,
+  msUntilNextRun,
+};

--- a/src/helpers/seoYoutubeRadar/scoring.js
+++ b/src/helpers/seoYoutubeRadar/scoring.js
@@ -1,0 +1,91 @@
+const DEFAULT_KEYWORDS = [
+  "seo",
+  "technical seo",
+  "google algorithm update",
+  "search console",
+  "local seo",
+  "ai seo",
+];
+
+function normalizePositiveNumber(value, fallback, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(min, Math.min(max, Math.round(number)));
+}
+
+function normalizeKeywords(value) {
+  if (!Array.isArray(value)) return DEFAULT_KEYWORDS;
+  const keywords = value.map((item) => String(item).trim()).filter(Boolean);
+  return keywords.length > 0 ? [...new Set(keywords)] : DEFAULT_KEYWORDS;
+}
+
+function normalizeRadarConfig(input = {}) {
+  return {
+    enabled: Boolean(input.enabled),
+    keywords: normalizeKeywords(input.keywords),
+    lookbackHours: normalizePositiveNumber(input.lookbackHours, 72, { min: 1, max: 168 }),
+    maxSearchResultsPerQuery: normalizePositiveNumber(input.maxSearchResultsPerQuery, 10, {
+      min: 1,
+      max: 25,
+    }),
+    maxVideosToProcess: normalizePositiveNumber(input.maxVideosToProcess, 5, { min: 1, max: 10 }),
+    minDurationSeconds: normalizePositiveNumber(input.minDurationSeconds, 180, {
+      min: 0,
+      max: 86_400,
+    }),
+    excludeShorts: input.excludeShorts !== false,
+    regionCode: String(input.regionCode || "US").trim().toUpperCase() || "US",
+    language: String(input.language || "en").trim().toLowerCase() || "en",
+    runHourLocal: normalizePositiveNumber(input.runHourLocal, 7, { min: 0, max: 23 }),
+    localModelId: String(input.localModelId || "").trim(),
+  };
+}
+
+function buildSearchQueries(config) {
+  return normalizeRadarConfig(config).keywords.map((keyword) => `${keyword} SEO`);
+}
+
+function dedupeCandidates(candidates) {
+  const seen = new Set();
+  const result = [];
+  for (const candidate of candidates || []) {
+    if (!candidate?.id || seen.has(candidate.id)) continue;
+    seen.add(candidate.id);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function scoreVideoCandidate(video, nowMs = Date.now()) {
+  const publishedMs = Date.parse(video?.publishedAt || "");
+  const ageHours = Math.max(1, (nowMs - (Number.isFinite(publishedMs) ? publishedMs : nowMs)) / 3_600_000);
+  const viewsPerHour = Math.round((Number(video?.viewCount) || 0) / ageHours);
+  const engagement = (Number(video?.likeCount) || 0) * 0.5 + (Number(video?.commentCount) || 0) * 2;
+  const durationPenalty = video?.durationSeconds && video.durationSeconds < 180 ? 500 : 0;
+  return {
+    videoId: video?.id,
+    viewsPerHour,
+    score: Math.round(viewsPerHour + engagement - durationPenalty),
+  };
+}
+
+function buildLocalRelevancePrompt(video) {
+  return [
+    "You are filtering YouTube videos for an SEO operator.",
+    "Return strict JSON with keys: relevanceScore, reason, reject.",
+    "relevanceScore must be 0-100. reject must be true for spam, generic marketing, crypto, dropshipping, or non-SEO content.",
+    "",
+    `Title: ${video?.title || ""}`,
+    `Channel: ${video?.channelTitle || ""}`,
+    `Description: ${video?.description || ""}`,
+  ].join("\n");
+}
+
+module.exports = {
+  DEFAULT_KEYWORDS,
+  normalizeRadarConfig,
+  buildSearchQueries,
+  dedupeCandidates,
+  scoreVideoCandidate,
+  buildLocalRelevancePrompt,
+};

--- a/src/helpers/seoYoutubeRadar/store.js
+++ b/src/helpers/seoYoutubeRadar/store.js
@@ -1,0 +1,89 @@
+const fs = require("fs");
+const path = require("path");
+const { normalizeRadarConfig } = require("./scoring");
+
+const EMPTY_STATE = Object.freeze({
+  config: {},
+  videos: {},
+  runs: [],
+});
+
+function cloneState(data) {
+  return {
+    config: { ...(data?.config || {}) },
+    videos: { ...(data?.videos || {}) },
+    runs: Array.isArray(data?.runs) ? [...data.runs] : [],
+  };
+}
+
+function readJsonFile(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return cloneState(EMPTY_STATE);
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return cloneState(parsed);
+  } catch {
+    return cloneState(EMPTY_STATE);
+  }
+}
+
+function writeJsonAtomic(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+function createSeoYoutubeRadarStore({ filePath }) {
+  if (!filePath) throw new Error("SEO YouTube Radar store filePath is required");
+
+  const load = () => readJsonFile(filePath);
+  const save = (data) => {
+    const state = cloneState(data);
+    writeJsonAtomic(filePath, state);
+    return state;
+  };
+
+  return {
+    load,
+    save,
+
+    getConfig() {
+      return normalizeRadarConfig(load().config);
+    },
+
+    setConfig(config = {}) {
+      const state = load();
+      state.config = normalizeRadarConfig({ ...state.config, ...config });
+      save(state);
+      return state.config;
+    },
+
+    markVideo(videoId, status, meta = {}) {
+      if (!videoId) return;
+      const state = load();
+      state.videos[videoId] = {
+        ...(state.videos[videoId] || {}),
+        ...meta,
+        status,
+        updatedAt: new Date().toISOString(),
+      };
+      save(state);
+    },
+
+    hasProcessed(videoId) {
+      const entry = load().videos[videoId];
+      return entry?.status === "processed";
+    },
+
+    appendRun(run) {
+      const state = load();
+      state.runs.unshift({ ...run, createdAt: run.createdAt || new Date().toISOString() });
+      state.runs = state.runs.slice(0, 30);
+      save(state);
+    },
+  };
+}
+
+module.exports = {
+  createSeoYoutubeRadarStore,
+};

--- a/src/helpers/seoYoutubeRadar/youtubeClient.js
+++ b/src/helpers/seoYoutubeRadar/youtubeClient.js
@@ -1,0 +1,65 @@
+const API_BASE = "https://www.googleapis.com/youtube/v3";
+
+function parseDurationSeconds(value) {
+  const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value || "");
+  if (!match) return 0;
+  return (Number(match[1]) || 0) * 3600 + (Number(match[2]) || 0) * 60 + (Number(match[3]) || 0);
+}
+
+async function fetchJson(fetchImpl, url) {
+  const response = await fetchImpl(url.toString());
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.error?.message || `YouTube API request failed: ${response.status}`);
+  }
+  return data;
+}
+
+function createYouTubeClient({ apiKey, fetchImpl = fetch }) {
+  const key = String(apiKey || "").trim();
+  if (!key) throw new Error("YouTube API key is required");
+  if (typeof fetchImpl !== "function") throw new Error("fetch implementation is required");
+
+  return {
+    async searchVideos({ query, publishedAfter, maxResults, regionCode, language }) {
+      const url = new URL(`${API_BASE}/search`);
+      url.searchParams.set("key", key);
+      url.searchParams.set("part", "snippet");
+      url.searchParams.set("type", "video");
+      url.searchParams.set("order", "viewCount");
+      url.searchParams.set("q", String(query || ""));
+      url.searchParams.set("publishedAfter", publishedAfter);
+      url.searchParams.set("maxResults", String(Math.min(Math.max(Number(maxResults) || 1, 1), 25)));
+      url.searchParams.set("regionCode", String(regionCode || "US"));
+      url.searchParams.set("relevanceLanguage", String(language || "en"));
+      const data = await fetchJson(fetchImpl, url);
+      return (data.items || [])
+        .map((item) => ({ id: item?.id?.videoId, snippet: item?.snippet || {} }))
+        .filter((item) => item.id);
+    },
+
+    async getVideoDetails(videoIds) {
+      const ids = [...new Set((videoIds || []).filter(Boolean))];
+      if (ids.length === 0) return [];
+      const url = new URL(`${API_BASE}/videos`);
+      url.searchParams.set("key", key);
+      url.searchParams.set("part", "snippet,statistics,contentDetails");
+      url.searchParams.set("id", ids.join(","));
+      const data = await fetchJson(fetchImpl, url);
+      return (data.items || []).map((item) => ({
+        id: item.id,
+        title: item.snippet?.title || "",
+        channelTitle: item.snippet?.channelTitle || "",
+        publishedAt: item.snippet?.publishedAt || "",
+        description: item.snippet?.description || "",
+        viewCount: Number(item.statistics?.viewCount || 0),
+        likeCount: Number(item.statistics?.likeCount || 0),
+        commentCount: Number(item.statistics?.commentCount || 0),
+        durationSeconds: parseDurationSeconds(item.contentDetails?.duration),
+        url: `https://www.youtube.com/watch?v=${item.id}`,
+      }));
+    },
+  };
+}
+
+module.exports = { createYouTubeClient, parseDurationSeconds };

--- a/src/helpers/youtubeImport.js
+++ b/src/helpers/youtubeImport.js
@@ -1,0 +1,172 @@
+const { spawn } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+function isYoutubeHost(hostname) {
+  const host = hostname.toLowerCase();
+  return (
+    host === "youtu.be" ||
+    host === "youtube.com" ||
+    host.endsWith(".youtube.com") ||
+    host === "youtube-nocookie.com" ||
+    host.endsWith(".youtube-nocookie.com")
+  );
+}
+
+function normalizeYoutubeUrl(rawUrl) {
+  const input = String(rawUrl || "").trim();
+  if (!input) {
+    throw new Error("Paste a YouTube link first.");
+  }
+
+  const withProtocol = /^[a-z][a-z\d+\-.]*:\/\//i.test(input) ? input : `https://${input}`;
+
+  let parsed;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Paste a valid YouTube link.");
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Paste a valid YouTube link.");
+  }
+
+  if (!isYoutubeHost(parsed.hostname)) {
+    throw new Error("Paste a YouTube link.");
+  }
+
+  return parsed.toString();
+}
+
+function parseYtowOutput(stdout) {
+  const text = String(stdout || "");
+  const audioMatch = text.match(/(?:^|\r?\n)Local audio:\s*(.+?)(?:\r?\n|$)/);
+  const promptMatch = text.match(/(?:^|\r?\n)OpenWhispr prompt:\s*(.+?)(?:\r?\n|$)/);
+
+  return {
+    audioPath: audioMatch?.[1]?.trim() || null,
+    promptPath: promptMatch?.[1]?.trim() || null,
+  };
+}
+
+function resolveYtowBinary() {
+  const localBin = path.join(os.homedir(), ".local", "bin", "ytow");
+  if (fs.existsSync(localBin)) return localBin;
+  return "ytow";
+}
+
+function buildFailureMessage(stdout, stderr, fallback) {
+  const output = `${stderr || ""}\n${stdout || ""}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-6)
+    .join("\n");
+
+  return output || fallback;
+}
+
+async function importYoutubeAudio(rawUrl, options = {}) {
+  let url;
+  try {
+    url = normalizeYoutubeUrl(rawUrl);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+
+  const spawnImpl = options.spawnImpl || spawn;
+  const ytowBin = options.ytowBin || resolveYtowBinary();
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const verifyExists = options.verifyExists !== false;
+  const env = {
+    ...process.env,
+    PATH: [path.join(os.homedir(), ".local", "bin"), process.env.PATH]
+      .filter(Boolean)
+      .join(path.delimiter),
+  };
+
+  return await new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const child = spawnImpl(ytowBin, [url], {
+      env,
+      shell: false,
+      windowsHide: true,
+    });
+
+    const timer = setTimeout(() => {
+      if (typeof child.kill === "function") child.kill("SIGTERM");
+      finish({
+        success: false,
+        error: "YouTube import timed out. Try a shorter video or run the import again.",
+      });
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      const message =
+        error.code === "ENOENT"
+          ? "YouTube import is not installed. Run the setup once, then restart OpenWhispr."
+          : error.message || "YouTube import failed.";
+      finish({ success: false, error: message });
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        finish({
+          success: false,
+          error: buildFailureMessage(stdout, stderr, "YouTube import failed."),
+        });
+        return;
+      }
+
+      const { audioPath, promptPath } = parseYtowOutput(stdout);
+      if (!audioPath) {
+        finish({
+          success: false,
+          error: buildFailureMessage(
+            stdout,
+            stderr,
+            "YouTube import finished but did not return an audio file."
+          ),
+        });
+        return;
+      }
+
+      if (verifyExists && !fs.existsSync(audioPath)) {
+        finish({
+          success: false,
+          error: "YouTube import finished but the audio file was not found.",
+        });
+        return;
+      }
+
+      finish({ success: true, audioPath, promptPath: promptPath || undefined });
+    });
+  });
+}
+
+module.exports = {
+  importYoutubeAudio,
+  normalizeYoutubeUrl,
+  parseYtowOutput,
+};

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2111,7 +2111,13 @@
       "switchToCloudForLargeFiles": "Wechsle zu OpenWhispr Cloud, um diese Datei zu transkribieren.",
       "createAccount": "Konto erstellen",
       "upgrade": "Upgraden",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "YouTube-Link",
+      "youtubeUrlPlaceholder": "YouTube-Link einfügen",
+      "youtubeImport": "Importieren",
+      "youtubeImporting": "Importiert",
+      "youtubeImportUnavailable": "YouTube-Import ist nicht verfügbar. Starte OpenWhispr neu und versuche es erneut.",
+      "youtubeImportFailed": "Das YouTube-Audio konnte nicht importiert werden."
     },
     "meeting": {
       "title": "Besprechungsnotizen",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1837,6 +1837,29 @@
         "keyCreatedTitle": "API-Schlüssel erstellt",
         "keyCreatedDescription": "Kopieren Sie diesen Schlüssel jetzt — Sie können ihn nicht erneut sehen."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1925,6 +1925,29 @@
       "endpointUrl": "Endpoint URL",
       "serverUrl": "Server URL",
       "apiKeyOptional": "API Key (optional)"
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2310,7 +2310,13 @@
       "switchToCloudForLargeFiles": "Switch to OpenWhispr Cloud to transcribe this file.",
       "createAccount": "Create Account",
       "upgrade": "Upgrade",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "YouTube link",
+      "youtubeUrlPlaceholder": "Paste YouTube link",
+      "youtubeImport": "Import",
+      "youtubeImporting": "Importing",
+      "youtubeImportUnavailable": "YouTube import is not available. Restart OpenWhispr and try again.",
+      "youtubeImportFailed": "Could not import the YouTube audio."
     },
     "meeting": {
       "title": "Meeting Notes",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1885,6 +1885,29 @@
         "keyCreatedTitle": "Clave API creada",
         "keyCreatedDescription": "Copia esta clave ahora — no podrás verla de nuevo."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2159,7 +2159,13 @@
       "switchToCloudForLargeFiles": "Cambia a OpenWhispr Cloud para transcribir este archivo.",
       "createAccount": "Crear cuenta",
       "upgrade": "Mejorar plan",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "Enlace de YouTube",
+      "youtubeUrlPlaceholder": "Pega enlace de YouTube",
+      "youtubeImport": "Importar",
+      "youtubeImporting": "Importando",
+      "youtubeImportUnavailable": "La importación de YouTube no está disponible. Reinicia OpenWhispr e inténtalo de nuevo.",
+      "youtubeImportFailed": "No se pudo importar el audio de YouTube."
     },
     "meeting": {
       "title": "Notas de reunión",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1885,6 +1885,29 @@
         "keyCreatedTitle": "Clé API créée",
         "keyCreatedDescription": "Copiez cette clé maintenant — vous ne pourrez plus la voir."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2222,7 +2222,13 @@
       "switchToCloudForLargeFiles": "Passez à OpenWhispr Cloud pour transcrire ce fichier.",
       "createAccount": "Créer un compte",
       "upgrade": "Mettre à niveau",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "Lien YouTube",
+      "youtubeUrlPlaceholder": "Collez le lien YouTube",
+      "youtubeImport": "Importer",
+      "youtubeImporting": "Importation",
+      "youtubeImportUnavailable": "L'import YouTube n'est pas disponible. Redémarrez OpenWhispr et réessayez.",
+      "youtubeImportFailed": "Impossible d'importer l'audio YouTube."
     },
     "meeting": {
       "title": "Notes de réunion",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2111,7 +2111,13 @@
       "switchToCloudForLargeFiles": "Passa a OpenWhispr Cloud per trascrivere questo file.",
       "createAccount": "Crea account",
       "upgrade": "Aggiorna",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "Link YouTube",
+      "youtubeUrlPlaceholder": "Incolla link YouTube",
+      "youtubeImport": "Importa",
+      "youtubeImporting": "Importazione",
+      "youtubeImportUnavailable": "L'importazione da YouTube non è disponibile. Riavvia OpenWhispr e riprova.",
+      "youtubeImportFailed": "Impossibile importare l'audio di YouTube."
     },
     "meeting": {
       "title": "Note delle riunioni",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1837,6 +1837,29 @@
         "keyCreatedTitle": "Clé API créée",
         "keyCreatedDescription": "Copiez cette clé maintenant — vous ne pourrez plus la voir."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2094,7 +2094,13 @@
       "switchToCloudForLargeFiles": "このファイルを文字起こしするには OpenWhispr Cloud に切り替えてください。",
       "createAccount": "アカウント作成",
       "upgrade": "アップグレード",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "YouTube リンク",
+      "youtubeUrlPlaceholder": "YouTube リンクを貼り付け",
+      "youtubeImport": "インポート",
+      "youtubeImporting": "インポート中",
+      "youtubeImportUnavailable": "YouTube インポートは利用できません。OpenWhispr を再起動してもう一度お試しください。",
+      "youtubeImportFailed": "YouTube 音声をインポートできませんでした。"
     },
     "meeting": {
       "title": "議事録",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1837,6 +1837,29 @@
         "keyCreatedTitle": "Clave API creada",
         "keyCreatedDescription": "Copia esta clave ahora — no podrás verla de nuevo."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1816,6 +1816,29 @@
         "keyCreatedTitle": "Clave API creada",
         "keyCreatedDescription": "Copia esta clave ahora — no podrás verla de nuevo."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2111,7 +2111,13 @@
       "switchToCloudForLargeFiles": "Mude para o OpenWhispr Cloud para transcrever este arquivo.",
       "createAccount": "Criar conta",
       "upgrade": "Fazer upgrade",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "Link do YouTube",
+      "youtubeUrlPlaceholder": "Cole o link do YouTube",
+      "youtubeImport": "Importar",
+      "youtubeImporting": "Importando",
+      "youtubeImportUnavailable": "A importação do YouTube não está disponível. Reinicie o OpenWhispr e tente novamente.",
+      "youtubeImportFailed": "Não foi possível importar o áudio do YouTube."
     },
     "meeting": {
       "title": "Notas de reunião",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2111,7 +2111,13 @@
       "switchToCloudForLargeFiles": "Переключитесь на OpenWhispr Cloud, чтобы транскрибировать этот файл.",
       "createAccount": "Создать аккаунт",
       "upgrade": "Обновить",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "Ссылка YouTube",
+      "youtubeUrlPlaceholder": "Вставьте ссылку YouTube",
+      "youtubeImport": "Импорт",
+      "youtubeImporting": "Импорт",
+      "youtubeImportUnavailable": "Импорт YouTube недоступен. Перезапустите OpenWhispr и попробуйте снова.",
+      "youtubeImportFailed": "Не удалось импортировать аудио YouTube."
     },
     "meeting": {
       "title": "Заметки со встреч",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1837,6 +1837,29 @@
         "keyCreatedTitle": "API-Schlüssel erstellt",
         "keyCreatedDescription": "Kopieren Sie diesen Schlüssel jetzt — Sie können ihn nicht erneut sehen."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1176,7 +1176,12 @@
           "annualEquivalent": "$16.67",
           "includesPrefix": "所有 Pro 功能 +",
           "badge": "最受欢迎",
-          "features": ["无限会议录制", "代理模式", "与您的数据对话", "优先支持"],
+          "features": [
+            "无限会议录制",
+            "代理模式",
+            "与您的数据对话",
+            "优先支持"
+          ],
           "cta": "开始使用",
           "switchToAnnual": "切换为年付"
         },
@@ -1832,6 +1837,29 @@
         "keyCreatedTitle": "Clave API creada",
         "keyCreatedDescription": "Copia esta clave ahora — no podrás verla de nuevo."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2106,7 +2106,13 @@
       "switchToCloudForLargeFiles": "切换到 OpenWhispr Cloud 来转录此文件。",
       "createAccount": "创建账户",
       "upgrade": "升级",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "YouTube 链接",
+      "youtubeUrlPlaceholder": "粘贴 YouTube 链接",
+      "youtubeImport": "导入",
+      "youtubeImporting": "导入中",
+      "youtubeImportUnavailable": "YouTube 导入不可用。请重启 OpenWhispr 后重试。",
+      "youtubeImportFailed": "无法导入 YouTube 音频。"
     },
     "meeting": {
       "title": "会议笔记",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1176,7 +1176,12 @@
           "annualEquivalent": "$16.67",
           "includesPrefix": "所有 Pro 功能 +",
           "badge": "最熱門",
-          "features": ["無限會議錄製", "代理模式", "與您的資料對話", "優先支援"],
+          "features": [
+            "無限會議錄製",
+            "代理模式",
+            "與您的資料對話",
+            "優先支援"
+          ],
           "cta": "開始使用",
           "switchToAnnual": "切換為年付"
         },
@@ -1832,6 +1837,29 @@
         "keyCreatedTitle": "Clave API creada",
         "keyCreatedDescription": "Copia esta clave ahora — no podrás verla de nuevo."
       }
+    },
+    "seoRadar": {
+      "title": "SEO YouTube Radar",
+      "description": "Find newly popular SEO videos, transcribe them, and summarize them with local AI.",
+      "enabled": "Run daily",
+      "enabledDescription": "Automatically checks YouTube once per day using cached video IDs.",
+      "apiKey": "YouTube API key",
+      "apiKeySaved": "YouTube API key saved",
+      "apiKeyPlaceholder": "Paste a YouTube Data API key",
+      "save": "Save",
+      "keywords": "Search topics",
+      "keywordsPlaceholder": "seo, technical seo, google algorithm update",
+      "maxVideos": "Max videos per run",
+      "lookbackHours": "Lookback hours",
+      "runHour": "Run hour",
+      "runNow": "Run now",
+      "running": "Running",
+      "lastRun": "Last run",
+      "noRunYet": "No runs yet",
+      "saved": "SEO Radar settings saved",
+      "failed": "SEO Radar failed",
+      "alreadyRunning": "SEO Radar is already running",
+      "lastRunSummary": "{{processed}} processed, {{rejected}} rejected, {{skipped}} skipped"
     }
   },
   "models": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2106,7 +2106,13 @@
       "switchToCloudForLargeFiles": "切換到 OpenWhispr Cloud 來轉錄此檔案。",
       "createAccount": "建立帳戶",
       "upgrade": "升級",
-      "switchToCloud": "OpenWhispr Cloud"
+      "switchToCloud": "OpenWhispr Cloud",
+      "youtubeUrlLabel": "YouTube 連結",
+      "youtubeUrlPlaceholder": "貼上 YouTube 連結",
+      "youtubeImport": "匯入",
+      "youtubeImporting": "匯入中",
+      "youtubeImportUnavailable": "YouTube 匯入無法使用。請重新啟動 OpenWhispr 後再試。",
+      "youtubeImportFailed": "無法匯入 YouTube 音訊。"
     },
     "meeting": {
       "title": "會議筆記",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -676,6 +676,12 @@ declare global {
       // Audio file operations
       selectAudioFile: () => Promise<{ canceled: boolean; filePath?: string }>;
       getFileSize?: (filePath: string) => Promise<number>;
+      importYoutubeAudio?: (url: string) => Promise<{
+        success: boolean;
+        audioPath?: string;
+        promptPath?: string;
+        error?: string;
+      }>;
       transcribeAudioFile: (
         filePath: string,
         options?: {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -65,6 +65,29 @@ export interface NoteItem {
   team_id?: string | null;
 }
 
+export interface SeoRadarConfig {
+  enabled: boolean;
+  keywords: string[];
+  lookbackHours: number;
+  maxSearchResultsPerQuery: number;
+  maxVideosToProcess: number;
+  minDurationSeconds: number;
+  excludeShorts: boolean;
+  regionCode: string;
+  language: string;
+  runHourLocal: number;
+  localModelId: string;
+}
+
+export interface SeoRadarRunResult {
+  processed: number;
+  rejected: number;
+  skipped: number;
+  candidates: number;
+  errors: Array<{ videoId?: string; stage?: string; error: string }>;
+  skipReason?: string;
+}
+
 export type ShareVisibility = "private" | "link" | "domain" | "invited";
 
 export interface ShareSettings {
@@ -692,6 +715,19 @@ declare global {
         }
       ) => Promise<{ success: boolean; text?: string; error?: string }>;
       getPathForFile: (file: File) => string;
+
+      // SEO YouTube Radar
+      seoRadarGetConfig: () => Promise<SeoRadarConfig>;
+      seoRadarSetConfig: (
+        config: Partial<SeoRadarConfig>
+      ) => Promise<{ success: boolean; config?: SeoRadarConfig; error?: string }>;
+      seoRadarSaveYouTubeKey: (key: string) => Promise<{ success: boolean; error?: string }>;
+      seoRadarHasYouTubeKey: () => Promise<{ success: boolean; hasKey: boolean; error?: string }>;
+      seoRadarRunNow: () => Promise<{
+        success: boolean;
+        result?: SeoRadarRunResult;
+        error?: string;
+      }>;
 
       // Note event listeners
       onNoteAdded?: (callback: (note: NoteItem) => void) => () => void;

--- a/src/utils/uploadTranscriptSummary.ts
+++ b/src/utils/uploadTranscriptSummary.ts
@@ -1,0 +1,114 @@
+import type { InferenceMode } from "../types/electron";
+import type { ReasoningConfig } from "../services/BaseReasoningService";
+
+export const UPLOAD_SUMMARY_SYSTEM_PROMPT = `You summarize uploaded audio and video transcripts for OpenWhispr notes.
+
+Return only the summary text in clean markdown. Do not include a title, preamble, or a "Summary" heading.
+Focus on the main points, decisions, useful details, and any clear action items.
+Keep it concise, but preserve specific names, tools, dates, numbers, and links when they matter.`;
+
+export interface UploadSummaryFormattingConfig {
+  mode: InferenceMode;
+  provider: string;
+  model: string;
+  cloudBaseUrl?: string;
+  remoteUrl?: string;
+  customApiKey?: string;
+  disableThinking: boolean;
+}
+
+export interface UploadSummaryReasoning {
+  modelId: string;
+  config: ReasoningConfig;
+}
+
+const REMOTE_REASONING_PROVIDERS = new Set([
+  "",
+  "openai",
+  "anthropic",
+  "gemini",
+  "groq",
+  "custom",
+  "bedrock",
+  "azure",
+  "vertex",
+  "openwhispr",
+]);
+
+function isLocalReasoningSelection(formatting: UploadSummaryFormattingConfig): boolean {
+  return (
+    formatting.mode === "local" ||
+    (!!formatting.model.trim() && !REMOTE_REASONING_PROVIDERS.has(formatting.provider))
+  );
+}
+
+export function buildUploadEnhancedContent({
+  summary,
+  transcript,
+}: {
+  summary: string;
+  transcript: string;
+}): string {
+  return `## Summary\n\n${summary.trim()}\n\n## Full Transcript\n\n${transcript.trim()}`;
+}
+
+export function makeUploadContentHash(transcript: string): string {
+  return `${transcript.length}-${transcript.slice(0, 50)}-${transcript.slice(-50)}`;
+}
+
+export function resolveUploadSummaryReasoning(
+  formatting: UploadSummaryFormattingConfig
+): UploadSummaryReasoning | null {
+  const modelId = formatting.model.trim();
+
+  if (isLocalReasoningSelection(formatting)) {
+    if (!modelId) return null;
+    return {
+      modelId,
+      config: {
+        provider: "local",
+        disableThinking: formatting.disableThinking,
+      },
+    };
+  }
+
+  if (formatting.mode === "openwhispr") {
+    return {
+      modelId: "",
+      config: {
+        provider: "openwhispr",
+        disableThinking: formatting.disableThinking,
+      },
+    };
+  }
+
+  if (formatting.mode === "self-hosted") {
+    const lanUrl = formatting.remoteUrl?.trim();
+    if (!lanUrl) return null;
+    return {
+      modelId: formatting.model.trim() || "default",
+      config: {
+        provider: "lan",
+        lanUrl,
+        customApiKey: formatting.customApiKey,
+        disableThinking: formatting.disableThinking,
+      },
+    };
+  }
+
+  if (!modelId) return null;
+
+  return {
+    modelId,
+    config: {
+      provider: formatting.provider || undefined,
+      ...(formatting.provider === "custom"
+        ? {
+            baseUrl: formatting.cloudBaseUrl,
+            customApiKey: formatting.customApiKey,
+          }
+        : {}),
+      disableThinking: formatting.disableThinking,
+    },
+  };
+}

--- a/test/helpers/seoYoutubeRadar.ipcContract.test.js
+++ b/test/helpers/seoYoutubeRadar.ipcContract.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..", "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("SEO Radar renderer API methods are exposed and typed", () => {
+  const preload = read("preload.js");
+  const types = read("src/types/electron.ts");
+  for (const method of [
+    "seoRadarGetConfig",
+    "seoRadarSetConfig",
+    "seoRadarSaveYouTubeKey",
+    "seoRadarHasYouTubeKey",
+    "seoRadarRunNow",
+  ]) {
+    assert.match(preload, new RegExp(`${method}:`));
+    assert.match(types, new RegExp(`${method}:`));
+  }
+});
+
+test("SEO Radar IPC handlers and secure env key are registered", () => {
+  const ipcHandlers = read("src/helpers/ipcHandlers.js");
+  const environment = read("src/helpers/environment.js");
+  for (const channel of [
+    "seo-radar-get-config",
+    "seo-radar-set-config",
+    "seo-radar-save-youtube-key",
+    "seo-radar-has-youtube-key",
+    "seo-radar-run-now",
+  ]) {
+    assert.match(ipcHandlers, new RegExp(channel));
+  }
+  assert.match(environment, /YOUTUBE_DATA_API_KEY/);
+  assert.match(environment, /saveYouTubeDataApiKey/);
+  assert.match(environment, /getYouTubeDataApiKey/);
+});

--- a/test/helpers/seoYoutubeRadar.runner.test.js
+++ b/test/helpers/seoYoutubeRadar.runner.test.js
@@ -1,0 +1,104 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { runSeoYoutubeRadar } = require("../../src/helpers/seoYoutubeRadar/runner.js");
+
+test("runner imports, transcribes, summarizes locally, and saves selected SEO videos", async () => {
+  const memory = {};
+  const store = {
+    load: () => memory,
+    save: (data) => Object.assign(memory, data),
+    hasProcessed: () => false,
+    markVideo: (id, status, meta) => {
+      memory.videos = memory.videos || {};
+      memory.videos[id] = { status, ...meta };
+    },
+    appendRun: (run) => {
+      memory.runs = [run];
+    },
+  };
+  const youtubeClient = {
+    searchVideos: async () => [{ id: "abc123" }],
+    getVideoDetails: async () => [
+      {
+        id: "abc123",
+        title: "Technical SEO update",
+        channelTitle: "SEO Channel",
+        url: "https://www.youtube.com/watch?v=abc123",
+        publishedAt: "2026-07-06T06:00:00Z",
+        durationSeconds: 900,
+        viewCount: 12000,
+        likeCount: 100,
+        commentCount: 20,
+        description: "Technical SEO update",
+      },
+    ],
+  };
+  const notes = [];
+  const result = await runSeoYoutubeRadar({
+    config: {
+      keywords: ["technical seo"],
+      lookbackHours: 72,
+      maxSearchResultsPerQuery: 10,
+      maxVideosToProcess: 1,
+      minDurationSeconds: 180,
+      excludeShorts: true,
+      regionCode: "US",
+      language: "en",
+    },
+    store,
+    youtubeClient,
+    importAudio: async () => ({ success: true, audioPath: "/tmp/abc123.mp3" }),
+    transcribeAudio: async () => ({ success: true, text: "Full transcript text" }),
+    summarizeLocal: async () => ({
+      relevanceScore: 92,
+      summary: "Useful technical SEO update.",
+      keyTakeaways: ["Check Search Console"],
+    }),
+    saveNote: async (note) => {
+      notes.push(note);
+      return { success: true, note: { id: 10 } };
+    },
+    nowMs: Date.parse("2026-07-06T12:00:00Z"),
+  });
+  assert.equal(result.processed, 1);
+  assert.equal(notes[0].title.includes("Technical SEO update"), true);
+  assert.match(notes[0].content, /Full transcript text/);
+  assert.match(notes[0].enhancedContent, /## Summary/);
+  assert.match(notes[0].enhancedContent, /## Full Transcript/);
+});
+
+test("runner rejects low-relevance videos before import", async () => {
+  let importCalled = false;
+  const store = {
+    hasProcessed: () => false,
+    markVideo: () => {},
+    appendRun: () => {},
+  };
+  const result = await runSeoYoutubeRadar({
+    config: { keywords: ["seo"], maxVideosToProcess: 1, minDurationSeconds: 180 },
+    store,
+    youtubeClient: {
+      searchVideos: async () => [{ id: "bad123" }],
+      getVideoDetails: async () => [
+        {
+          id: "bad123",
+          title: "Crypto side hustle",
+          publishedAt: "2026-07-06T06:00:00Z",
+          durationSeconds: 800,
+          viewCount: 20000,
+        },
+      ],
+    },
+    importAudio: async () => {
+      importCalled = true;
+      return { success: true, audioPath: "/tmp/bad.mp3" };
+    },
+    transcribeAudio: async () => ({ success: true, text: "" }),
+    summarizeLocal: async () => ({ relevanceScore: 20, reject: true, summary: "" }),
+    saveNote: async () => ({ success: true }),
+    nowMs: Date.parse("2026-07-06T12:00:00Z"),
+  });
+  assert.equal(result.rejected, 1);
+  assert.equal(importCalled, false);
+});

--- a/test/helpers/seoYoutubeRadar.scheduler.test.js
+++ b/test/helpers/seoYoutubeRadar.scheduler.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createSeoYoutubeRadarScheduler } = require("../../src/helpers/seoYoutubeRadar/scheduler.js");
+
+test("scheduler does not schedule when disabled", () => {
+  let scheduled = false;
+  const scheduler = createSeoYoutubeRadarScheduler({
+    store: { getConfig: () => ({ enabled: false }) },
+    runNow: async () => ({ processed: 0 }),
+    setTimeoutImpl: () => {
+      scheduled = true;
+      return 1;
+    },
+    clearTimeoutImpl: () => {},
+    now: () => new Date("2026-07-06T12:00:00Z"),
+  });
+  scheduler.start();
+  assert.equal(scheduled, false);
+});
+
+test("scheduler schedules enabled daily run", () => {
+  let delay = null;
+  const scheduler = createSeoYoutubeRadarScheduler({
+    store: { getConfig: () => ({ enabled: true, runHourLocal: 7 }) },
+    runNow: async () => ({ processed: 0 }),
+    setTimeoutImpl: (_fn, ms) => {
+      delay = ms;
+      return 1;
+    },
+    clearTimeoutImpl: () => {},
+    now: () => new Date("2026-07-06T06:00:00"),
+  });
+  scheduler.start();
+  assert.ok(delay > 0);
+});
+
+test("scheduler skips overlapping manual runs", async () => {
+  let resolveRun;
+  const activeRun = new Promise((resolve) => {
+    resolveRun = resolve;
+  });
+  const scheduler = createSeoYoutubeRadarScheduler({
+    store: { getConfig: () => ({ enabled: false }) },
+    runNow: () => activeRun,
+    setTimeoutImpl: () => 1,
+    clearTimeoutImpl: () => {},
+    now: () => new Date("2026-07-06T06:00:00"),
+  });
+  const first = scheduler.runNow();
+  const second = await scheduler.runNow();
+  assert.deepEqual(second, { processed: 0, rejected: 0, skipped: 0, candidates: 0, errors: [], skipReason: "already_running" });
+  resolveRun({ processed: 1 });
+  assert.equal((await first).processed, 1);
+});

--- a/test/helpers/seoYoutubeRadar.scoring.test.js
+++ b/test/helpers/seoYoutubeRadar.scoring.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  normalizeRadarConfig,
+  buildSearchQueries,
+  scoreVideoCandidate,
+  dedupeCandidates,
+  buildLocalRelevancePrompt,
+} = require("../../src/helpers/seoYoutubeRadar/scoring.js");
+
+test("normalizeRadarConfig applies safe local-first defaults", () => {
+  const config = normalizeRadarConfig({});
+  assert.deepEqual(config.keywords, [
+    "seo",
+    "technical seo",
+    "google algorithm update",
+    "search console",
+    "local seo",
+    "ai seo",
+  ]);
+  assert.equal(config.lookbackHours, 72);
+  assert.equal(config.maxSearchResultsPerQuery, 10);
+  assert.equal(config.maxVideosToProcess, 5);
+  assert.equal(config.minDurationSeconds, 180);
+  assert.equal(config.excludeShorts, true);
+});
+
+test("buildSearchQueries combines each keyword with practical SEO intent", () => {
+  const queries = buildSearchQueries(
+    normalizeRadarConfig({ keywords: ["technical seo", "search console"] })
+  );
+  assert.deepEqual(queries, ["technical seo SEO", "search console SEO"]);
+});
+
+test("scoreVideoCandidate rewards view velocity and engagement", () => {
+  const nowMs = Date.parse("2026-07-06T12:00:00Z");
+  const score = scoreVideoCandidate(
+    {
+      id: "vid1",
+      title: "Google SEO update explained",
+      channelTitle: "SEO Channel",
+      url: "https://www.youtube.com/watch?v=vid1",
+      publishedAt: "2026-07-06T06:00:00Z",
+      durationSeconds: 900,
+      viewCount: 12000,
+      likeCount: 600,
+      commentCount: 80,
+      description: "Useful technical SEO update",
+    },
+    nowMs
+  );
+  assert.equal(score.videoId, "vid1");
+  assert.equal(score.viewsPerHour, 2000);
+  assert.ok(score.score > 2000);
+});
+
+test("dedupeCandidates keeps first instance of each video id", () => {
+  const candidates = dedupeCandidates([
+    { id: "a", title: "A" },
+    { id: "b", title: "B" },
+    { id: "a", title: "A duplicate" },
+  ]);
+  assert.deepEqual(
+    candidates.map((c) => c.id),
+    ["a", "b"]
+  );
+});
+
+test("buildLocalRelevancePrompt asks for strict JSON classification", () => {
+  const prompt = buildLocalRelevancePrompt({
+    id: "vid1",
+    title: "SEO audit checklist",
+    channelTitle: "SEO Channel",
+    description: "A checklist for technical SEO audits",
+  });
+  assert.match(prompt, /Return strict JSON/);
+  assert.match(prompt, /relevanceScore/);
+  assert.match(prompt, /SEO audit checklist/);
+});

--- a/test/helpers/seoYoutubeRadar.store.test.js
+++ b/test/helpers/seoYoutubeRadar.store.test.js
@@ -1,0 +1,21 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { createSeoYoutubeRadarStore } = require("../../src/helpers/seoYoutubeRadar/store.js");
+
+test("store persists config and processed videos", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "seo-radar-"));
+  const filePath = path.join(dir, "radar.json");
+  const store = createSeoYoutubeRadarStore({ filePath });
+  const config = store.setConfig({ enabled: true, keywords: ["technical seo"] });
+  assert.equal(config.enabled, true);
+  assert.deepEqual(config.keywords, ["technical seo"]);
+  store.markVideo("abc123", "processed", { title: "SEO update" });
+
+  const reloaded = createSeoYoutubeRadarStore({ filePath });
+  assert.equal(reloaded.hasProcessed("abc123"), true);
+  assert.equal(reloaded.load().videos.abc123.title, "SEO update");
+});

--- a/test/helpers/seoYoutubeRadar.youtubeClient.test.js
+++ b/test/helpers/seoYoutubeRadar.youtubeClient.test.js
@@ -1,0 +1,60 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createYouTubeClient } = require("../../src/helpers/seoYoutubeRadar/youtubeClient.js");
+
+test("searchVideos calls YouTube search.list with quota-safe params", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(new URL(url));
+    return {
+      ok: true,
+      json: async () => ({
+        items: [{ id: { videoId: "abc123" }, snippet: { title: "SEO update" } }],
+      }),
+    };
+  };
+  const client = createYouTubeClient({ apiKey: "key", fetchImpl });
+  const result = await client.searchVideos({
+    query: "technical seo SEO",
+    publishedAfter: "2026-07-03T00:00:00.000Z",
+    maxResults: 10,
+    regionCode: "US",
+    language: "en",
+  });
+  assert.equal(result[0].id, "abc123");
+  assert.equal(calls[0].searchParams.get("part"), "snippet");
+  assert.equal(calls[0].searchParams.get("type"), "video");
+  assert.equal(calls[0].searchParams.get("order"), "viewCount");
+  assert.equal(calls[0].searchParams.get("maxResults"), "10");
+});
+
+test("getVideoDetails maps statistics and ISO 8601 duration", async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    json: async () => ({
+      items: [
+        {
+          id: "abc123",
+          snippet: {
+            title: "SEO update",
+            channelTitle: "SEO Channel",
+            publishedAt: "2026-07-06T00:00:00Z",
+            description: "Useful",
+          },
+          statistics: { viewCount: "1000", likeCount: "50", commentCount: "12" },
+          contentDetails: { duration: "PT12M34S" },
+        },
+      ],
+    }),
+  });
+  const client = createYouTubeClient({ apiKey: "key", fetchImpl });
+  const videos = await client.getVideoDetails(["abc123"]);
+  assert.equal(videos[0].durationSeconds, 754);
+  assert.equal(videos[0].url, "https://www.youtube.com/watch?v=abc123");
+  assert.equal(videos[0].viewCount, 1000);
+});
+
+test("client throws clear error for missing api key", async () => {
+  assert.throws(() => createYouTubeClient({ apiKey: "" }), /YouTube API key/);
+});

--- a/test/helpers/youtubeImport.test.js
+++ b/test/helpers/youtubeImport.test.js
@@ -1,0 +1,104 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  importYoutubeAudio,
+  normalizeYoutubeUrl,
+  parseYtowOutput,
+} = require("../../src/helpers/youtubeImport.js");
+
+function createSpawnStub({ stdout = "", stderr = "", code = 0, error = null } = {}) {
+  const calls = [];
+  const spawnImpl = (bin, args, options) => {
+    calls.push({ bin, args, options });
+
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+
+    setImmediate(() => {
+      if (error) {
+        child.emit("error", error);
+        return;
+      }
+      if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+      if (stderr) child.stderr.emit("data", Buffer.from(stderr));
+      child.emit("close", code);
+    });
+
+    return child;
+  };
+
+  return { calls, spawnImpl };
+}
+
+test("normalizeYoutubeUrl accepts common YouTube links and adds https when missing", () => {
+  assert.equal(normalizeYoutubeUrl("youtu.be/demo123"), "https://youtu.be/demo123");
+  assert.equal(
+    normalizeYoutubeUrl("https://www.youtube.com/watch?v=abc"),
+    "https://www.youtube.com/watch?v=abc"
+  );
+  assert.equal(
+    normalizeYoutubeUrl("https://music.youtube.com/watch?v=abc"),
+    "https://music.youtube.com/watch?v=abc"
+  );
+});
+
+test("normalizeYoutubeUrl rejects non-YouTube links", () => {
+  assert.throws(() => normalizeYoutubeUrl("https://example.com/watch?v=abc"), /YouTube link/);
+  assert.throws(() => normalizeYoutubeUrl(""), /Paste a YouTube link first/);
+});
+
+test("parseYtowOutput extracts local audio and prompt paths", () => {
+  assert.deepEqual(
+    parseYtowOutput(
+      `Done\nLocal audio: /tmp/video audio.mp3\nOpenWhispr prompt: /tmp/prompt.txt\n`
+    ),
+    {
+      audioPath: "/tmp/video audio.mp3",
+      promptPath: "/tmp/prompt.txt",
+    }
+  );
+});
+
+test("importYoutubeAudio runs ytow without a shell and returns the generated audio path", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-youtube-"));
+  const audioPath = path.join(dir, "video.mp3");
+  fs.writeFileSync(audioPath, "audio");
+
+  const { calls, spawnImpl } = createSpawnStub({
+    stdout: `Local audio: ${audioPath}\nOpenWhispr prompt: ${path.join(dir, "prompt.txt")}\n`,
+  });
+
+  const result = await importYoutubeAudio("youtu.be/demo123", {
+    spawnImpl,
+    ytowBin: "/usr/local/bin/ytow",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.audioPath, audioPath);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].bin, "/usr/local/bin/ytow");
+  assert.deepEqual(calls[0].args, ["https://youtu.be/demo123"]);
+  assert.equal(calls[0].options.shell, false);
+});
+
+test("importYoutubeAudio returns stderr details when ytow fails", async () => {
+  const { spawnImpl } = createSpawnStub({
+    stderr: "download failed",
+    code: 1,
+  });
+
+  const result = await importYoutubeAudio("https://youtube.com/watch?v=bad", {
+    spawnImpl,
+    ytowBin: "ytow",
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /download failed/);
+});

--- a/test/utils/uploadTranscriptSummary.test.js
+++ b/test/utils/uploadTranscriptSummary.test.js
@@ -1,0 +1,137 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("buildUploadEnhancedContent keeps the summary and full transcript", async () => {
+  const { buildUploadEnhancedContent } = await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  const result = buildUploadEnhancedContent({
+    summary: "This video explains the import workflow.",
+    transcript: "Speaker: Paste a link. Then import the audio.",
+  });
+
+  assert.equal(
+    result,
+    "## Summary\n\nThis video explains the import workflow.\n\n## Full Transcript\n\nSpeaker: Paste a link. Then import the audio."
+  );
+});
+
+test("buildUploadEnhancedContent trims generated summary and transcript", async () => {
+  const { buildUploadEnhancedContent } = await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  const result = buildUploadEnhancedContent({
+    summary: "\n\n  Short summary.  ",
+    transcript: "  Full transcript.  \n",
+  });
+
+  assert.equal(result, "## Summary\n\nShort summary.\n\n## Full Transcript\n\nFull transcript.");
+});
+
+test("makeUploadContentHash is stable for the same transcript", async () => {
+  const { makeUploadContentHash } = await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.equal(makeUploadContentHash("abcdef"), makeUploadContentHash("abcdef"));
+  assert.notEqual(makeUploadContentHash("abcdef"), makeUploadContentHash("abcdeg"));
+});
+
+test("resolveUploadSummaryReasoning uses OpenWhispr cloud without a model id", async () => {
+  const { resolveUploadSummaryReasoning } =
+    await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.deepEqual(
+    resolveUploadSummaryReasoning({
+      mode: "openwhispr",
+      provider: "",
+      model: "",
+      disableThinking: true,
+    }),
+    {
+      modelId: "",
+      config: {
+        provider: "openwhispr",
+        disableThinking: true,
+      },
+    }
+  );
+});
+
+test("resolveUploadSummaryReasoning uses LAN for self-hosted note formatting", async () => {
+  const { resolveUploadSummaryReasoning } =
+    await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.deepEqual(
+    resolveUploadSummaryReasoning({
+      mode: "self-hosted",
+      provider: "",
+      model: "qwen",
+      remoteUrl: " http://127.0.0.1:11434/v1 ",
+      customApiKey: "local-key",
+      disableThinking: false,
+    }),
+    {
+      modelId: "qwen",
+      config: {
+        provider: "lan",
+        lanUrl: "http://127.0.0.1:11434/v1",
+        customApiKey: "local-key",
+        disableThinking: false,
+      },
+    }
+  );
+});
+
+test("resolveUploadSummaryReasoning maps local model families to the local provider", async () => {
+  const { resolveUploadSummaryReasoning } =
+    await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.deepEqual(
+    resolveUploadSummaryReasoning({
+      mode: "local",
+      provider: "qwen",
+      model: "qwen3-4b",
+      disableThinking: true,
+    }),
+    {
+      modelId: "qwen3-4b",
+      config: {
+        provider: "local",
+        disableThinking: true,
+      },
+    }
+  );
+});
+
+test("resolveUploadSummaryReasoning prefers a configured local model over OpenWhispr cloud", async () => {
+  const { resolveUploadSummaryReasoning } =
+    await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.deepEqual(
+    resolveUploadSummaryReasoning({
+      mode: "openwhispr",
+      provider: "llama",
+      model: "llama-3.2-3b",
+      disableThinking: false,
+    }),
+    {
+      modelId: "llama-3.2-3b",
+      config: {
+        provider: "local",
+        disableThinking: false,
+      },
+    }
+  );
+});
+
+test("resolveUploadSummaryReasoning skips provider mode when no model is configured", async () => {
+  const { resolveUploadSummaryReasoning } =
+    await import("../../src/utils/uploadTranscriptSummary.ts");
+
+  assert.equal(
+    resolveUploadSummaryReasoning({
+      mode: "providers",
+      provider: "",
+      model: "",
+      disableThinking: true,
+    }),
+    null
+  );
+});


### PR DESCRIPTION
## Summary

Adds a local-first SEO YouTube Radar workflow for OpenWhispr:

- discovers newly popular SEO-related YouTube videos through YouTube Data API metadata
- filters and scores candidates, then uses local AI for relevance and summaries
- imports selected videos through the existing YouTube/audio path
- saves notes with the full transcript plus summary, key takeaways, and source metadata
- adds Settings -> Speech-to-Text -> Audio Upload controls for API key, topics, daily scheduling, and manual runs
- keeps the manual YouTube link upload path and adds automatic transcript summaries for uploaded audio/video notes

## Notes

- The YouTube Data API key is stored through the main-process secure environment manager, not renderer localStorage.
- The scheduled radar workflow uses local transcription and local reasoning only; no cloud AI fallback is used for discovery, relevance, or summaries.
- A live YouTube discovery run was not executed because it requires a YouTube API key and would consume quota.

## Validation

- Secrets scan passed
- Large-file guard passed
- `npm run typecheck`
- `npm run lint`
- `npm run i18n:check`
- `node --test test/helpers/seoYoutubeRadar.scoring.test.js test/helpers/seoYoutubeRadar.youtubeClient.test.js test/helpers/seoYoutubeRadar.store.test.js test/helpers/seoYoutubeRadar.runner.test.js test/helpers/seoYoutubeRadar.ipcContract.test.js test/helpers/seoYoutubeRadar.scheduler.test.js`
- `node --test test/helpers/youtubeImport.test.js test/utils/uploadTranscriptSummary.test.js test/helpers/azureTranscriptionUrl.test.js`
- `node --check` on new/changed main-process helper files
