### PR TITLE
refactor(sync): move ambient sync scheduling into SyncService

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -57,6 +57,14 @@ function MainApp() {
         import("./components/OnboardingFlow.tsx").catch(() => {});
       }
     }
+
+    // Both the dictation overlay and the control panel keep cloud data fresh,
+    // so sync runs even in tray-only sessions where the panel is never opened.
+    if (!isAgentPanel) {
+      import("./services/SyncService.js")
+        .then(({ syncService }) => syncService.startAutoSync())
+        .catch(() => {});
+    }
   }, [isAgentPanel, isControlPanel]);
 
   useEffect(() => {

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -58,8 +58,8 @@ function MainApp() {
       }
     }
 
-    // Both the dictation overlay and the control panel keep cloud data fresh,
-    // so sync runs even in tray-only sessions where the panel is never opened.
+    // Sync runs in every non-agent window, so tray-only sessions where the
+    // control panel is never opened still stay fresh.
     if (!isAgentPanel) {
       import("./services/SyncService.js")
         .then(({ syncService }) => syncService.startAutoSync())

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -375,31 +375,6 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   }, [toast, t]);
 
   useEffect(() => {
-    // Keep syncing during a long session, not just once at launch.
-    syncService.requestSyncAll("mount");
-
-    const onFocus = () => syncService.requestSyncAll("focus");
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") {
-        syncService.requestSyncAll("focus");
-      }
-    };
-    const onOnline = () => syncService.requestSyncAll("online");
-    window.addEventListener("focus", onFocus);
-    document.addEventListener("visibilitychange", onVisibility);
-    window.addEventListener("online", onOnline);
-
-    const interval = setInterval(() => syncService.requestSyncAll("interval"), 5 * 60 * 1000);
-
-    return () => {
-      window.removeEventListener("focus", onFocus);
-      document.removeEventListener("visibilitychange", onVisibility);
-      window.removeEventListener("online", onOnline);
-      clearInterval(interval);
-    };
-  }, []);
-
-  useEffect(() => {
     fetchStreamingProviders();
   }, []);
 

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -21,12 +21,16 @@ const BATCH_SIZE = 50;
 const TRANSCRIPTION_BATCH_SIZE = 100;
 const DICTIONARY_BATCH_SIZE = 200;
 const SNIPPET_BATCH_SIZE = 200;
-// Skip a redundant syncAll() if focus + interval fire close together.
+// Minimum gap between auto syncs, measured from the last completed pass in
+// any window (the stamp lives in shared localStorage).
 const AUTO_SYNC_THROTTLE_MS = 20000;
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 // Web Lock name serializing syncAll() across windows (each renderer has its
 // own SyncService instance, but localStorage and the local DB are shared).
 const SYNC_ALL_LOCK = "openwhispr-sync-all";
+// localStorage keys gating canSync(); a change in another window means sync
+// may have just become possible (sign-in, subscription, backup enabled).
+const CAN_SYNC_KEYS = ["isSignedIn", "cloudBackupEnabled", "isSubscribed"];
 
 // SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
 // the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
@@ -63,9 +67,8 @@ class SyncService {
     return iso ? Date.parse(iso) : 0;
   }
 
-  // Keeps data fresh for the whole session: initial pass, then re-sync on
-  // window focus/visibility, network reconnect, and a fixed interval.
-  // Runs in every window; the throttle and Web Lock dedupe across them.
+  // Runs in every window for the whole session; the throttle and Web Lock
+  // dedupe across windows.
   startAutoSync(): void {
     if (this.autoSyncStarted) return;
     this.autoSyncStarted = true;
@@ -78,10 +81,17 @@ class SyncService {
       }
     });
     window.addEventListener("online", () => this.requestSyncAll("online"));
+    // storage events fire only in the windows that didn't write the change,
+    // which is exactly where a first sync is still needed.
+    window.addEventListener("storage", (e) => {
+      if (e.key && CAN_SYNC_KEYS.includes(e.key)) {
+        this.requestSyncAll("start");
+      }
+    });
     setInterval(() => this.requestSyncAll("interval"), AUTO_SYNC_INTERVAL_MS);
   }
 
