### PR TITLE
fix(cloud): retry transient chunk failures and surface partial transcriptions

### DIFF
--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -60,6 +60,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     sizeBytes: number;
   } | null>(null);
   const [result, setResult] = useState<string | null>(null);
+  const [partialWarning, setPartialWarning] = useState(false);
   const [noteId, setNoteId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -301,6 +302,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     setState("idle");
     setFile(null);
     setResult(null);
+    setPartialWarning(false);
     setNoteId(null);
     setError(null);
     setProgress(0);
@@ -348,7 +350,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     }
 
     try {
-      let res: { success: boolean; text?: string; error?: string; code?: string };
+      let res: { success: boolean; text?: string; error?: string; code?: string; warning?: string };
 
       if (isOpenWhisprCloud) {
         res = await withSessionRefresh(async () => {
@@ -387,6 +389,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
       if (res.success && res.text) {
         setProgress(100);
         setResult(res.text);
+        setPartialWarning(!!res.warning);
 
         const textFallback = res.text.trim().split(/\s+/).slice(0, 6).join(" ");
         const fallbackTitle =
@@ -526,6 +529,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
             <CompleteView
               t={t}
               result={result}
+              partialWarning={partialWarning}
               folders={folders}
               selectedFolderId={selectedFolderId}
               handleFolderChange={handleFolderChange}
@@ -969,6 +973,7 @@ function TranscribingView({
 interface CompleteViewProps {
   t: (key: string) => string;
   result: string;
+  partialWarning: boolean;
   folders: FolderItem[];
   selectedFolderId: string;
   handleFolderChange: (val: string) => void;
@@ -980,6 +985,7 @@ interface CompleteViewProps {
 function CompleteView({
   t,
   result,
+  partialWarning,
   folders,
   selectedFolderId,
   handleFolderChange,
@@ -1033,6 +1039,12 @@ function CompleteView({
       <p className="text-xs text-foreground/25 max-w-[240px] text-center line-clamp-2 mb-4">
         {result.slice(0, 150)}
       </p>
+
+      {partialWarning && (
+        <p className="text-xs text-destructive/50 max-w-[240px] text-center mb-4 -mt-2">
+          {t("notes.upload.partialWarning")}
+        </p>
+      )}
 
       {folders.length > 0 && (
         <div className="flex items-center justify-center gap-2 mb-4">

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1637,6 +1637,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       wordsUsed: result.wordsUsed,
       wordsRemaining: result.wordsRemaining,
       clientTranscriptionId: result.clientTranscriptionId,
+      ...(result.warning ? { warning: result.warning } : {}),
     };
   }
 
@@ -3076,6 +3077,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     // If streaming produced no text, fall back to batch transcription
     // (batch fallback records usage server-side via /api/transcribe)
     let usedBatchFallback = false;
+    let batchWarning = null;
     if (!finalText && durationSeconds > 2 && fallbackBlob?.size > 0) {
       logger.info(
         "Streaming produced no text, falling back to batch transcription",
@@ -3089,6 +3091,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         if (batchResult?.text) {
           finalText = batchResult.text;
           usedBatchFallback = true;
+          batchWarning = batchResult.warning || null;
           logger.info("Batch fallback succeeded", { textLength: finalText.length }, "streaming");
         }
       } catch (fallbackErr) {
@@ -3111,6 +3114,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         text: finalText,
         rawText: finalText,
         source: `${this.getStreamingProviderName()}-streaming`,
+        ...(batchWarning ? { warning: batchWarning } : {}),
       });
 
       if (!usedBatchFallback) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -125,6 +125,7 @@ const AUDIO_MIME_TYPES = {
 const CLOUD_INLINE_LIMIT = 4 * 1024 * 1024;
 const CLOUD_CHUNK_CONCURRENCY = 5;
 const CLOUD_CHUNK_SEGMENT_SECONDS = 240;
+const CLOUD_CHUNK_MAX_ATTEMPTS = 3;
 
 function buildMultipartBody(fileBuffer, fileName, contentType, fields = {}) {
   const boundary = `----OpenWhispr${Date.now()}`;
@@ -168,7 +169,11 @@ async function postMultipart(url, body, boundary, headers = {}) {
   try {
     return { statusCode: response.status, data: JSON.parse(text) };
   } catch {
-    throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+    // Vercel platform errors (413 payload cap, 504 timeout) return non-JSON bodies.
+    throw Object.assign(new Error(`Server error ${response.status}: ${text.slice(0, 120)}`), {
+      code: "SERVER_ERROR",
+      statusCode: response.status,
+    });
   }
 }
 
@@ -191,9 +196,18 @@ function interpretTranscribeResponse(data) {
     });
   }
   if (data.statusCode !== 200) {
-    throw new Error(data.data?.error || `API error: ${data.statusCode}`);
+    throw Object.assign(new Error(data.data?.error || `API error: ${data.statusCode}`), {
+      statusCode: data.statusCode,
+    });
   }
   return data.data;
+}
+
+const NON_RETRYABLE_CHUNK_CODES = new Set(["AUTH_EXPIRED", "LIMIT_REACHED", "NO_SPEECH_DETECTED"]);
+
+function isTransientChunkError(err) {
+  if (NON_RETRYABLE_CHUNK_CODES.has(err.code)) return false;
+  return !err.statusCode || err.statusCode >= 500;
 }
 
 async function chunkedCloudTranscribe({
@@ -243,9 +257,21 @@ async function chunkedCloudTranscribe({
         multipartFields
       );
       const url = new URL(`${apiUrl}/api/transcribe`);
-      const data = await postMultipart(url, body, boundary, authHeader);
 
-      results[index] = interpretTranscribeResponse(data);
+      for (let attempt = 1; ; attempt++) {
+        try {
+          const data = await postMultipart(url, body, boundary, authHeader);
+          results[index] = interpretTranscribeResponse(data);
+          break;
+        } catch (err) {
+          if (attempt >= CLOUD_CHUNK_MAX_ATTEMPTS || !isTransientChunkError(err)) throw err;
+          debugLogger.warn(`Chunk ${index} attempt ${attempt} failed, retrying`, {
+            error: err.message,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 1000 * attempt + Math.random() * 500));
+        }
+      }
+
       completedCount++;
       onProgress?.({
         stage: "transcribing",
@@ -3705,7 +3731,7 @@ class IPCHandlers {
         debugLogger.debug("Cloud transcribe request", { audioSize: audioData.length }, "cloud-api");
 
         if (audioData.length > CLOUD_INLINE_LIMIT) {
-          const { text, responses, lastResponse } = await chunkedCloudTranscribe({
+          const { text, responses, lastResponse, warning } = await chunkedCloudTranscribe({
             buffer: audioData,
             apiUrl,
             authHeader,
@@ -3715,6 +3741,7 @@ class IPCHandlers {
           return {
             success: true,
             text,
+            ...(warning ? { warning } : {}),
             clientTranscriptionId,
             wordsUsed: lastResponse?.wordsUsed,
             wordsRemaining: lastResponse?.wordsRemaining,

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -146,6 +146,14 @@ export const useAudioRecording = (toast, options = {}) => {
           setTranscript(result.text);
           window.electronAPI?.completeDictationPreview?.({ text: result.text });
 
+          if (result.warning) {
+            toast({
+              title: t("hooks.audioRecording.partialTranscription.title"),
+              description: t("hooks.audioRecording.partialTranscription.description"),
+              variant: "default",
+            });
+          }
+
           const isStreaming = result.source?.includes("streaming");
           const { autoPasteEnabled, keepTranscriptionInClipboard } = getSettings();
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -542,6 +542,10 @@
         "title": "Kein Audio erkannt",
         "description": "Die Aufnahme enthielt kein erkennbares Audio. Bitte versuchen Sie es erneut."
       },
+      "partialTranscription": {
+        "title": "Unvollständige Transkription",
+        "description": "Ein Teil der Aufnahme konnte nicht transkribiert werden."
+      },
       "errorDescriptions": {
         "sessionExpired": "Deine OpenWhispr-Cloud-Sitzung ist nicht verfügbar. Bitte melde dich erneut über die Einstellungen an.",
         "offline": "Du bist offline. Die Cloud-Transkription benötigt eine Internetverbindung.",
@@ -2091,6 +2095,7 @@
       "transcribingProvider": "Wird über {{provider}} transkribiert...",
       "cancelTranscription": "Transkription abbrechen",
       "transcriptionComplete": "Transkription abgeschlossen",
+      "partialWarning": "Ein Teil der Audiodatei konnte nicht transkribiert werden.",
       "openNote": "Notiz öffnen",
       "uploadAnother": "Weitere hochladen",
       "retry": "Erneut versuchen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -542,6 +542,10 @@
         "title": "No Audio Detected",
         "description": "The recording contained no detectable audio. Please try again."
       },
+      "partialTranscription": {
+        "title": "Partial Transcription",
+        "description": "Part of the recording couldn't be transcribed."
+      },
       "errorDescriptions": {
         "sessionExpired": "Your OpenWhispr Cloud session is unavailable. Please sign in again from Settings.",
         "offline": "You're offline. Cloud transcription requires an internet connection.",
@@ -2290,6 +2294,7 @@
       "transcribingProvider": "Transcribing via {{provider}}...",
       "cancelTranscription": "Cancel transcription",
       "transcriptionComplete": "Transcription complete",
+      "partialWarning": "Part of the audio couldn't be transcribed.",
       "openNote": "Open Note",
       "uploadAnother": "Upload Another",
       "retry": "Retry",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -542,6 +542,10 @@
         "title": "No se detectó audio",
         "description": "La grabación no contiene audio detectable. Inténtalo de nuevo."
       },
+      "partialTranscription": {
+        "title": "Transcripción parcial",
+        "description": "No se pudo transcribir una parte de la grabación."
+      },
       "errorDescriptions": {
         "sessionExpired": "Tu sesión de OpenWhispr Cloud no está disponible. Vuelve a iniciar sesión desde Ajustes.",
         "offline": "Estás sin conexión. La transcripción en la nube requiere conexión a Internet.",
@@ -2139,6 +2143,7 @@
       "transcribingProvider": "Transcribiendo con {{provider}}...",
       "cancelTranscription": "Cancelar transcripción",
       "transcriptionComplete": "Transcripción completada",
+      "partialWarning": "No se pudo transcribir una parte del audio.",
       "openNote": "Abrir nota",
       "uploadAnother": "Subir otro",
       "retry": "Reintentar",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -542,6 +542,10 @@
         "title": "Aucun audio détecté",
         "description": "L'enregistrement ne contient pas d'audio détectable. Réessayez."
       },
+      "partialTranscription": {
+        "title": "Transcription partielle",
+        "description": "Une partie de l'enregistrement n'a pas pu être transcrite."
+      },
       "errorDescriptions": {
         "sessionExpired": "Votre session OpenWhispr Cloud est indisponible. Reconnectez-vous depuis Paramètres.",
         "offline": "Vous êtes hors ligne. La transcription cloud nécessite une connexion Internet.",
@@ -2202,6 +2206,7 @@
       "transcribingProvider": "Transcription via {{provider}}...",
       "cancelTranscription": "Annuler la transcription",
       "transcriptionComplete": "Transcription terminée",
+      "partialWarning": "Une partie de l'audio n'a pas pu être transcrite.",
       "openNote": "Ouvrir la note",
       "uploadAnother": "Téléverser un autre fichier",
       "retry": "Réessayer",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -542,6 +542,10 @@
         "title": "Nessun audio rilevato",
         "description": "La registrazione non contiene audio rilevabile. Riprova."
       },
+      "partialTranscription": {
+        "title": "Trascrizione parziale",
+        "description": "Non è stato possibile trascrivere una parte della registrazione."
+      },
       "errorDescriptions": {
         "sessionExpired": "La tua sessione OpenWhispr Cloud non è disponibile. Effettua di nuovo l'accesso dalle Impostazioni.",
         "offline": "Sei offline. La trascrizione cloud richiede una connessione Internet.",
@@ -2091,6 +2095,7 @@
       "transcribingProvider": "Trascrizione tramite {{provider}}...",
       "cancelTranscription": "Annulla trascrizione",
       "transcriptionComplete": "Trascrizione completata",
+      "partialWarning": "Non è stato possibile trascrivere una parte dell'audio.",
       "openNote": "Apri nota",
       "uploadAnother": "Carica un altro",
       "retry": "Riprova",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -542,6 +542,10 @@
         "title": "音声が検出されませんでした",
         "description": "録音に音声が含まれていませんでした。もう一度お試しください。"
       },
+      "partialTranscription": {
+        "title": "部分的な文字起こし",
+        "description": "録音の一部を文字起こしできませんでした。"
+      },
       "errorDescriptions": {
         "sessionExpired": "OpenWhispr Cloud のセッションが利用できません。「設定」から再度サインインしてください。",
         "offline": "オフラインです。クラウド文字起こしにはインターネット接続が必要です。",
@@ -2074,6 +2078,7 @@
       "transcribingProvider": "{{provider}} で文字起こし中...",
       "cancelTranscription": "文字起こしをキャンセル",
       "transcriptionComplete": "文字起こし完了",
+      "partialWarning": "音声の一部を文字起こしできませんでした。",
       "openNote": "ノートを開く",
       "uploadAnother": "別のファイルをアップロード",
       "retry": "再試行",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -521,6 +521,10 @@
         "title": "Nenhum áudio detectado",
         "description": "A gravação não contém áudio detectável. Tente novamente."
       },
+      "partialTranscription": {
+        "title": "Transcrição parcial",
+        "description": "Não foi possível transcrever parte da gravação."
+      },
       "errorDescriptions": {
         "sessionExpired": "Sua sessão do OpenWhispr Cloud está indisponível. Entre novamente nas Configurações.",
         "offline": "Você está offline. A transcrição na nuvem exige conexão com a internet.",
@@ -2091,6 +2095,7 @@
       "transcribingProvider": "Transcrevendo via {{provider}}...",
       "cancelTranscription": "Cancelar transcrição",
       "transcriptionComplete": "Transcrição concluída",
+      "partialWarning": "Não foi possível transcrever parte do áudio.",
       "openNote": "Abrir nota",
       "uploadAnother": "Enviar outro",
       "retry": "Tentar novamente",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -542,6 +542,10 @@
         "title": "Звук не обнаружен",
         "description": "В записи не обнаружен звук. Попробуйте ещё раз."
       },
+      "partialTranscription": {
+        "title": "Частичная транскрипция",
+        "description": "Не удалось транскрибировать часть записи."
+      },
       "errorDescriptions": {
         "sessionExpired": "Сессия OpenWhispr Cloud недоступна. Войдите снова из Настроек.",
         "offline": "Вы офлайн. Облачная транскрипция требует подключения к интернету.",
@@ -2091,6 +2095,7 @@
       "transcribingProvider": "Транскрибирование через {{provider}}...",
       "cancelTranscription": "Отменить транскрибирование",
       "transcriptionComplete": "Транскрибирование завершено",
+      "partialWarning": "Не удалось транскрибировать часть аудио.",
       "openNote": "Открыть заметку",
       "uploadAnother": "Загрузить ещё",
       "retry": "Повторить",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -542,6 +542,10 @@
         "title": "未检测到音频",
         "description": "录音中未检测到音频，请重试。"
       },
+      "partialTranscription": {
+        "title": "部分转录",
+        "description": "部分录音内容无法转录。"
+      },
       "errorDescriptions": {
         "sessionExpired": "OpenWhispr Cloud 会话不可用。请到「设置」中重新登录。",
         "offline": "你目前离线。云端转录需要互联网连接。",
@@ -2086,6 +2090,7 @@
       "transcribingProvider": "正在通过 {{provider}} 转录...",
       "cancelTranscription": "取消转录",
       "transcriptionComplete": "转录完成",
+      "partialWarning": "部分音频内容无法转录。",
       "openNote": "打开笔记",
       "uploadAnother": "上传另一个",
       "retry": "重试",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -542,6 +542,10 @@
         "title": "未偵測到音訊",
         "description": "錄音中未偵測到聲音。請再試一次。"
       },
+      "partialTranscription": {
+        "title": "部分轉錄",
+        "description": "部分錄音內容無法轉錄。"
+      },
       "errorDescriptions": {
         "sessionExpired": "OpenWhispr Cloud 工作階段無法使用。請至「設定」重新登入。",
         "offline": "你目前離線。雲端轉錄需要網際網路連線。",
@@ -2086,6 +2090,7 @@
       "transcribingProvider": "透過 {{provider}} 轉錄中...",
       "cancelTranscription": "取消轉錄",
       "transcriptionComplete": "轉錄完成",
+      "partialWarning": "部分音訊內容無法轉錄。",
       "openNote": "開啟筆記",
       "uploadAnother": "上傳另一個",
       "retry": "重試",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1144,6 +1144,7 @@ declare global {
       ) => Promise<{
         success: boolean;
         text?: string;
+        warning?: string;
         clientTranscriptionId?: string;
         wordsUsed?: number;
         wordsRemaining?: number;
@@ -1267,6 +1268,7 @@ declare global {
       transcribeAudioFileCloud?: (filePath: string) => Promise<{
         success: boolean;
         text?: string;
+        warning?: string;
         error?: string;
         code?: string;
       }>;


### PR DESCRIPTION
## Summary
Long OpenWhispr Cloud recordings (>4 MB, ~4 min) are split into ~4-minute chunks and uploaded in parallel. Three defects made long recordings fail or silently lose content:

1. **No retries** — a single transient failure (Vercel 504, 5xx, network blip) permanently dropped that chunk, leaving a hole in the transcript, or failed the whole job ("All chunks failed to transcribe").
2. **Unclassified platform errors** — Vercel platform rejections return non-JSON bodies, which surfaced as uncoded `Invalid JSON response` errors that couldn't be handled.
3. **Silent partial failures** — `chunkedCloudTranscribe` computes a `warning` when chunks fail, but the dictation path dropped it, so users got a transcript missing minutes with no indication.

## Changes
- Retry failed chunks up to 2 additional attempts with linear backoff + jitter; permanent errors (auth, word limit, no speech, 4xx) are never retried
- Classify non-JSON platform error bodies as `SERVER_ERROR` with the HTTP status attached; attach `statusCode` to generic API errors so retry classification can distinguish 4xx from 5xx
- Propagate `warning` through the `cloud-transcribe` IPC result and the streaming batch fallback
- Surface partial failures: toast on dictation, notice line on upload completion (keys added to all 10 locales)

## Testing
- `npm run typecheck`, `npm run lint`, `npm run i18n:check` all pass
- Prettier clean on all touched files

Pairs with OpenWhispr/openwhispr-api#109 (raises transcribe maxDuration 30s → 60s).