### PR TITLE
nix: update to 1.7.4

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,11 +6,11 @@
 
 let
   pname = "openwhispr";
-  version = "1.7.2";
+  version = "1.7.4";
 
   src = fetchurl {
     url = "https://github.com/OpenWhispr/openwhispr/releases/download/v${version}/OpenWhispr-${version}-linux-x86_64.AppImage";
-    hash = "sha256-EPJTZFtd2bQ026KNcI/FOHfoAMu96HKfJxTPceTc5jw=";
+    hash = "sha256-hp7FVUi5/K+QiQam8YAOrRsemFkC8MnupT+hhroP+6Y=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname version src; };


### PR DESCRIPTION
Automated bump of the Nix package to v1.7.4. (Branch was pushed by the update-nix workflow; PR created manually because the workflow's PR step was blocked before the Actions PR-creation permission was enabled. Catches up from 1.7.2 — the 1.7.3 bump hit the same permission block.)