-  async syncAll(): Promise<void> {
+  async syncAll(waitForLock = false): Promise<void> {
     if (!this.canSync()) return;
     // A pass already running may have synced past the data this request covers,
     // so flag a re-run instead of dropping it.
@@ -91,9 +101,10 @@ class SyncService {
     }
     this.syncing = true;
     try {
-      // Skip when another window holds the lock — its pass reads the same
-      // local DB and cloud state, so it covers this request.
-      await navigator.locks.request(SYNC_ALL_LOCK, { ifAvailable: true }, async (lock) => {
+      // Ambient passes skip when another window holds the lock — that pass
+      // reads the same local DB and cloud state, so it covers this request.
+      // Manual passes wait so a user action is never silently dropped.
+      await navigator.locks.request(SYNC_ALL_LOCK, { ifAvailable: !waitForLock }, async (lock) => {
         if (!lock) return;
         await this.syncFolders();
         await this.syncNotes();
@@ -130,7 +141,7 @@ class SyncService {
     ) {
       return;
     }
-    void this.syncAll();
+    void this.syncAll(reason === "manual");
   }
 
   async syncDictionaryNow(): Promise<void> {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -23,6 +23,10 @@ const DICTIONARY_BATCH_SIZE = 200;
 const SNIPPET_BATCH_SIZE = 200;
 // Skip a redundant syncAll() if focus + interval fire close together.
 const AUTO_SYNC_THROTTLE_MS = 20000;
+const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+// Web Lock name serializing syncAll() across windows (each renderer has its
+// own SyncService instance, but localStorage and the local DB are shared).
+const SYNC_ALL_LOCK = "openwhispr-sync-all";
 
 // SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
 // the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
@@ -38,10 +42,10 @@ function normalizeTimestamp(value: string | null | undefined): string {
 class SyncService {
   private syncing = false;
   private syncAllPending = false;
+  private autoSyncStarted = false;
   private dictionaryDirty = false;
   private snippetsDirty = false;
   private pushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  private lastSyncAllAt = 0;
 
   canSync(): boolean {
     return (
@@ -49,6 +53,32 @@ class SyncService {
       localStorage.getItem("cloudBackupEnabled") === "true" &&
       localStorage.getItem("isSubscribed") === "true"
     );
+  }
+
+  // lastSyncedAt is written only when a syncAll() pass completes, and
+  // localStorage is shared across windows, so it doubles as the global
+  // "last completed sync" stamp for throttling.
+  private lastCompletedSyncAt(): number {
+    const iso = localStorage.getItem("lastSyncedAt");
+    return iso ? Date.parse(iso) : 0;
+  }
+
+  // Keeps data fresh for the whole session: initial pass, then re-sync on
+  // window focus/visibility, network reconnect, and a fixed interval.
+  // Runs in every window; the throttle and Web Lock dedupe across them.
+  startAutoSync(): void {
+    if (this.autoSyncStarted) return;
+    this.autoSyncStarted = true;
+
+    this.requestSyncAll("start");
+    window.addEventListener("focus", () => this.requestSyncAll("focus"));
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        this.requestSyncAll("focus");
+      }
+    });
+    window.addEventListener("online", () => this.requestSyncAll("online"));
+    setInterval(() => this.requestSyncAll("interval"), AUTO_SYNC_INTERVAL_MS);
   }
 
   async syncAll(): Promise<void> {
@@ -61,22 +91,26 @@ class SyncService {
     }
     this.syncing = true;
     try {
-      await this.syncFolders();
-      await this.syncNotes();
-      await this.syncConversations();
-      await this.syncTranscriptions();
-      // Edits during the awaits above set dictionaryDirty (syncing is already
-      // true), so re-run until clean rather than stalling until the next trigger.
-      do {
-        this.dictionaryDirty = false;
-        await this.syncDictionary();
-      } while (this.dictionaryDirty);
-      do {
-        this.snippetsDirty = false;
-        await this.syncSnippets();
-      } while (this.snippetsDirty);
-      localStorage.setItem("lastSyncedAt", new Date().toISOString());
-      this.lastSyncAllAt = Date.now();
+      // Skip when another window holds the lock — its pass reads the same
+      // local DB and cloud state, so it covers this request.
+      await navigator.locks.request(SYNC_ALL_LOCK, { ifAvailable: true }, async (lock) => {
+        if (!lock) return;
+        await this.syncFolders();
+        await this.syncNotes();
+        await this.syncConversations();
+        await this.syncTranscriptions();
+        // Edits during the awaits above set dictionaryDirty (syncing is already
+        // true), so re-run until clean rather than stalling until the next trigger.
+        do {
+          this.dictionaryDirty = false;
+          await this.syncDictionary();
+        } while (this.dictionaryDirty);
+        do {
+          this.snippetsDirty = false;
+          await this.syncSnippets();
+        } while (this.snippetsDirty);
+        localStorage.setItem("lastSyncedAt", new Date().toISOString());
+      });
     } catch (err) {
       console.error("Sync failed:", err);
     } finally {
@@ -88,11 +122,11 @@ class SyncService {
     }
   }
 
-  requestSyncAll(reason: "mount" | "focus" | "interval" | "online" | "manual"): void {
+  requestSyncAll(reason: "start" | "focus" | "interval" | "online" | "manual"): void {
     if (!this.canSync()) return;
     if (
       reason !== "manual" &&
-      (this.syncing || Date.now() - this.lastSyncAllAt < AUTO_SYNC_THROTTLE_MS)
+      (this.syncing || Date.now() - this.lastCompletedSyncAt() < AUTO_SYNC_THROTTLE_MS)
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

Follow-up to #1070. That PR added ambient re-sync triggers, but they lived in ControlPanel's mount effect — so a start-minimized session that never opens the control panel had **no sync at all**: dictations stayed local-only and edits from other devices never pulled down until the panel was opened. This moves sync scheduling to where it belongs and makes it window-independent, with no hidden background window needed.

## Changes

- **`SyncService.startAutoSync()`** now owns all ambient triggers: initial pass, window focus/visibility, network reconnect (`online`), and the 5-minute interval. It's bootstrapped from `AppRouter` in both the dictation overlay and the control panel, so tray-only sessions sync too.
- **Cross-window coordination via a Web Lock** (`navigator.locks`): each renderer has its own SyncService instance, but they share `localStorage` and the local DB. `syncAll()` runs under a shared lock with `ifAvailable` — if another window is mid-pass, this window skips, since that pass covers the same data.
- **Shared throttle stamp**: the auto-sync throttle now reads `lastSyncedAt` (written only when a pass completes, shared across windows) instead of a per-renderer in-memory field, so all windows share one 20s throttle window.
- ControlPanel's sync effect is deleted; its manual triggers (`requestSyncAll("manual")`) are unchanged. The `"mount"` reason is renamed `"start"`.

## Behavior

- Start-minimized users now get full background sync (push and pull) without opening the control panel.
- With both windows open, only one syncs at a time; the other's triggers are throttled or skip via the lock — no duplicate passes.
- Agent overlay and transient notification overlays are excluded; `canSync()` still gates everything (signed in + cloud backup + subscribed).

## Verification

- Typecheck: no new errors (5 pre-existing `tinfoil` module errors on `main` are unchanged).
- ESLint and Prettier: clean.