### PR TITLE
Fix(tinfoil): Make the model list dynamic

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -381,6 +381,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   proxyCortiTranscription: (data) => ipcRenderer.invoke("proxy-corti-transcription", data),
   getTinfoilKey: () => ipcRenderer.invoke("get-tinfoil-key"),
   saveTinfoilKey: (key) => ipcRenderer.invoke("save-tinfoil-key", key),
+  getTinfoilChatModels: () => ipcRenderer.invoke("get-tinfoil-chat-models"),
 
   // Custom endpoint API keys
   getCustomTranscriptionKey: () => ipcRenderer.invoke("get-custom-transcription-key"),

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -442,6 +442,21 @@ export default function ReasoningModelSelector({
     loadDownloadedModels();
   }, [loadDownloadedModels]);
 
+  const selectDefaultModelForProvider = (provider: string) => {
+    if (provider === "custom") return;
+
+    if (provider === "tinfoil") {
+      const defaultModel = pickDefaultTinfoilModel(tinfoilModels);
+      if (defaultModel) setReasoningModel(defaultModel.id);
+      return;
+    }
+
+    const providerData = REASONING_PROVIDERS[provider as keyof typeof REASONING_PROVIDERS];
+    if (providerData?.models?.length > 0) {
+      setReasoningModel(providerData.models[0].value);
+    }
+  };
+
   const handleModeChange = async (newMode: "cloud" | "local") => {
     setSelectedMode(newMode);
     setReasoningModeProp?.(newMode === "local" ? "local" : "providers");
@@ -449,20 +464,7 @@ export default function ReasoningModelSelector({
     if (newMode === "cloud") {
       window.electronAPI?.llamaServerStop?.();
       setLocalReasoningProvider(selectedCloudProvider);
-
-      if (selectedCloudProvider === "custom") return;
-
-      if (selectedCloudProvider === "tinfoil") {
-        const defaultModel = pickDefaultTinfoilModel(tinfoilModels);
-        if (defaultModel) setReasoningModel(defaultModel.id);
-        return;
-      }
-
-      const provider =
-        REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
-      if (provider?.models?.length > 0) {
-        setReasoningModel(provider.models[0].value);
-      }
+      selectDefaultModelForProvider(selectedCloudProvider);
     } else {
       setLocalReasoningProvider(selectedLocalProvider);
       const downloaded = await loadDownloadedModels();
@@ -482,21 +484,7 @@ export default function ReasoningModelSelector({
   const handleCloudProviderChange = (provider: string) => {
     setSelectedCloudProvider(provider);
     setLocalReasoningProvider(provider);
-
-    if (provider === "custom") return;
-
-    // Tinfoil's list order isn't a preference, and the refresh may not have
-    // landed yet, so don't let either decide which model the user starts on.
-    if (provider === "tinfoil") {
-      const defaultModel = pickDefaultTinfoilModel(tinfoilModels);
-      if (defaultModel) setReasoningModel(defaultModel.id);
-      return;
-    }
-
-    const providerData = REASONING_PROVIDERS[provider as keyof typeof REASONING_PROVIDERS];
-    if (providerData?.models?.length > 0) {
-      setReasoningModel(providerData.models[0].value);
-    }
+    selectDefaultModelForProvider(provider);
   };
 
   const handleLocalProviderChange = async (providerId: string) => {
@@ -697,8 +685,6 @@ export default function ReasoningModelSelector({
                     selectedModel={reasoningModel}
                     onModelSelect={setReasoningModel}
                   />
-                  {/* The known list renders straight away; a refresh, when one
-                      is due, reports itself underneath and swaps the list in. */}
                   {selectedCloudProvider === "tinfoil" && (
                     <>
                       {tinfoilModelsLoading && (

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -692,11 +692,18 @@ export default function ReasoningModelSelector({
                   <h4 className="text-sm font-medium text-foreground">
                     {t("reasoning.selectModel")}
                   </h4>
+                  <ModelCardList
+                    models={selectedCloudModels}
+                    selectedModel={reasoningModel}
+                    onModelSelect={setReasoningModel}
+                  />
+                  {/* The known list renders straight away; a refresh, when one
+                      is due, reports itself underneath and swaps the list in. */}
                   {selectedCloudProvider === "tinfoil" && (
                     <>
                       {tinfoilModelsLoading && (
-                        <p className="text-xs text-primary">
-                          {t("reasoning.custom.fetchingModels")}
+                        <p className="text-xs text-muted-foreground">
+                          {t("reasoning.tinfoil.refreshingModels")}
                         </p>
                       )}
                       {!tinfoilModelsLoading && tinfoilModelsError && (
@@ -706,11 +713,6 @@ export default function ReasoningModelSelector({
                       )}
                     </>
                   )}
-                  <ModelCardList
-                    models={selectedCloudModels}
-                    selectedModel={reasoningModel}
-                    onModelSelect={setReasoningModel}
-                  />
                 </div>
               </>
             )}

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -379,7 +379,6 @@ export default function ReasoningModelSelector({
     const iconUrl = getProviderIcon(selectedCloudProvider);
     const invertInDark = isMonochromeProvider(selectedCloudProvider);
 
-    // Tinfoil's list is dynamic. Redraw when it changes
     const models =
       selectedCloudProvider === "tinfoil"
         ? tinfoilModels.map(toReasoningModel)

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -18,6 +18,7 @@ import { API_ENDPOINTS } from "../config/constants";
 import logger from "../utils/logger";
 import { REASONING_PROVIDERS } from "../models/ModelRegistry";
 import { useTinfoilModels } from "../hooks/useTinfoilModels";
+import { pickDefaultTinfoilModel } from "../models/tinfoilModels";
 import { modelRegistry } from "../models/ModelRegistry";
 import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { createExternalLinkHandler } from "../utils/externalLinks";
@@ -330,7 +331,7 @@ export default function ReasoningModelSelector({
     models: tinfoilModels,
     loading: tinfoilModelsLoading,
     error: tinfoilModelsError,
-  } = useTinfoilModels();
+  } = useTinfoilModels(selectedCloudProvider === "tinfoil");
 
   const effectiveMode = mode || selectedMode;
 
@@ -451,6 +452,12 @@ export default function ReasoningModelSelector({
 
       if (selectedCloudProvider === "custom") return;
 
+      if (selectedCloudProvider === "tinfoil") {
+        const defaultModel = pickDefaultTinfoilModel(tinfoilModels);
+        if (defaultModel) setReasoningModel(defaultModel.id);
+        return;
+      }
+
       const provider =
         REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
       if (provider?.models?.length > 0) {
@@ -477,6 +484,14 @@ export default function ReasoningModelSelector({
     setLocalReasoningProvider(provider);
 
     if (provider === "custom") return;
+
+    // Tinfoil's list order isn't a preference, and the refresh may not have
+    // landed yet, so don't let either decide which model the user starts on.
+    if (provider === "tinfoil") {
+      const defaultModel = pickDefaultTinfoilModel(tinfoilModels);
+      if (defaultModel) setReasoningModel(defaultModel.id);
+      return;
+    }
 
     const providerData = REASONING_PROVIDERS[provider as keyof typeof REASONING_PROVIDERS];
     if (providerData?.models?.length > 0) {
@@ -679,7 +694,7 @@ export default function ReasoningModelSelector({
                   </h4>
                   {selectedCloudProvider === "tinfoil" && (
                     <>
-                      {tinfoilModelsLoading && selectedCloudModels.length === 0 && (
+                      {tinfoilModelsLoading && (
                         <p className="text-xs text-primary">
                           {t("reasoning.custom.fetchingModels")}
                         </p>

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -17,6 +17,7 @@ import OpenAICompatiblePanel from "./OpenAICompatiblePanel";
 import { API_ENDPOINTS } from "../config/constants";
 import logger from "../utils/logger";
 import { REASONING_PROVIDERS } from "../models/ModelRegistry";
+import { useTinfoilModels } from "../hooks/useTinfoilModels";
 import { modelRegistry } from "../models/ModelRegistry";
 import { getProviderIcon, isMonochromeProvider } from "../utils/providerIcons";
 import { createExternalLinkHandler } from "../utils/externalLinks";
@@ -325,6 +326,11 @@ export default function ReasoningModelSelector({
   const [selectedMode, setSelectedMode] = useState<"cloud" | "local">(mode || "cloud");
   const [selectedCloudProvider, setSelectedCloudProvider] = useState("openai");
   const [selectedLocalProvider, setSelectedLocalProvider] = useState("qwen");
+  const {
+    models: tinfoilModels,
+    loading: tinfoilModelsLoading,
+    error: tinfoilModelsError,
+  } = useTinfoilModels();
 
   const effectiveMode = mode || selectedMode;
 
@@ -369,11 +375,26 @@ export default function ReasoningModelSelector({
     if (selectedCloudProvider === "openai") return openaiModelOptions;
     if (selectedCloudProvider === "custom") return [];
 
+    const iconUrl = getProviderIcon(selectedCloudProvider);
+    const invertInDark = isMonochromeProvider(selectedCloudProvider);
+
+    // Tinfoil's list is fetched at runtime, so read it from the hook rather
+    // than the registry snapshot taken at module load.
+    if (selectedCloudProvider === "tinfoil") {
+      return tinfoilModels.map((model) => ({
+        value: model.id,
+        label: model.name,
+        description: model.descriptionKey
+          ? t(model.descriptionKey, { defaultValue: model.description })
+          : model.description,
+        icon: iconUrl,
+        invertInDark,
+      }));
+    }
+
     const provider = REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
     if (!provider?.models) return [];
 
-    const iconUrl = getProviderIcon(selectedCloudProvider);
-    const invertInDark = isMonochromeProvider(selectedCloudProvider);
     return provider.models.map((model) => ({
       ...model,
       description: model.descriptionKey
@@ -382,7 +403,7 @@ export default function ReasoningModelSelector({
       icon: iconUrl,
       invertInDark,
     }));
-  }, [selectedCloudProvider, openaiModelOptions, t]);
+  }, [selectedCloudProvider, openaiModelOptions, tinfoilModels, t]);
 
   useEffect(() => {
     const localProviderIds = localProviders.map((p) => p.id);
@@ -394,6 +415,15 @@ export default function ReasoningModelSelector({
       setSelectedCloudProvider(localReasoningProvider);
     }
   }, [localProviders, localReasoningProvider]);
+
+  // The fetched list may not contain the saved model (first run, or Tinfoil
+  // retired it), so fall back to the first available one.
+  useEffect(() => {
+    if (selectedCloudProvider !== "tinfoil") return;
+    if (tinfoilModels.length === 0) return;
+    if (tinfoilModels.some((model) => model.id === reasoningModel)) return;
+    setReasoningModel(tinfoilModels[0].id);
+  }, [selectedCloudProvider, tinfoilModels, reasoningModel, setReasoningModel]);
 
   const [downloadedModels, setDownloadedModels] = useState<Set<string>>(new Set());
 
@@ -655,6 +685,20 @@ export default function ReasoningModelSelector({
                   <h4 className="text-sm font-medium text-foreground">
                     {t("reasoning.selectModel")}
                   </h4>
+                  {selectedCloudProvider === "tinfoil" && selectedCloudModels.length === 0 && (
+                    <>
+                      {tinfoilModelsLoading && (
+                        <p className="text-xs text-primary">
+                          {t("reasoning.custom.fetchingModels")}
+                        </p>
+                      )}
+                      {!tinfoilModelsLoading && tinfoilModelsError && (
+                        <p className="text-xs text-destructive">
+                          {t("reasoning.custom.unableToLoadModels")}
+                        </p>
+                      )}
+                    </>
+                  )}
                   <ModelCardList
                     models={selectedCloudModels}
                     selectedModel={reasoningModel}

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -16,7 +16,7 @@ import { ProviderTabs } from "./ui/ProviderTabs";
 import OpenAICompatiblePanel from "./OpenAICompatiblePanel";
 import { API_ENDPOINTS } from "../config/constants";
 import logger from "../utils/logger";
-import { REASONING_PROVIDERS } from "../models/ModelRegistry";
+import { REASONING_PROVIDERS, toReasoningModel } from "../models/ModelRegistry";
 import { useTinfoilModels } from "../hooks/useTinfoilModels";
 import { pickDefaultTinfoilModel } from "../models/tinfoilModels";
 import { modelRegistry } from "../models/ModelRegistry";
@@ -379,25 +379,15 @@ export default function ReasoningModelSelector({
     const iconUrl = getProviderIcon(selectedCloudProvider);
     const invertInDark = isMonochromeProvider(selectedCloudProvider);
 
-    // The registry is still the source of truth; refreshTinfoilModels writes
-    // this same list into it. The hook hands it back so React re-renders when
-    // it changes, which mutating the registry alone wouldn't do.
-    if (selectedCloudProvider === "tinfoil") {
-      return tinfoilModels.map((model) => ({
-        value: model.id,
-        label: model.name,
-        description: model.descriptionKey
-          ? t(model.descriptionKey, { defaultValue: model.description })
-          : model.description,
-        icon: iconUrl,
-        invertInDark,
-      }));
-    }
+    // Tinfoil's list is dynamic. Redraw when it changes
+    const models =
+      selectedCloudProvider === "tinfoil"
+        ? tinfoilModels.map(toReasoningModel)
+        : REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS]?.models;
 
-    const provider = REASONING_PROVIDERS[selectedCloudProvider as keyof typeof REASONING_PROVIDERS];
-    if (!provider?.models) return [];
+    if (!models) return [];
 
-    return provider.models.map((model) => ({
+    return models.map((model) => ({
       ...model,
       description: model.descriptionKey
         ? t(model.descriptionKey, { defaultValue: model.description })

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -330,6 +330,7 @@ export default function ReasoningModelSelector({
     models: tinfoilModels,
     loading: tinfoilModelsLoading,
     error: tinfoilModelsError,
+    fetched: tinfoilModelsFetched,
   } = useTinfoilModels();
 
   const effectiveMode = mode || selectedMode;
@@ -416,14 +417,21 @@ export default function ReasoningModelSelector({
     }
   }, [localProviders, localReasoningProvider]);
 
-  // The fetched list may not contain the saved model (first run, or Tinfoil
-  // retired it), so fall back to the first available one.
+  // Tinfoil may have retired the saved model, so move to one it still serves.
+  // Only once it has actually answered — offline, a model missing from the
+  // bundled list is unknown, not gone, and switching away would lose it.
   useEffect(() => {
     if (selectedCloudProvider !== "tinfoil") return;
-    if (tinfoilModels.length === 0) return;
+    if (!tinfoilModelsFetched) return;
     if (tinfoilModels.some((model) => model.id === reasoningModel)) return;
     setReasoningModel(tinfoilModels[0].id);
-  }, [selectedCloudProvider, tinfoilModels, reasoningModel, setReasoningModel]);
+  }, [
+    selectedCloudProvider,
+    tinfoilModels,
+    tinfoilModelsFetched,
+    reasoningModel,
+    setReasoningModel,
+  ]);
 
   const [downloadedModels, setDownloadedModels] = useState<Set<string>>(new Set());
 
@@ -685,9 +693,9 @@ export default function ReasoningModelSelector({
                   <h4 className="text-sm font-medium text-foreground">
                     {t("reasoning.selectModel")}
                   </h4>
-                  {selectedCloudProvider === "tinfoil" && selectedCloudModels.length === 0 && (
+                  {selectedCloudProvider === "tinfoil" && (
                     <>
-                      {tinfoilModelsLoading && (
+                      {tinfoilModelsLoading && selectedCloudModels.length === 0 && (
                         <p className="text-xs text-primary">
                           {t("reasoning.custom.fetchingModels")}
                         </p>

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -330,7 +330,6 @@ export default function ReasoningModelSelector({
     models: tinfoilModels,
     loading: tinfoilModelsLoading,
     error: tinfoilModelsError,
-    fetched: tinfoilModelsFetched,
   } = useTinfoilModels();
 
   const effectiveMode = mode || selectedMode;
@@ -417,22 +416,6 @@ export default function ReasoningModelSelector({
       setSelectedCloudProvider(localReasoningProvider);
     }
   }, [localProviders, localReasoningProvider]);
-
-  // Tinfoil may have retired the saved model, so move to one it still serves.
-  // Only once it has actually answered — an unreachable endpoint says nothing
-  // about which models exist, and switching away would lose the user's choice.
-  useEffect(() => {
-    if (selectedCloudProvider !== "tinfoil") return;
-    if (!tinfoilModelsFetched) return;
-    if (tinfoilModels.some((model) => model.id === reasoningModel)) return;
-    setReasoningModel(tinfoilModels[0].id);
-  }, [
-    selectedCloudProvider,
-    tinfoilModels,
-    tinfoilModelsFetched,
-    reasoningModel,
-    setReasoningModel,
-  ]);
 
   const [downloadedModels, setDownloadedModels] = useState<Set<string>>(new Set());
 

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -379,8 +379,9 @@ export default function ReasoningModelSelector({
     const iconUrl = getProviderIcon(selectedCloudProvider);
     const invertInDark = isMonochromeProvider(selectedCloudProvider);
 
-    // Tinfoil's list is fetched at runtime, so read it from the hook rather
-    // than the registry snapshot taken at module load.
+    // The registry is still the source of truth; refreshTinfoilModels writes
+    // this same list into it. The hook hands it back so React re-renders when
+    // it changes, which mutating the registry alone wouldn't do.
     if (selectedCloudProvider === "tinfoil") {
       return tinfoilModels.map((model) => ({
         value: model.id,
@@ -418,8 +419,8 @@ export default function ReasoningModelSelector({
   }, [localProviders, localReasoningProvider]);
 
   // Tinfoil may have retired the saved model, so move to one it still serves.
-  // Only once it has actually answered — offline, a model missing from the
-  // bundled list is unknown, not gone, and switching away would lose it.
+  // Only once it has actually answered — an unreachable endpoint says nothing
+  // about which models exist, and switching away would lose the user's choice.
   useEffect(() => {
     if (selectedCloudProvider !== "tinfoil") return;
     if (!tinfoilModelsFetched) return;

--- a/src/components/TinfoilModelSwitchToastListener.tsx
+++ b/src/components/TinfoilModelSwitchToastListener.tsx
@@ -7,9 +7,7 @@ import {
 } from "../stores/tinfoilModelSwitchStore";
 
 /**
- * Headless. Tinfoil can retire the model a user selected, and the switch onto a
- * replacement happens in the background — say so rather than silently changing
- * which model their dictation goes to.
+ * Tinfoils models are a bit ephemeral, alert user if one switches out from under them
  */
 export default function TinfoilModelSwitchToastListener() {
   const { t } = useTranslation();

--- a/src/components/TinfoilModelSwitchToastListener.tsx
+++ b/src/components/TinfoilModelSwitchToastListener.tsx
@@ -6,9 +6,12 @@ import {
   useTinfoilModelSwitchStore,
 } from "../stores/tinfoilModelSwitchStore";
 
-/**
- * Tinfoils models are a bit ephemeral, alert user if one switches out from under them
- */
+const isDictationPanelWindow = () => {
+  const { search, pathname } = window.location;
+  return !pathname.includes("control") && !search.includes("panel=true");
+};
+
+/** Alerts the user when a retired Tinfoil model was switched out from under them. */
 export default function TinfoilModelSwitchToastListener() {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -17,6 +20,10 @@ export default function TinfoilModelSwitchToastListener() {
 
   useEffect(() => {
     if (switchCount === 0) return;
+    // The panel may already be hidden after dictation; surface it so the toast is seen.
+    if (isDictationPanelWindow()) {
+      window.electronAPI?.showDictationPanel?.();
+    }
     for (const event of consumeTinfoilModelSwitches()) {
       toast({
         title: t("reasoning.tinfoil.modelRetiredTitle"),

--- a/src/components/TinfoilModelSwitchToastListener.tsx
+++ b/src/components/TinfoilModelSwitchToastListener.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "./ui/useToast";
+import {
+  consumeTinfoilModelSwitches,
+  useTinfoilModelSwitchStore,
+} from "../stores/tinfoilModelSwitchStore";
+
+/**
+ * Headless. Tinfoil can retire the model a user selected, and the switch onto a
+ * replacement happens in the background — say so rather than silently changing
+ * which model their dictation goes to.
+ */
+export default function TinfoilModelSwitchToastListener() {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+
+  const switchCount = useTinfoilModelSwitchStore((s) => s.events.length);
+
+  useEffect(() => {
+    if (switchCount === 0) return;
+    for (const event of consumeTinfoilModelSwitches()) {
+      toast({
+        title: t("reasoning.tinfoil.modelRetiredTitle"),
+        description: t("reasoning.tinfoil.modelRetired", { from: event.from, to: event.to }),
+      });
+    }
+  }, [switchCount, toast, t]);
+
+  return null;
+}

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -15,6 +15,7 @@ const CortiStreaming = require("./cortiStreaming");
 const OpenAIRealtimeStreaming = require("./openaiRealtimeStreaming");
 const { getCortiToken } = require("./cortiAuth");
 const { createTinfoilRealtimeSocket } = require("./tinfoilSecureClient");
+const { getTinfoilChatModels } = require("./tinfoilCatalog");
 const AudioStorageManager = require("./audioStorage");
 
 // Tinfoil's only realtime STT model — fallback when the renderer omits one.
@@ -2784,6 +2785,10 @@ class IPCHandlers {
 
     ipcMain.handle("save-tinfoil-key", async (event, key) => {
       return this.environmentManager.saveTinfoilKey(key);
+    });
+
+    ipcMain.handle("get-tinfoil-chat-models", async () => {
+      return getTinfoilChatModels();
     });
 
     ipcMain.handle("get-custom-transcription-key", async () => {

--- a/src/helpers/tinfoilCatalog.js
+++ b/src/helpers/tinfoilCatalog.js
@@ -5,13 +5,11 @@ const { net } = require("electron");
 const debugLogger = require("./debugLogger");
 
 const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
-const REFETCH_INTERVAL_MS = 60 * 60 * 1000;
 // Callers refresh before every request, so don't make each one wait out the
 // timeout while Tinfoil is unreachable.
 const RETRY_AFTER_FAILURE_MS = 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
 
-let cached = null;
 let lastFailureAt = 0;
 let inFlight = null;
 
@@ -56,15 +54,12 @@ async function fetchModels() {
 }
 
 /**
- * Resolves to Tinfoil's chat models, refetching at most once an hour. Rejects
- * when the fetch fails so callers can tell "Tinfoil says this model is gone"
- * apart from "we couldn't ask".
+ * Resolves to Tinfoil's chat models. How often to ask is the renderer's call —
+ * it holds the persisted list and the timestamp that goes with it. Rejects when
+ * the fetch fails so callers can tell "Tinfoil says this model is gone" apart
+ * from "we couldn't ask".
  */
 async function getTinfoilChatModels() {
-  if (cached && Date.now() - cached.fetchedAt < REFETCH_INTERVAL_MS) {
-    return cached.models;
-  }
-
   if (Date.now() - lastFailureAt < RETRY_AFTER_FAILURE_MS) {
     throw new Error("Tinfoil models unavailable");
   }
@@ -72,7 +67,6 @@ async function getTinfoilChatModels() {
   if (!inFlight) {
     inFlight = fetchModels()
       .then((models) => {
-        cached = { models, fetchedAt: Date.now() };
         lastFailureAt = 0;
         return models;
       })

--- a/src/helpers/tinfoilCatalog.js
+++ b/src/helpers/tinfoilCatalog.js
@@ -1,4 +1,4 @@
-// Tinfoil's model list comes from the attested endoint.
+// Tinfoil's model list comes from the attested endpoint.
 // Fetching from the main process rather than the renderer lets every window share one request.
 const debugLogger = require("./debugLogger");
 const { tinfoilSecureFetch } = require("./tinfoilSecureClient");

--- a/src/helpers/tinfoilCatalog.js
+++ b/src/helpers/tinfoilCatalog.js
@@ -1,12 +1,9 @@
-// Tinfoil serves its model list from an unauthenticated OpenAI-compatible
-// endpoint. Fetching it here rather than in the renderer keeps the request off
-// the page's origin and lets every window share one throttle.
-const { net } = require("electron");
+// Tinfoil's model list comes from the attested endoint.
+// Fetching from the main process rather than the renderer lets every window share one request.
 const debugLogger = require("./debugLogger");
+const { tinfoilSecureFetch } = require("./tinfoilSecureClient");
 
-const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
-// Callers refresh before every request, so don't make each one wait out the
-// timeout while Tinfoil is unreachable.
+const TINFOIL_MODELS_PATH = "/v1/models";
 const RETRY_AFTER_FAILURE_MS = 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
 
@@ -42,10 +39,10 @@ function parseModels(payload) {
 }
 
 async function fetchModels() {
-  const response = await net.fetch(TINFOIL_MODELS_URL, {
+  // The first call also attests the enclave, so allow for more than a plain GET.
+  const response = await tinfoilSecureFetch(TINFOIL_MODELS_PATH, {
     method: "GET",
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    useSessionCookies: false,
   });
   if (!response.ok) {
     throw new Error(`Tinfoil models request failed: ${response.status}`);
@@ -54,8 +51,7 @@ async function fetchModels() {
 }
 
 /**
- * Resolves to Tinfoil's chat models. How often to ask is the renderer's call —
- * it holds the persisted list and the timestamp that goes with it. Rejects when
+ * Resolves to Tinfoil's chat models. Rejects when
  * the fetch fails so callers can tell "Tinfoil says this model is gone" apart
  * from "we couldn't ask".
  */

--- a/src/helpers/tinfoilCatalog.js
+++ b/src/helpers/tinfoilCatalog.js
@@ -6,9 +6,13 @@ const debugLogger = require("./debugLogger");
 
 const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
 const REFETCH_INTERVAL_MS = 60 * 60 * 1000;
+// Callers refresh before every request, so don't make each one wait out the
+// timeout while Tinfoil is unreachable.
+const RETRY_AFTER_FAILURE_MS = 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
 
 let cached = null;
+let lastFailureAt = 0;
 let inFlight = null;
 
 /**
@@ -61,13 +65,19 @@ async function getTinfoilChatModels() {
     return cached.models;
   }
 
+  if (Date.now() - lastFailureAt < RETRY_AFTER_FAILURE_MS) {
+    throw new Error("Tinfoil models unavailable");
+  }
+
   if (!inFlight) {
     inFlight = fetchModels()
       .then((models) => {
         cached = { models, fetchedAt: Date.now() };
+        lastFailureAt = 0;
         return models;
       })
       .catch((error) => {
+        lastFailureAt = Date.now();
         debugLogger.warn("Failed to fetch Tinfoil models", { error: error.message });
         throw error;
       })

--- a/src/helpers/tinfoilCatalog.js
+++ b/src/helpers/tinfoilCatalog.js
@@ -1,0 +1,82 @@
+// Tinfoil serves its model list from an unauthenticated OpenAI-compatible
+// endpoint. Fetching it here rather than in the renderer keeps the request off
+// the page's origin and lets every window share one throttle.
+const { net } = require("electron");
+const debugLogger = require("./debugLogger");
+
+const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
+const REFETCH_INTERVAL_MS = 60 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+let cached = null;
+let inFlight = null;
+
+/**
+ * The list mixes chat, audio, tts, embedding and tool models, so narrow it to
+ * the ones we can send a chat completion to.
+ */
+function isChatModel(model) {
+  if (!model || model.type !== "chat") return false;
+  return Array.isArray(model.endpoints) && model.endpoints.includes("/v1/chat/completions");
+}
+
+function toCatalogModel(model) {
+  return {
+    id: model.id,
+    name: typeof model.name === "string" && model.name ? model.name : model.id,
+    description: typeof model.description === "string" ? model.description : "",
+    supportsThinking: model.reasoning === true,
+  };
+}
+
+function parseModels(payload) {
+  const data = payload?.data;
+  if (!Array.isArray(data)) {
+    throw new Error("Malformed models list");
+  }
+  return data
+    .filter((model) => typeof model?.id === "string" && model.id && isChatModel(model))
+    .map(toCatalogModel);
+}
+
+async function fetchModels() {
+  const response = await net.fetch(TINFOIL_MODELS_URL, {
+    method: "GET",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    useSessionCookies: false,
+  });
+  if (!response.ok) {
+    throw new Error(`Tinfoil models request failed: ${response.status}`);
+  }
+  return parseModels(await response.json());
+}
+
+/**
+ * Resolves to Tinfoil's chat models, refetching at most once an hour. Rejects
+ * when the fetch fails so callers can tell "Tinfoil says this model is gone"
+ * apart from "we couldn't ask".
+ */
+async function getTinfoilChatModels() {
+  if (cached && Date.now() - cached.fetchedAt < REFETCH_INTERVAL_MS) {
+    return cached.models;
+  }
+
+  if (!inFlight) {
+    inFlight = fetchModels()
+      .then((models) => {
+        cached = { models, fetchedAt: Date.now() };
+        return models;
+      })
+      .catch((error) => {
+        debugLogger.warn("Failed to fetch Tinfoil models", { error: error.message });
+        throw error;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+
+  return inFlight;
+}
+
+module.exports = { getTinfoilChatModels };

--- a/src/helpers/tinfoilSecureClient.js
+++ b/src/helpers/tinfoilSecureClient.js
@@ -1,6 +1,6 @@
-// WebSocket access to Tinfoil's realtime transcription endpoint. The SDK's
-// SecureClient attests the enclave and pins the socket's TLS connection to the
-// attested key; one client is held per session so attestation is paid once.
+// Attested access to Tinfoil.
+// The SDK's SecureClient verifies the enclave and pins the connection to the attested key;
+// one client is held per session so attestation is paid once and shared by every caller.
 let clientPromise = null;
 
 function getSecureClient() {
@@ -23,4 +23,10 @@ async function createTinfoilRealtimeSocket({ model, apiKey }) {
   });
 }
 
-module.exports = { createTinfoilRealtimeSocket };
+/** Fetches an enclave path over the attested transport. Needs no API key. */
+async function tinfoilSecureFetch(path, init) {
+  const client = await getSecureClient();
+  return client.fetch(path, init);
+}
+
+module.exports = { createTinfoilRealtimeSocket, tinfoilSecureFetch };

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getTinfoilModels, type CloudModelDefinition } from "../models/ModelRegistry";
-import { refreshTinfoilModels } from "../models/tinfoilModels";
+import { isTinfoilListFresh, refreshTinfoilModels } from "../models/tinfoilModels";
 import logger from "../utils/logger";
 
 interface UseTinfoilModelsResult {
@@ -30,7 +30,11 @@ export function useTinfoilModels(enabled: boolean): UseTinfoilModelsResult {
   }, []);
 
   const refresh = useCallback(async () => {
-    if (isMountedRef.current) {
+    // A list we fetched within the hour resolves without touching the network,
+    // so don't flash a "refreshing" state the user can't even read.
+    const willFetch = !isTinfoilListFresh();
+
+    if (willFetch && isMountedRef.current) {
       setLoading(true);
       setError(null);
     }
@@ -48,7 +52,7 @@ export function useTinfoilModels(enabled: boolean): UseTinfoilModelsResult {
         setError((err as Error).message || "Unable to load models");
       }
     } finally {
-      if (isMountedRef.current) {
+      if (willFetch && isMountedRef.current) {
         setLoading(false);
       }
     }

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -7,8 +7,6 @@ interface UseTinfoilModelsResult {
   models: CloudModelDefinition[];
   loading: boolean;
   error: string | null;
-  /** True once Tinfoil has answered. Until then its list can't be trusted to be complete. */
-  fetched: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -21,7 +19,6 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
   const [models, setModels] = useState<CloudModelDefinition[]>(() => getTinfoilModels());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [fetched, setFetched] = useState(false);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -41,7 +38,6 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
       const fresh = await refreshTinfoilModels();
       if (isMountedRef.current) {
         setModels(fresh);
-        setFetched(true);
       }
     } catch (err) {
       // Leave the known list in place: without an answer we can't tell a
@@ -61,5 +57,5 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
     refresh();
   }, [refresh]);
 
-  return { models, loading, error, fetched, refresh };
+  return { models, loading, error, refresh };
 }

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -11,11 +11,12 @@ interface UseTinfoilModelsResult {
 }
 
 /**
- * Refreshes Tinfoil's model list into the registry and re-renders with it. The
- * registry keeps its last known list when the fetch fails, so the picker stays
- * usable offline.
+ * Refreshes Tinfoil's model list into the registry and re-renders with it. Pass
+ * `enabled` only while the user is looking at Tinfoil, so nobody else's settings
+ * visit reaches out to it. The registry keeps its last known list when the fetch
+ * fails, so the picker stays usable offline.
  */
-export function useTinfoilModels(): UseTinfoilModelsResult {
+export function useTinfoilModels(enabled: boolean): UseTinfoilModelsResult {
   const [models, setModels] = useState<CloudModelDefinition[]>(() => getTinfoilModels());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,8 +55,9 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
   }, []);
 
   useEffect(() => {
+    if (!enabled) return;
     refresh();
-  }, [refresh]);
+  }, [enabled, refresh]);
 
   return { models, loading, error, refresh };
 }

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  applyTinfoilModels,
-  getTinfoilModels,
-  type CloudModelDefinition,
-} from "../models/ModelRegistry";
-import { fetchTinfoilModels } from "../models/tinfoilModels";
+import { getTinfoilModels, type CloudModelDefinition } from "../models/ModelRegistry";
+import { refreshTinfoilModels } from "../models/tinfoilModels";
 import logger from "../utils/logger";
 
 interface UseTinfoilModelsResult {
@@ -17,8 +13,9 @@ interface UseTinfoilModelsResult {
 }
 
 /**
- * Loads Tinfoil's model list from its /v1/models endpoint, falling back to the
- * models bundled with the app so the picker stays usable offline.
+ * Refreshes Tinfoil's model list into the registry and re-renders with it. The
+ * registry keeps its last known list when the fetch fails, so the picker stays
+ * usable offline.
  */
 export function useTinfoilModels(): UseTinfoilModelsResult {
   const [models, setModels] = useState<CloudModelDefinition[]>(() => getTinfoilModels());
@@ -41,19 +38,13 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
     }
 
     try {
-      const fresh = await fetchTinfoilModels();
-      // An empty list would mean Tinfoil serves no chat models at all. Far more
-      // likely something upstream broke, so keep the bundled ones.
-      if (fresh.length === 0) {
-        throw new Error("Tinfoil returned no chat models");
-      }
-      applyTinfoilModels(fresh);
+      const fresh = await refreshTinfoilModels();
       if (isMountedRef.current) {
         setModels(fresh);
         setFetched(true);
       }
     } catch (err) {
-      // Leave the bundled list in place: without an answer we can't tell a
+      // Leave the known list in place: without an answer we can't tell a
       // retired model from an unreachable endpoint.
       logger.error("Failed to load Tinfoil models", { error: err }, "models");
       if (isMountedRef.current) {

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -4,24 +4,27 @@ import {
   getTinfoilModels,
   type CloudModelDefinition,
 } from "../models/ModelRegistry";
-import { fetchTinfoilModels, writeCachedTinfoilModels } from "../models/tinfoilModels";
+import { fetchTinfoilModels } from "../models/tinfoilModels";
 import logger from "../utils/logger";
 
 interface UseTinfoilModelsResult {
   models: CloudModelDefinition[];
   loading: boolean;
   error: string | null;
+  /** True once Tinfoil has answered. Until then its list can't be trusted to be complete. */
+  fetched: boolean;
   refresh: () => Promise<void>;
 }
 
 /**
  * Loads Tinfoil's model list from its /v1/models endpoint, falling back to the
- * last good fetch so the picker stays usable offline.
+ * models bundled with the app so the picker stays usable offline.
  */
 export function useTinfoilModels(): UseTinfoilModelsResult {
   const [models, setModels] = useState<CloudModelDefinition[]>(() => getTinfoilModels());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fetched, setFetched] = useState(false);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -39,12 +42,19 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
 
     try {
       const fresh = await fetchTinfoilModels();
+      // An empty list would mean Tinfoil serves no chat models at all. Far more
+      // likely something upstream broke, so keep the bundled ones.
+      if (fresh.length === 0) {
+        throw new Error("Tinfoil returned no chat models");
+      }
       applyTinfoilModels(fresh);
-      writeCachedTinfoilModels(fresh);
       if (isMountedRef.current) {
         setModels(fresh);
+        setFetched(true);
       }
     } catch (err) {
+      // Leave the bundled list in place: without an answer we can't tell a
+      // retired model from an unreachable endpoint.
       logger.error("Failed to load Tinfoil models", { error: err }, "models");
       if (isMountedRef.current) {
         setError((err as Error).message || "Unable to load models");
@@ -60,5 +70,5 @@ export function useTinfoilModels(): UseTinfoilModelsResult {
     refresh();
   }, [refresh]);
 
-  return { models, loading, error, refresh };
+  return { models, loading, error, fetched, refresh };
 }

--- a/src/hooks/useTinfoilModels.ts
+++ b/src/hooks/useTinfoilModels.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyTinfoilModels,
+  getTinfoilModels,
+  type CloudModelDefinition,
+} from "../models/ModelRegistry";
+import { fetchTinfoilModels, writeCachedTinfoilModels } from "../models/tinfoilModels";
+import logger from "../utils/logger";
+
+interface UseTinfoilModelsResult {
+  models: CloudModelDefinition[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Loads Tinfoil's model list from its /v1/models endpoint, falling back to the
+ * last good fetch so the picker stays usable offline.
+ */
+export function useTinfoilModels(): UseTinfoilModelsResult {
+  const [models, setModels] = useState<CloudModelDefinition[]>(() => getTinfoilModels());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (isMountedRef.current) {
+      setLoading(true);
+      setError(null);
+    }
+
+    try {
+      const fresh = await fetchTinfoilModels();
+      applyTinfoilModels(fresh);
+      writeCachedTinfoilModels(fresh);
+      if (isMountedRef.current) {
+        setModels(fresh);
+      }
+    } catch (err) {
+      logger.error("Failed to load Tinfoil models", { error: err }, "models");
+      if (isMountedRef.current) {
+        setError((err as Error).message || "Unable to load models");
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { models, loading, error, refresh };
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Modell nicht mehr verfügbar",
-      "modelRetired": "Tinfoil hat {{from}} eingestellt. Zu {{to}} gewechselt."
+      "modelRetired": "Tinfoil hat {{from}} eingestellt. Zu {{to}} gewechselt.",
+      "refreshingModels": "Modelle werden aktualisiert…"
     }
   },
   "transcription": {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Verwendet Application Default Credentials. Führen Sie aus: gcloud auth application-default login",
         "apikeyHelp": "API-Schlüssel für Vertex AI Express Mode aus Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Modell nicht mehr verfügbar",
+      "modelRetired": "Tinfoil hat {{from}} eingestellt. Zu {{to}} gewechselt."
     }
   },
   "transcription": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Model no longer available",
-      "modelRetired": "Tinfoil retired {{from}}. Switched to {{to}}."
+      "modelRetired": "Tinfoil retired {{from}}. Switched to {{to}}.",
+      "refreshingModels": "Refreshing models…"
     }
   },
   "transcription": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Uses Application Default Credentials. Run: gcloud auth application-default login",
         "apikeyHelp": "Vertex AI Express Mode API key from Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Model no longer available",
+      "modelRetired": "Tinfoil retired {{from}}. Switched to {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Modelo ya no disponible",
-      "modelRetired": "Tinfoil retiró {{from}}. Se cambió a {{to}}."
+      "modelRetired": "Tinfoil retiró {{from}}. Se cambió a {{to}}.",
+      "refreshingModels": "Actualizando modelos…"
     }
   },
   "transcription": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Usa Application Default Credentials. Ejecuta: gcloud auth application-default login",
         "apikeyHelp": "Clave API de Vertex AI Express Mode obtenida en Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Modelo ya no disponible",
+      "modelRetired": "Tinfoil retiró {{from}}. Se cambió a {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Modèle non disponible",
-      "modelRetired": "Tinfoil a retiré {{from}}. Basculé vers {{to}}."
+      "modelRetired": "Tinfoil a retiré {{from}}. Basculé vers {{to}}.",
+      "refreshingModels": "Actualisation des modèles…"
     }
   },
   "transcription": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Utilise Application Default Credentials. Exécutez : gcloud auth application-default login",
         "apikeyHelp": "Clé API Vertex AI Express Mode obtenue depuis Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Modèle non disponible",
+      "modelRetired": "Tinfoil a retiré {{from}}. Basculé vers {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Modello non più disponibile",
-      "modelRetired": "Tinfoil ha ritirato {{from}}. Passato a {{to}}."
+      "modelRetired": "Tinfoil ha ritirato {{from}}. Passato a {{to}}.",
+      "refreshingModels": "Aggiornamento dei modelli…"
     }
   },
   "transcription": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Usa Application Default Credentials. Esegui: gcloud auth application-default login",
         "apikeyHelp": "Chiave API Vertex AI Express Mode da Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Modello non più disponibile",
+      "modelRetired": "Tinfoil ha ritirato {{from}}. Passato a {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "モデルが利用できません",
-      "modelRetired": "Tinfoil は {{from}} を提供終了しました。{{to}} に切り替えました。"
+      "modelRetired": "Tinfoil は {{from}} を提供終了しました。{{to}} に切り替えました。",
+      "refreshingModels": "モデルを更新しています…"
     }
   },
   "transcription": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Application Default Credentials を使用します。次を実行してください: gcloud auth application-default login",
         "apikeyHelp": "Google AI Studio で取得した Vertex AI Express Mode の API キー。"
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "モデルが利用できません",
+      "modelRetired": "Tinfoil は {{from}} を提供終了しました。{{to}} に切り替えました。"
     }
   },
   "transcription": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -480,7 +480,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Modelo não disponível",
-      "modelRetired": "A Tinfoil descontinuou {{from}}. Alterado para {{to}}."
+      "modelRetired": "A Tinfoil descontinuou {{from}}. Alterado para {{to}}.",
+      "refreshingModels": "A atualizar modelos…"
     }
   },
   "transcription": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -477,6 +477,10 @@
         "adcHelp": "Usa Application Default Credentials. Execute: gcloud auth application-default login",
         "apikeyHelp": "Chave API do Vertex AI Express Mode obtida no Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Modelo não disponível",
+      "modelRetired": "A Tinfoil descontinuou {{from}}. Alterado para {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "Модель больше недоступна",
-      "modelRetired": "Tinfoil прекратил поддержку {{from}}. Выполнен переход на {{to}}."
+      "modelRetired": "Tinfoil прекратил поддержку {{from}}. Выполнен переход на {{to}}.",
+      "refreshingModels": "Обновление моделей…"
     }
   },
   "transcription": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "Использует Application Default Credentials. Выполните: gcloud auth application-default login",
         "apikeyHelp": "API-ключ Vertex AI Express Mode из Google AI Studio."
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "Модель больше недоступна",
+      "modelRetired": "Tinfoil прекратил поддержку {{from}}. Выполнен переход на {{to}}."
     }
   },
   "transcription": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "模型已不可用",
-      "modelRetired": "Tinfoil 已停用 {{from}}，已切换至 {{to}}。"
+      "modelRetired": "Tinfoil 已停用 {{from}}，已切换至 {{to}}。",
+      "refreshingModels": "正在刷新模型…"
     }
   },
   "transcription": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "使用 Application Default Credentials。请执行：gcloud auth application-default login",
         "apikeyHelp": "从 Google AI Studio 获取的 Vertex AI Express Mode API 密钥。"
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "模型已不可用",
+      "modelRetired": "Tinfoil 已停用 {{from}}，已切换至 {{to}}。"
     }
   },
   "transcription": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -501,7 +501,8 @@
     },
     "tinfoil": {
       "modelRetiredTitle": "模型已無法使用",
-      "modelRetired": "Tinfoil 已停用 {{from}}，已切換至 {{to}}。"
+      "modelRetired": "Tinfoil 已停用 {{from}}，已切換至 {{to}}。",
+      "refreshingModels": "正在重新整理模型…"
     }
   },
   "transcription": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -498,6 +498,10 @@
         "adcHelp": "使用 Application Default Credentials。請執行：gcloud auth application-default login",
         "apikeyHelp": "從 Google AI Studio 取得的 Vertex AI Express Mode API 金鑰。"
       }
+    },
+    "tinfoil": {
+      "modelRetiredTitle": "模型已無法使用",
+      "modelRetired": "Tinfoil 已停用 {{from}}，已切換至 {{to}}。"
     }
   },
   "transcription": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { I18nextProvider } from "react-i18next";
 import AppRouter from "./AppRouter.jsx";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
+import TinfoilModelSwitchToastListener from "./components/TinfoilModelSwitchToastListener.tsx";
 import { ToastProvider } from "./components/ui/Toast.tsx";
 import { SettingsProvider } from "./hooks/useSettings";
 
@@ -16,6 +17,7 @@ root.render(
       <I18nextProvider i18n={i18n}>
         <SettingsProvider>
           <ToastProvider>
+            <TinfoilModelSwitchToastListener />
             <AppRouter />
           </ToastProvider>
         </SettingsProvider>

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -119,9 +119,10 @@ function getTinfoilCloudProvider(): CloudProviderData | undefined {
   return modelData.cloudProviders.find((provider) => provider.id === "tinfoil");
 }
 
-// Tinfoil's models come from its /v1/models endpoint rather than the static
-// registry. Seed from the last good fetch so ids resolve before a refresh
-// lands — getOpenAiApiConfig and getModelProvider both read this synchronously.
+// Tinfoil's models are fetched from its /v1/models endpoint, but getOpenAiApiConfig
+// and getCloudModel read the registry synchronously. Seed from the last good fetch
+// so a cold start doesn't fall through to the wrong defaults for these ids
+// (max_completion_tokens and no temperature, rather than max_tokens with one).
 const seededTinfoilProvider = getTinfoilCloudProvider();
 if (seededTinfoilProvider) {
   seededTinfoilProvider.models = readCachedTinfoilModels();

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -119,9 +119,6 @@ function getTinfoilCloudProvider(): CloudProviderData | undefined {
   return modelData.cloudProviders.find((provider) => provider.id === "tinfoil");
 }
 
-// Start from the last list Tinfoil gave us, so a model the user selected while
-// online survives a launch that can't reach the endpoint. The bundled models
-// are only the first-run floor, before any fetch has ever landed.
 const cachedTinfoilModels = readCachedTinfoilModels().models;
 if (cachedTinfoilModels.length > 0) {
   const tinfoilProvider = getTinfoilCloudProvider();
@@ -287,12 +284,6 @@ export function getTinfoilModels(): CloudModelDefinition[] {
   return getTinfoilCloudProvider()?.models ?? [];
 }
 
-/**
- * Replaces the bundled Tinfoil model list with a freshly fetched one. The list
- * has to land in the registry, not just the picker: getOpenAiApiConfig and
- * getCloudModel read it synchronously to decide token params and thinking
- * suppression, and fall through to OpenAI's defaults for ids they don't know.
- */
 export function applyTinfoilModels(models: CloudModelDefinition[]): void {
   const provider = getTinfoilCloudProvider();
   if (provider) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -122,7 +122,7 @@ function getTinfoilCloudProvider(): CloudProviderData | undefined {
 // Start from the last list Tinfoil gave us, so a model the user selected while
 // online survives a launch that can't reach the endpoint. The bundled models
 // are only the first-run floor, before any fetch has ever landed.
-const cachedTinfoilModels = readCachedTinfoilModels();
+const cachedTinfoilModels = readCachedTinfoilModels().models;
 if (cachedTinfoilModels.length > 0) {
   const tinfoilProvider = getTinfoilCloudProvider();
   if (tinfoilProvider) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -322,9 +322,8 @@ export function getModelProvider(modelId: string): string {
 
   const storedProvider = getSettings().cleanupProvider;
 
-  // Trust the provider the user chose over the heuristic
-  if (storedProvider === "custom" || storedProvider === "tinfoil") {
-    return storedProvider;
+  if (storedProvider === "custom") {
+    return "custom";
   }
 
   if (isEnterpriseProvider(storedProvider)) {
@@ -334,6 +333,9 @@ export function getModelProvider(modelId: string): string {
   const model = getAllReasoningModels().find((m) => m.value === modelId);
 
   if (!model) {
+    // An unknown model here is one Tinfoil retired or added since our last
+    // sync — don't let the id heuristics misroute it.
+    if (storedProvider === "tinfoil") return "tinfoil";
     if (modelId.includes("claude")) return "anthropic";
     if (modelId.includes("gemini") && !modelId.includes("gemma")) return "gemini";
     if ((modelId.includes("gpt-4") || modelId.includes("gpt-5")) && !modelId.includes("gpt-oss"))

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -1,6 +1,5 @@
 import modelDataRaw from "./modelRegistryData.json";
 import { isCloudCleanupMode, getSettings } from "../stores/settingsStore";
-import { readCachedTinfoilModels } from "./tinfoilModels";
 
 export interface ModelDefinition {
   id: string;
@@ -117,15 +116,6 @@ const modelData: ModelRegistryData = modelDataRaw as ModelRegistryData;
 
 function getTinfoilCloudProvider(): CloudProviderData | undefined {
   return modelData.cloudProviders.find((provider) => provider.id === "tinfoil");
-}
-
-// Tinfoil's models are fetched from its /v1/models endpoint, but getOpenAiApiConfig
-// and getCloudModel read the registry synchronously. Seed from the last good fetch
-// so a cold start doesn't fall through to the wrong defaults for these ids
-// (max_completion_tokens and no temperature, rather than max_tokens with one).
-const seededTinfoilProvider = getTinfoilCloudProvider();
-if (seededTinfoilProvider) {
-  seededTinfoilProvider.models = readCachedTinfoilModels();
 }
 
 function createPromptFormatter(template: string): (text: string, systemPrompt: string) => string {
@@ -285,7 +275,12 @@ export function getTinfoilModels(): CloudModelDefinition[] {
   return getTinfoilCloudProvider()?.models ?? [];
 }
 
-/** Replaces Tinfoil's model list with a freshly fetched one. */
+/**
+ * Replaces the bundled Tinfoil model list with a freshly fetched one. The list
+ * has to land in the registry, not just the picker: getOpenAiApiConfig and
+ * getCloudModel read it synchronously to decide token params and thinking
+ * suppression, and fall through to OpenAI's defaults for ids they don't know.
+ */
 export function applyTinfoilModels(models: CloudModelDefinition[]): void {
   const provider = getTinfoilCloudProvider();
   if (provider) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -237,7 +237,7 @@ export function isEnterpriseProvider(value: unknown): value is EnterpriseProvide
   return typeof value === "string" && (ENTERPRISE_PROVIDERS as readonly string[]).includes(value);
 }
 
-function toReasoningModel(m: CloudModelDefinition): ReasoningModel {
+export function toReasoningModel(m: CloudModelDefinition): ReasoningModel {
   return {
     value: m.id,
     label: m.name,

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -322,14 +322,9 @@ export function getModelProvider(modelId: string): string {
 
   const storedProvider = getSettings().cleanupProvider;
 
-  if (storedProvider === "custom") {
-    return "custom";
-  }
-
-  // Tinfoil's model list is fetched at runtime, so a selected id may not be in
-  // the registry yet. Trust the stored provider rather than guessing from the id.
-  if (storedProvider === "tinfoil") {
-    return "tinfoil";
+  // Trust the provider the user chose over the heuristic
+  if (storedProvider === "custom" || storedProvider === "tinfoil") {
+    return storedProvider;
   }
 
   if (isEnterpriseProvider(storedProvider)) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -1,5 +1,6 @@
 import modelDataRaw from "./modelRegistryData.json";
 import { isCloudCleanupMode, getSettings } from "../stores/settingsStore";
+import { readCachedTinfoilModels } from "./tinfoilModels";
 
 export interface ModelDefinition {
   id: string;
@@ -114,6 +115,18 @@ interface ModelRegistryData {
 
 const modelData: ModelRegistryData = modelDataRaw as ModelRegistryData;
 
+function getTinfoilCloudProvider(): CloudProviderData | undefined {
+  return modelData.cloudProviders.find((provider) => provider.id === "tinfoil");
+}
+
+// Tinfoil's models come from its /v1/models endpoint rather than the static
+// registry. Seed from the last good fetch so ids resolve before a refresh
+// lands — getOpenAiApiConfig and getModelProvider both read this synchronously.
+const seededTinfoilProvider = getTinfoilCloudProvider();
+if (seededTinfoilProvider) {
+  seededTinfoilProvider.models = readCachedTinfoilModels();
+}
+
 function createPromptFormatter(template: string): (text: string, systemPrompt: string) => string {
   return (text: string, systemPrompt: string) => {
     return template.replace("{system}", systemPrompt).replace("{user}", text);
@@ -221,18 +234,22 @@ export function isEnterpriseProvider(value: unknown): value is EnterpriseProvide
   return typeof value === "string" && (ENTERPRISE_PROVIDERS as readonly string[]).includes(value);
 }
 
+function toReasoningModel(m: CloudModelDefinition): ReasoningModel {
+  return {
+    value: m.id,
+    label: m.name,
+    description: m.description,
+    descriptionKey: m.descriptionKey,
+  };
+}
+
 function buildReasoningProviders(): ReasoningProviders {
   const providers: ReasoningProviders = {};
 
   for (const cloudProvider of modelRegistry.getCloudProviders()) {
     providers[cloudProvider.id] = {
       name: cloudProvider.name,
-      models: cloudProvider.models.map((m) => ({
-        value: m.id,
-        label: m.name,
-        description: m.description,
-        descriptionKey: m.descriptionKey,
-      })),
+      models: cloudProvider.models.map(toReasoningModel),
     };
   }
 
@@ -263,6 +280,22 @@ function buildReasoningProviders(): ReasoningProviders {
 
 export const REASONING_PROVIDERS = buildReasoningProviders();
 
+export function getTinfoilModels(): CloudModelDefinition[] {
+  return getTinfoilCloudProvider()?.models ?? [];
+}
+
+/** Replaces Tinfoil's model list with a freshly fetched one. */
+export function applyTinfoilModels(models: CloudModelDefinition[]): void {
+  const provider = getTinfoilCloudProvider();
+  if (provider) {
+    provider.models = models;
+  }
+  const reasoningProvider = REASONING_PROVIDERS.tinfoil;
+  if (reasoningProvider) {
+    reasoningProvider.models = models.map(toReasoningModel);
+  }
+}
+
 export interface ReasoningModelWithProvider extends ReasoningModel {
   provider: string;
   fullLabel: string;
@@ -292,6 +325,12 @@ export function getModelProvider(modelId: string): string {
 
   if (storedProvider === "custom") {
     return "custom";
+  }
+
+  // Tinfoil's model list is fetched at runtime, so a selected id may not be in
+  // the registry yet. Trust the stored provider rather than guessing from the id.
+  if (storedProvider === "tinfoil") {
+    return "tinfoil";
   }
 
   if (isEnterpriseProvider(storedProvider)) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -1,5 +1,6 @@
 import modelDataRaw from "./modelRegistryData.json";
 import { isCloudCleanupMode, getSettings } from "../stores/settingsStore";
+import { readCachedTinfoilModels } from "./tinfoilModelCache";
 
 export interface ModelDefinition {
   id: string;
@@ -116,6 +117,17 @@ const modelData: ModelRegistryData = modelDataRaw as ModelRegistryData;
 
 function getTinfoilCloudProvider(): CloudProviderData | undefined {
   return modelData.cloudProviders.find((provider) => provider.id === "tinfoil");
+}
+
+// Start from the last list Tinfoil gave us, so a model the user selected while
+// online survives a launch that can't reach the endpoint. The bundled models
+// are only the first-run floor, before any fetch has ever landed.
+const cachedTinfoilModels = readCachedTinfoilModels();
+if (cachedTinfoilModels.length > 0) {
+  const tinfoilProvider = getTinfoilCloudProvider();
+  if (tinfoilProvider) {
+    tinfoilProvider.models = cachedTinfoilModels;
+  }
 }
 
 function createPromptFormatter(template: string): (text: string, systemPrompt: string) => string {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -457,6 +457,15 @@
       "name": "Tinfoil",
       "models": [
         {
+          "id": "kimi-k2-6",
+          "name": "Kimi K2.6",
+          "description": "Private long-horizon coding and multimodal model, 256K context",
+          "tokenParam": "max_tokens",
+          "supportsTemperature": true,
+          "descriptionKey": "models.descriptions.cloud.tinfoil_kimi_k2_6",
+          "supportsThinking": true
+        },
+        {
           "id": "glm-5-2",
           "name": "GLM-5.2",
           "description": "Private agentic engineering model in secure enclaves, 384K context",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -455,61 +455,7 @@
     {
       "id": "tinfoil",
       "name": "Tinfoil",
-      "models": [
-        {
-          "id": "deepseek-v4-pro",
-          "name": "DeepSeek V4 Pro",
-          "description": "Private long-context reasoning in secure enclaves, 800K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_deepseek_v4_pro",
-          "supportsThinking": true
-        },
-        {
-          "id": "glm-5-2",
-          "name": "GLM-5.2",
-          "description": "Private agentic engineering model in secure enclaves, 384K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_glm_5_2",
-          "supportsThinking": true
-        },
-        {
-          "id": "kimi-k2-6",
-          "name": "Kimi K2.6",
-          "description": "Private long-horizon coding and multimodal model, 256K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_kimi_k2_6",
-          "supportsThinking": true
-        },
-        {
-          "id": "gemma4-31b",
-          "name": "Gemma 4 31B",
-          "description": "Private multilingual reasoning model with tool calling, 256K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_gemma4_31b",
-          "supportsThinking": true
-        },
-        {
-          "id": "gpt-oss-120b",
-          "name": "GPT-OSS 120B",
-          "description": "Private open-weight reasoning model with tool use, 131K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_gpt_oss_120b",
-          "supportsThinking": true
-        },
-        {
-          "id": "llama3-3-70b",
-          "name": "Llama 3.3 70B",
-          "description": "Private conversational model with tool calling, 128K context",
-          "tokenParam": "max_tokens",
-          "supportsTemperature": true,
-          "descriptionKey": "models.descriptions.cloud.tinfoil_llama3_3_70b"
-        }
-      ]
+      "models": []
     }
   ],
   "enterpriseProviders": [

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -455,7 +455,35 @@
     {
       "id": "tinfoil",
       "name": "Tinfoil",
-      "models": []
+      "models": [
+        {
+          "id": "glm-5-2",
+          "name": "GLM-5.2",
+          "description": "Private agentic engineering model in secure enclaves, 384K context",
+          "tokenParam": "max_tokens",
+          "supportsTemperature": true,
+          "descriptionKey": "models.descriptions.cloud.tinfoil_glm_5_2",
+          "supportsThinking": true
+        },
+        {
+          "id": "gpt-oss-120b",
+          "name": "GPT-OSS 120B",
+          "description": "Private open-weight reasoning model with tool use, 131K context",
+          "tokenParam": "max_tokens",
+          "supportsTemperature": true,
+          "descriptionKey": "models.descriptions.cloud.tinfoil_gpt_oss_120b",
+          "supportsThinking": true
+        },
+        {
+          "id": "gemma4-31b",
+          "name": "Gemma 4 31B",
+          "description": "Private multilingual reasoning model with tool calling, 256K context",
+          "tokenParam": "max_tokens",
+          "supportsTemperature": true,
+          "descriptionKey": "models.descriptions.cloud.tinfoil_gemma4_31b",
+          "supportsThinking": true
+        }
+      ]
     }
   ],
   "enterpriseProviders": [

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -1,27 +1,42 @@
 import type { CloudModelDefinition } from "./ModelRegistry";
 
 const CACHE_KEY = "tinfoilModels";
+const MAX_AGE_MS = 60 * 60 * 1000;
+
+export interface CachedTinfoilModels {
+  models: CloudModelDefinition[];
+  /** Epoch ms of the fetch that produced `models`, or 0 if we've never fetched. */
+  fetchedAt: number;
+}
+
+const EMPTY: CachedTinfoilModels = { models: [], fetchedAt: 0 };
 
 /**
- * The last list Tinfoil gave us. Persisting it means a launch that hasn't
- * refreshed yet still knows every model the user has seen, rather than falling
- * back to whatever happened to be bundled at build time.
+ * The last list Tinfoil gave us, and when. Persisting both means a launch still
+ * knows every model the user has seen, and doesn't refetch a list it pulled a
+ * minute before the app restarted.
  */
-export function readCachedTinfoilModels(): CloudModelDefinition[] {
+export function readCachedTinfoilModels(): CachedTinfoilModels {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return [];
+    if (!raw) return EMPTY;
+
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    if (!Array.isArray(parsed?.models) || typeof parsed.fetchedAt !== "number") return EMPTY;
+    return { models: parsed.models, fetchedAt: parsed.fetchedAt };
   } catch {
-    return [];
+    return EMPTY;
   }
 }
 
 export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(models));
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ models, fetchedAt: Date.now() }));
   } catch {
     // Cache is best-effort; a failed write just means a refetch next launch.
   }
+}
+
+export function isCachedListFresh(cached: CachedTinfoilModels): boolean {
+  return cached.models.length > 0 && Date.now() - cached.fetchedAt < MAX_AGE_MS;
 }

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -3,6 +3,8 @@ import type { CloudModelDefinition } from "./ModelRegistry";
 const CACHE_KEY = "tinfoilModels";
 const MAX_AGE_MS = 60 * 60 * 1000;
 
+const isBrowser = typeof window !== "undefined";
+
 export interface CachedTinfoilModels {
   models: CloudModelDefinition[];
   /** Epoch ms of the fetch that produced `models`, or 0 if we've never fetched. */
@@ -12,6 +14,7 @@ export interface CachedTinfoilModels {
 const EMPTY: CachedTinfoilModels = { models: [], fetchedAt: 0 };
 
 export function readCachedTinfoilModels(): CachedTinfoilModels {
+  if (!isBrowser) return EMPTY;
   try {
     const raw = localStorage.getItem(CACHE_KEY);
     if (!raw) return EMPTY;
@@ -25,6 +28,7 @@ export function readCachedTinfoilModels(): CachedTinfoilModels {
 }
 
 export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
+  if (!isBrowser) return;
   try {
     localStorage.setItem(CACHE_KEY, JSON.stringify({ models, fetchedAt: Date.now() }));
   } catch {}

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -1,0 +1,27 @@
+import type { CloudModelDefinition } from "./ModelRegistry";
+
+const CACHE_KEY = "tinfoilModels";
+
+/**
+ * The last list Tinfoil gave us. Persisting it means a launch that hasn't
+ * refreshed yet still knows every model the user has seen, rather than falling
+ * back to whatever happened to be bundled at build time.
+ */
+export function readCachedTinfoilModels(): CloudModelDefinition[] {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(models));
+  } catch {
+    // Cache is best-effort; a failed write just means a refetch next launch.
+  }
+}

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -11,11 +11,6 @@ export interface CachedTinfoilModels {
 
 const EMPTY: CachedTinfoilModels = { models: [], fetchedAt: 0 };
 
-/**
- * The last list Tinfoil gave us, and when. Persisting both means a launch still
- * knows every model the user has seen, and doesn't refetch a list it pulled a
- * minute before the app restarted.
- */
 export function readCachedTinfoilModels(): CachedTinfoilModels {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
@@ -32,9 +27,7 @@ export function readCachedTinfoilModels(): CachedTinfoilModels {
 export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
   try {
     localStorage.setItem(CACHE_KEY, JSON.stringify({ models, fetchedAt: Date.now() }));
-  } catch {
-    // Cache is best-effort; a failed write just means a refetch next launch.
-  }
+  } catch {}
 }
 
 export function isCachedListFresh(cached: CachedTinfoilModels): boolean {

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -18,7 +18,7 @@ export interface TinfoilCatalogModel {
 
 /**
  * Curated, translated descriptions keyed by model id. The endpoint only returns
- * English copy
+ * English copy.
  */
 const DESCRIPTION_KEYS: Record<string, string> = {
   "deepseek-v4-pro": "models.descriptions.cloud.tinfoil_deepseek_v4_pro",
@@ -29,9 +29,6 @@ const DESCRIPTION_KEYS: Record<string, string> = {
   "llama3-3-70b": "models.descriptions.cloud.tinfoil_llama3_3_70b",
 };
 
-/**
- * Turns Tinfoil's live list into registry entries.
- */
 function toCloudModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
   return catalog.map((model) => ({
     id: model.id,

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -36,7 +36,7 @@ const DESCRIPTION_KEYS: Record<string, string> = {
  * drop out and models we've never heard of appear. Only the description is
  * ours: every Tinfoil model takes max_tokens and supports temperature.
  */
-export function mergeTinfoilModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
+function toCloudModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
   return catalog.map((model) => ({
     id: model.id,
     name: model.name,
@@ -102,7 +102,7 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
     throw new Error("Tinfoil model list is unavailable");
   }
 
-  const models = mergeTinfoilModels(await fetchModels());
+  const models = toCloudModels(await fetchModels());
   // An empty list would mean Tinfoil serves no chat models at all. Far more
   // likely something upstream broke, so keep what we already have.
   if (models.length === 0) {
@@ -116,6 +116,11 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
   return models;
 }
 
+/** Whether refreshTinfoilModels would hit the network rather than short-circuit. */
+export function isTinfoilListFresh(): boolean {
+  return isCachedListFresh(readCachedTinfoilModels());
+}
+
 /**
  * Pulls Tinfoil's model list into the registry, at most once an hour. Cheap to
  * call before every request: a list we fetched recently short-circuits without
@@ -124,11 +129,6 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
  * leaving the registry as it was — an unreachable endpoint says nothing about
  * which models still exist.
  */
-/** Whether refreshTinfoilModels would hit the network rather than short-circuit. */
-export function isTinfoilListFresh(): boolean {
-  return isCachedListFresh(readCachedTinfoilModels());
-}
-
 export function refreshTinfoilModels(): Promise<CloudModelDefinition[]> {
   const cached = readCachedTinfoilModels();
   if (isCachedListFresh(cached)) {

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -1,5 +1,9 @@
 import { applyTinfoilModels, getTinfoilModels, type CloudModelDefinition } from "./ModelRegistry";
-import { writeCachedTinfoilModels } from "./tinfoilModelCache";
+import {
+  isCachedListFresh,
+  readCachedTinfoilModels,
+  writeCachedTinfoilModels,
+} from "./tinfoilModelCache";
 import { INFERENCE_SCOPES } from "../config/inferenceScopes";
 import { getSettings, setStringSetting } from "../stores/settingsStore";
 import { recordTinfoilModelSwitch } from "../stores/tinfoilModelSwitchStore";
@@ -113,12 +117,26 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
 }
 
 /**
- * Pulls Tinfoil's model list into the registry and the cache. The main process
- * refetches at most once an hour, so this is cheap to call before every
- * request. Rejects when Tinfoil can't be reached, leaving the registry as it
- * was — an unreachable endpoint says nothing about which models still exist.
+ * Pulls Tinfoil's model list into the registry, at most once an hour. Cheap to
+ * call before every request: a list we fetched recently short-circuits without
+ * touching the network, and the timestamp is persisted so a restart doesn't
+ * refetch a list we pulled a minute ago. Rejects when Tinfoil can't be reached,
+ * leaving the registry as it was — an unreachable endpoint says nothing about
+ * which models still exist.
  */
+/** Whether refreshTinfoilModels would hit the network rather than short-circuit. */
+export function isTinfoilListFresh(): boolean {
+  return isCachedListFresh(readCachedTinfoilModels());
+}
+
 export function refreshTinfoilModels(): Promise<CloudModelDefinition[]> {
+  const cached = readCachedTinfoilModels();
+  if (isCachedListFresh(cached)) {
+    // Another window may have fetched this; make sure our registry has it too.
+    applyTinfoilModels(cached.models);
+    return Promise.resolve(cached.models);
+  }
+
   if (!inFlight) {
     inFlight = fetchAndApply().finally(() => {
       inFlight = null;

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -18,8 +18,7 @@ export interface TinfoilCatalogModel {
 
 /**
  * Curated, translated descriptions keyed by model id. The endpoint only returns
- * English copy, so prefer these where we have them and fall back to the
- * endpoint's own description for models we haven't written one for.
+ * English copy
  */
 const DESCRIPTION_KEYS: Record<string, string> = {
   "deepseek-v4-pro": "models.descriptions.cloud.tinfoil_deepseek_v4_pro",
@@ -31,10 +30,7 @@ const DESCRIPTION_KEYS: Record<string, string> = {
 };
 
 /**
- * Turns Tinfoil's live list into registry entries. The endpoint is the source
- * of truth for which models exist and what they do, so models it doesn't list
- * drop out and models we've never heard of appear. Only the description is
- * ours: every Tinfoil model takes max_tokens and supports temperature.
+ * Turns Tinfoil's live list into registry entries.
  */
 function toCloudModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
   return catalog.map((model) => ({
@@ -50,11 +46,6 @@ function toCloudModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
 
 const DEFAULT_MODEL_ID = "glm-5-2";
 
-/**
- * The model to select when the user hasn't chosen one, or when the one they
- * chose is gone. Tinfoil's list order isn't a preference and can change without
- * an app release, so don't let it decide this.
- */
 export function pickDefaultTinfoilModel(
   models: CloudModelDefinition[]
 ): CloudModelDefinition | undefined {
@@ -103,9 +94,8 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
   }
 
   const models = toCloudModels(await fetchModels());
-  // An empty list would mean Tinfoil serves no chat models at all. Far more
-  // likely something upstream broke, so keep what we already have.
   if (models.length === 0) {
+    // Far more likely something upstream broke, so keep what we already have.
     throw new Error("Tinfoil returned no chat models");
   }
 
@@ -126,8 +116,7 @@ export function isTinfoilListFresh(): boolean {
  * call before every request: a list we fetched recently short-circuits without
  * touching the network, and the timestamp is persisted so a restart doesn't
  * refetch a list we pulled a minute ago. Rejects when Tinfoil can't be reached,
- * leaving the registry as it was — an unreachable endpoint says nothing about
- * which models still exist.
+ * leaving the registry as it was.
  */
 export function refreshTinfoilModels(): Promise<CloudModelDefinition[]> {
   const cached = readCachedTinfoilModels();

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -1,8 +1,12 @@
 import type { CloudModelDefinition } from "./ModelRegistry";
 
-export const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
-
-const CACHE_KEY = "tinfoilModels";
+/** A chat model as reported by Tinfoil's /v1/models, narrowed by the main process. */
+export interface TinfoilCatalogModel {
+  id: string;
+  name: string;
+  description: string;
+  supportsThinking: boolean;
+}
 
 /**
  * Curated, translated descriptions keyed by model id. The endpoint only returns
@@ -18,73 +22,28 @@ const DESCRIPTION_KEYS: Record<string, string> = {
   "llama3-3-70b": "models.descriptions.cloud.tinfoil_llama3_3_70b",
 };
 
-interface TinfoilApiModel {
-  id?: unknown;
-  name?: unknown;
-  description?: unknown;
-  type?: unknown;
-  reasoning?: unknown;
-  endpoints?: unknown;
-}
-
 /**
- * Tinfoil serves chat, audio, embedding, tts and tool models from one list, so
- * the reasoning picker has to narrow it to models it can actually send a chat
- * completion to.
+ * Turns Tinfoil's live list into registry entries. The endpoint is the source
+ * of truth for which models exist and what they do, so models it doesn't list
+ * drop out and models we've never heard of appear. Only the description is
+ * ours: every Tinfoil model takes max_tokens and supports temperature.
  */
-function isChatModel(model: TinfoilApiModel): boolean {
-  if (model.type !== "chat") return false;
-  return Array.isArray(model.endpoints) && model.endpoints.includes("/v1/chat/completions");
-}
-
-function toCloudModel(model: TinfoilApiModel): CloudModelDefinition | null {
-  const id = typeof model.id === "string" ? model.id : "";
-  if (!id) return null;
-
-  return {
-    id,
-    name: typeof model.name === "string" && model.name ? model.name : id,
-    description: typeof model.description === "string" ? model.description : "",
-    descriptionKey: DESCRIPTION_KEYS[id],
-    supportsThinking: model.reasoning === true,
+export function mergeTinfoilModels(catalog: TinfoilCatalogModel[]): CloudModelDefinition[] {
+  return catalog.map((model) => ({
+    id: model.id,
+    name: model.name,
+    description: model.description,
+    descriptionKey: DESCRIPTION_KEYS[model.id],
+    supportsThinking: model.supportsThinking,
     tokenParam: "max_tokens",
     supportsTemperature: true,
-  };
+  }));
 }
 
-export function parseTinfoilModels(payload: unknown): CloudModelDefinition[] {
-  const data = (payload as { data?: unknown } | null)?.data;
-  if (!Array.isArray(data)) return [];
-
-  return (data as TinfoilApiModel[])
-    .filter(isChatModel)
-    .map(toCloudModel)
-    .filter((model): model is CloudModelDefinition => model !== null);
-}
-
-export async function fetchTinfoilModels(signal?: AbortSignal): Promise<CloudModelDefinition[]> {
-  const response = await fetch(TINFOIL_MODELS_URL, { method: "GET", signal });
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`.trim());
+export async function fetchTinfoilModels(): Promise<CloudModelDefinition[]> {
+  const fetchModels = window.electronAPI?.getTinfoilChatModels;
+  if (!fetchModels) {
+    throw new Error("Tinfoil model list is unavailable");
   }
-  return parseTinfoilModels(await response.json());
-}
-
-export function readCachedTinfoilModels(): CloudModelDefinition[] {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
-  try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(models));
-  } catch {
-    // Cache is best-effort; a failed write just means a refetch next launch.
-  }
+  return mergeTinfoilModels(await fetchModels());
 }

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -1,5 +1,8 @@
-import { applyTinfoilModels, type CloudModelDefinition } from "./ModelRegistry";
+import { applyTinfoilModels, getTinfoilModels, type CloudModelDefinition } from "./ModelRegistry";
 import { writeCachedTinfoilModels } from "./tinfoilModelCache";
+import { INFERENCE_SCOPES } from "../config/inferenceScopes";
+import { getSettings, setStringSetting } from "../stores/settingsStore";
+import { recordTinfoilModelSwitch } from "../stores/tinfoilModelSwitchStore";
 
 /** A chat model as reported by Tinfoil's /v1/models, narrowed by the main process. */
 export interface TinfoilCatalogModel {
@@ -41,6 +44,38 @@ export function mergeTinfoilModels(catalog: TinfoilCatalogModel[]): CloudModelDe
   }));
 }
 
+/**
+ * Moves any scope still pointing at a model Tinfoil has retired onto one it
+ * still serves — otherwise the next request is a 404 the user can't diagnose.
+ * Only ever called after a successful fetch, so a missing model really is gone.
+ */
+function reconcileSelectedModels(
+  previous: CloudModelDefinition[],
+  models: CloudModelDefinition[]
+): void {
+  const available = new Set(models.map((model) => model.id));
+  const settings = getSettings() as unknown as Record<string, unknown>;
+  const replacement = models[0];
+  const announced = new Set<string>();
+
+  for (const scope of Object.values(INFERENCE_SCOPES)) {
+    const { provider, model } = scope.storeKeys;
+    if (settings[provider] !== "tinfoil") continue;
+
+    const selected = settings[model];
+    if (typeof selected !== "string" || !selected || available.has(selected)) continue;
+
+    setStringSetting(model, replacement.id);
+    // Several scopes can share a retired model; say so once.
+    if (announced.has(selected)) continue;
+    announced.add(selected);
+    recordTinfoilModelSwitch({
+      from: previous.find((m) => m.id === selected)?.name ?? selected,
+      to: replacement.name,
+    });
+  }
+}
+
 let inFlight: Promise<CloudModelDefinition[]> | null = null;
 
 async function fetchAndApply(): Promise<CloudModelDefinition[]> {
@@ -56,8 +91,10 @@ async function fetchAndApply(): Promise<CloudModelDefinition[]> {
     throw new Error("Tinfoil returned no chat models");
   }
 
+  const previous = getTinfoilModels();
   applyTinfoilModels(models);
   writeCachedTinfoilModels(models);
+  reconcileSelectedModels(previous, models);
   return models;
 }
 

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -1,4 +1,5 @@
-import type { CloudModelDefinition } from "./ModelRegistry";
+import { applyTinfoilModels, type CloudModelDefinition } from "./ModelRegistry";
+import { writeCachedTinfoilModels } from "./tinfoilModelCache";
 
 /** A chat model as reported by Tinfoil's /v1/models, narrowed by the main process. */
 export interface TinfoilCatalogModel {
@@ -40,10 +41,37 @@ export function mergeTinfoilModels(catalog: TinfoilCatalogModel[]): CloudModelDe
   }));
 }
 
-export async function fetchTinfoilModels(): Promise<CloudModelDefinition[]> {
+let inFlight: Promise<CloudModelDefinition[]> | null = null;
+
+async function fetchAndApply(): Promise<CloudModelDefinition[]> {
   const fetchModels = window.electronAPI?.getTinfoilChatModels;
   if (!fetchModels) {
     throw new Error("Tinfoil model list is unavailable");
   }
-  return mergeTinfoilModels(await fetchModels());
+
+  const models = mergeTinfoilModels(await fetchModels());
+  // An empty list would mean Tinfoil serves no chat models at all. Far more
+  // likely something upstream broke, so keep what we already have.
+  if (models.length === 0) {
+    throw new Error("Tinfoil returned no chat models");
+  }
+
+  applyTinfoilModels(models);
+  writeCachedTinfoilModels(models);
+  return models;
+}
+
+/**
+ * Pulls Tinfoil's model list into the registry and the cache. The main process
+ * refetches at most once an hour, so this is cheap to call before every
+ * request. Rejects when Tinfoil can't be reached, leaving the registry as it
+ * was — an unreachable endpoint says nothing about which models still exist.
+ */
+export function refreshTinfoilModels(): Promise<CloudModelDefinition[]> {
+  if (!inFlight) {
+    inFlight = fetchAndApply().finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
 }

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -1,0 +1,90 @@
+import type { CloudModelDefinition } from "./ModelRegistry";
+
+export const TINFOIL_MODELS_URL = "https://inference.tinfoil.sh/v1/models";
+
+const CACHE_KEY = "tinfoilModels";
+
+/**
+ * Curated, translated descriptions keyed by model id. The endpoint only returns
+ * English copy, so prefer these where we have them and fall back to the
+ * endpoint's own description for models we haven't written one for.
+ */
+const DESCRIPTION_KEYS: Record<string, string> = {
+  "deepseek-v4-pro": "models.descriptions.cloud.tinfoil_deepseek_v4_pro",
+  "glm-5-2": "models.descriptions.cloud.tinfoil_glm_5_2",
+  "kimi-k2-6": "models.descriptions.cloud.tinfoil_kimi_k2_6",
+  "gemma4-31b": "models.descriptions.cloud.tinfoil_gemma4_31b",
+  "gpt-oss-120b": "models.descriptions.cloud.tinfoil_gpt_oss_120b",
+  "llama3-3-70b": "models.descriptions.cloud.tinfoil_llama3_3_70b",
+};
+
+interface TinfoilApiModel {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+  type?: unknown;
+  reasoning?: unknown;
+  endpoints?: unknown;
+}
+
+/**
+ * Tinfoil serves chat, audio, embedding, tts and tool models from one list, so
+ * the reasoning picker has to narrow it to models it can actually send a chat
+ * completion to.
+ */
+function isChatModel(model: TinfoilApiModel): boolean {
+  if (model.type !== "chat") return false;
+  return Array.isArray(model.endpoints) && model.endpoints.includes("/v1/chat/completions");
+}
+
+function toCloudModel(model: TinfoilApiModel): CloudModelDefinition | null {
+  const id = typeof model.id === "string" ? model.id : "";
+  if (!id) return null;
+
+  return {
+    id,
+    name: typeof model.name === "string" && model.name ? model.name : id,
+    description: typeof model.description === "string" ? model.description : "",
+    descriptionKey: DESCRIPTION_KEYS[id],
+    supportsThinking: model.reasoning === true,
+    tokenParam: "max_tokens",
+    supportsTemperature: true,
+  };
+}
+
+export function parseTinfoilModels(payload: unknown): CloudModelDefinition[] {
+  const data = (payload as { data?: unknown } | null)?.data;
+  if (!Array.isArray(data)) return [];
+
+  return (data as TinfoilApiModel[])
+    .filter(isChatModel)
+    .map(toCloudModel)
+    .filter((model): model is CloudModelDefinition => model !== null);
+}
+
+export async function fetchTinfoilModels(signal?: AbortSignal): Promise<CloudModelDefinition[]> {
+  const response = await fetch(TINFOIL_MODELS_URL, { method: "GET", signal });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`.trim());
+  }
+  return parseTinfoilModels(await response.json());
+}
+
+export function readCachedTinfoilModels(): CloudModelDefinition[] {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeCachedTinfoilModels(models: CloudModelDefinition[]): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(models));
+  } catch {
+    // Cache is best-effort; a failed write just means a refetch next launch.
+  }
+}

--- a/src/models/tinfoilModels.ts
+++ b/src/models/tinfoilModels.ts
@@ -44,6 +44,19 @@ export function mergeTinfoilModels(catalog: TinfoilCatalogModel[]): CloudModelDe
   }));
 }
 
+const DEFAULT_MODEL_ID = "glm-5-2";
+
+/**
+ * The model to select when the user hasn't chosen one, or when the one they
+ * chose is gone. Tinfoil's list order isn't a preference and can change without
+ * an app release, so don't let it decide this.
+ */
+export function pickDefaultTinfoilModel(
+  models: CloudModelDefinition[]
+): CloudModelDefinition | undefined {
+  return models.find((model) => model.id === DEFAULT_MODEL_ID) ?? models[0];
+}
+
 /**
  * Moves any scope still pointing at a model Tinfoil has retired onto one it
  * still serves — otherwise the next request is a 404 the user can't diagnose.
@@ -55,7 +68,8 @@ function reconcileSelectedModels(
 ): void {
   const available = new Set(models.map((model) => model.id));
   const settings = getSettings() as unknown as Record<string, unknown>;
-  const replacement = models[0];
+  const replacement = pickDefaultTinfoilModel(models);
+  if (!replacement) return;
   const announced = new Set<string>();
 
   for (const scope of Object.values(INFERENCE_SCOPES)) {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -592,8 +592,7 @@ class ReasoningService extends BaseReasoningService {
         provider === "custom" ? config.baseUrl?.trim() || getConfiguredOpenAIBase() : undefined;
     }
     const aiProvider = isLocalProvider || isLanCleanup ? "local" : provider;
-    // Resolving the model can refresh the registry (Tinfoil pulls its list at
-    // request time), so read model config only once that has settled.
+    // Resolving a Tinfoil model refreshes the registry, so read model config after it.
     const aiModel = await getAIModel(aiProvider, model, apiKey, baseURL);
 
     const apiConfig = getOpenAiApiConfig(model);

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -591,11 +591,12 @@ class ReasoningService extends BaseReasoningService {
       baseURL =
         provider === "custom" ? config.baseUrl?.trim() || getConfiguredOpenAIBase() : undefined;
     }
-    const apiConfig = getOpenAiApiConfig(model);
-
     const aiProvider = isLocalProvider || isLanCleanup ? "local" : provider;
+    // Resolving the model can refresh the registry (Tinfoil pulls its list at
+    // request time), so read model config only once that has settled.
     const aiModel = await getAIModel(aiProvider, model, apiKey, baseURL);
 
+    const apiConfig = getOpenAiApiConfig(model);
     const modelDef = getCloudModel(model);
     const userSuppressesThinking = config.disableThinking === true && !!modelDef?.supportsThinking;
     const needsGroqDisableThinking =

--- a/src/services/ai/inferenceProviders/tinfoil.ts
+++ b/src/services/ai/inferenceProviders/tinfoil.ts
@@ -1,6 +1,5 @@
 import type { InferenceProvider } from "./types";
 import { TOKEN_LIMITS } from "../../../config/constants";
-import { getOpenAiApiConfig } from "../../../models/ModelRegistry";
 import { withRetry, createApiRetryStrategy } from "../../../utils/retry";
 import logger from "../../../utils/logger";
 import { applyThinkingSuppression } from "../thinkingSuppression";
@@ -26,7 +25,6 @@ export const tinfoilProvider: InferenceProvider = {
       { role: "user", content: userContent },
     ];
 
-    const apiConfig = getOpenAiApiConfig(model);
     const maxTokens =
       config.maxTokens ||
       Math.max(
@@ -39,15 +37,15 @@ export const tinfoilProvider: InferenceProvider = {
         )
       );
 
+    // Every Tinfoil model takes max_tokens and supports temperature, so don't
+    // resolve these through the registry — its model list is fetched at runtime
+    // and a cold start would otherwise fall back to the wrong defaults.
     const requestBody: Record<string, unknown> = {
       model,
       messages,
-      [apiConfig.tokenParam]: maxTokens,
+      max_tokens: maxTokens,
+      temperature: config.temperature ?? (config.systemPrompt ? 0.3 : 0),
     };
-
-    if (apiConfig.supportsTemperature) {
-      requestBody.temperature = config.temperature ?? (config.systemPrompt ? 0.3 : 0);
-    }
 
     applyThinkingSuppression(requestBody, model, "tinfoil", config);
 

--- a/src/services/ai/inferenceProviders/tinfoil.ts
+++ b/src/services/ai/inferenceProviders/tinfoil.ts
@@ -37,9 +37,6 @@ export const tinfoilProvider: InferenceProvider = {
         )
       );
 
-    // Every Tinfoil model takes max_tokens and supports temperature, so don't
-    // resolve these through the registry — its model list is fetched at runtime
-    // and a cold start would otherwise fall back to the wrong defaults.
     const requestBody: Record<string, unknown> = {
       model,
       messages,

--- a/src/services/ai/tinfoilClient.ts
+++ b/src/services/ai/tinfoilClient.ts
@@ -30,22 +30,16 @@ function normalizeApiKey(apiKey: string): string {
 }
 
 /**
- * Tinfoil adds and retires models without an app release, so pull its list into
- * the registry before every request — later code reads token params and
- * thinking support from there. The main process caps this at one fetch an hour,
- * and a failure leaves the registry on its last known list.
+ * Tinfoil adds and retires models semi-often, so kick off a sync of Tinfoils model registry
  */
-async function syncTinfoilCatalog(): Promise<void> {
-  try {
-    await refreshTinfoilModels();
-  } catch {
-    // Offline or endpoint down: keep the models we already know about.
-  }
+function syncTinfoilCatalog(): void {
+  // Offline or endpoint down: keep the models we already know about.
+  void refreshTinfoilModels().catch(() => {});
 }
 
 export async function getTinfoilChatClient(apiKey: string): Promise<TinfoilAI> {
   const key = normalizeApiKey(apiKey);
-  await syncTinfoilCatalog();
+  syncTinfoilCatalog();
   const cached = chatClientCache.get(key);
   if (cached) return cached;
 
@@ -66,7 +60,7 @@ export async function getTinfoilChatClient(apiKey: string): Promise<TinfoilAI> {
 
 async function getTinfoilAISDKProvider(apiKey: string): Promise<TinfoilAISDKProvider> {
   const key = normalizeApiKey(apiKey);
-  await syncTinfoilCatalog();
+  syncTinfoilCatalog();
   const cached = aiSdkProviderCache.get(key);
   if (cached) return cached;
 

--- a/src/services/ai/tinfoilClient.ts
+++ b/src/services/ai/tinfoilClient.ts
@@ -29,9 +29,7 @@ function normalizeApiKey(apiKey: string): string {
   return key;
 }
 
-/**
- * Tinfoil adds and retires models semi-often, so kick off a sync of Tinfoils model registry
- */
+/** Tinfoil adds and retires models often; sync the registry in the background. */
 function syncTinfoilCatalog(): void {
   void refreshTinfoilModels().catch(() => {});
 }

--- a/src/services/ai/tinfoilClient.ts
+++ b/src/services/ai/tinfoilClient.ts
@@ -33,7 +33,6 @@ function normalizeApiKey(apiKey: string): string {
  * Tinfoil adds and retires models semi-often, so kick off a sync of Tinfoils model registry
  */
 function syncTinfoilCatalog(): void {
-  // Offline or endpoint down: keep the models we already know about.
   void refreshTinfoilModels().catch(() => {});
 }
 

--- a/src/services/ai/tinfoilClient.ts
+++ b/src/services/ai/tinfoilClient.ts
@@ -1,5 +1,6 @@
 import type { LanguageModel } from "ai";
 import type { TinfoilAI } from "tinfoil";
+import { refreshTinfoilModels } from "../../models/tinfoilModels";
 
 type TinfoilModule = typeof import("tinfoil");
 type TinfoilAISDKProvider = Awaited<ReturnType<TinfoilModule["createTinfoilAI"]>>;
@@ -28,8 +29,23 @@ function normalizeApiKey(apiKey: string): string {
   return key;
 }
 
+/**
+ * Tinfoil adds and retires models without an app release, so pull its list into
+ * the registry before every request — later code reads token params and
+ * thinking support from there. The main process caps this at one fetch an hour,
+ * and a failure leaves the registry on its last known list.
+ */
+async function syncTinfoilCatalog(): Promise<void> {
+  try {
+    await refreshTinfoilModels();
+  } catch {
+    // Offline or endpoint down: keep the models we already know about.
+  }
+}
+
 export async function getTinfoilChatClient(apiKey: string): Promise<TinfoilAI> {
   const key = normalizeApiKey(apiKey);
+  await syncTinfoilCatalog();
   const cached = chatClientCache.get(key);
   if (cached) return cached;
 
@@ -50,6 +66,7 @@ export async function getTinfoilChatClient(apiKey: string): Promise<TinfoilAI> {
 
 async function getTinfoilAISDKProvider(apiKey: string): Promise<TinfoilAISDKProvider> {
   const key = normalizeApiKey(apiKey);
+  await syncTinfoilCatalog();
   const cached = aiSdkProviderCache.get(key);
   if (cached) return cached;
 

--- a/src/stores/actionProcessingStore.ts
+++ b/src/stores/actionProcessingStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import reasoningService from "../services/ReasoningService";
-import { getSettings } from "./settingsStore";
+import { getSettings, selectResolvedNoteFormatting } from "./settingsStore";
 import { appendDictionarySuffix } from "../config/prompts";
 import { generateNoteTitle } from "../utils/generateTitle";
 import type { ActionItem } from "../types/electron";
@@ -123,7 +123,18 @@ export function runBackgroundAction(
     try {
       const basePrompt = options.isMeetingNote ? MEETING_SYSTEM_PROMPT : BASE_SYSTEM_PROMPT;
       const settings = getSettings();
-      const provider = options.isCloudMode ? "openwhispr" : undefined;
+      const noteFormatting = selectResolvedNoteFormatting(settings);
+      const provider = options.isCloudMode
+        ? "openwhispr"
+        : noteFormatting.mode === "providers"
+          ? noteFormatting.provider || undefined
+          : undefined;
+      const isCustom = provider === "custom";
+      const providerOverrides = {
+        provider,
+        baseUrl: isCustom ? noteFormatting.cloudBaseUrl || undefined : undefined,
+        customApiKey: isCustom ? settings.noteFormattingCustomApiKey || undefined : undefined,
+      };
       const systemPrompt = appendDictionarySuffix(
         basePrompt + action.prompt,
         options.isMeetingNote ? settings.customDictionary : undefined,
@@ -133,14 +144,14 @@ export function runBackgroundAction(
         systemPrompt,
         temperature: 0.3,
         disableThinking: settings.noteFormattingDisableThinking,
-        provider,
+        ...providerOverrides,
       });
 
       if (cancelledFlags.get(noteId)) return;
 
       let title: string | undefined;
       if (getSettings().autoGenerateNoteTitle) {
-        const generated = await generateNoteTitle(enhanced, modelId, provider);
+        const generated = await generateNoteTitle(enhanced, modelId, providerOverrides);
         if (generated) title = generated;
       }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -681,7 +681,7 @@ function createStringSetter(key: string) {
 }
 
 /** Writes a string setting whose key is computed rather than known up front. */
-export function setStringSetting(key: string, value: string): void {
+export function setStringSetting(key: keyof SettingsState, value: string): void {
   createStringSetter(key)(value);
 }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -680,6 +680,11 @@ function createStringSetter(key: string) {
   };
 }
 
+/** Writes a string setting whose key is computed rather than known up front. */
+export function setStringSetting(key: string, value: string): void {
+  createStringSetter(key)(value);
+}
+
 function createBooleanSetter(key: string) {
   return (value: boolean) => {
     if (isBrowser) localStorage.setItem(key, String(value));

--- a/src/stores/tinfoilModelSwitchStore.ts
+++ b/src/stores/tinfoilModelSwitchStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+export interface TinfoilModelSwitch {
+  /** Display name of the model Tinfoil retired. */
+  from: string;
+  /** Display name of the model we moved the user to. */
+  to: string;
+}
+
+interface TinfoilModelSwitchState {
+  events: TinfoilModelSwitch[];
+}
+
+export const useTinfoilModelSwitchStore = create<TinfoilModelSwitchState>(() => ({
+  events: [],
+}));
+
+export function recordTinfoilModelSwitch(event: TinfoilModelSwitch): void {
+  useTinfoilModelSwitchStore.setState((state) => ({ events: [...state.events, event] }));
+}
+
+export function consumeTinfoilModelSwitches(): TinfoilModelSwitch[] {
+  const { events } = useTinfoilModelSwitchStore.getState();
+  if (events.length > 0) {
+    useTinfoilModelSwitchStore.setState({ events: [] });
+  }
+  return events;
+}

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1,3 +1,5 @@
+import type { TinfoilCatalogModel } from "../models/tinfoilModels";
+
 export type LocalTranscriptionProvider = "whisper" | "nvidia";
 
 export type InferenceMode = "openwhispr" | "providers" | "local" | "self-hosted" | "enterprise";
@@ -1032,6 +1034,7 @@ declare global {
       }) => Promise<{ text: string }>;
       getTinfoilKey?: () => Promise<string | null>;
       saveTinfoilKey?: (key: string) => Promise<void>;
+      getTinfoilChatModels?: () => Promise<TinfoilCatalogModel[]>;
 
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;

--- a/src/utils/generateTitle.ts
+++ b/src/utils/generateTitle.ts
@@ -1,4 +1,5 @@
 import reasoningService from "../services/ReasoningService";
+import type { ReasoningConfig } from "../services/BaseReasoningService";
 import { getSettings } from "../stores/settingsStore";
 
 const TITLE_SYSTEM_PROMPT =
@@ -7,14 +8,14 @@ const TITLE_SYSTEM_PROMPT =
 export async function generateNoteTitle(
   text: string,
   modelId: string,
-  provider?: string
+  config?: Pick<ReasoningConfig, "provider" | "baseUrl" | "customApiKey">
 ): Promise<string> {
   try {
     const raw = await reasoningService.processText(text.slice(0, 2000), modelId, null, {
       systemPrompt: TITLE_SYSTEM_PROMPT,
       temperature: 0.3,
       disableThinking: getSettings().noteFormattingDisableThinking,
-      provider,
+      ...config,
     });
     const cleaned = raw.trim().replace(/^["']|["']$/g, "");
     return cleaned.length > 0 && cleaned.length < 100 ? cleaned : "";

--- a/test/helpers/tinfoilCatalog.test.js
+++ b/test/helpers/tinfoilCatalog.test.js
@@ -9,8 +9,8 @@ function loadCatalog(fetchImpl) {
   delete require.cache[catalogModulePath];
 
   Module._load = function loadWithMocks(request, parent, isMain) {
-    if (request === "electron") {
-      return { net: { fetch: fetchImpl } };
+    if (request === "./tinfoilSecureClient") {
+      return { tinfoilSecureFetch: fetchImpl };
     }
     if (request === "./debugLogger") {
       return { warn() {} };

--- a/test/helpers/tinfoilCatalog.test.js
+++ b/test/helpers/tinfoilCatalog.test.js
@@ -62,7 +62,7 @@ test("reports supportsThinking from the reasoning flag", async () => {
   assert.equal(model.supportsThinking, false);
 });
 
-test("refetches at most once an hour and shares one request between callers", async () => {
+test("shares one in-flight request between concurrent callers", async () => {
   let calls = 0;
   const { getTinfoilChatModels } = loadCatalog(async () => {
     calls += 1;
@@ -70,11 +70,9 @@ test("refetches at most once an hour and shares one request between callers", as
   });
 
   const [first, second] = await Promise.all([getTinfoilChatModels(), getTinfoilChatModels()]);
-  const third = await getTinfoilChatModels();
 
   assert.equal(calls, 1);
   assert.equal(first, second);
-  assert.equal(first, third);
 });
 
 test("rejects rather than returning a list when the payload is malformed", async () => {

--- a/test/helpers/tinfoilCatalog.test.js
+++ b/test/helpers/tinfoilCatalog.test.js
@@ -1,0 +1,108 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const catalogModulePath = require.resolve("../../src/helpers/tinfoilCatalog.js");
+const originalLoad = Module._load;
+
+function loadCatalog(fetchImpl) {
+  delete require.cache[catalogModulePath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return { net: { fetch: fetchImpl } };
+    }
+    if (request === "./debugLogger") {
+      return { warn() {} };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(catalogModulePath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function okResponse(data) {
+  return { ok: true, status: 200, json: async () => ({ object: "list", data }) };
+}
+
+const CHAT_MODEL = {
+  id: "glm-5-2",
+  name: "GLM-5.2",
+  description: "d",
+  type: "chat",
+  reasoning: true,
+  endpoints: ["/v1/chat/completions"],
+};
+
+test("keeps only chat models reachable at /v1/chat/completions", async () => {
+  const { getTinfoilChatModels } = loadCatalog(async () =>
+    okResponse([
+      CHAT_MODEL,
+      { id: "voxtral", name: "Voxtral", type: "audio", endpoints: ["/v1/audio/transcriptions"] },
+      { id: "embed", name: "Embed", type: "embedding", endpoints: ["/v1/embeddings"] },
+      { id: "chat-no-endpoint", name: "Odd", type: "chat", endpoints: ["/v1/responses"] },
+    ])
+  );
+
+  assert.deepEqual(await getTinfoilChatModels(), [
+    { id: "glm-5-2", name: "GLM-5.2", description: "d", supportsThinking: true },
+  ]);
+});
+
+test("reports supportsThinking from the reasoning flag", async () => {
+  const { getTinfoilChatModels } = loadCatalog(async () =>
+    okResponse([{ ...CHAT_MODEL, id: "llama3-3-70b", name: "Llama", reasoning: false }])
+  );
+
+  const [model] = await getTinfoilChatModels();
+  assert.equal(model.supportsThinking, false);
+});
+
+test("refetches at most once an hour and shares one request between callers", async () => {
+  let calls = 0;
+  const { getTinfoilChatModels } = loadCatalog(async () => {
+    calls += 1;
+    return okResponse([CHAT_MODEL]);
+  });
+
+  const [first, second] = await Promise.all([getTinfoilChatModels(), getTinfoilChatModels()]);
+  const third = await getTinfoilChatModels();
+
+  assert.equal(calls, 1);
+  assert.equal(first, second);
+  assert.equal(first, third);
+});
+
+test("rejects rather than returning a list when the payload is malformed", async () => {
+  const { getTinfoilChatModels } = loadCatalog(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ object: "list" }),
+  }));
+
+  await assert.rejects(getTinfoilChatModels(), /Malformed models list/);
+});
+
+test("rejects on a non-200 response", async () => {
+  const { getTinfoilChatModels } = loadCatalog(async () => ({ ok: false, status: 503 }));
+
+  await assert.rejects(getTinfoilChatModels(), /503/);
+});
+
+test("backs off after a failure instead of refetching on every call", async () => {
+  let calls = 0;
+  const { getTinfoilChatModels } = loadCatalog(async () => {
+    calls += 1;
+    throw new Error("ENOTFOUND");
+  });
+
+  await assert.rejects(getTinfoilChatModels());
+  await assert.rejects(getTinfoilChatModels(), /unavailable/);
+  await assert.rejects(getTinfoilChatModels(), /unavailable/);
+
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
# Summary 

Tinfoil is unique in that our models are more ephemeral than most of the providers (unlike openai, ant, etc.). It's closer to custom/self-hosted models, which fetch from /models, but it's also different from them in that we know the shape of what we should get, eg `max_tokens` and per-model `reasoning`.

This PR changes tinfoil handlers to refresh the list of active models every hour.  It saves these in localStorage, so they are persistent. After fetching the active list, we set this as the current registry for tinfoil. If this fails, we keep the registry the same. In the unfortunate case that a user was using this model, the model is switched to a different tinfoil model and a toast popup alerts them. 

The tinfoil model sync runs in the background, and is only triggered if someone is using tinfoil, so it doesn't fetch for users who don't use TInfoil. The model registry comes with a set of Tinfoil models that will probably be accurate for a while, so users don't have to wait to see what's available

# Problem
Tinfoil's model list was hardcoded in `modelRegistryData.json` and had already drifted (it still listed `deepseek-v4-pro`, which the API no longer serves). Now it's fetched from `https://inference.tinfoil.sh/v1/models`, filtered to `type: "chat"` models that expose `/v1/chat/completions`.

# Other things
Curated translated descriptions for the existing models are kept as the api only returns english descriptions.

The tinfoil model list lives in localStorage on the renderer instead of on the main process because it's needed immediately (The main process actually does the fetch). This follows the pattern in settingsStore for user preferences.


<img width="340" height="137" alt="Screenshot 2026-07-09 at 4 08 28 PM" src="https://github.com/user-attachments/assets/fc63fbcf-8c72-42c2-8b75-97c1b3fbb158" />
