### PR TITLE
refactor(corti): fold BYOK reasoning key into the shared secret-key manifest

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -13,6 +13,7 @@ const BYOK_KEY_BRIDGES = [
   { base: "mistral", get: "getMistralKey", save: "saveMistralKey" },
   { base: "openrouter", get: "getOpenrouterKey", save: "saveOpenrouterKey" },
   { base: "tinfoil", get: "getTinfoilKey", save: "saveTinfoilKey" },
+  { base: "corti", get: "getCortiKey", save: "saveCortiKey" },
 ];
 const secretKeyApi = {};
 for (const k of BYOK_KEY_BRIDGES) {
@@ -379,8 +380,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveCortiClientId: (key) => ipcRenderer.invoke("save-corti-client-id", key),
   getCortiClientSecret: () => ipcRenderer.invoke("get-corti-client-secret"),
   saveCortiClientSecret: (key) => ipcRenderer.invoke("save-corti-client-secret", key),
-  getCortiApiKey: () => ipcRenderer.invoke("get-corti-api-key"),
-  saveCortiApiKey: (key) => ipcRenderer.invoke("save-corti-api-key", key),
   proxyCortiTranscription: (data) => ipcRenderer.invoke("proxy-corti-transcription", data),
   getTinfoilChatModels: () => ipcRenderer.invoke("get-tinfoil-chat-models"),
   proxyTinfoilTranscription: (data) => ipcRenderer.invoke("proxy-tinfoil-transcription", data),

--- a/src/config/secretKeys.js
+++ b/src/config/secretKeys.js
@@ -57,6 +57,13 @@ const BYOK_API_KEYS = [
     save: "saveTinfoilKey",
     storeKey: "tinfoilApiKey",
   },
+  {
+    base: "corti",
+    env: "CORTI_API_KEY",
+    get: "getCortiKey",
+    save: "saveCortiKey",
+    storeKey: "cortiApiKey",
+  },
 ];
 
 module.exports = { BYOK_API_KEYS };

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -13,7 +13,6 @@ const SECRET_KEYS = [
   "DEEPGRAM_API_KEY",
   "CORTI_CLIENT_ID",
   "CORTI_CLIENT_SECRET",
-  "CORTI_API_KEY",
   "CUSTOM_TRANSCRIPTION_API_KEY",
   "CUSTOM_CLEANUP_API_KEY",
   "BEDROCK_ACCESS_KEY_ID",
@@ -292,14 +291,6 @@ class EnvironmentManager {
 
   saveCortiClientSecret(key) {
     return this._saveKey("CORTI_CLIENT_SECRET", key);
-  }
-
-  getCortiApiKey() {
-    return this._getKey("CORTI_API_KEY");
-  }
-
-  saveCortiApiKey(key) {
-    return this._saveKey("CORTI_API_KEY", key);
   }
 
   getCustomTranscriptionKey() {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2752,14 +2752,6 @@ class IPCHandlers {
       return this.environmentManager.saveCortiClientSecret(key);
     });
 
-    ipcMain.handle("get-corti-api-key", async () => {
-      return this.environmentManager.getCortiApiKey();
-    });
-
-    ipcMain.handle("save-corti-api-key", async (event, key) => {
-      return this.environmentManager.saveCortiApiKey(key);
-    });
-
     ipcMain.handle(
       "proxy-corti-transcription",
       async (event, { audioBuffer, language, environment, tenant }) => {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -108,7 +108,7 @@ class ReasoningService extends BaseReasoningService {
           groq: () => window.electronAPI.getGroqKey(),
           openrouter: () => window.electronAPI.getOpenrouterKey(),
           tinfoil: () => window.electronAPI.getTinfoilKey?.(),
-          corti: () => window.electronAPI.getCortiApiKey?.(),
+          corti: () => window.electronAPI.getCortiKey?.(),
         };
         apiKey = (await keyGetters[provider]()) ?? undefined;
 
@@ -941,7 +941,7 @@ class ReasoningService extends BaseReasoningService {
       const groqKey = await window.electronAPI?.getGroqKey?.();
       const openrouterKey = await window.electronAPI?.getOpenrouterKey?.();
       const tinfoilKey = await window.electronAPI?.getTinfoilKey?.();
-      const cortiKey = await window.electronAPI?.getCortiApiKey?.();
+      const cortiKey = await window.electronAPI?.getCortiKey?.();
       const localAvailable = await window.electronAPI?.checkLocalReasoningAvailable?.();
 
       logger.logReasoning("API_KEY_CHECK", {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -770,7 +770,7 @@ const SECRET_IPC_SAVERS = {
   openrouter: "saveOpenrouterKey",
   cortiClientId: "saveCortiClientId",
   cortiClientSecret: "saveCortiClientSecret",
-  cortiApiKey: "saveCortiApiKey",
+  cortiApiKey: "saveCortiKey",
   tinfoil: "saveTinfoilKey",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
@@ -1338,11 +1338,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     debouncedSaveSecret("cortiClientSecret", key);
     invalidateApiKeyCaches("corti");
   },
-  setCortiApiKey: (key: string) => {
-    set({ cortiApiKey: key });
-    debouncedSaveSecret("cortiApiKey", key);
-    invalidateApiKeyCaches("corti");
-  },
+  setCortiApiKey: createSecretSetter("cortiApiKey", "cortiApiKey", "corti"),
   setCortiEnvironment: createStringSetter("cortiEnvironment"),
   setCortiTenant: createStringSetter("cortiTenant"),
   setTinfoilApiKey: createSecretSetter("tinfoilApiKey", "tinfoil", "tinfoil"),
@@ -2040,7 +2036,7 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getOpenrouterKey?.(),
         window.electronAPI.getCortiClientId?.(),
         window.electronAPI.getCortiClientSecret?.(),
-        window.electronAPI.getCortiApiKey?.(),
+        window.electronAPI.getCortiKey?.(),
         window.electronAPI.getTinfoilKey?.(),
         window.electronAPI.getCustomTranscriptionKey?.(),
         window.electronAPI.getCleanupCustomKey?.(),

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1046,8 +1046,8 @@ declare global {
       saveCortiClientId?: (key: string) => Promise<void>;
       getCortiClientSecret?: () => Promise<string | null>;
       saveCortiClientSecret?: (key: string) => Promise<void>;
-      getCortiApiKey?: () => Promise<string | null>;
-      saveCortiApiKey?: (key: string) => Promise<void>;
+      getCortiKey?: () => Promise<string | null>;
+      saveCortiKey?: (key: string) => Promise<void>;
       proxyCortiTranscription?: (data: {
         audioBuffer: ArrayBuffer;
         language: string;


### PR DESCRIPTION
## Summary
The Corti reasoning API key (added in #1111) was the only cloud LLM secret still hand-wired, duplicating the per-provider plumbing that `BYOK_API_KEYS` generates for every other provider (`environment.js` accessors, `ipcHandlers.js` channel registration, `preload.js` bridges). This folds it into the manifest so Corti is defined in exactly one place like the rest.

## Changes
- `src/config/secretKeys.js` — add the `corti` entry (`{ base, env: CORTI_API_KEY, get: getCortiKey, save: saveCortiKey, storeKey: cortiApiKey }`)
- `preload.js` — add corti to the mirrored `BYOK_KEY_BRIDGES`; drop the two manual bridge lines
- `src/helpers/environment.js` — drop the manual `getCortiApiKey`/`saveCortiApiKey` methods and the manual `CORTI_API_KEY` entry in `SECRET_KEYS` (now supplied by the manifest spread)
- `src/helpers/ipcHandlers.js` — drop the manual `get-corti-api-key`/`save-corti-api-key` handlers (the manifest loop registers `get-corti-key`/`save-corti-key`)
- `src/services/ReasoningService.ts`, `src/types/electron.ts` — use the renamed `getCortiKey`
- `src/stores/settingsStore.ts` — point the saver map at `saveCortiKey` and route `setCortiApiKey` through the shared `createSecretSetter`

Net −15 lines.

## Naming
Aligns the IPC method/channel names to the established convention (`getCortiApiKey` → `getCortiKey`, `get-corti-api-key` → `get-corti-key`). The store-facing `cortiApiKey` field and `setCortiApiKey` action are unchanged, and the `CORTI_API_KEY` env var is untouched, so existing saved keys keep loading — no migration.

## Verification
- `test/helpers/secretKeys.test.js` — corti now round-trips through the generated accessors and preload mirrors the manifest exactly (15 pass)
- Full suite 266 pass / 0 fail, `tsc --noEmit` clean, ESLint + prettier clean
- Traced the full save→persist→load→use→availability chain end-to-end (store setter → `SECRET_IPC_SAVERS` → preload `save-corti-key` → ipc → env `CORTI_API_KEY`, and back); every link verified