### PR TITLE
fix(auto-learn): make paste monitoring read-only, never set AXEnhancedUserInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- **Dictating into Claude Desktop and claude.ai no longer breaks after the first paste.** The auto-learn correction monitor used to force the `AXEnhancedUserInterface` accessibility flag onto the app it pasted into. On some Chromium apps (Claude Desktop, claude.ai in any browser) that flag permanently blurs the message composer, so every dictation after the first pasted into a field that no longer had keyboard focus. Monitoring is now strictly read-only: apps that expose their accessibility tree keep auto-learn working as before, and apps that don't simply skip correction learning for that paste. Restart the affected app once after updating to clear the stuck flag.
 - **No more Windows Firewall prompt for local Parakeet transcription.** The bundled sherpa-onnx server only serves OpenWhispr itself over `127.0.0.1`, but the upstream binary has no loopback-only bind option, so Windows raised an "allow public and private networks" prompt when it started. All-users installs now register a scoped inbound block rule for the server binary: the prompt is gone, the port is closed to the network, and transcription is unaffected because Windows never filters loopback traffic. The rule is removed on uninstall. (#1090)
 
 ## [1.7.4] - 2026-07-07

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -11,17 +11,13 @@ const INITIAL_QUERY_RETRY_DELAY_MS = 300;
 const ACTIVATE_CONFIRM_RETRIES = 6; // Poll the frontmost app until activation lands
 const ACTIVATE_CONFIRM_DELAY_MS = 25;
 
-// AppleScript to enable AXEnhancedUserInterface on the target app.
-// Chromium-based apps (Chrome, Electron, VS Code, Slack, etc.) don't build their
-// accessibility tree until an assistive technology announces itself via this attribute.
-// This is the same technique Grammarly uses on macOS.
-const MACOS_AX_ENABLE_SCRIPT = (pid) =>
-  `tell application "System Events"\n` +
-  `\tset targetProc to first application process whose unix id is ${pid}\n` +
-  `\ttry\n` +
-  `\t\tset value of attribute "AXEnhancedUserInterface" of targetProc to true\n` +
-  `\tend try\n` +
-  `end tell`;
+// Monitoring is strictly read-only: never write AXEnhancedUserInterface (or any
+// AX attribute) on the target app to force its accessibility tree. Flipping that
+// flag switches the whole process into screen-reader mode for its lifetime and
+// blurs the focused editor in some Chromium apps (Claude Desktop, claude.ai),
+// so every dictation after the first pasted into a field that no longer had
+// keyboard focus. Modern Chromium builds the tree on demand when our
+// reads arrive; where it doesn't, we skip auto-learn for that paste instead.
 
 // Returns the character before the cursor for smart-spacing. Output protocol:
 //   "OK:X"   — preceding char is X
@@ -362,26 +358,6 @@ class TextEditMonitor extends EventEmitter {
   }
 
   /**
-   * macOS: tell the target app that an assistive technology is present.
-   * This causes Chromium/Electron apps to build their accessibility tree.
-   */
-  _enableAccessibility(pid) {
-    return new Promise((resolve) => {
-      const script = MACOS_AX_ENABLE_SCRIPT(pid);
-      execFile("osascript", ["-e", script], { timeout: 3000 }, (err) => {
-        if (err) {
-          debugLogger.debug("[TextEditMonitor] macOS: AXEnhancedUserInterface failed", {
-            error: err.message,
-          });
-        } else {
-          debugLogger.debug("[TextEditMonitor] macOS: AXEnhancedUserInterface enabled", { pid });
-        }
-        resolve();
-      });
-    });
-  }
-
-  /**
    * macOS: use the native Swift AXObserver binary for event-based text monitoring.
    * Falls back to osascript polling if the binary fails to start.
    */
@@ -396,9 +372,6 @@ class TextEditMonitor extends EventEmitter {
       targetPid,
       textPreview: originalText.substring(0, 80),
     });
-
-    await this._enableAccessibility(targetPid);
-    if (this.currentOriginalText === null) return;
 
     await new Promise((r) => setTimeout(r, INITIAL_QUERY_DELAY_MS));
     if (this.currentOriginalText === null) return;
@@ -488,15 +461,11 @@ class TextEditMonitor extends EventEmitter {
       textPreview: originalText.substring(0, 80),
     });
 
