### PR TITLE
fix: link default folders to existing cloud folders instead of registering duplicates

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -825,6 +825,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   upsertFolderFromCloud: (cloudFolder) =>
     ipcRenderer.invoke("db-upsert-folder-from-cloud", cloudFolder),
   markFolderSynced: (id, cloudId) => ipcRenderer.invoke("db-mark-folder-synced", id, cloudId),
+  adoptFolderIdentity: (id, clientFolderId, cloudId, updatedAt) =>
+    ipcRenderer.invoke("db-adopt-folder-identity", id, clientFolderId, cloudId, updatedAt),
   getFolderIdMap: () => ipcRenderer.invoke("db-get-folder-id-map"),
   getPendingFolderDeletes: () => ipcRenderer.invoke("db-get-pending-folder-deletes"),
   hardDeleteFolder: (id) => ipcRenderer.invoke("db-hard-delete-folder", id),

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -2862,6 +2862,21 @@ class DatabaseManager {
     }
   }
 
+  adoptFolderIdentity(id, clientFolderId, cloudId, updatedAt) {
+    try {
+      if (!this.db) throw new Error("Database not initialized");
+      this.db
+        .prepare(
+          "UPDATE folders SET client_folder_id = ?, cloud_id = ?, sync_status = 'synced', updated_at = COALESCE(?, updated_at) WHERE id = ?"
+        )
+        .run(clientFolderId, cloudId, updatedAt ?? null, id);
+      return { success: true };
+    } catch (error) {
+      debugLogger.error("Error adopting folder identity", { error: error.message }, "database");
+      throw error;
+    }
+  }
+
   getFolderIdMap() {
     try {
       if (!this.db) throw new Error("Database not initialized");

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1394,6 +1394,9 @@ class IPCHandlers {
     ipcMain.handle("db-mark-folder-synced", (_, id, cloudId) =>
       this.databaseManager.markFolderSynced(id, cloudId)
     );
+    ipcMain.handle("db-adopt-folder-identity", (_, id, clientFolderId, cloudId, updatedAt) =>
+      this.databaseManager.adoptFolderIdentity(id, clientFolderId, cloudId, updatedAt)
+    );
     ipcMain.handle("db-get-folder-id-map", () => this.databaseManager.getFolderIdMap());
     ipcMain.handle("db-get-pending-folder-deletes", () =>
       this.databaseManager.getPendingFolderDeletes()

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -326,9 +326,42 @@ class SyncService {
   }
 
   private async syncFolders(): Promise<void> {
+    await this.adoptDefaultFolders();
     await this.pushPendingFolders();
     await this.pushFolderDeletes();
     await this.pullFolders();
+  }
+
+  // Each platform seeds "Personal"/"Meetings" with its own random
+  // client_folder_id, so the second device to sync would register them as
+  // new folders and collide with the cloud's per-user unique folder name.
+  // Before the first push, adopt the cloud identity of any same-named
+  // default folder so both platforms converge on a single folder.
+  private async adoptDefaultFolders(): Promise<void> {
+    const pending = (await window.electronAPI.getPendingFolders?.()) ?? [];
+    const unlinkedDefaults = pending.filter((f) => f.is_default && !f.cloud_id);
+    if (unlinkedDefaults.length === 0) return;
+
+    try {
+      const { folders: cloudFolders } = await FoldersService.list();
+      const cloudByName = new Map(
+        cloudFolders
+          .filter((f) => f.is_default && !f.deleted_at)
+          .map((f) => [f.name.toLowerCase(), f])
+      );
+      for (const local of unlinkedDefaults) {
+        const match = cloudByName.get(local.name.toLowerCase());
+        if (!match) continue;
+        await window.electronAPI.adoptFolderIdentity?.(
+          local.id,
+          match.client_folder_id ?? local.client_folder_id,
+          match.id,
+          match.updated_at
+        );
+      }
+    } catch (err) {
+      console.error("Default folder adoption failed:", err);
+    }
   }
 
   private async pushFolderDeletes(): Promise<void> {
@@ -370,9 +403,30 @@ class SyncService {
             sort_order: f.sort_order,
           }))
         );
-        for (const cloudFolder of created) {
-          const local = fresh.find((f) => f.client_folder_id === cloudFolder.client_folder_id);
-          if (local) await window.electronAPI.markFolderSynced?.(local.id, cloudFolder.id);
+        // created preserves input order; the cloud may return an existing
+        // folder with a different client_folder_id when a same-named
+        // default already exists there — adopt its identity in that case.
+        if (created.length !== fresh.length) {
+          console.error(
+            `Folder batch create returned ${created.length} folders for ${fresh.length} inputs; skipping identity adoption`
+          );
+          return;
+        }
+        for (const [i, cloudFolder] of created.entries()) {
+          const local = fresh[i];
+          if (
+            cloudFolder.client_folder_id &&
+            cloudFolder.client_folder_id !== local.client_folder_id
+          ) {
+            await window.electronAPI.adoptFolderIdentity?.(
+              local.id,
+              cloudFolder.client_folder_id,
+              cloudFolder.id,
+              cloudFolder.updated_at
+            );
+          } else {
+            await window.electronAPI.markFolderSynced?.(local.id, cloudFolder.id);
+          }
         }
       } catch (err) {
         console.error("Folder batch create failed:", err);
@@ -394,6 +448,25 @@ class SyncService {
         if (cloudFolder.deleted_at) {
           if (local) await window.electronAPI.hardDeleteFolder?.(local.id);
           continue;
+        }
+
+        // A default folder created on another platform arrives with an
+        // unknown client_folder_id; inserting it would violate the local
+        // unique folder name. Match it by name and adopt its identity.
+        if (!local && cloudFolder.is_default) {
+          const allFolders = (await window.electronAPI.getFolderIdMap?.()) ?? [];
+          const nameMatch = allFolders.find(
+            (f) => f.is_default && f.name.toLowerCase() === cloudFolder.name.toLowerCase()
+          );
+          if (nameMatch) {
+            await window.electronAPI.adoptFolderIdentity?.(
+              nameMatch.id,
+              cloudFolder.client_folder_id ?? nameMatch.client_folder_id,
+              cloudFolder.id,
+              cloudFolder.updated_at
+            );
+            continue;
+          }
         }
 
         if (local?.deleted_at) continue;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1899,6 +1899,12 @@ declare global {
       getFolderByClientId?: (clientFolderId: string) => Promise<FolderItem | null>;
       upsertFolderFromCloud?: (cloudFolder: Record<string, unknown>) => Promise<FolderItem>;
       markFolderSynced?: (id: number, cloudId: string) => Promise<void>;
+      adoptFolderIdentity?: (
+        id: number,
+        clientFolderId: string,
+        cloudId: string,
+        updatedAt?: string
+      ) => Promise<void>;
       getFolderIdMap?: () => Promise<FolderItem[]>;
       getPendingFolderDeletes?: () => Promise<FolderItem[]>;
       hardDeleteFolder?: (id: number) => Promise<{ success: boolean; id: number }>;


### PR DESCRIPTION
## Bug

Both desktop and mobile seed the default "Personal" and "Meetings" folders locally,
each with its own randomly generated `client_folder_id`. Folder sync matches purely
on that id, so the two platforms registered the *same* conceptual folders as
*different* folders.

Concretely, when mobile synced first and desktop signed in afterwards:

- **Push**: desktop sent its defaults with unknown client ids; the server fell
  through to a plain INSERT and hit its `UNIQUE (user_id, name)` constraint, which
  500'd the entire batch — including any legitimately new folders. The defaults
  stayed `pending` and re-failed on every sync.
- **Pull**: the incoming cloud defaults matched nothing locally, so the upsert tried
  to INSERT a second "Personal"/"Meetings" and crashed on the local unique folder
  name, aborting the pull before the sync cursor was saved. Folder sync was wedged
  in both directions, and notes filed in the defaults synced unfiled.

Mobile already solves this with a name-based adoption step on first sync
(`initialBackfill`); desktop had no equivalent.

## Fix

- **`SyncService.adoptDefaultFolders()`** (new): runs before the first folder push.
  If any default folder is still unlinked, fetch the cloud folder list, match
  defaults by name (case-insensitive), and adopt the cloud's `client_folder_id` +
  cloud id instead of pushing our own. Mirrors mobile's reconciliation.
- **`pushPendingFolders`**: map batch-create responses to local folders by position
  (the server preserves input order — same contract mobile relies on) instead of by
  `client_folder_id`, and adopt the returned identity when the server hands back an
  existing folder (see companion API MR).
- **`pullFolders`**: when a cloud default arrives with an unknown client id, match a
  local default by name and adopt its identity instead of INSERTing a duplicate row
  that violates the local unique name.
- Plumbing: new `adoptFolderIdentity` DB method + IPC handler + preload binding +
  `electronAPI` typing.

## Companion MR

Requires/pairs with the `openwhispr-api` `fix/notes-sync` MR (server-side adoption
on default-name collision). Desktop's pre-push adoption alone fixes the reported
bug; the positional mapping makes the server-side fallback effective too.