### PR TITLE
fix(notes): stop enhancement from using another note's transcript and renaming titled notes

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -480,11 +480,20 @@ export default function PersonalNotesView({
     runAction,
   } = useActionProcessing(activeNoteId ?? null);
 
+  // The realtime transcript outlives its recording — only use it for the note it was recorded on.
+  const activeNoteRawTranscript =
+    (recordingNoteId === activeNote?.id ? realtimeTranscript : "") || activeNote?.transcript || "";
+
   const isEnhancementStale = useMemo(() => {
     if (!activeNote?.enhanced_content || !activeNote?.enhanced_at_content_hash) return false;
-    const currentHash = makeContentHash(localContent);
+    const currentHash = makeContentHash(`${localContent}\n${activeNoteRawTranscript}`);
     return currentHash !== activeNote.enhanced_at_content_hash;
-  }, [activeNote?.enhanced_content, activeNote?.enhanced_at_content_hash, localContent]);
+  }, [
+    activeNote?.enhanced_content,
+    activeNote?.enhanced_at_content_hash,
+    localContent,
+    activeNoteRawTranscript,
+  ]);
 
   const handleExportNote = useCallback(
     async (format: "md" | "txt") => {
@@ -971,15 +980,14 @@ export default function PersonalNotesView({
                 <ActionPicker
                   onRunAction={(action) => {
                     if (!editorNote) return;
-                    const rawTranscript = realtimeTranscript || editorNote.transcript;
                     const noteContent = editorNote.content;
                     const hasNotes = !!noteContent.trim();
-                    if (!hasNotes && !rawTranscript) return;
+                    if (!hasNotes && !activeNoteRawTranscript) return;
 
                     let formattedTranscript = "";
                     let isMeetingNote = false;
-                    if (rawTranscript) {
-                      const segments = parseTranscriptSegments(rawTranscript);
+                    if (activeNoteRawTranscript) {
+                      const segments = parseTranscriptSegments(activeNoteRawTranscript);
                       if (segments.length > 0) {
                         isMeetingNote = true;
                         formattedTranscript = segments
@@ -990,7 +998,7 @@ export default function PersonalNotesView({
                           .join("\n");
                       }
                       if (!formattedTranscript) {
-                        formattedTranscript = rawTranscript;
+                        formattedTranscript = activeNoteRawTranscript;
                       }
                     }
 
@@ -1000,11 +1008,19 @@ export default function PersonalNotesView({
                     ]
                       .filter(Boolean)
                       .join("\n\n");
-                    runAction(action, parts, makeContentHash(noteContent), {
-                      isCloudMode,
-                      modelId: effectiveModelId,
-                      isMeetingNote,
-                    });
+                    runAction(
+                      action,
+                      parts,
+                      makeContentHash(`${noteContent}\n${activeNoteRawTranscript}`),
+                      {
+                        isCloudMode,
+                        modelId: effectiveModelId,
+                        isMeetingNote,
+                        allowTitleGeneration:
+                          !editorNote.title.trim() ||
+                          editorNote.title === t("notes.list.untitledNote"),
+                      }
+                    );
                   }}
                   onManageActions={() => setShowActionManager(true)}
                   disabled={

--- a/src/stores/actionProcessingStore.ts
+++ b/src/stores/actionProcessingStore.ts
@@ -88,6 +88,8 @@ export interface RunActionOptions {
   isCloudMode: boolean;
   modelId: string;
   isMeetingNote?: boolean;
+  /** Opt-in so enhancement never renames a note the user has titled. */
+  allowTitleGeneration?: boolean;
 }
 
 export interface RunActionLabels {
@@ -150,7 +152,7 @@ export function runBackgroundAction(
       if (cancelledFlags.get(noteId)) return;
 
       let title: string | undefined;
-      if (getSettings().autoGenerateNoteTitle) {
+      if (options.allowTitleGeneration && getSettings().autoGenerateNoteTitle) {
         const generated = await generateNoteTitle(enhanced, modelId, providerOverrides);
         if (generated) title = generated;
       }


### PR DESCRIPTION
## Problem

Two user-reported bugs in note enhancement:

1. **Enhanced content generated from the wrong note's transcript (data leak).** The meeting recording store's `transcript` is global and persists after a recording stops (`stopRecording()` even re-sets it to the final result). The enhance action read it unguarded (`realtimeTranscript || editorNote.transcript`), so after recording a meeting in note A, enhancing note B (or C) fed the LLM note A's transcript — producing identical enhanced content across different notes and silently leaking one meeting's content into another note. Dangerous if those notes are then shared.

2. **Enhancement overwrites manually-set titles.** With `autoGenerateNoteTitle` on (the default), every enhancement regenerated the title from the enhanced content and wrote it unconditionally. Since the enhancement prompts deliberately strip participant names, hand-named notes like "Customer Reference A/B/C" became generic, unmappable titles like "Talk with customer".

## Fix

- **Transcript selection is now scoped to the note.** A single `activeNoteRawTranscript` only uses the realtime transcript when `recordingNoteId` matches the active note, falling back to the note's own saved transcript. Keying on note identity (not the is-recording flag) keeps the freshest transcript available when enhancing the note that was just recorded.
- **Auto-titling is opt-in per action run.** New `allowTitleGeneration` option on `RunActionOptions` (defaults off). The caller only allows it when the title is blank or still the untitled default — a note the user has named is never renamed.
- **Staleness detection now covers the transcript.** `enhanced_at_content_hash` is computed over content + transcript at both the write site and the `isEnhancementStale` check, so resuming a recording after enhancing correctly marks the enhancement stale (previously only manual-notes edits did).

## Behavior notes

- Previously-enhanced notes that have a transcript will show the stale badge once, since their stored hash predates the new format. It self-heals on the next enhancement.
- Meeting notes titled from a calendar event summary no longer get an AI title on enhancement (they aren't "untitled"). Restoring that would need a `title_manually_set` schema flag — intentionally out of scope here.

## Testing

- `npm run typecheck`, `eslint`, and `prettier --check` pass on changed files.