-    // Enable accessibility on the target app first (needed for Chromium/Electron apps),
-    // then delay before querying to let the paste keystroke be processed.
-    this._enableAccessibility(targetPid).then(() => {
-      if (this.currentOriginalText === null) return; // guard against stopMonitoring()
-      setTimeout(
-        () => this._queryInitialValue(targetPid, originalText, timeoutMs),
-        INITIAL_QUERY_DELAY_MS
-      );
-    });
+    // Delay before querying to let the paste keystroke be processed.
+    setTimeout(
+      () => this._queryInitialValue(targetPid, originalText, timeoutMs),
+      INITIAL_QUERY_DELAY_MS
+    );
   }
 
   /**

--- a/test/helpers/textEditMonitorPrecedingChar.test.js
+++ b/test/helpers/textEditMonitorPrecedingChar.test.js
@@ -37,3 +37,27 @@ test("activateTargetPid resolves false for an unmapped PID", async () => {
   assert.equal(result, false);
   assert.ok(Date.now() - start < 3000);
 });
+
+const darwinOnly = { skip: process.platform !== "darwin" };
+
+test("startMonitoring stops immediately without a target PID", darwinOnly, () => {
+  const m = new TextEditMonitor();
+  m.startMonitoring("pasted text", 5000, { targetPid: null });
+  assert.equal(m.currentOriginalText, null);
+  assert.equal(m.process, null);
+});
+
+test("startMonitoring self-terminates when the target has no accessible focused element", darwinOnly, async () => {
+  const m = new TextEditMonitor();
+  // Auto-learn must degrade by giving up (NO_ELEMENT → stopMonitoring), never by
+  // writing AX attributes like AXEnhancedUserInterface onto the target app —
+  // that flag blurs the focused editor in some Chromium apps (see module comment).
+  m.startMonitoring("pasted text", 4000, { targetPid: 99999999 });
+  const deadline = Date.now() + 6000;
+  while (m.currentOriginalText !== null && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  assert.equal(m.currentOriginalText, null);
+  assert.equal(m.process, null);
+  assert.equal(m._pollInterval, null);
+});


### PR DESCRIPTION
## Problem

Dictating into Claude Desktop (or claude.ai in any browser) worked once, then every later dictation silently pasted nothing — the composer visibly lost focus.

## Root cause

After every paste, the auto-learn correction monitor ran an AppleScript that set `AXEnhancedUserInterface=true` on the target app so Chromium apps would build their accessibility tree. That attribute is a private VoiceOver-era signal, and setting it:

- flips the **entire target process** into screen-reader mode for its lifetime (it outlives OpenWhispr and survives our restarts),
- triggers a full accessibility-tree rebuild whose focus churn **permanently blurs the composer** in some Chromium apps (Claude Desktop and claude.ai are confirmed; ChatGPT's editor happens to survive it),
- cannot be undone — setting it back to `false` does not restore focus; only restarting the target app does.

So the first dictation landed, the flag was set 500ms later, the input blurred, and every subsequent Cmd+V had no first responder to land in. This is the same attribute that historically caused the VS Code "window jumps while dragging" bug when third-party utilities set it.

Verified end-to-end on Claude Desktop with a controlled A/B: a CGEvent Cmd+V lands in the composer on a fresh instance; after setting the flag the identical paste fails and Cmd+A selects the page body instead of the composer; clearing the flag does not recover.

## Fix

Monitoring is now strictly read-only — the flag write (`MACOS_AX_ENABLE_SCRIPT` / `_enableAccessibility`) is removed from both the native and the polling paths:

- The Swift monitor already retries `AXFocusedUIElement` 5× and exits `NO_ELEMENT` when the tree is unavailable, which the JS side already handles by stopping cleanly. Modern Chromium enables accessibility on demand when AX API calls arrive.
- Apps that expose an accessibility tree keep auto-learn exactly as before; apps that don't now **skip correction learning for that paste** instead of being forced into a degraded mode that breaks dictation.

The paste path itself (#1000) is untouched — it was working correctly.

Users on an already-poisoned app need to restart that app once after updating (noted in the changelog).

## Testing

- New regression tests: `startMonitoring` with no/unmapped PID self-terminates via the `NO_ELEMENT` path (exercises the real binary) without touching the target.
- Full suite: 196 pass, 0 fail, 11 platform-skipped.