### PR TITLE
fix(audio): fail speech gate open when its AudioContext never runs

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -484,6 +484,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       try {
         this._silenceCtx = new AudioContext();
+        if (this._silenceCtx.state === "suspended") {
+          // Not awaited — resume() can hang when the output device is wedged.
+          this._silenceCtx.resume().catch(() => {});
+        }
         this._silenceAnalyser = this._silenceCtx.createAnalyser();
         this._silenceAnalyser.fftSize = 2048;
         const sourceNode = this._silenceCtx.createMediaStreamSource(micStream);
@@ -491,6 +495,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         this._localSpeechGateState = createLocalSpeechGateState();
         const dataArray = new Uint8Array(this._silenceAnalyser.fftSize);
         this._silenceInterval = setInterval(() => {
+          // A stalled context reads flat silence; recording no windows fails the gate open.
+          if (this._silenceCtx?.state !== "running") return;
           this._silenceAnalyser.getByteTimeDomainData(dataArray);
           let sum = 0;
           let peak = 0;
@@ -522,13 +528,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       };
 
       this.mediaRecorder.onstop = async () => {
-        if (this._silenceInterval) {
-          clearInterval(this._silenceInterval);
-          this._silenceInterval = null;
-        }
-        this._silenceCtx?.close().catch(() => {});
-        this._silenceCtx = null;
-        this._silenceAnalyser = null;
+        this.teardownSpeechGate();
 
         this.cleanupPreview({ showCleanup: this.shouldShowPreviewCleanupState() });
 
@@ -658,9 +658,22 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return false;
   }
 
+  teardownSpeechGate() {
+    if (this._silenceInterval) {
+      clearInterval(this._silenceInterval);
+      this._silenceInterval = null;
+    }
+    this._silenceCtx?.close().catch(() => {});
+    this._silenceCtx = null;
+    this._silenceAnalyser = null;
+  }
+
   cancelRecording() {
     if (this.mediaRecorder && this.mediaRecorder.state === "recording") {
       this.mediaRecorder.onstop = () => {
+        this.teardownSpeechGate();
+        this._localSpeechGateState = null;
+
         const durationSeconds = this.recordingStartTime
           ? (Date.now() - this.recordingStartTime) / 1000
           : null;

--- a/test/helpers/localSpeechGate.test.js
+++ b/test/helpers/localSpeechGate.test.js
@@ -1,6 +1,17 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
+test("fails open when no windows were recorded", async () => {
+  const { createLocalSpeechGateState, getLocalSpeechGateDecision } =
+    await import("../../src/helpers/localSpeechGate.js");
+
+  assert.deepEqual(getLocalSpeechGateDecision(createLocalSpeechGateState()), {
+    skip: false,
+    reason: "unavailable",
+  });
+  assert.deepEqual(getLocalSpeechGateDecision(null), { skip: false, reason: "unavailable" });
+});
+
 test("treats near silence as skippable", async () => {
   const { createLocalSpeechGateState, recordLocalSpeechWindow, getLocalSpeechGateDecision } =
     await import("../../src/helpers/localSpeechGate.js");


### PR DESCRIPTION
## Problem

Windows users report **"No audio detected"** on every recording, regardless of length, even though the mic works fine in other apps.

Root cause: the local speech gate added in #1073-era work samples mic level through a dedicated `AudioContext` that is never resumed. On Windows that context can stay suspended or stall (Bluetooth headsets, unavailable/wedged output devices — the context clock is driven by the *output* device). A stalled analyser reads flat silence, so `peakRms` is 0, the gate verdict is `silence`, and `processAudio` discards the recording **before transcription, for all providers including cloud** — even though the MediaRecorder blob contains real speech.

## Fix

- Resume a suspended gate context, fire-and-forget (same idiom as `dictationCues.js` and the streaming path; not awaited because `resume()` can hang on a wedged output device and must never block recording start).
- Skip gate sampling windows while the context isn't `running`. A gate that never sees a running context records zero windows, returns `{ skip: false, reason: "unavailable" }`, and the recording proceeds to transcription — fail open instead of deleting the user's audio. Backends keep their own blank-audio detection (`[BLANK_AUDIO]`), so genuinely silent recordings still surface the same toast.
- Extract `teardownSpeechGate()` and call it from `cancelRecording` too: the cancel path replaces `onstop` and previously leaked the sampling interval and `AudioContext` on every cancelled dictation, with the leaked interval writing into the next recording's gate state.

## Tests

- New test: gate with no recorded windows (or null state) fails open as `unavailable`.
- Full suite: 197 pass / 0 fail. ESLint, Prettier, typecheck clean.