### PR TITLE
fix(meeting): stop diarization collapsing remote speakers into one

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -58,6 +58,7 @@ import { MEETINGS_FOLDER_NAME, findDefaultFolder } from "./shared";
 import logger from "../../utils/logger";
 import { parseTranscriptSegments } from "../../utils/parseTranscriptSegments";
 import { serializeTranscriptSegments } from "../../utils/transcriptSpeakerState";
+import { resolveExpectedSpeakerCount } from "../../utils/participants";
 import {
   useNotes,
   useActiveNoteId,
@@ -232,7 +233,7 @@ export default function PersonalNotesView({
       folderId: note?.folder_id ?? null,
       seedSegments,
       diarizationEnabled: note?.diarization_enabled == null ? null : note.diarization_enabled === 1,
-      expectedCount: note?.expected_speaker_count ?? null,
+      expectedCount: resolveExpectedSpeakerCount(note),
     });
   }, [notes]);
 
@@ -521,7 +522,7 @@ export default function PersonalNotesView({
       folderId: note?.folder_id ?? meetingRecordingRequest.folderId ?? null,
       seedSegments,
       diarizationEnabled: note?.diarization_enabled == null ? null : note.diarization_enabled === 1,
-      expectedCount: note?.expected_speaker_count ?? null,
+      expectedCount: resolveExpectedSpeakerCount(note),
     });
     onMeetingRecordingRequestHandled?.();
   }, [meetingRecordingRequest, activeNoteId, notes, onMeetingRecordingRequestHandled]);

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -1491,6 +1491,11 @@ class DatabaseManager {
         }
       }
       if (fields.length === 0) return { success: false };
+      // Re-queue for cloud sync on any local edit, so post-sync field changes aren't
+      // left local-only and overwritten by a later pull.
+      if (!("sync_status" in updates)) {
+        fields.push("sync_status = 'pending'");
+      }
       fields.push("updated_at = CURRENT_TIMESTAMP");
       values.push(id);
       const stmt = this.db.prepare(`UPDATE notes SET ${fields.join(", ")} WHERE id = ?`);
