### PR TITLE
fix(meeting): require transcript match before dropping held-back mic segments

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -21,6 +21,7 @@ const AudioStorageManager = require("./audioStorage");
 const TINFOIL_REALTIME_MODEL = "voxtral-mini-4b-realtime";
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
+const { partitionPendingMicFinals } = require("./meetingMicHoldback");
 const { applySmartSpacing } = require("./smartSpacing");
 const {
   transcriptsOverlap,
@@ -3963,7 +3964,13 @@ class IPCHandlers {
     const DUPLICATE_TRANSCRIPT_WINDOW_MS = 6000;
     const DUPLICATE_TRANSCRIPT_MERGE_LIMIT = 3;
     const STREAMING_RISKY_MIC_SEGMENT_HOLDBACK_MS = 3000;
-    const LOCAL_RISKY_MIC_SEGMENT_HOLDBACK_MS = 4500;
+    const LOCAL_MEETING_CHUNK_INTERVAL_MS = 5000;
+    // Must outlast one local transcription cycle: when a remote utterance
+    // straddles a chunk boundary, its system-side tail is only transcribed in
+    // the next cycle, and the buffered mic echo has to still be held back for
+    // that transcript to confirm it as a duplicate.
+    const LOCAL_RISKY_MIC_SEGMENT_HOLDBACK_MS = LOCAL_MEETING_CHUNK_INTERVAL_MS + 1000;
+    const RACING_MIC_RETRACT_WINDOW_MS = 4000;
 
     const buildNearbyTranscriptCandidates = (
       targetSource,
@@ -4035,9 +4042,19 @@ class IPCHandlers {
       for (let i = meetingDiarizationSegments.length - 1; i >= 0; i -= 1) {
         const candidate = meetingDiarizationSegments[i];
         if (candidate.source !== "mic" || candidate.timestamp == null) continue;
-        if (systemTimestamp != null && Math.abs(candidate.timestamp - systemTimestamp) > 4000) {
-          if (candidate.timestamp < systemTimestamp) break;
-          continue;
+        if (systemTimestamp != null) {
+          // Bleed-flagged segments get the full duplicate window: their
+          // confirming system transcript can land after the holdback released
+          // them (local mode transcribes in cycles), and the retract is the
+          // last live chance to remove the echo.
+          const retractWindowMs =
+            candidate.hasBleedEvidence || candidate.likelyRenderBleed
+              ? DUPLICATE_TRANSCRIPT_WINDOW_MS
+              : RACING_MIC_RETRACT_WINDOW_MS;
+          if (Math.abs(candidate.timestamp - systemTimestamp) > retractWindowMs) {
+            if (candidate.timestamp < systemTimestamp - DUPLICATE_TRANSCRIPT_WINDOW_MS) break;
+            continue;
+          }
         }
         const hasMicDuplicateRisk =
           candidate.likelyRenderBleed ||
@@ -4067,6 +4084,19 @@ class IPCHandlers {
       if (!text) return;
       meetingLocalTranscript += `${meetingLocalTranscript ? " " : ""}${text}`;
     };
+
+    // Held-back mic segments are appended at release time, after system
+    // segments spoken later — so insertion order is not spoken order. The
+    // stable sort leaves segments without timestamps in place.
+    const buildOrderedTranscriptText = (segments) =>
+      segments
+        .slice()
+        .sort((left, right) =>
+          left.timestamp != null && right.timestamp != null ? left.timestamp - right.timestamp : 0
+        )
+        .map((segment) => segment.text)
+        .join(" ")
+        .trim();
 
     const storeMeetingDiarizationSegment = (text, source, timestamp, micSuppression = null) => {
       meetingDiarizationSegments.push({
@@ -4112,52 +4142,41 @@ class IPCHandlers {
         return;
       }
 
-      const ready = [];
-      const deferred = [];
-      const now = Date.now();
-
-      for (const pending of meetingPendingMicFinals) {
-        if (!force && pending.releaseAt > now) {
-          deferred.push(pending);
-          continue;
-        }
-
-        if (
-          shouldSkipDuplicateMicSegment(pending.text, pending.timestamp, pending.micSuppression)
-        ) {
-          debugLogger.debug(
-            "Dropping buffered mic segment after system context confirmed duplicate",
-            {
-              text: pending.text.slice(0, 80),
-              averageCorrelation: pending.micSuppression?.averageCorrelation?.toFixed(3),
-              averageResidual: pending.micSuppression?.averageResidual?.toFixed(3),
-            }
-          );
-          continue;
-        }
-
-        ready.push(pending);
-      }
+      const { deferred, duplicates, releases } = partitionPendingMicFinals({
+        pending: meetingPendingMicFinals,
+        now: Date.now(),
+        force,
+        isDuplicate: (entry) =>
+          shouldSkipDuplicateMicSegment(entry.text, entry.timestamp, entry.micSuppression),
+      });
 
       meetingPendingMicFinals = deferred;
       schedulePendingMicFinalFlush();
 
-      for (const pending of ready) {
-        if (pending.micSuppression?.hasBleedEvidence) {
-          debugLogger.debug("Dropping flagged-bleed mic segment after holdback", {
+      for (const pending of duplicates) {
+        debugLogger.debug(
+          "Dropping buffered mic segment after system context confirmed duplicate",
+          {
             text: pending.text.slice(0, 80),
-            holdbackMs: pending.holdbackMs,
             averageCorrelation: pending.micSuppression?.averageCorrelation?.toFixed(3),
             averageResidual: pending.micSuppression?.averageResidual?.toFixed(3),
-          });
-          continue;
-        }
-        debugLogger.debug("Releasing buffered mic segment after duplicate holdback", {
-          text: pending.text.slice(0, 80),
-          holdbackMs: pending.holdbackMs,
-          averageCorrelation: pending.micSuppression?.averageCorrelation?.toFixed(3),
-          averageResidual: pending.micSuppression?.averageResidual?.toFixed(3),
-        });
+          }
+        );
+      }
+
+      for (const pending of releases) {
+        debugLogger.debug(
+          pending.micSuppression?.hasBleedEvidence
+            ? "Releasing bleed-flagged mic segment after holdback (no transcript match)"
+            : "Releasing buffered mic segment after duplicate holdback",
+          {
+            text: pending.text.slice(0, 80),
+            holdbackMs: pending.holdbackMs,
+            reason: pending.micSuppression?.reason,
+            averageCorrelation: pending.micSuppression?.averageCorrelation?.toFixed(3),
+            averageResidual: pending.micSuppression?.averageResidual?.toFixed(3),
+          }
+        );
         pending.emit();
       }
     }
@@ -5537,7 +5556,7 @@ class IPCHandlers {
 
           meetingLocalTimer = setInterval(() => {
             transcribeAllLocalBuffers();
-          }, 5000);
+          }, LOCAL_MEETING_CHUNK_INTERVAL_MS);
 
           ({ systemAudioMode, systemAudioStrategy } = await startMeetingSystemAudio(
             event,
@@ -5784,10 +5803,7 @@ class IPCHandlers {
           const { diarizationPcmPath, diarizationSegments, diarizationStartedAt } =
             await captureMeetingDiarizationState();
           const transcript =
-            diarizationSegments
-              .map((segment) => segment.text)
-              .join(" ")
-              .trim() || meetingLocalTranscript;
+            buildOrderedTranscriptText(diarizationSegments) || meetingLocalTranscript;
           const sessionSpeakerConfigSnapshot = this.activeMeetingSpeakerConfig;
           const noteIdSnapshot = meetingNoteId;
           this.activeMeetingSpeakerConfig = null;
@@ -5812,10 +5828,8 @@ class IPCHandlers {
         const { diarizationPcmPath, diarizationSegments, diarizationStartedAt } =
           await captureMeetingDiarizationState();
         const transcript =
-          diarizationSegments
-            .map((segment) => segment.text)
-            .join(" ")
-            .trim() || [results[0]?.text, results[1]?.text].filter(Boolean).join(" ");
+          buildOrderedTranscriptText(diarizationSegments) ||
+          [results[0]?.text, results[1]?.text].filter(Boolean).join(" ");
 
         const sessionSpeakerConfigSnapshot = this.activeMeetingSpeakerConfig;
         const noteIdSnapshot = meetingNoteId;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -21,7 +21,7 @@ const AudioStorageManager = require("./audioStorage");
 const TINFOIL_REALTIME_MODEL = "voxtral-mini-4b-realtime";
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
-const { partitionPendingMicFinals } = require("./meetingMicHoldback");
+const { partitionPendingMicFinals, isWithinRetractWindow } = require("./meetingMicHoldback");
 const { applySmartSpacing } = require("./smartSpacing");
 const {
   transcriptsOverlap,
@@ -3965,10 +3965,8 @@ class IPCHandlers {
     const DUPLICATE_TRANSCRIPT_MERGE_LIMIT = 3;
     const STREAMING_RISKY_MIC_SEGMENT_HOLDBACK_MS = 3000;
     const LOCAL_MEETING_CHUNK_INTERVAL_MS = 5000;
-    // Must outlast one local transcription cycle: when a remote utterance
-    // straddles a chunk boundary, its system-side tail is only transcribed in
-    // the next cycle, and the buffered mic echo has to still be held back for
-    // that transcript to confirm it as a duplicate.
+    // Must outlast one local transcription cycle so a straddling remote
+    // utterance's next-cycle system transcript can confirm buffered echo.
     const LOCAL_RISKY_MIC_SEGMENT_HOLDBACK_MS = LOCAL_MEETING_CHUNK_INTERVAL_MS + 1000;
     const RACING_MIC_RETRACT_WINDOW_MS = 4000;
 
@@ -4043,15 +4041,11 @@ class IPCHandlers {
         const candidate = meetingDiarizationSegments[i];
         if (candidate.source !== "mic" || candidate.timestamp == null) continue;
         if (systemTimestamp != null) {
-          // Bleed-flagged segments get the full duplicate window: their
-          // confirming system transcript can land after the holdback released
-          // them (local mode transcribes in cycles), and the retract is the
-          // last live chance to remove the echo.
-          const retractWindowMs =
+          const windowMs =
             candidate.hasBleedEvidence || candidate.likelyRenderBleed
               ? DUPLICATE_TRANSCRIPT_WINDOW_MS
               : RACING_MIC_RETRACT_WINDOW_MS;
-          if (Math.abs(candidate.timestamp - systemTimestamp) > retractWindowMs) {
+          if (!isWithinRetractWindow({ candidate, systemTimestamp, windowMs })) {
             if (candidate.timestamp < systemTimestamp - DUPLICATE_TRANSCRIPT_WINDOW_MS) break;
             continue;
           }
@@ -4085,15 +4079,12 @@ class IPCHandlers {
       meetingLocalTranscript += `${meetingLocalTranscript ? " " : ""}${text}`;
     };
 
-    // Held-back mic segments are appended at release time, after system
-    // segments spoken later — so insertion order is not spoken order. The
-    // stable sort leaves segments without timestamps in place.
+    // Held-back mic segments are appended at release time, so insertion order
+    // is not spoken order.
     const buildOrderedTranscriptText = (segments) =>
       segments
         .slice()
-        .sort((left, right) =>
-          left.timestamp != null && right.timestamp != null ? left.timestamp - right.timestamp : 0
-        )
+        .sort((left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0))
         .map((segment) => segment.text)
         .join(" ")
         .trim();
@@ -4103,6 +4094,7 @@ class IPCHandlers {
         text,
         source,
         timestamp,
+        committedAt: Date.now(),
         suppressionReason: source === "mic" ? micSuppression?.reason || null : null,
         hasBleedEvidence: source === "mic" ? !!micSuppression?.hasBleedEvidence : false,
         likelyRenderBleed: source === "mic" ? !!micSuppression?.likelyRenderBleed : false,
@@ -5005,7 +4997,7 @@ class IPCHandlers {
         source === "mic" &&
         rms < MEETING_MIC_BLEED_RMS_CEILING &&
         peak < MEETING_MIC_BLEED_PEAK_CEILING &&
-        meetingEchoLeakDetector.isSystemSpeaking(Date.now() - 5000)
+        meetingEchoLeakDetector.isSystemSpeaking(Date.now() - LOCAL_MEETING_CHUNK_INTERVAL_MS)
       ) {
         debugLogger.debug("Skipping system-dominant mic chunk", {
           source,

--- a/src/helpers/meetingMicHoldback.js
+++ b/src/helpers/meetingMicHoldback.js
@@ -1,0 +1,46 @@
+/**
+ * Holdback policy for buffered ("risky") meeting mic finals.
+ *
+ * Mic segments that overlap system audio (double-talk, echo-leak evidence,
+ * startup warmup, system speech activity) are buffered for a holdback window
+ * before being committed, giving the system channel time to produce a
+ * transcript that confirms the mic text as an echo duplicate.
+ *
+ * Policy: a held-back mic segment may only be dropped when system transcript
+ * text actually matches it (`isDuplicate`). Audio-only echo evidence
+ * (correlation/residual heuristics) is enough to delay a segment, never to
+ * discard it — field logs showed genuine local speech scoring correlations
+ * of 0.73–0.81 during double-talk, above every audio gate.
+ *
+ * Coverage after release: bleed-flagged segments can still be retracted by
+ * the racing retract when their matching system transcript arrives late
+ * (`removeRacingMicEntriesFor` widens its window for them). Segments buffered
+ * only for warmup or system speech activity carry no bleed flags, so the
+ * duplicate matcher never confirms them — their drop opportunity is a system
+ * transcript arriving while they are still buffered; after release they are
+ * committed. The post-meeting merge dedupe additionally filters the
+ * diarization payload, but does not rewrite segments already committed live.
+ */
+const partitionPendingMicFinals = ({ pending, now, force = false, isDuplicate }) => {
+  const deferred = [];
+  const duplicates = [];
+  const releases = [];
+
+  for (const entry of pending) {
+    if (!force && entry.releaseAt > now) {
+      deferred.push(entry);
+      continue;
+    }
+
+    if (isDuplicate(entry)) {
+      duplicates.push(entry);
+      continue;
+    }
+
+    releases.push(entry);
+  }
+
+  return { deferred, duplicates, releases };
+};
+
+module.exports = { partitionPendingMicFinals };

--- a/src/helpers/meetingMicHoldback.js
+++ b/src/helpers/meetingMicHoldback.js
@@ -1,25 +1,14 @@
 /**
- * Holdback policy for buffered ("risky") meeting mic finals.
+ * Partitions buffered ("risky") meeting mic finals into entries still inside
+ * their holdback window, confirmed system-audio duplicates, and entries to
+ * release.
  *
- * Mic segments that overlap system audio (double-talk, echo-leak evidence,
- * startup warmup, system speech activity) are buffered for a holdback window
- * before being committed, giving the system channel time to produce a
- * transcript that confirms the mic text as an echo duplicate.
- *
- * Policy: a held-back mic segment may only be dropped when system transcript
- * text actually matches it (`isDuplicate`). Audio-only echo evidence
- * (correlation/residual heuristics) is enough to delay a segment, never to
- * discard it — field logs showed genuine local speech scoring correlations
- * of 0.73–0.81 during double-talk, above every audio gate.
- *
- * Coverage after release: bleed-flagged segments can still be retracted by
- * the racing retract when their matching system transcript arrives late
- * (`removeRacingMicEntriesFor` widens its window for them). Segments buffered
- * only for warmup or system speech activity carry no bleed flags, so the
- * duplicate matcher never confirms them — their drop opportunity is a system
- * transcript arriving while they are still buffered; after release they are
- * committed. The post-meeting merge dedupe additionally filters the
- * diarization payload, but does not rewrite segments already committed live.
+ * Policy: a text match (`isDuplicate`) is the only condition that may drop a
+ * held-back segment. Audio-only echo evidence delays a segment, never
+ * discards it — field logs showed genuine local speech scoring correlations
+ * of 0.73–0.81 during double-talk, above every audio gate. Released segments
+ * with bleed flags can still be retracted when a matching system transcript
+ * arrives late (see removeRacingMicEntriesFor in ipcHandlers.js).
  */
 const partitionPendingMicFinals = ({ pending, now, force = false, isDuplicate }) => {
   const deferred = [];
@@ -43,4 +32,26 @@ const partitionPendingMicFinals = ({ pending, now, force = false, isDuplicate })
   return { deferred, duplicates, releases };
 };
 
-module.exports = { partitionPendingMicFinals };
+/**
+ * A committed mic segment may be retracted by an arriving system transcript
+ * when the two plausibly describe the same audio. Capture timestamps race
+ * directly for segments committed on arrival; held-back segments commit only
+ * after their holdback window, so their confirming transcript — delayed by up
+ * to a transcription cycle — races their commit time instead. Without the
+ * commit-time comparison, a segment released at capture + holdback could
+ * never be retracted: the confirming transcript always arrives more than
+ * `holdback` away from the capture timestamp.
+ */
+const isWithinRetractWindow = ({ candidate, systemTimestamp, windowMs }) => {
+  if (Math.abs(candidate.timestamp - systemTimestamp) <= windowMs) {
+    return true;
+  }
+
+  return (
+    candidate.committedAt != null &&
+    systemTimestamp >= candidate.timestamp &&
+    Math.abs(candidate.committedAt - systemTimestamp) <= windowMs
+  );
+};
+
+module.exports = { partitionPendingMicFinals, isWithinRetractWindow };

--- a/test/helpers/meetingMicHoldback.test.js
+++ b/test/helpers/meetingMicHoldback.test.js
@@ -1,0 +1,168 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { partitionPendingMicFinals } = require("../../src/helpers/meetingMicHoldback");
+
+const NOW = 1_000_000;
+
+const entry = (overrides = {}) => ({
+  text: "hello there",
+  timestamp: NOW - 5000,
+  releaseAt: NOW - 1,
+  micSuppression: null,
+  ...overrides,
+});
+
+test("defers entries whose holdback has not elapsed without evaluating them", () => {
+  const waiting = entry({ releaseAt: NOW + 2000 });
+  const due = entry({ releaseAt: NOW - 500 });
+  const evaluated = [];
+
+  const { deferred, duplicates, releases } = partitionPendingMicFinals({
+    pending: [waiting, due],
+    now: NOW,
+    isDuplicate: (candidate) => {
+      evaluated.push(candidate);
+      return false;
+    },
+  });
+
+  assert.deepEqual(deferred, [waiting]);
+  assert.deepEqual(duplicates, []);
+  assert.deepEqual(releases, [due]);
+  // The dedupe verdict must be taken at release time, when the system channel
+  // has had the full holdback window to produce a matching transcript.
+  assert.deepEqual(evaluated, [due]);
+});
+
+test("entries due exactly at now are evaluated, not re-deferred", () => {
+  // The flush timer fires at exactly releaseAt, so now === releaseAt is the
+  // common case; re-deferring would cause a needless 0ms reschedule loop.
+  const due = entry({ releaseAt: NOW });
+
+  const { deferred, releases } = partitionPendingMicFinals({
+    pending: [due],
+    now: NOW,
+    isDuplicate: () => false,
+  });
+
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(releases, [due]);
+});
+
+test("force flush evaluates entries still inside the holdback window", () => {
+  const waiting = entry({ releaseAt: NOW + 2000 });
+
+  const { deferred, releases } = partitionPendingMicFinals({
+    pending: [waiting],
+    now: NOW,
+    force: true,
+    isDuplicate: () => false,
+  });
+
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(releases, [waiting]);
+});
+
+test("force flush still drops confirmed duplicates (meeting-stop path)", () => {
+  // flushPendingMicFinals(true) runs at meeting stop; entries inside their
+  // holdback window get their one and only dedupe check there.
+  const echoed = entry({ releaseAt: NOW + 2000, text: "so that is eight dollars a month" });
+  const genuine = entry({ releaseAt: NOW + 2000, text: "thanks for taking the time" });
+
+  const { deferred, duplicates, releases } = partitionPendingMicFinals({
+    pending: [echoed, genuine],
+    now: NOW,
+    force: true,
+    isDuplicate: (candidate) => candidate === echoed,
+  });
+
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(duplicates, [echoed]);
+  assert.deepEqual(releases, [genuine]);
+});
+
+test("drops entries only when the transcript matcher confirms a duplicate", () => {
+  const echoed = entry({ text: "we have our own cloud server" });
+  const genuine = entry({ text: "how do you make money off of this" });
+
+  const { duplicates, releases } = partitionPendingMicFinals({
+    pending: [echoed, genuine],
+    now: NOW,
+    isDuplicate: (candidate) => candidate === echoed,
+  });
+
+  assert.deepEqual(duplicates, [echoed]);
+  assert.deepEqual(releases, [genuine]);
+});
+
+test("regression: bleed-flagged speech without a transcript match is released, not dropped", () => {
+  // Field logs (2026-07-02, Windows): genuine local speech during double-talk
+  // scored correlations of 0.73–0.81 and was silently discarded after holdback
+  // even though no system transcript ever matched it.
+  const flagged = entry({
+    text: "how do you make money off of this one",
+    micSuppression: {
+      reason: "double_talk",
+      hasBleedEvidence: true,
+      likelyRenderBleed: false,
+      averageCorrelation: 0.742,
+      averageResidual: 0.45,
+    },
+  });
+
+  const { deferred, duplicates, releases } = partitionPendingMicFinals({
+    pending: [flagged],
+    now: NOW,
+    isDuplicate: () => false,
+  });
+
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(duplicates, []);
+  assert.deepEqual(releases, [flagged]);
+});
+
+test("bleed-flagged speech that matches a system transcript is still dropped", () => {
+  const echoed = entry({
+    text: "we are very early and so i am still trying to figure out the best",
+    micSuppression: { hasBleedEvidence: true, averageCorrelation: 0.81 },
+  });
+
+  const { duplicates, releases } = partitionPendingMicFinals({
+    pending: [echoed],
+    now: NOW,
+    isDuplicate: () => true,
+  });
+
+  assert.deepEqual(duplicates, [echoed]);
+  assert.deepEqual(releases, []);
+});
+
+test("preserves queue order within each partition", () => {
+  const first = entry({ text: "first", releaseAt: NOW - 30 });
+  const second = entry({ text: "second", releaseAt: NOW - 20 });
+  const third = entry({ text: "third", releaseAt: NOW - 10 });
+
+  const { releases } = partitionPendingMicFinals({
+    pending: [first, second, third],
+    now: NOW,
+    isDuplicate: () => false,
+  });
+
+  assert.deepEqual(
+    releases.map((candidate) => candidate.text),
+    ["first", "second", "third"]
+  );
+});
+
+test("handles an empty queue", () => {
+  const { deferred, duplicates, releases } = partitionPendingMicFinals({
+    pending: [],
+    now: NOW,
+    isDuplicate: () => false,
+  });
+
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(duplicates, []);
+  assert.deepEqual(releases, []);
+});

--- a/test/helpers/meetingMicHoldback.test.js
+++ b/test/helpers/meetingMicHoldback.test.js
@@ -1,7 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { partitionPendingMicFinals } = require("../../src/helpers/meetingMicHoldback");
+const {
+  partitionPendingMicFinals,
+  isWithinRetractWindow,
+} = require("../../src/helpers/meetingMicHoldback");
 
 const NOW = 1_000_000;
 
@@ -165,4 +168,61 @@ test("handles an empty queue", () => {
   assert.deepEqual(deferred, []);
   assert.deepEqual(duplicates, []);
   assert.deepEqual(releases, []);
+});
+
+test("retract window matches on capture timestamps for segments committed on arrival", () => {
+  const candidate = { timestamp: NOW, committedAt: NOW };
+
+  assert.equal(
+    isWithinRetractWindow({ candidate, systemTimestamp: NOW + 3000, windowMs: 6000 }),
+    true
+  );
+  assert.equal(
+    isWithinRetractWindow({ candidate, systemTimestamp: NOW + 6001, windowMs: 6000 }),
+    false
+  );
+});
+
+test("regression: late confirmation races commit time for held-back segments", () => {
+  // Local mode stamps segments at transcription completion and releases them
+  // holdback ms later, so a confirming next-cycle system transcript is always
+  // more than `holdback` past the capture timestamp. On capture timestamps
+  // alone this candidate could categorically never be retracted.
+  const holdback = 6000;
+  const released = { timestamp: NOW, committedAt: NOW + holdback };
+
+  assert.equal(
+    isWithinRetractWindow({ candidate: released, systemTimestamp: NOW + 6500, windowMs: 6000 }),
+    true
+  );
+  assert.equal(
+    isWithinRetractWindow({
+      candidate: released,
+      systemTimestamp: NOW + holdback + 6001,
+      windowMs: 6000,
+    }),
+    false
+  );
+});
+
+test("commit-time race never matches system transcripts from before the segment was spoken", () => {
+  const released = { timestamp: NOW, committedAt: NOW + 6000 };
+
+  assert.equal(
+    isWithinRetractWindow({ candidate: released, systemTimestamp: NOW - 6500, windowMs: 6000 }),
+    false
+  );
+});
+
+test("segments without a commit time fall back to the capture window only", () => {
+  const legacy = { timestamp: NOW, committedAt: null };
+
+  assert.equal(
+    isWithinRetractWindow({ candidate: legacy, systemTimestamp: NOW + 6500, windowMs: 6000 }),
+    false
+  );
+  assert.equal(
+    isWithinRetractWindow({ candidate: legacy, systemTimestamp: NOW + 5000, windowMs: 6000 }),
+    true
+  );
 });


### PR DESCRIPTION
## Problem

During meetings, genuine local speech is silently deleted from the transcript. Field debug logs (Windows, 2026-07-02) show utterances like *"How do you make money off of this one"* and *"Can you hear me?"* being discarded with:

```
Dropping flagged-bleed mic segment after holdback { averageCorrelation: "0.742", ... }
```

Root cause: `flushPendingMicFinals` dropped a held-back mic segment **unconditionally on audio-only echo evidence** (`hasBleedEvidence`) — even though the text-dedupe check it had just run (`shouldSkipDuplicateMicSegment`) confirmed **no system transcript matched** the segment. The audio heuristic's own gate is correlation ≥ 0.7, and every falsely dropped utterance in the field log scored 0.728–0.812 during double-talk — the heuristic cannot distinguish "local speech while remote audio plays" from "echo" in exactly the situation where it decides to drop. Losing real speech is silent and unrecoverable; a leaked echo duplicate is visible and removable.

## What this does

**1. Transcript confirmation is now the only condition that can drop a held-back mic segment at flush time.** The holdback window exists to give the system channel time to produce matching text; if it never does, the segment is released instead of destroyed. The decision logic is extracted into a pure helper (`src/helpers/meetingMicHoldback.js`, `partitionPendingMicFinals`) following the `transcriptText.js` pattern, so the policy is unit-testable. Deferral, force-flush at meeting stop, timer rescheduling, and queue ordering are unchanged (verified by review — see below).

**2. The local-mode holdback now outlasts one transcription cycle.** Local mode transcribes in 5s chunks; a remote utterance straddling a chunk boundary gets its system-side tail transcribed one cycle later. The old 4.5s holdback expired *before* that confirming transcript could arrive. The holdback is now derived as `LOCAL_MEETING_CHUNK_INTERVAL_MS + 1000` (6s), so echo is confirmed and dropped while still buffered in the common case.

**3. The racing retract now works for late confirmations.** `removeRacingMicEntriesFor` — which retracts an already-committed mic segment when a matching system transcript arrives — gated on capture timestamps with a hard 4s window. For held-back segments that gate is unreachable by construction: a segment released at `capture + holdback` can only meet its confirming transcript *more* than the holdback away from its capture timestamp. Retract eligibility now also races the segment's **commit time** (`committedAt`, stamped in `storeMeetingDiarizationSegment`), with bleed-flagged segments getting the full `DUPLICATE_TRANSCRIPT_WINDOW_MS` (6s) window; the early-scan `break` is corrected to the max window. This covers late confirmations in both local and streaming modes; the renderer already handles `retract` events end-to-end (`meetingRecordingStore.ts`).

**4. Stop-time transcripts are joined in spoken order.** Held-back segments are appended at release time, after system segments spoken later; the stop-time transcript string now sorts by timestamp via `buildOrderedTranscriptText` (transitive comparator), used by both the local and streaming stop paths.

## Echo containment after this change

A released segment is still covered by text-gated nets, each verified end-to-end in code:

1. **While buffered**: `removePendingMicFinalsFor` drops it the moment a matching system transcript arrives (now covers a full local transcription cycle).
2. **At flush**: `shouldSkipDuplicateMicSegment` re-checks against all accumulated system transcripts (strict matcher for bleed-flagged, relaxed for double-talk).
3. **After commit**: the racing retract removes it from `meetingDiarizationSegments` and the renderer's live transcript — now genuinely reachable in both modes via the commit-time race (point 3 above); a second clean-room verification pass proved the capture-timestamp-only version was mathematically dead in local mode.

High-confidence capture-time suppression (`suppress: true`, reason `render_bleed` — no double-talk, strong gates) is intentionally **unchanged**: it exists for pure echo where the system channel may produce no text at all.

Known limitation (pre-existing, documented in the helper's doc comment): the post-diarization merge dedupe (`dedupeMicAgainstSystem`) filters only the diarization payload; the renderer's note merge preserves already-committed segments, so that net cannot remove text from the saved note. The live nets above are the effective containment; making the note merge respect the deduped payload is a candidate follow-up.

## Scope / risk

- Pure JS in the main process; identical behavior on macOS, Windows, and Linux, and in both cloud-streaming and local (whisper/Parakeet) meeting modes.
- No IPC, schema, settings, or renderer changes. No new strings.
- Live-view latency for risky **local-mode** mic segments increases 4.5s → 6s (still within one transcription cycle of the system channel's own inherent lag).
- Worst-case regression: when system-channel ASR returns empty for remote speech (echo has no text to match, seen in field logs as "Parakeet returned empty text for non-silent audio"), an echoed line can appear attributed to the mic instead of being silently dropped — the deliberate trade, since the previous behavior deleted real user speech in the same situation.

## Testing

- New `test/helpers/meetingMicHoldback.test.js` (13 tests): the field-log regression (bleed-flagged, correlation 0.742, no transcript match → must be released), the inverse (transcript match → still dropped), the meeting-stop force-flush × duplicate interaction, the `releaseAt === now` timer boundary, deferred entries never evaluated early, and the retract-window arithmetic — including a regression test proving a held-back segment's late confirmation matches on commit time where capture time categorically cannot.
- Full suite: 194 pass / 0 fail (11 skipped, platform-specific). `tsc` ✅ ESLint ✅ Prettier ✅.
- Two adversarial review passes with independent verification of every finding. Pass 1 (4 lenses over the core change) confirmed the flush refactor preserves old semantics except the intended policy change, and surfaced the local-mode holdback/cycle arithmetic. Pass 2 (clean-room trace of the final state) proved the first retract widening was still unreachable in local mode on capture timestamps — fixed via the commit-time race — and confirmed streaming provider timestamps (Deepgram/AssemblyAI/OpenAI/Corti) are epoch-ms comparable for the sorted stop join. All confirmed findings are addressed; refuted findings are documented in the review artifacts.

## Verification on real hardware

The definitive check is the field scenario from the debug log: Windows laptop, speakers + mic array (no headphones), local Parakeet meeting mode, both parties talking over each other. Expect: local speech during double-talk appears in the transcript (possibly after the ~6s holdback); echoed remote speech either never appears or is retracted within seconds.
