### PR TITLE
fix(corti): route US onboarding LLM to OpenWhispr Cloud, keep Corti EU-only

### DIFF
--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -657,6 +657,7 @@ export default function ReasoningModelSelector({
 
                 {selectedCloudProvider === "corti" && (
                   <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">{t("reasoning.corti.euOnly")}</p>
                     <div className="flex items-baseline justify-between">
                       <h4 className="font-medium text-foreground">{t("common.apiKey")}</h4>
                       <GetApiKeyLink url="https://www.corti.ai/?utm_source=referral&utm_campaign=openwhispr" />

--- a/src/components/onboarding/FinishStep.tsx
+++ b/src/components/onboarding/FinishStep.tsx
@@ -49,16 +49,18 @@ export default function FinishStep({
     cortiClientId.trim().length > 0 && cortiClientSecret.trim().length > 0;
 
   const startWithCorti = () => {
-    // Route all four LLM scopes to Corti too so PHI never leaves Corti. No LLM
-    // routing when the Corti registry entry or model is missing, or outside the EU region.
+    // Transcription always routes to Corti. Reasoning routes to Corti only in the
+    // EU with an API key (Corti Models is EU-only); otherwise the HIPAA-compliant
+    // OpenWhispr Cloud handles language features so PHI never reaches a third party.
     const reasoningProvider = modelRegistry.getCloudProviders().find((p) => p.id === "corti");
     const { transcription, reasoning } = buildCortiOnboardingPayloads(
       cortiProvider,
       reasoningProvider,
-      cortiEnvironment
+      cortiEnvironment,
+      cortiApiKey.trim().length > 0
     );
     setCloudTranscriptionForAllScopes(transcription);
-    if (reasoning && cortiApiKey.trim()) setCloudReasoningForAllScopes(reasoning);
+    setCloudReasoningForAllScopes(reasoning);
     onFinish(false);
   };
 
@@ -116,12 +118,6 @@ export default function FinishStep({
           </div>
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-foreground">
-              {t("transcription.corti.apiKey")}
-            </label>
-            <ApiKeyInput apiKey={cortiApiKey} setApiKey={setCortiApiKey} label="" helpText="" />
-          </div>
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-foreground">
               {t("transcription.corti.environment")}
             </label>
             <Select value={cortiEnvironment} onValueChange={setCortiEnvironment}>
@@ -136,12 +132,22 @@ export default function FinishStep({
             <p className="text-xs text-muted-foreground/70">
               {t("onboarding.finish.corti.regionHint")}
             </p>
-            {cortiEnvironment === "eu" && cortiApiKey.trim() && (
-              <p className="text-xs text-muted-foreground/70">
-                {t("onboarding.finish.corti.llmHint")}
-              </p>
-            )}
           </div>
+          {/* Corti Models (LLM) is EU-only; US projects use OpenWhispr Cloud for
+              language features, so the key is only collected in the EU region. */}
+          {cortiEnvironment === "eu" && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-foreground">
+                {t("transcription.corti.apiKey")}
+              </label>
+              <ApiKeyInput apiKey={cortiApiKey} setApiKey={setCortiApiKey} label="" helpText="" />
+              {cortiApiKey.trim() && (
+                <p className="text-xs text-muted-foreground/70">
+                  {t("onboarding.finish.corti.llmHint")}
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="flex items-center justify-center gap-2">

--- a/src/helpers/reasoningRouting.js
+++ b/src/helpers/reasoningRouting.js
@@ -25,12 +25,16 @@ export function buildReasoningScopePatches(settings, mode) {
   };
 }
 
-// Onboarding "use Corti everywhere" payloads. `reasoning` is null outside the EU
-// region or when the provider/model is missing; useCleanupModel is forced true so routing sticks.
+// Onboarding "use Corti everywhere" payloads. Transcription always routes to
+// Corti. Reasoning routes to Corti only in the EU region with an API key, since
+// Corti Models is EU-only and needs its own key; otherwise it routes to the
+// HIPAA-compliant OpenWhispr Cloud so clinical text never reaches a third party.
+// useCleanupModel is forced true either way so the routing sticks.
 export function buildCortiOnboardingPayloads(
   transcriptionProvider,
   reasoningProvider,
-  environment
+  environment,
+  hasApiKey
 ) {
   const transcription = {
     useLocalWhisper: false,
@@ -38,14 +42,15 @@ export function buildCortiOnboardingPayloads(
     cloudTranscriptionProvider: "corti",
     cloudTranscriptionModel: transcriptionProvider?.models?.[0]?.id,
   };
-  const reasoningModel = environment === "eu" ? reasoningProvider?.models?.[0]?.id : undefined;
-  const reasoning = reasoningModel
-    ? {
-        useCleanupModel: true,
-        cleanupProvider: "corti",
-        cleanupModel: reasoningModel,
-        cleanupCloudMode: "byok",
-      }
-    : null;
+  const cortiModel = reasoningProvider?.models?.[0]?.id;
+  const reasoning =
+    environment === "eu" && hasApiKey && cortiModel
+      ? {
+          useCleanupModel: true,
+          cleanupProvider: "corti",
+          cleanupModel: cortiModel,
+          cleanupCloudMode: "byok",
+        }
+      : { useCleanupModel: true, cleanupCloudMode: "openwhispr" };
   return { transcription, reasoning };
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Modell nicht mehr verfügbar",
       "modelRetired": "Tinfoil hat {{from}} eingestellt. Zu {{to}} gewechselt.",
       "refreshingModels": "Modelle werden aktualisiert…"
+    },
+    "corti": {
+      "euOnly": "Corti-Modelle sind nur in der EU-Region verfügbar."
     }
   },
   "transcription": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Model no longer available",
       "modelRetired": "Tinfoil retired {{from}}. Switched to {{to}}.",
       "refreshingModels": "Refreshing models…"
+    },
+    "corti": {
+      "euOnly": "Corti's models are only available in the EU region."
     }
   },
   "transcription": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Modelo ya no disponible",
       "modelRetired": "Tinfoil retiró {{from}}. Se cambió a {{to}}.",
       "refreshingModels": "Actualizando modelos…"
+    },
+    "corti": {
+      "euOnly": "Los modelos de Corti solo están disponibles en la región de la UE."
     }
   },
   "transcription": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Modèle non disponible",
       "modelRetired": "Tinfoil a retiré {{from}}. Basculé vers {{to}}.",
       "refreshingModels": "Actualisation des modèles…"
+    },
+    "corti": {
+      "euOnly": "Les modèles Corti ne sont disponibles que dans la région UE."
     }
   },
   "transcription": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Modello non più disponibile",
       "modelRetired": "Tinfoil ha ritirato {{from}}. Passato a {{to}}.",
       "refreshingModels": "Aggiornamento dei modelli…"
+    },
+    "corti": {
+      "euOnly": "I modelli Corti sono disponibili solo nella regione UE."
     }
   },
   "transcription": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "モデルが利用できません",
       "modelRetired": "Tinfoil は {{from}} を提供終了しました。{{to}} に切り替えました。",
       "refreshingModels": "モデルを更新しています…"
+    },
+    "corti": {
+      "euOnly": "Corti のモデルは EU リージョンでのみ利用できます。"
     }
   },
   "transcription": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -495,6 +495,9 @@
       "modelRetiredTitle": "Modelo não disponível",
       "modelRetired": "A Tinfoil descontinuou {{from}}. Alterado para {{to}}.",
       "refreshingModels": "A atualizar modelos…"
+    },
+    "corti": {
+      "euOnly": "Os modelos da Corti estão disponíveis apenas na região da UE."
     }
   },
   "transcription": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "Модель больше недоступна",
       "modelRetired": "Tinfoil прекратил поддержку {{from}}. Выполнен переход на {{to}}.",
       "refreshingModels": "Обновление моделей…"
