### PR TITLE
fix(hotkeys): support push-to-talk on GNOME via low-level key listener

### DIFF
--- a/main.js
+++ b/main.js
@@ -813,6 +813,9 @@ async function startApp() {
   ipcMain.on("activation-mode-changed", (_event, mode) => {
     windowManager.setActivationModeCache(mode);
     environmentManager.saveActivationMode(mode);
+    // Retune the low-level key listener now, not on the next unrelated
+    // hotkey change, since push mode needs it watching the dictation keys.
+    windowManager.reconcileNativeKeyListeners();
   });
 
   ipcMain.on("floating-icon-auto-hide-changed", (_event, enabled) => {

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -389,6 +389,16 @@ class HotkeyManager extends EventEmitter {
     return keys;
   }
 
+  /**
+   * Dictation hotkeys minus macOS-only globe or mouse keys, used to watch
+   * push-to-talk on GNOME and KDE since D-Bus bindings never report key-up.
+   */
+  getDictationHotkeys() {
+    return (this.slots.get("dictation")?.hotkeys ?? []).filter(
+      (hotkey) => hotkey && !isGlobeLikeHotkey(hotkey) && !isMouseButtonHotkey(hotkey)
+    );
+  }
+
   // Register one hotkey without mutating any slot. `accelerator` is null for
   // hotkeys handled by native listeners.
   _registerSingleHotkey(hotkey, callback) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -510,11 +510,17 @@ class WindowManager {
   reconcileNativeKeyListeners() {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     if (this.hotkeyManager.isInListeningMode()) return;
-    // GNOME/KDE/Hyprland deliver hotkeys via D-Bus native shortcuts; the low-level
-    // listener would be redundant there and could double-fire, so watch nothing.
-    const keys = this.hotkeyManager.isUsingNativeShortcut()
-      ? []
-      : this.hotkeyManager.getNativeListenerKeys(this.getActivationMode());
+    // D-Bus desktops (GNOME, KDE, Hyprland) skip the low-level listener normally,
+    // but push-to-talk on Linux needs it, since D-Bus never sends key-up.
+    let keys;
+    if (this.hotkeyManager.isUsingNativeShortcut()) {
+      keys =
+        process.platform === "linux" && this.getActivationMode() === "push"
+          ? this.hotkeyManager.getDictationHotkeys()
+          : [];
+    } else {
+      keys = this.hotkeyManager.getNativeListenerKeys(this.getActivationMode());
+    }
     if (process.platform === "win32" && this.windowsKeyManager) {
       this.windowsKeyManager.setKeys(keys);
     } else if (process.platform === "linux" && this.linuxKeyManager) {


### PR DESCRIPTION
## Problem

Push-to-talk is documented as unavailable on GNOME. Two root causes:

1. GNOME and KDE deliver custom shortcuts over D-Bus, and those bindings fire on key-press only, then re-fire on autorepeat. There is no key-release signal, so a held key can never be un-held. In tap mode this doesn't matter, but push mode needs to know when the key comes back up; holding the hotkey chops the recording into useless 50-100ms fragments instead.
2. `reconcileNativeKeyListeners()` deliberately watches nothing when D-Bus shortcuts are active, on the assumption that the low-level evdev listener would be redundant and could double-fire alongside D-Bus. That's the right call in tap mode, but it also means the one listener that *can* see key-up (evdev) never runs, even in push mode.

## Fix

When `activationMode === "push"` on Linux, `reconcileNativeKeyListeners()` now watches just the dictation hotkeys with the existing low-level (evdev) listener, even on D-Bus-shortcut desktops. Tap mode is untouched, and non-dictation slots are untouched.

This doesn't double-fire: the dictation callback already has a guard that defers to the native listener and ignores D-Bus toggle events while push mode is active, so D-Bus and evdev don't both drive the same recording.

Also fixes a smaller bug alongside this: the `activation-mode-changed` IPC handler wasn't calling `reconcileNativeKeyListeners()`, so switching between tap and push didn't retune the listener until some unrelated hotkey change happened to trigger it. Now it retunes immediately on mode switch.

## Requirements / limits

The evdev listener needs read access to `/dev/input`, i.e. the user's account needs to be in the `input` group. This isn't new: the existing `permission-denied` -> renderer notification path already covers that fallback UX.

Tested on Ubuntu 24.04, GNOME 46, X11, with a real keyboard: press starts recording, release stops it, autorepeat is filtered out by the listener's `value==2` check, and a short tap in push mode behaves as designed (150ms threshold). I did not test on Wayland. evdev is display-server-agnostic so it should work identically there in principle, but I want to say plainly that I haven't verified it.
