### PR TITLE
Sync zoom across all windows and scale the popups

### DIFF
--- a/src/helpers/menuManager.js
+++ b/src/helpers/menuManager.js
@@ -2,6 +2,36 @@ const { Menu } = require("electron");
 const { i18nMain } = require("./i18nMain");
 
 class MenuManager {
+  // Zoom items route through onZoom(window, direction) so a single app-managed
+  // zoom level stays in sync across every window (see ZoomManager). Plain
+  // `role` items would only zoom the focused webContents and emit no event.
+  static zoomMenuItems(onZoom) {
+    return [
+      {
+        label: i18nMain.t("menu.actualSize"),
+        accelerator: "CommandOrControl+0",
+        click: (_item, window) => onZoom?.(window, "reset"),
+      },
+      {
+        label: i18nMain.t("menu.zoomIn"),
+        accelerator: "CommandOrControl+Plus",
+        click: (_item, window) => onZoom?.(window, "in"),
+      },
+      {
+        // Common habit: Ctrl/Cmd + "=" (the unshifted "+" key).
+        label: i18nMain.t("menu.zoomIn"),
+        accelerator: "CommandOrControl+=",
+        visible: false,
+        click: (_item, window) => onZoom?.(window, "in"),
+      },
+      {
+        label: i18nMain.t("menu.zoomOut"),
+        accelerator: "CommandOrControl+-",
+        click: (_item, window) => onZoom?.(window, "out"),
+      },
+    ];
+  }
+
   static setupMainMenu(onOpenSettings) {
     if (process.platform === "darwin") {
       const template = [
@@ -31,7 +61,7 @@ class MenuManager {
     }
   }
 
-  static setupControlPanelMenu(controlPanelWindow, onOpenSettings) {
+  static setupControlPanelMenu(controlPanelWindow, onOpenSettings, onZoom) {
     if (process.platform === "darwin") {
       // On macOS, create a proper application menu
       const template = [
@@ -81,9 +111,7 @@ class MenuManager {
             { role: "forceReload" },
             { role: "toggleDevTools" },
             { type: "separator" },
-            { role: "resetZoom" },
-            { role: "zoomIn" },
-            { role: "zoomOut" },
+            ...MenuManager.zoomMenuItems(onZoom),
             { type: "separator" },
             { role: "togglefullscreen" },
           ],
@@ -150,9 +178,7 @@ class MenuManager {
             { role: "forceReload" },
             { role: "toggleDevTools" },
             { type: "separator" },
-            { role: "resetZoom" },
-            { role: "zoomIn" },
-            { role: "zoomOut" },
+            ...MenuManager.zoomMenuItems(onZoom),
             { type: "separator" },
             { role: "togglefullscreen" },
           ],

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -173,8 +173,9 @@ class WindowPositionUtil {
     return { x, y, width, height };
   }
 
-  static getNotificationPosition(display) {
-    const { width, height } = NOTIFICATION_WINDOW_CONFIG;
+  static getNotificationPosition(display, factor = 1) {
+    const width = Math.round(NOTIFICATION_WINDOW_CONFIG.width * factor);
+    const height = Math.round(NOTIFICATION_WINDOW_CONFIG.height * factor);
     const MARGIN = 16;
     const workArea = display.workArea || display.bounds;
     const x = Math.max(0, workArea.x + workArea.width - width - MARGIN);

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -4,6 +4,7 @@ const HotkeyManager = require("./hotkeyManager");
 const { isGlobeLikeHotkey } = HotkeyManager;
 const DragManager = require("./dragManager");
 const MenuManager = require("./menuManager");
+const ZoomManager = require("./zoomManager");
 const DevServerManager = require("./devServerManager");
 const { i18nMain } = require("./i18nMain");
 const { DEV_SERVER_PORT } = DevServerManager;
@@ -37,6 +38,7 @@ class WindowManager {
     this.tray = null;
     this.hotkeyManager = new HotkeyManager();
     this.dragManager = new DragManager();
+    this.zoomManager = new ZoomManager();
     this.isQuitting = false;
     this.loadErrorShown = false;
     this.macCompoundPushState = null;
@@ -70,6 +72,7 @@ class WindowManager {
 
     this.setMainWindowInteractivity(false);
     this.registerMainWindowEvents();
+    this.zoomManager.register(this.mainWindow.webContents);
 
     // Register load event handlers BEFORE loading to catch all events
     this.mainWindow.webContents.on(
@@ -608,6 +611,7 @@ class WindowManager {
     }
 
     this.controlPanelWindow = new BrowserWindow(CONTROL_PANEL_CONFIG);
+    this.zoomManager.register(this.controlPanelWindow.webContents);
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
@@ -672,7 +676,11 @@ class WindowManager {
       this.controlPanelWindow = null;
     });
 
-    MenuManager.setupControlPanelMenu(this.controlPanelWindow, () => this.openSettings());
+    MenuManager.setupControlPanelMenu(
+      this.controlPanelWindow,
+      () => this.openSettings(),
+      (window, direction) => this.zoomManager.applyZoomCommand(window, direction)
+    );
 
     this.controlPanelWindow.webContents.on("did-finish-load", () => {
       clearVisibilityTimer();
@@ -727,6 +735,7 @@ class WindowManager {
     }
 
     this.agentWindow = new BrowserWindow(AGENT_OVERLAY_CONFIG);
+    this.zoomManager.register(this.agentWindow.webContents);
 
     this.agentWindow.once("ready-to-show", () => {
       WindowPositionUtil.setupAlwaysOnTop(this.agentWindow);
@@ -805,6 +814,7 @@ class WindowManager {
     }
 
     this.transcriptionPreviewWindow = new BrowserWindow(TRANSCRIPTION_PREVIEW_CONFIG);
+    this.zoomManager.register(this.transcriptionPreviewWindow.webContents);
 
     this.transcriptionPreviewWindow.on("closed", () => {
       this.transcriptionPreviewWindow = null;
@@ -1167,6 +1177,7 @@ class WindowManager {
       ...NOTIFICATION_WINDOW_CONFIG,
       ...position,
     });
+    this.zoomManager.register(this.notificationWindow.webContents);
 
     if (process.platform === "darwin") {
       this.notificationWindow.setIgnoreMouseEvents(true, { forward: true });
@@ -1261,6 +1272,7 @@ class WindowManager {
       ...NOTIFICATION_WINDOW_CONFIG,
       ...position,
     });
+    this.zoomManager.register(this.updateNotificationWindow.webContents);
 
     WindowPositionUtil.setupAlwaysOnTop(this.updateNotificationWindow);
 
@@ -1389,7 +1401,11 @@ class WindowManager {
     MenuManager.setupMainMenu(() => this.openSettings());
 
     if (this.controlPanelWindow && !this.controlPanelWindow.isDestroyed()) {
-      MenuManager.setupControlPanelMenu(this.controlPanelWindow, () => this.openSettings());
+      MenuManager.setupControlPanelMenu(
+        this.controlPanelWindow,
+        () => this.openSettings(),
+        (window, direction) => this.zoomManager.applyZoomCommand(window, direction)
+      );
       this.controlPanelWindow.setTitle(i18nMain.t("window.controlPanelTitle"));
     }
 

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -39,6 +39,12 @@ class WindowManager {
     this.hotkeyManager = new HotkeyManager();
     this.dragManager = new DragManager();
     this.zoomManager = new ZoomManager();
+    // Fixed-size windows must grow with the zoom factor so zoomed content fits.
+    // Track the state needed to re-scale them live when the zoom level changes.
+    this._mainWindowSizeKey = "BASE";
+    this._lastPreviewContentSize = null;
+    this._lastAgentContentSize = null;
+    this.zoomManager.setOnChange(() => this._applyZoomToOpenWindows());
     this.isQuitting = false;
     this.loadErrorShown = false;
     this.macCompoundPushState = null;
@@ -104,6 +110,11 @@ class WindowManager {
     });
 
     await this.loadMainWindow();
+    // If a non-default zoom is already persisted, scale the overlay to match so
+    // the zoomed pill/toast content isn't clipped by the default 96x96 frame.
+    if (this.zoomManager.getFactor() !== 1) {
+      this.resizeMainWindow(this._mainWindowSizeKey);
+    }
     await this.initializeHotkey();
     this.dragManager.setTargetWindow(this.mainWindow);
     MenuManager.setupMainMenu(() => this.openSettings());
@@ -144,7 +155,13 @@ class WindowManager {
       return { success: false, message: "Window not available" };
     }
 
-    const newSize = WINDOW_SIZES[sizeKey] || WINDOW_SIZES.BASE;
+    const baseSize = WINDOW_SIZES[sizeKey] || WINDOW_SIZES.BASE;
+    this._mainWindowSizeKey = WINDOW_SIZES[sizeKey] ? sizeKey : "BASE";
+    const factor = this.zoomManager.getFactor();
+    const newSize = {
+      width: Math.round(baseSize.width * factor),
+      height: Math.round(baseSize.height * factor),
+    };
     const currentBounds = this.mainWindow.getBounds();
     const position = this._panelStartPosition;
 
@@ -184,6 +201,40 @@ class WindowManager {
     });
 
     return { success: true, bounds: { x: newX, y: newY, ...newSize } };
+  }
+
+  // Re-scale the fixed-size windows that are currently open when the shared zoom
+  // level changes, so their frames keep matching the zoomed content. Content
+  // windows (control panel, agent chat scroll) don't need this. Invoked by the
+  // ZoomManager onChange hook.
+  _applyZoomToOpenWindows() {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.resizeMainWindow(this._mainWindowSizeKey);
+    }
+
+    const factor = this.zoomManager.getFactor();
+    for (const win of [this.notificationWindow, this.updateNotificationWindow]) {
+      if (win && !win.isDestroyed() && win.isVisible()) {
+        const bounds = win.getBounds();
+        const display = screen.getDisplayNearestPoint({ x: bounds.x, y: bounds.y });
+        win.setBounds(WindowPositionUtil.getNotificationPosition(display, factor));
+      }
+    }
+
+    if (
+      this._lastPreviewContentSize &&
+      this.transcriptionPreviewWindow &&
+      !this.transcriptionPreviewWindow.isDestroyed()
+    ) {
+      this.resizeTranscriptionPreview(
+        this._lastPreviewContentSize.width,
+        this._lastPreviewContentSize.height
+      );
+    }
+
+    if (this._lastAgentContentSize && this.agentWindow && !this.agentWindow.isDestroyed()) {
+      this.resizeAgentWindow(this._lastAgentContentSize.width, this._lastAgentContentSize.height);
+    }
   }
 
   async loadWindowContent(window, isControlPanel = false, isAgent = false) {
@@ -774,7 +825,7 @@ class WindowManager {
     const display = screen.getDisplayNearestPoint({ x: refPoint.x, y: refPoint.y });
     const workArea = display.workArea || display.bounds;
 
-    const width = AGENT_OVERLAY_CONFIG.width;
+    const width = Math.round(AGENT_OVERLAY_CONFIG.width * this.zoomManager.getFactor());
     const height = workArea.height;
 
     // Center horizontally relative to main window, fill work area height
@@ -843,9 +894,10 @@ class WindowManager {
 
     if (mainBounds) {
       const display = screen.getDisplayNearestPoint({ x: mainBounds.x, y: mainBounds.y });
+      const factor = this.zoomManager.getFactor();
       const position = WindowPositionUtil.getTranscriptionPreviewPosition(display, mainBounds, {
-        width: TRANSCRIPTION_PREVIEW_CONFIG.width,
-        height: TRANSCRIPTION_PREVIEW_CONFIG.height,
+        width: Math.round(TRANSCRIPTION_PREVIEW_CONFIG.width * factor),
+        height: Math.round(TRANSCRIPTION_PREVIEW_CONFIG.height * factor),
       });
       this.transcriptionPreviewWindow.setBounds(position);
     }
@@ -890,13 +942,18 @@ class WindowManager {
       return { success: false, error: "Preview window not available" };
     }
 
+    // Renderer measures content in unzoomed CSS px; scale to device px so the
+    // zoomed content fits. Clamp against the design limits scaled by the same
+    // factor. Remember the unscaled request to re-apply if the zoom changes.
+    this._lastPreviewContentSize = { width, height };
+    const factor = this.zoomManager.getFactor();
     const targetWidth = Math.max(
-      TRANSCRIPTION_PREVIEW_SIZE_LIMITS.minWidth,
-      Math.min(Math.round(width), TRANSCRIPTION_PREVIEW_SIZE_LIMITS.maxWidth)
+      TRANSCRIPTION_PREVIEW_SIZE_LIMITS.minWidth * factor,
+      Math.min(Math.round(width * factor), TRANSCRIPTION_PREVIEW_SIZE_LIMITS.maxWidth * factor)
     );
     const targetHeight = Math.max(
-      TRANSCRIPTION_PREVIEW_SIZE_LIMITS.minHeight,
-      Math.min(Math.round(height), TRANSCRIPTION_PREVIEW_SIZE_LIMITS.maxHeight)
+      TRANSCRIPTION_PREVIEW_SIZE_LIMITS.minHeight * factor,
+      Math.min(Math.round(height * factor), TRANSCRIPTION_PREVIEW_SIZE_LIMITS.maxHeight * factor)
     );
 
     const anchorBounds =
@@ -929,13 +986,17 @@ class WindowManager {
     const ANIMATION_DURATION_MS = 250;
     const TICK_MS = 16;
 
+    // Renderer measures in unzoomed CSS px; scale to device px (and scale the
+    // clamp limits by the same factor) so zoomed chat content fits.
+    this._lastAgentContentSize = { width, height };
+    const factor = this.zoomManager.getFactor();
     const targetWidth = Math.max(
-      AGENT_OVERLAY_CONFIG.minWidth,
-      Math.min(width, AGENT_OVERLAY_CONFIG.maxWidth)
+      AGENT_OVERLAY_CONFIG.minWidth * factor,
+      Math.min(width * factor, AGENT_OVERLAY_CONFIG.maxWidth * factor)
     );
     const targetHeight = Math.max(
-      AGENT_OVERLAY_CONFIG.minHeight,
-      Math.min(height, AGENT_OVERLAY_CONFIG.maxHeight)
+      AGENT_OVERLAY_CONFIG.minHeight * factor,
+      Math.min(height * factor, AGENT_OVERLAY_CONFIG.maxHeight * factor)
     );
 
     const currentBounds = this.agentWindow.getBounds();
@@ -1171,7 +1232,10 @@ class WindowManager {
     }
 
     const display = screen.getPrimaryDisplay();
-    const position = WindowPositionUtil.getNotificationPosition(display);
+    const position = WindowPositionUtil.getNotificationPosition(
+      display,
+      this.zoomManager.getFactor()
+    );
 
     this.notificationWindow = new BrowserWindow({
       ...NOTIFICATION_WINDOW_CONFIG,
@@ -1266,7 +1330,10 @@ class WindowManager {
     }
 
     const display = screen.getPrimaryDisplay();
-    const position = WindowPositionUtil.getNotificationPosition(display);
+    const position = WindowPositionUtil.getNotificationPosition(
+      display,
+      this.zoomManager.getFactor()
+    );
 
     this.updateNotificationWindow = new BrowserWindow({
       ...NOTIFICATION_WINDOW_CONFIG,

--- a/src/helpers/zoomManager.js
+++ b/src/helpers/zoomManager.js
@@ -1,0 +1,139 @@
+const fs = require("fs");
+const path = require("path");
+const { app } = require("electron");
+const debugLogger = require("./debugLogger");
+
+const STATE_FILE = "zoom.json";
+// Electron zoom levels are logarithmic (factor = 1.2 ^ level). Clamp to the
+// same range Chromium exposes in its zoom UI (~50%..300%).
+const MIN_ZOOM_LEVEL = -3;
+const MAX_ZOOM_LEVEL = 3;
+const ZOOM_STEP = 0.5;
+
+/**
+ * App-managed zoom shared across every window.
+ *
+ * Chromium tracks zoom per-host, which does not propagate to the frameless
+ * popup/notification windows (they load via `file://`, so there is no shared
+ * host). This manager keeps a single zoom level, applies it to every
+ * registered window on load, and re-syncs all windows whenever the user zooms
+ * one of them (keyboard via the menu, or Ctrl+wheel). The level is persisted so
+ * it survives restarts deterministically.
+ */
+class ZoomManager {
+  constructor() {
+    this._level = 0;
+    this._registered = new Set();
+    this._loaded = false;
+  }
+
+  _statePath() {
+    return path.join(app.getPath("userData"), STATE_FILE);
+  }
+
+  _clamp(level) {
+    if (!Number.isFinite(level)) return 0;
+    return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, level));
+  }
+
+  _load() {
+    if (this._loaded) return;
+    this._loaded = true;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this._statePath(), "utf-8"));
+      if (typeof parsed.level === "number") {
+        this._level = this._clamp(parsed.level);
+      }
+    } catch {
+      // No saved zoom yet; default to 0 (100%).
+    }
+  }
+
+  _persist() {
+    try {
+      fs.writeFileSync(this._statePath(), JSON.stringify({ level: this._level }), "utf-8");
+    } catch (error) {
+      debugLogger.warn("Failed to persist zoom level", { error: error?.message }, "window");
+    }
+  }
+
+  getLevel() {
+    this._load();
+    return this._level;
+  }
+
+  /**
+   * Register a window's webContents so it always reflects the shared zoom
+   * level. Idempotent: registering the same webContents twice is a no-op.
+   */
+  register(webContents) {
+    if (!webContents || webContents.isDestroyed() || this._registered.has(webContents)) {
+      return;
+    }
+    this._load();
+    this._registered.add(webContents);
+
+    const apply = () => {
+      if (webContents.isDestroyed()) return;
+      try {
+        webContents.setZoomLevel(this._level);
+      } catch {
+        // Window may have gone away mid-load.
+      }
+    };
+
+    // Apply on the initial load and on any subsequent reload/navigation.
+    webContents.on("did-finish-load", apply);
+    if (!webContents.isLoadingMainFrame()) apply();
+
+    // Ctrl+wheel: Chromium has already zoomed this webContents, so mirror its
+    // new level onto the others without re-applying to the origin.
+    webContents.on("zoom-changed", () => {
+      if (webContents.isDestroyed()) return;
+      this.setLevel(webContents.getZoomLevel(), webContents);
+    });
+
+    webContents.once("destroyed", () => {
+      this._registered.delete(webContents);
+    });
+  }
+
+  /**
+   * Set the shared zoom level and propagate it to every registered window.
+   * @param {number} level target zoom level
+   * @param {Electron.WebContents} [origin] window already at this level (skipped)
+   */
+  setLevel(level, origin) {
+    this._load();
+    const clamped = this._clamp(level);
+    const changed = clamped !== this._level;
+    this._level = clamped;
+
+    for (const wc of this._registered) {
+      if (wc === origin || wc.isDestroyed()) continue;
+      try {
+        wc.setZoomLevel(clamped);
+      } catch {
+        // Skip dead windows.
+      }
+    }
+
+    if (changed) this._persist();
+  }
+
+  /**
+   * Handle a menu-driven zoom command against the focused window, using its
+   * current level as the base so the shared level never drifts.
+   * @param {Electron.BrowserWindow} window focused window from the menu click
+   * @param {"in"|"out"|"reset"} direction
+   */
+  applyZoomCommand(window, direction) {
+    if (!window || window.isDestroyed()) return;
+    const current = window.webContents.getZoomLevel();
+    const next =
+      direction === "reset" ? 0 : current + (direction === "in" ? ZOOM_STEP : -ZOOM_STEP);
+    this.setLevel(next);
+  }
+}
+
+module.exports = ZoomManager;

--- a/src/helpers/zoomManager.js
+++ b/src/helpers/zoomManager.js
@@ -62,6 +62,20 @@ class ZoomManager {
     return this._level;
   }
 
+  // Electron/Chromium zoom factor for the current level (scale = 1.2 ^ level).
+  // Fixed-size windows must multiply their dimensions by this so zoomed content
+  // (which the renderer still measures in unzoomed CSS px) fits.
+  getFactor() {
+    this._load();
+    return Math.pow(1.2, this._level);
+  }
+
+  // Invoked after the shared level changes so the owner can resize any
+  // fixed-size windows that are currently open to match the new factor.
+  setOnChange(fn) {
+    this._onChange = fn;
+  }
+
   /**
    * Register a window's webContents so it always reflects the shared zoom
    * level. Idempotent: registering the same webContents twice is a no-op.
@@ -118,7 +132,14 @@ class ZoomManager {
       }
     }
 
-    if (changed) this._persist();
+    if (changed) {
+      this._persist();
+      try {
+        this._onChange?.();
+      } catch {
+        // Resize hook is best-effort; never let it break zoom propagation.
+      }
+    }
   }
 
   /**

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -44,7 +44,10 @@
     "help": "Hilfe",
     "learnMore": "Mehr erfahren",
     "file": "Datei",
-    "closeWindow": "Fenster schließen"
+    "closeWindow": "Fenster schließen",
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern",
+    "actualSize": "Tatsächliche Größe"
   },
   "window": {
     "voiceRecorderTitle": "Sprachrekorder",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -44,7 +44,10 @@
     "help": "Help",
     "learnMore": "Learn More",
     "file": "File",
-    "closeWindow": "Close Window"
+    "closeWindow": "Close Window",
+    "zoomIn": "Zoom In",
+    "zoomOut": "Zoom Out",
+    "actualSize": "Actual Size"
   },
   "window": {
     "voiceRecorderTitle": "Voice Recorder",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -44,7 +44,10 @@
     "help": "Ayuda",
     "learnMore": "Más información",
     "file": "Archivo",
-    "closeWindow": "Cerrar ventana"
+    "closeWindow": "Cerrar ventana",
+    "zoomIn": "Acercar",
+    "zoomOut": "Alejar",
+    "actualSize": "Tamaño real"
   },
   "window": {
     "voiceRecorderTitle": "Grabadora de voz",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -44,7 +44,10 @@
     "help": "Aide",
     "learnMore": "En savoir plus",
     "file": "Fichier",
-    "closeWindow": "Fermer la fenêtre"
+    "closeWindow": "Fermer la fenêtre",
+    "zoomIn": "Zoom avant",
+    "zoomOut": "Zoom arrière",
+    "actualSize": "Taille réelle"
   },
   "window": {
     "voiceRecorderTitle": "Enregistreur vocal",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -44,7 +44,10 @@
     "help": "Aiuto",
     "learnMore": "Scopri di più",
     "file": "File",
-    "closeWindow": "Chiudi finestra"
+    "closeWindow": "Chiudi finestra",
+    "zoomIn": "Ingrandisci",
+    "zoomOut": "Riduci",
+    "actualSize": "Dimensioni effettive"
   },
   "window": {
     "voiceRecorderTitle": "Registratore vocale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -44,7 +44,10 @@
     "help": "ヘルプ",
     "learnMore": "詳細を見る",
     "file": "ファイル",
-    "closeWindow": "ウィンドウを閉じる"
+    "closeWindow": "ウィンドウを閉じる",
+    "zoomIn": "拡大",
+    "zoomOut": "縮小",
+    "actualSize": "実際のサイズ"
   },
   "window": {
     "voiceRecorderTitle": "ボイスレコーダー",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -44,7 +44,10 @@
     "help": "Ajuda",
     "learnMore": "Saiba mais",
     "file": "Arquivo",
-    "closeWindow": "Fechar janela"
+    "closeWindow": "Fechar janela",
+    "zoomIn": "Ampliar",
+    "zoomOut": "Reduzir",
+    "actualSize": "Tamanho real"
   },
   "window": {
     "voiceRecorderTitle": "Gravador de voz",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -44,7 +44,10 @@
     "help": "Справка",
     "learnMore": "Узнать больше",
     "file": "Файл",
-    "closeWindow": "Закрыть окно"
+    "closeWindow": "Закрыть окно",
+    "zoomIn": "Увеличить",
+    "zoomOut": "Уменьшить",
+    "actualSize": "Реальный размер"
   },
   "window": {
     "voiceRecorderTitle": "Диктофон",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -44,7 +44,10 @@
     "help": "帮助",
     "learnMore": "了解更多",
     "file": "文件",
-    "closeWindow": "关闭窗口"
+    "closeWindow": "关闭窗口",
+    "zoomIn": "放大",
+    "zoomOut": "缩小",
+    "actualSize": "实际大小"
   },
   "window": {
     "voiceRecorderTitle": "录音器",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -44,7 +44,10 @@
     "help": "說明",
     "learnMore": "瞭解更多",
     "file": "檔案",
-    "closeWindow": "關閉視窗"
+    "closeWindow": "關閉視窗",
+    "zoomIn": "放大",
+    "zoomOut": "縮小",
+    "actualSize": "實際大小"
   },
   "window": {
     "voiceRecorderTitle": "錄音器",


### PR DESCRIPTION
Two issues with zoom:

- Ctrl +/-/0 only zoomed the focused window, so the notification, transcription-preview and agent popups stayed at 100%.
- Those windows are fixed-size, so once they did zoom the content clipped.

This routes the View-menu zoom items through a small `ZoomManager` that keeps one shared zoom level, applies it to every window (and persists it across restarts), and scales the fixed-size popups by the zoom factor so their frames grow to fit. Also adds the Ctrl/Cmd+`=` accelerator.

Translations are auto-generated (it's a common text so should be OK, and probably better than no text at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