+    },
+    "corti": {
+      "euOnly": "Модели Corti доступны только в регионе ЕС."
     }
   },
   "transcription": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "模型已不可用",
       "modelRetired": "Tinfoil 已停用 {{from}}，已切换至 {{to}}。",
       "refreshingModels": "正在刷新模型…"
+    },
+    "corti": {
+      "euOnly": "Corti 模型仅在欧盟地区可用。"
     }
   },
   "transcription": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -516,6 +516,9 @@
       "modelRetiredTitle": "模型已無法使用",
       "modelRetired": "Tinfoil 已停用 {{from}}，已切換至 {{to}}。",
       "refreshingModels": "正在重新整理模型…"
+    },
+    "corti": {
+      "euOnly": "Corti 模型僅在歐盟地區可用。"
     }
   },
   "transcription": {

--- a/test/helpers/reasoningRouting.test.js
+++ b/test/helpers/reasoningRouting.test.js
@@ -60,12 +60,15 @@ test("fan-out with partial settings only mirrors the provided routing fields", a
   }
 });
 
-test("onboarding payloads route both transcription and reasoning to corti in the eu region", async () => {
+const OPENWHISPR_REASONING = { useCleanupModel: true, cleanupCloudMode: "openwhispr" };
+
+test("onboarding routes transcription and reasoning to corti in the eu region with an api key", async () => {
   const { buildCortiOnboardingPayloads } = await load();
   const { transcription, reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     { id: "corti", models: [{ id: "corti-s1-instant" }, { id: "corti-s1" }] },
-    "eu"
+    "eu",
+    true
   );
 
   assert.deepEqual(transcription, {
@@ -87,51 +90,67 @@ test("onboarding forces cleanup enabled on the corti path", async () => {
   const { reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     { id: "corti", models: [{ id: "corti-s1-instant" }] },
-    "eu"
+    "eu",
+    true
   );
   assert.equal(reasoning.useCleanupModel, true);
 });
 
-test("us data region yields no reasoning payload", async () => {
+test("us data region routes reasoning to openwhispr cloud, transcription stays corti", async () => {
   const { buildCortiOnboardingPayloads } = await load();
   const { transcription, reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     { id: "corti", models: [{ id: "corti-s1-instant" }] },
-    "us"
+    "us",
+    true
   );
 
-  assert.equal(reasoning, null);
+  assert.deepEqual(reasoning, OPENWHISPR_REASONING);
   assert.equal(transcription.cloudTranscriptionProvider, "corti");
 });
 
-test("undefined data region yields no reasoning payload", async () => {
+test("eu region without an api key routes reasoning to openwhispr cloud", async () => {
   const { buildCortiOnboardingPayloads } = await load();
   const { reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     { id: "corti", models: [{ id: "corti-s1-instant" }] },
-    undefined
+    "eu",
+    false
   );
-  assert.equal(reasoning, null);
+  assert.deepEqual(reasoning, OPENWHISPR_REASONING);
 });
 
-test("missing corti reasoning provider yields no reasoning payload", async () => {
+test("undefined data region routes reasoning to openwhispr cloud", async () => {
+  const { buildCortiOnboardingPayloads } = await load();
+  const { reasoning } = buildCortiOnboardingPayloads(
+    { id: "corti", models: [{ id: "corti-transcribe" }] },
+    { id: "corti", models: [{ id: "corti-s1-instant" }] },
+    undefined,
+    true
+  );
+  assert.deepEqual(reasoning, OPENWHISPR_REASONING);
+});
+
+test("missing corti reasoning provider routes reasoning to openwhispr cloud", async () => {
   const { buildCortiOnboardingPayloads } = await load();
   const { transcription, reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     undefined,
-    "eu"
+    "eu",
+    true
   );
 
-  assert.equal(reasoning, null);
+  assert.deepEqual(reasoning, OPENWHISPR_REASONING);
   assert.equal(transcription.cloudTranscriptionProvider, "corti");
 });
 
-test("corti reasoning provider with empty models yields no reasoning payload", async () => {
+test("corti reasoning provider with empty models routes reasoning to openwhispr cloud", async () => {
   const { buildCortiOnboardingPayloads } = await load();
   const { reasoning } = buildCortiOnboardingPayloads(
     { id: "corti", models: [{ id: "corti-transcribe" }] },
     { id: "corti", models: [] },
-    "eu"
+    "eu",
+    true
   );
-  assert.equal(reasoning, null);
+  assert.deepEqual(reasoning, OPENWHISPR_REASONING);
 });


### PR DESCRIPTION
## Problem
Corti Models (the LLM gateway, `ai.eu.corti.app`) is **EU-only** and needs its **own API key** (OAuth via client-id/secret is "coming soon" but not available). In the onboarding "Use Corti" flow, a **US** clinical user got Corti speech-to-text but every LLM scope stayed on the default provider (OpenAI) — so transcribed clinical text was sent to a third party, and the API-key field was shown even though it can't be used outside the EU.

## Change
`buildCortiOnboardingPayloads` now always returns a reasoning payload:
- **EU + API key present** → route the four LLM scopes to **Corti** (unchanged).
- **Otherwise** (US region, or EU without the key) → route them to the HIPAA-compliant **OpenWhispr Cloud** (`cleanupMode`/`cleanupCloudMode: "openwhispr"`).

So onboarding always lands language features on Corti or OpenWhispr Cloud — never a third-party LLM. Result for a US clinical user: **Corti STT + OpenWhispr Cloud LLM**.

Onboarding UI (`FinishStep`):
- The **Corti API-key field is shown only in the EU region**; US users don't see it, and there's no LLM notice for them.
- The region selector moved **above** the key field so region drives its visibility.

## Files
- `src/helpers/reasoningRouting.js` — `buildCortiOnboardingPayloads` gains a `hasApiKey` arg and the OpenWhispr-Cloud fallback
- `src/components/onboarding/FinishStep.tsx` — always apply the reasoning payload; EU-gate the API-key field + LLM hint; reorder region above the key
- `test/helpers/reasoningRouting.test.js` — cover EU+key → Corti, and US / EU-no-key / undefined-region / missing-provider / empty-models → OpenWhispr Cloud

## Verification
- `test/helpers/reasoningRouting.test.js` 12 pass; full suite 267 pass / 0 fail; `tsc --noEmit` clean; ESLint + prettier clean
- Traced all three onboarding paths: US → Corti STT + OpenWhispr LLM; EU+key → Corti STT + Corti LLM; EU without key → Corti STT + OpenWhispr LLM

## Follow-up (not in this PR)
The Settings → reasoning provider list still offers Corti to US users (it would fail against the EU-only gateway at request time). Region-gating that selector is a separate change; flagging it here.