@@ -2685,10 +2690,10 @@ class DatabaseManager {
           enhanced_at_content_hash = excluded.enhanced_at_content_hash,
           transcript = excluded.transcript,
           folder_id = excluded.folder_id,
-          participants = excluded.participants,
-          calendar_event_id = excluded.calendar_event_id,
-          diarization_enabled = excluded.diarization_enabled,
-          expected_speaker_count = excluded.expected_speaker_count,
+          participants = COALESCE(excluded.participants, participants),
+          calendar_event_id = COALESCE(excluded.calendar_event_id, calendar_event_id),
+          diarization_enabled = COALESCE(excluded.diarization_enabled, diarization_enabled),
+          expected_speaker_count = COALESCE(excluded.expected_speaker_count, expected_speaker_count),
           sync_status = 'synced',
           updated_at = excluded.updated_at
       `);

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5782,9 +5782,8 @@ class IPCHandlers {
         meetingOneOnOneProfileBound = false;
         meetingNoteId = options.noteId ?? null;
 
-        // Seed the speaker cap from the note (and its calendar participants) so live
-        // identification isn't stuck at the default when the renderer never pushes a
-        // config. Kept in memory for the whole session, immune to later note edits/sync.
+        // Seed the speaker cap from the note/calendar participants up front so live
+        // identification isn't stuck at the default if the renderer never pushes a config.
         if (!this.activeMeetingSpeakerConfig) {
           this.activeMeetingSpeakerConfig = this._resolveInitialMeetingSpeakerConfig(meetingNoteId);
         }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -534,6 +534,34 @@ class IPCHandlers {
     return { displayName, email };
   }
 
+  _resolveNoteExpectedSpeakerCount(note) {
+    const stored = Number(note?.expected_speaker_count);
+    if (Number.isFinite(stored) && stored > 0) {
+      return Math.min(stored, MAX_SPEAKER_COUNT);
+    }
+    const others = this._parseNonSelfParticipants(note?.participants).length;
+    if (others > 0) {
+      return Math.min(others + 1, MAX_SPEAKER_COUNT);
+    }
+    return DEFAULT_EXPECTED_SPEAKER_COUNT;
+  }
+
+  _resolveInitialMeetingSpeakerConfig(noteId) {
+    let note = null;
+    if (noteId != null) {
+      try {
+        note = this.databaseManager.getNote(noteId);
+      } catch (_) {
+        note = null;
+      }
+    }
+    const enabled =
+      (note?.diarization_enabled == null
+        ? this.speakerDiarizationEnabled
+        : note.diarization_enabled !== 0) !== false;
+    return { enabled, expectedCount: this._resolveNoteExpectedSpeakerCount(note) };
+  }
+
   _rebuildMirror(basePath) {
     const markdownMirror = require("./markdownMirror");
     if (basePath) markdownMirror.init(basePath);
@@ -5571,6 +5599,7 @@ class IPCHandlers {
       await stopLiveSpeakerIdentification().catch(() => {});
       resetMeetingLocalState();
       await disconnectMeetingStreaming().catch(() => {});
+      this.activeMeetingSpeakerConfig = null;
     };
 
     const setupDictationCallbacks = (streaming, event) => {
@@ -5752,6 +5781,13 @@ class IPCHandlers {
         meetingOneOnOneAttendee = resolveOneOnOneAttendeeForNote(options.noteId);
         meetingOneOnOneProfileBound = false;
         meetingNoteId = options.noteId ?? null;
+
+        // Seed the speaker cap from the note (and its calendar participants) so live
+        // identification isn't stuck at the default when the renderer never pushes a
+        // config. Kept in memory for the whole session, immune to later note edits/sync.
+        if (!this.activeMeetingSpeakerConfig) {
+          this.activeMeetingSpeakerConfig = this._resolveInitialMeetingSpeakerConfig(meetingNoteId);
+        }
 
         if (systemAudioMode === "unsupported" && this._meetingSystemStreaming?.isConnected) {
           await this._meetingSystemStreaming.disconnect().catch(() => ({ text: "" }));

--- a/src/utils/participants.ts
+++ b/src/utils/participants.ts
@@ -1,10 +1,7 @@
 import type { CalendarAttendee } from "../types/calendar";
 
-/**
- * Expected total speaker count for a meeting note: the explicit stored value when
- * present, otherwise derived from the calendar participants (non-self attendees + you).
- * Returns null when there's no signal, letting callers fall back to their default.
- */
+// Expected total speaker count for a meeting note: the stored value, else derived from
+// calendar participants (non-self attendees + you), else null so callers use their default.
 export const resolveExpectedSpeakerCount = (note?: {
   expected_speaker_count?: number | null;
   participants?: string | null;

--- a/src/utils/participants.ts
+++ b/src/utils/participants.ts
@@ -1,0 +1,25 @@
+import type { CalendarAttendee } from "../types/calendar";
+
+/**
+ * Expected total speaker count for a meeting note: the explicit stored value when
+ * present, otherwise derived from the calendar participants (non-self attendees + you).
+ * Returns null when there's no signal, letting callers fall back to their default.
+ */
+export const resolveExpectedSpeakerCount = (note?: {
+  expected_speaker_count?: number | null;
+  participants?: string | null;
+}): number | null => {
+  if (note?.expected_speaker_count != null) return note.expected_speaker_count;
+  if (!note?.participants) return null;
+
+  let attendees: CalendarAttendee[];
+  try {
+    const parsed = JSON.parse(note.participants);
+    attendees = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return null;
+  }
+
+  const others = attendees.filter((attendee) => attendee?.self !== true).length;
+  return others > 0 ? others + 1 : null;
+};

--- a/src/utils/transcriptSpeakerState.ts
+++ b/src/utils/transcriptSpeakerState.ts
@@ -111,9 +111,8 @@ const mergeSpeakerFields = (existing: TranscriptSegment, incoming: TranscriptSeg
   }
 
   if (isTranscriptSpeakerLocked(existing)) {
-    // Preserve the user's chosen name and lock, but let offline diarization refine the
-    // underlying speaker cluster — otherwise a single locked label freezes a bucket that
-    // diarization splits into multiple speakers.
+    // Keep the user's name/lock but let diarization refine the speaker cluster, so one
+    // locked label can't freeze a bucket diarization splits into multiple speakers.
     for (const field of SPEAKER_STATE_FIELDS) {
       if (field === "speaker" || field === "speakerIsPlaceholder") continue;
       if (existingFields[field] !== undefined) {

--- a/src/utils/transcriptSpeakerState.ts
+++ b/src/utils/transcriptSpeakerState.ts
@@ -111,7 +111,11 @@ const mergeSpeakerFields = (existing: TranscriptSegment, incoming: TranscriptSeg
   }
 
   if (isTranscriptSpeakerLocked(existing)) {
+    // Preserve the user's chosen name and lock, but let offline diarization refine the
+    // underlying speaker cluster — otherwise a single locked label freezes a bucket that
+    // diarization splits into multiple speakers.
     for (const field of SPEAKER_STATE_FIELDS) {
+      if (field === "speaker" || field === "speakerIsPlaceholder") continue;
       if (existingFields[field] !== undefined) {
         mergedFields[field] = existingFields[field];
       }


### PR DESCRIPTION
## Problem

In a real 3-person meeting (verified from production debug logs + the local SQLite note), every remote participant collapsed into a single speaker. Labeling that one speaker mid-call then attributed the entire remote side of the conversation to that person.

Root cause: when a meeting note has no `expected_speaker_count` and no stored `participants`, the speaker resolution falls back to `DEFAULT_EXPECTED_SPEAKER_COUNT` (2), which makes the "other speaker" cap `1`. Both the backend live remapper and the renderer placeholder minter then force **all** non-mic voices into `speaker_0`. The offline end-of-call diarization hit the same fallback. The renderer also never pushed a session speaker config at start, so `activeMeetingSpeakerConfig` stayed `null` for the whole call.

The affected note also had its `participants`/`calendar_event_id` silently wiped: the calendar event still had all 3 attendees, but a cloud-sync round-trip nulled the note's copy (see the sync fix below).

## Fixes

### Speaker cap
- **Seed `activeMeetingSpeakerConfig` at meeting start** from the note and its calendar participants, so live identification reflects real attendees even when the renderer never pushes a config. Held in memory for the session (immune to later note edits/sync), and the stop-time snapshot carries the same expectation into the offline diarization pass.
- **Seed the renderer's expected speaker count** from calendar participants (`resolveExpectedSpeakerCount`) so placeholder assignment and the stepper match the backend cap.
- **Reset the config on start rollback** so a failed start can't leak a stale cap into the next meeting.
- **Let offline diarization refine the speaker cluster on user-locked segments** (preserving the user's chosen name/lock) so a single locked label can't freeze a bucket diarization splits into multiple speakers.

### Sync (why the note lost its participants)
`updateNote` never re-flagged a note as `pending`, so `participants`, `calendar_event_id`, and transcript edits made after the note's first sync stayed local and were overwritten by the next last-write-wins pull.
- **`updateNote` now marks the note sync-pending on any local edit** (unless the caller sets `sync_status` explicitly), matching the dictionary/transcription paths, so local edits actually push to the cloud.
- **`upsertNoteFromCloud` preserves local `participants`, `calendar_event_id`, `diarization_enabled`, and `expected_speaker_count`** when the pulled copy lacks them (`COALESCE`), mirroring the cloud API's own update behavior.

## Notes
- Fix "locked segments": the user's chosen name is always preserved; in the degenerate single-bucket case a split-out cluster may temporarily carry that name until relabeled — strictly better than the previous hard freeze, and rare once the cap is correct.

## Testing
- `npm run typecheck`, `npm run lint`, and prettier all clean
- `node --test` suites pass (244 passed, 0 failed)
- Verified the resolver against the real meeting's attendee data: 2 non-self → expected 3 → other-speaker cap 2 (both remote speakers tracked)
- Verified the `COALESCE` upsert in SQLite: a null pull preserves local participants, a real value overwrites