### PR TITLE
fix: bundled binaries missing from app.asar.unpacked break Windows local transcription

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -87,6 +87,7 @@
   ],
   "asarUnpack": [
     "**/node_modules/ffmpeg-static/**/*",
+    "**/node_modules/ps-list/**/*",
     "**/node_modules/better-sqlite3/**/*",
     "**/node_modules/onnxruntime-node/**/*",
     "**/node_modules/@napi-rs/keyring/**/*",

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -10,6 +10,8 @@
 //    user flags from ~/.config/open-whispr-flags.conf, and falls back to
 //    --no-sandbox where the Chromium sandbox cannot work (AppImage/tar.gz
 //    on distros that restrict unprivileged user namespaces).
+// 3. Fails the build if required binaries (ffmpeg-static, ps-list vendor exe)
+//    are missing from app.asar.unpacked/.
 
 const fs = require("fs");
 const path = require("path");
@@ -200,6 +202,43 @@ function verifyMeetingAecHelper(context) {
   }
 }
 
+function verifyUnpackedBinaries(context) {
+  const unpackedModulesDir = path.join(
+    resolveResourcesDir(context),
+    "app.asar.unpacked",
+    "node_modules"
+  );
+
+  const isWindows = context.electronPlatformName === "win32";
+
+  const ffmpegPath = path.join(
+    unpackedModulesDir,
+    "ffmpeg-static",
+    isWindows ? "ffmpeg.exe" : "ffmpeg"
+  );
+  if (!fs.existsSync(ffmpegPath)) {
+    throw new Error(
+      `afterPack: missing ${ffmpegPath} — ffmpeg-static was not unpacked from app.asar (asarUnpack/packaging failure); the packed app cannot spawn FFmpeg`
+    );
+  }
+
+  // electron-builder strips *.exe from node_modules on non-Windows targets,
+  // so the ps-list vendor executable only exists in Windows builds.
+  if (isWindows) {
+    const psListVendorDir = path.join(unpackedModulesDir, "ps-list", "vendor");
+    const hasFastlist =
+      fs.existsSync(psListVendorDir) &&
+      fs.readdirSync(psListVendorDir).some((name) => /^fastlist-.*\.exe$/.test(name));
+    if (!hasFastlist) {
+      throw new Error(
+        `afterPack: no fastlist-*.exe in ${psListVendorDir} — ps-list vendor executable was not unpacked from app.asar (asarUnpack/packaging failure); Windows process detection would break`
+      );
+    }
+  }
+
+  console.log("  afterPack: verified unpacked bundled binaries");
+}
+
 // ---------------------------------------------------------------------------
 // Main hook
 // ---------------------------------------------------------------------------
@@ -208,5 +247,6 @@ exports.default = async function (context) {
   stripOnnxruntimeBinaries(context);
   wrapLinuxBinary(context);
   verifyMeetingAecHelper(context);
+  verifyUnpackedBinaries(context);
   registerMacResourceBinariesForSigning(context);
 };

--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -37,8 +37,9 @@ function getFFmpegPath() {
       return unpackedPath;
     }
 
-    // Try original path (development or if not in ASAR)
-    if (fs.existsSync(ffmpegPath)) {
+    // Try original path (development or if not in ASAR). An in-asar path passes
+    // existsSync but can never be spawned, so fall through to system FFmpeg instead.
+    if (!unpackedPath && fs.existsSync(ffmpegPath)) {
       if (process.platform !== "win32") {
         try {
           fs.accessSync(ffmpegPath, fs.constants.X_OK);
@@ -113,7 +114,11 @@ function convertToWav(inputPath, outputPath, options = {}) {
   return new Promise((resolve, reject) => {
     const ffmpegPath = getFFmpegPath();
     if (!ffmpegPath) {
-      reject(new Error("FFmpeg not found - required for audio conversion"));
+      reject(
+        new Error(
+          "FFmpeg not found - the bundled FFmpeg is missing from this install and no system FFmpeg was found on PATH; reinstalling OpenWhispr should fix this"
+        )
+      );
       return;
     }
 


### PR DESCRIPTION
## Problem

A v1.7.2 Windows portable debug log shows two spawn ENOENT failures:

- `ffmpeg.exe` resolved to a path **inside** `app.asar` → spawn ENOENT → all local transcription (Parakeet and Whisper) broken.
- `ps-list`'s `vendor/fastlist-0.3.0-x64.exe` missing from `app.asar.unpacked` → Windows meeting-app detection fails on every 30s poll (non-fatal, falls back to an empty list with recurring log spam).

## Root cause

1. `ffmpeg.exe` ended up packed inline inside `app.asar` instead of `app.asar.unpacked`, despite `ffmpeg-static` being listed in `asarUnpack` (the glob itself is correct). An in-asar path can never be spawned.
2. `ps-list` is not in `asarUnpack` at all. ps-list@9 resolves its exe via `path.join(__dirname, 'vendor', ...)` with zero asar awareness; electron-builder smart-unpacked its JS but not the exe.
3. `getFFmpegPath()` in `src/helpers/ffmpegUtils.js` falls back to `fs.existsSync` on the original in-asar path — which returns **true** for files inside an asar — and returns it as spawnable. This turns a packaging gap into a guaranteed cryptic ENOENT and short-circuits the system-FFmpeg PATH scan further down the function.

## Changes

- **electron-builder.json**: add `**/node_modules/ps-list/**/*` to `asarUnpack`.
- **src/helpers/ffmpegUtils.js**: never return an in-asar path from `getFFmpegPath()` — when the unpacked binary is missing, fall through to the system-candidate + PATH scan. Make the `convertToWav` "FFmpeg not found" rejection actionable (bundled FFmpeg missing and no system FFmpeg; reinstalling fixes it).
- **scripts/afterPack.js**: new `verifyUnpackedBinaries` step that **throws** (unlike the warn-and-continue AEC helper check) if `app.asar.unpacked/node_modules/` is missing the ffmpeg-static binary (all platforms) or a `fastlist-*.exe` in `ps-list/vendor/` (Windows targets only — electron-builder strips `*.exe` from node_modules on non-Windows builds). A build missing these must fail loudly instead of shipping broken.

## Verification

- `npm run lint`, `npm run typecheck`, `prettier --check` on changed files, `node --test` (206 pass, 11 skipped, 0 fail).
- Local `electron-builder --mac --dir` pack: succeeds; `afterPack: verified unpacked bundled binaries` printed; `asar list --is-pack` confirms ffmpeg-static and ps-list files are `unpack`, not inline.
- Local `electron-builder --win --dir` pack (unsigned config): `app.asar.unpacked/node_modules/ps-list/vendor/` now contains both `fastlist-*.exe` files, all marked `unpack` in the asar index. The new ffmpeg assertion correctly failed this cross-compiled pack because macOS-installed `ffmpeg-static` ships the darwin binary (no `ffmpeg.exe`); real Windows builds run on `windows-latest` in CI where `ffmpeg.exe` is installed, so the assertion passes there — and it doubles as a guard against shipping cross-built Windows artifacts with the wrong ffmpeg.

Heads-up: #830 also edits `asarUnpack` in electron-builder.json, so whichever PR merges second will have a trivial one-line conflict.