### PR TITLE
fix(transcription): scale local transcription timeouts with audio duration

### DIFF
--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -16,6 +16,7 @@ const {
   transcriptsLooselyOverlap,
   buildMergedCandidates,
 } = require("./transcriptText");
+const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
 
 const DIARIZATION_TIMEOUT_MS = 3600000; // 60 minutes
 const POST_MERGE_CONTEXT_WINDOW_MS = 6000;
@@ -318,6 +319,15 @@ class DiarizationManager {
       wavPath,
     });
 
+    // 16 kHz mono s16le WAV is 32000 bytes/s; scale with length but never below the 60-minute floor.
+    let timeoutMs = DIARIZATION_TIMEOUT_MS;
+    try {
+      timeoutMs = Math.max(
+        DIARIZATION_TIMEOUT_MS,
+        computeTranscriptionTimeoutMs(fs.statSync(wavPath).size / 32000)
+      );
+    } catch {}
+
     return new Promise((resolve) => {
       let stdout = "";
       let stderr = "";
@@ -341,10 +351,10 @@ class DiarizationManager {
       };
 
       const timeout = setTimeout(() => {
-        debugLogger.warn("Diarization timed out", { timeoutMs: DIARIZATION_TIMEOUT_MS });
+        debugLogger.warn("Diarization timed out", { timeoutMs });
         gracefulStopProcess(proc);
         resolve([]);
-      }, DIARIZATION_TIMEOUT_MS);
+      }, timeoutMs);
 
       proc.stdout.on("data", (data) => {
         stdout += data.toString();

--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -16,7 +16,10 @@ const {
   transcriptsLooselyOverlap,
   buildMergedCandidates,
 } = require("./transcriptText");
-const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
+const {
+  computeTranscriptionTimeoutMs,
+  PCM16_MONO_16K_BYTES_PER_SECOND,
+} = require("./transcriptionTimeout");
 
 const DIARIZATION_TIMEOUT_MS = 3600000; // 60 minutes
 const POST_MERGE_CONTEXT_WINDOW_MS = 6000;
@@ -319,14 +322,16 @@ class DiarizationManager {
       wavPath,
     });
 
-    // 16 kHz mono s16le WAV is 32000 bytes/s; scale with length but never below the 60-minute floor.
+    // Scale with the recording length, but never below the 60-minute floor.
     let timeoutMs = DIARIZATION_TIMEOUT_MS;
     try {
       timeoutMs = Math.max(
         DIARIZATION_TIMEOUT_MS,
-        computeTranscriptionTimeoutMs(fs.statSync(wavPath).size / 32000)
+        computeTranscriptionTimeoutMs(fs.statSync(wavPath).size / PCM16_MONO_16K_BYTES_PER_SECOND)
       );
-    } catch {}
+    } catch {
+      // Unreadable WAV: keep the flat cap.
+    }
 
     return new Promise((resolve) => {
       let stdout = "";

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -8,6 +8,7 @@ const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
+const { UNKNOWN_DURATION_TIMEOUT_MS } = require("./transcriptionTimeout");
 
 // Range kept clear of cliBridge (8200-8219) to avoid port-bind collisions.
 const PORT_RANGE_START = 8221;
@@ -471,7 +472,8 @@ class LlamaServerManager {
             "Content-Type": "application/json",
             "Content-Length": Buffer.byteLength(body),
           },
-          timeout: 300000,
+          // No audio duration to scale on here; use the flat cap.
+          timeout: UNKNOWN_DURATION_TIMEOUT_MS,
         },
         (res) => {
           let data = "";

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -8,7 +8,6 @@ const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
-const { UNKNOWN_DURATION_TIMEOUT_MS } = require("./transcriptionTimeout");
 
 // Range kept clear of cliBridge (8200-8219) to avoid port-bind collisions.
 const PORT_RANGE_START = 8221;
@@ -472,8 +471,7 @@ class LlamaServerManager {
             "Content-Type": "application/json",
             "Content-Length": Buffer.byteLength(body),
           },
-          // No audio duration to scale on here; use the flat cap.
-          timeout: UNKNOWN_DURATION_TIMEOUT_MS,
+          timeout: 300000,
         },
         (res) => {
           let data = "";

--- a/src/helpers/parakeetWsServer.js
+++ b/src/helpers/parakeetWsServer.js
@@ -13,6 +13,7 @@ const { getSafeTempDir } = require("./safeTempDir");
 const sidecarPidFile = require("./sidecarPidFile");
 const { parseOfflineMessage, createOnlineAccumulator } = require("./parakeetWsResult");
 const { pcm16ToFloat32 } = require("../utils/audioUtils");
+const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
 
 const PORT_RANGE_START = 6006;
 const PORT_RANGE_END = 6029;
@@ -260,6 +261,11 @@ class ParakeetWsServer {
   }
 
   _transcribeOffline(samplesBuffer, sampleRate) {
+    // float32 samples: 4 bytes each; scale the timeout with audio length.
+    const timeoutMs = computeTranscriptionTimeoutMs(
+      sampleRate > 0 ? samplesBuffer.length / 4 / sampleRate : NaN
+    );
+
     return new Promise((resolve, reject) => {
       const startTime = Date.now();
       let result = "";
@@ -269,7 +275,7 @@ class ParakeetWsServer {
           ws.close();
         } catch {}
         reject(new Error("parakeet-ws transcription timed out"));
-      }, TRANSCRIPTION_TIMEOUT_MS);
+      }, timeoutMs);
 
       const ws = new WebSocket(`ws://127.0.0.1:${this.port}`);
 

--- a/src/helpers/parakeetWsServer.js
+++ b/src/helpers/parakeetWsServer.js
@@ -13,15 +13,20 @@ const { getSafeTempDir } = require("./safeTempDir");
 const sidecarPidFile = require("./sidecarPidFile");
 const { parseOfflineMessage, createOnlineAccumulator } = require("./parakeetWsResult");
 const { pcm16ToFloat32 } = require("../utils/audioUtils");
-const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
+const {
+  computeTranscriptionTimeoutMs,
+  TRANSCRIPTION_TIMEOUT_FLOOR_MS,
+} = require("./transcriptionTimeout");
 
 const PORT_RANGE_START = 6006;
 const PORT_RANGE_END = 6029;
 const STARTUP_TIMEOUT_MS = 60000;
 const HEALTH_CHECK_INTERVAL_MS = 5000;
-const TRANSCRIPTION_TIMEOUT_MS = 300000;
-const ONLINE_CHUNK_BYTES = 8000 * 4;
-const FLOAT32_BYTES_PER_SECOND = 16000 * 4;
+const FLOAT32_BYTES_PER_SAMPLE = 4;
+const ONLINE_CHUNK_BYTES = 8000 * FLOAT32_BYTES_PER_SAMPLE;
+const FLOAT32_BYTES_PER_SECOND = 16000 * FLOAT32_BYTES_PER_SAMPLE;
+// Streaming decodes as the audio drains, so its hard cap is tighter than the offline budget.
+const ONLINE_TIMEOUT_PER_AUDIO_SECOND_MS = 2000;
 // After "Done" is sent, give up only after this long without any result message.
 const ONLINE_FINISH_IDLE_TIMEOUT_MS = 10000;
 // Must cover the model's 560ms chunk so the flush decodes the final words.
@@ -261,9 +266,8 @@ class ParakeetWsServer {
   }
 
   _transcribeOffline(samplesBuffer, sampleRate) {
-    // float32 samples: 4 bytes each; scale the timeout with audio length.
     const timeoutMs = computeTranscriptionTimeoutMs(
-      sampleRate > 0 ? samplesBuffer.length / 4 / sampleRate : NaN
+      samplesBuffer.length / FLOAT32_BYTES_PER_SAMPLE / sampleRate
     );
 
     return new Promise((resolve, reject) => {
@@ -359,7 +363,7 @@ class ParakeetWsServer {
         timedOut = true;
         stream.abort();
       },
-      Math.max(TRANSCRIPTION_TIMEOUT_MS, audioSeconds * 2000)
+      Math.max(TRANSCRIPTION_TIMEOUT_FLOOR_MS, audioSeconds * ONLINE_TIMEOUT_PER_AUDIO_SECOND_MS)
     );
     try {
       const idleTimeoutMs = Math.max(ONLINE_FINISH_IDLE_TIMEOUT_MS, audioSeconds * 500);

--- a/src/helpers/transcriptionTimeout.js
+++ b/src/helpers/transcriptionTimeout.js
@@ -1,0 +1,29 @@
+// Floor keeps short dictations on the same 5-minute budget as before.
+const TRANSCRIPTION_TIMEOUT_FLOOR_MS = 300000;
+// 10x real-time budget covers big models on slow CPUs.
+const TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS = 10000;
+// Flat 60-minute cap when duration is unknown; a hung server must still fail.
+const UNKNOWN_DURATION_TIMEOUT_MS = 3600000;
+// 24-hour ceiling keeps the scaled value well under the 32-bit setTimeout limit.
+const TRANSCRIPTION_TIMEOUT_CEILING_MS = 86400000;
+
+function computeTranscriptionTimeoutMs(estimatedDurationSeconds) {
+  if (!Number.isFinite(estimatedDurationSeconds) || estimatedDurationSeconds <= 0) {
+    return UNKNOWN_DURATION_TIMEOUT_MS;
+  }
+  return Math.min(
+    TRANSCRIPTION_TIMEOUT_CEILING_MS,
+    Math.max(
+      TRANSCRIPTION_TIMEOUT_FLOOR_MS,
+      Math.ceil(estimatedDurationSeconds * TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS)
+    )
+  );
+}
+
+module.exports = {
+  TRANSCRIPTION_TIMEOUT_FLOOR_MS,
+  TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS,
+  UNKNOWN_DURATION_TIMEOUT_MS,
+  TRANSCRIPTION_TIMEOUT_CEILING_MS,
+  computeTranscriptionTimeoutMs,
+};

--- a/src/helpers/transcriptionTimeout.js
+++ b/src/helpers/transcriptionTimeout.js
@@ -6,6 +6,8 @@ const TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS = 10000;
 const UNKNOWN_DURATION_TIMEOUT_MS = 3600000;
 // 24-hour ceiling keeps the scaled value well under the 32-bit setTimeout limit.
 const TRANSCRIPTION_TIMEOUT_CEILING_MS = 86400000;
+// Every local engine is fed 16 kHz mono s16le, so byte length is a duration estimate.
+const PCM16_MONO_16K_BYTES_PER_SECOND = 16000 * 2;
 
 function computeTranscriptionTimeoutMs(estimatedDurationSeconds) {
   if (!Number.isFinite(estimatedDurationSeconds) || estimatedDurationSeconds <= 0) {
@@ -25,5 +27,6 @@ module.exports = {
   TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS,
   UNKNOWN_DURATION_TIMEOUT_MS,
   TRANSCRIPTION_TIMEOUT_CEILING_MS,
+  PCM16_MONO_16K_BYTES_PER_SECOND,
   computeTranscriptionTimeoutMs,
 };

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -12,6 +12,7 @@ const { getSafeTempDir } = require("./safeTempDir");
 const { convertToWav } = require("./ffmpegUtils");
 const sidecarPidFile = require("./sidecarPidFile");
 const { sanitizeWhisperVadConfig, DEFAULT_WHISPER_VAD_CONFIG } = require("./whisperVadConfig");
+const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
 
 const PORT_RANGE_START = 8178;
 const PORT_RANGE_END = 8199;
@@ -778,6 +779,9 @@ class WhisperServerManager extends EventEmitter {
   }
 
   _postInference(body, boundary) {
+    // body is the WAV plus a little multipart boilerplate; 16 kHz mono s16le is 32000 bytes/s, so this tracks audio length.
+    const timeoutMs = computeTranscriptionTimeoutMs(body.length / 32000);
+
     return new Promise((resolve, reject) => {
       const startTime = Date.now();
 
@@ -791,7 +795,7 @@ class WhisperServerManager extends EventEmitter {
             "Content-Type": `multipart/form-data; boundary=${boundary}`,
             "Content-Length": body.length,
           },
-          timeout: 300000,
+          timeout: timeoutMs,
         },
         (res) => {
           let data = "";

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -12,7 +12,10 @@ const { getSafeTempDir } = require("./safeTempDir");
 const { convertToWav } = require("./ffmpegUtils");
 const sidecarPidFile = require("./sidecarPidFile");
 const { sanitizeWhisperVadConfig, DEFAULT_WHISPER_VAD_CONFIG } = require("./whisperVadConfig");
-const { computeTranscriptionTimeoutMs } = require("./transcriptionTimeout");
+const {
+  computeTranscriptionTimeoutMs,
+  PCM16_MONO_16K_BYTES_PER_SECOND,
+} = require("./transcriptionTimeout");
 
 const PORT_RANGE_START = 8178;
 const PORT_RANGE_END = 8199;
@@ -779,8 +782,8 @@ class WhisperServerManager extends EventEmitter {
   }
 
   _postInference(body, boundary) {
-    // body is the WAV plus a little multipart boilerplate; 16 kHz mono s16le is 32000 bytes/s, so this tracks audio length.
-    const timeoutMs = computeTranscriptionTimeoutMs(body.length / 32000);
+    // Multipart boilerplate adds under a kilobyte, so body length tracks audio length.
+    const timeoutMs = computeTranscriptionTimeoutMs(body.length / PCM16_MONO_16K_BYTES_PER_SECOND);
 
     return new Promise((resolve, reject) => {
       const startTime = Date.now();

--- a/test/helpers/transcriptionTimeout.test.js
+++ b/test/helpers/transcriptionTimeout.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  TRANSCRIPTION_TIMEOUT_FLOOR_MS,
+  TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS,
+  UNKNOWN_DURATION_TIMEOUT_MS,
+  TRANSCRIPTION_TIMEOUT_CEILING_MS,
+  computeTranscriptionTimeoutMs,
+} = require("../../src/helpers/transcriptionTimeout");
+
+test("long audio scales past the old 5-minute limit", () => {
+  const timeoutMs = computeTranscriptionTimeoutMs(3600);
+  assert.ok(timeoutMs > 300000);
+  assert.equal(timeoutMs, Math.ceil(3600 * TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS));
+});
+
+test("short audio keeps the exact 5-minute floor", () => {
+  assert.equal(computeTranscriptionTimeoutMs(30), TRANSCRIPTION_TIMEOUT_FLOOR_MS);
+  assert.equal(computeTranscriptionTimeoutMs(0.5), TRANSCRIPTION_TIMEOUT_FLOOR_MS);
+  assert.equal(TRANSCRIPTION_TIMEOUT_FLOOR_MS, 300000);
+});
+
+test("audio just past the floor breakpoint scales by the formula", () => {
+  assert.equal(computeTranscriptionTimeoutMs(30.1), Math.ceil(30.1 * 10000));
+});
+
+test("absurd durations are clamped under the 32-bit setTimeout limit", () => {
+  assert.equal(computeTranscriptionTimeoutMs(1e9), TRANSCRIPTION_TIMEOUT_CEILING_MS);
+  assert.ok(TRANSCRIPTION_TIMEOUT_CEILING_MS <= 2147483647);
+});
+
+test("unknown or invalid durations fall back to the flat cap", () => {
+  assert.equal(computeTranscriptionTimeoutMs(undefined), UNKNOWN_DURATION_TIMEOUT_MS);
+  assert.equal(computeTranscriptionTimeoutMs(NaN), UNKNOWN_DURATION_TIMEOUT_MS);
+  assert.equal(computeTranscriptionTimeoutMs(0), UNKNOWN_DURATION_TIMEOUT_MS);
+  assert.equal(computeTranscriptionTimeoutMs(-5), UNKNOWN_DURATION_TIMEOUT_MS);
+  assert.equal(computeTranscriptionTimeoutMs(Infinity), UNKNOWN_DURATION_TIMEOUT_MS);
+});
+
+test("result is always a finite number", () => {
+  for (const input of [undefined, NaN, 0, -1, 0.5, 30, 3600, 1e9, Infinity]) {
+    const timeoutMs = computeTranscriptionTimeoutMs(input);
+    assert.equal(typeof timeoutMs, "number");
+    assert.ok(Number.isFinite(timeoutMs));
+  }
+});

--- a/test/helpers/transcriptionTimeout.test.js
+++ b/test/helpers/transcriptionTimeout.test.js
@@ -6,12 +6,13 @@ const {
   TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS,
   UNKNOWN_DURATION_TIMEOUT_MS,
   TRANSCRIPTION_TIMEOUT_CEILING_MS,
+  PCM16_MONO_16K_BYTES_PER_SECOND,
   computeTranscriptionTimeoutMs,
 } = require("../../src/helpers/transcriptionTimeout");
 
 test("long audio scales past the old 5-minute limit", () => {
   const timeoutMs = computeTranscriptionTimeoutMs(3600);
-  assert.ok(timeoutMs > 300000);
+  assert.ok(timeoutMs > TRANSCRIPTION_TIMEOUT_FLOOR_MS);
   assert.equal(timeoutMs, Math.ceil(3600 * TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS));
 });
 
@@ -22,7 +23,18 @@ test("short audio keeps the exact 5-minute floor", () => {
 });
 
 test("audio just past the floor breakpoint scales by the formula", () => {
-  assert.equal(computeTranscriptionTimeoutMs(30.1), Math.ceil(30.1 * 10000));
+  assert.equal(
+    computeTranscriptionTimeoutMs(30.1),
+    Math.ceil(30.1 * TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS)
+  );
+});
+
+test("WAV byte length converts to the right duration", () => {
+  const tenMinutesOf16kMonoS16le = 600 * 32000;
+  assert.equal(
+    computeTranscriptionTimeoutMs(tenMinutesOf16kMonoS16le / PCM16_MONO_16K_BYTES_PER_SECOND),
+    600 * TRANSCRIPTION_TIMEOUT_PER_AUDIO_SECOND_MS
+  );
 });
 
 test("absurd durations are clamped under the 32-bit setTimeout limit", () => {


### PR DESCRIPTION
## Summary

Local transcription dies after exactly 5 minutes on long recordings: the local single-request paths hardcode a 300000 ms request timeout (`whisperServer.js` POST /inference, `parakeetWsServer.js` transcribe, llama post-processing, diarization), and the wall is on inference time, so a long file on a slow CPU with a big model gets killed mid-transcription. The new `src/helpers/transcriptionTimeout.js` scales the timeout with the estimated audio duration (max(300000, seconds \* 10000), with a 24-hour ceiling to stay under the 32-bit setTimeout limit) and uses a flat 60-minute cap where duration is not cheaply available, so short dictations keep exactly today's behavior and a genuinely hung server still fails eventually.

Fixes OpenWhispr/openwhispr#976

## Changes

* src/helpers/transcriptionTimeout.js: new shared module with the floor, per-second, flat-cap and ceiling constants plus computeTranscriptionTimeoutMs()
* src/helpers/whisperServer.js: /inference request timeout scales with the converted WAV buffer duration
* src/helpers/parakeetWsServer.js: per-call timeout computed from the sample buffer instead of the flat 5-minute constant
* src/helpers/llamaServer.js: post-processing timeout uses the 60-minute flat cap since no audio duration exists there
* src/helpers/diarization.js: per-run timeout derived from the WAV file size, falling back to the flat cap
* test/helpers/transcriptionTimeout.test.js: floor, scaling, ceiling and invalid-input coverage