### PR TITLE
fix(audio): fall back when the preferred microphone remains muted

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -441,7 +441,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       },
       logger,
       {
-        fallbackOnAcquisitionError: Boolean(pinnedDeviceId),
+        fallbackOnAcquisitionError: isBuiltInPreference,
         onFallbackSuccess: ({ reason }) => {
           // A health failure or stale ID is stable enough to avoid retrying the same auto-picked
           // built-in on every recording. Generic acquisition failures may be transient, and an

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1,7 +1,7 @@
 import ReasoningService from "../services/ReasoningService";
 import { API_ENDPOINTS, buildApiUrl, normalizeBaseUrl } from "../config/constants";
 import logger from "../utils/logger";
-import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
+import { findBuiltInMicrophone } from "../utils/audioDeviceUtils";
 import {
   isSecureEndpoint,
   isAzureOpenAIEndpoint,
@@ -15,7 +15,6 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { reacquireIfDead } from "./micTrackHealth";
-import { isStaleDeviceError } from "./staleMicDevice";
 import { shouldSaveDiscardedRecording } from "./discardedRecording";
 import {
   getSettings,
@@ -208,10 +207,14 @@ class AudioManager {
     };
     window.addEventListener("api-key-changed", this._onApiKeyChanged);
 
+    this.cachedMicDeviceId = null;
+    this.unavailableBuiltInMicDeviceId = null;
+
     // Invalidate the pinned mic device when the OS adds/removes/suspends inputs.
     // Otherwise wake-after-idle keeps requesting a stale deviceId that yields silence.
     this._onDeviceChange = () => {
       this.cachedMicDeviceId = null;
+      this.unavailableBuiltInMicDeviceId = null;
       this.micDriverWarmedUp = false;
     };
     navigator.mediaDevices?.addEventListener?.("devicechange", this._onDeviceChange);
@@ -231,7 +234,6 @@ class AudioManager {
     this.streamingPartialText = "";
     this.streamingTextResolve = null;
     this.streamingTextDebounce = null;
-    this.cachedMicDeviceId = null;
     this.persistentAudioContext = null;
     this.workletModuleLoaded = false;
     this.workletBlobUrl = null;
@@ -369,12 +371,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     // Pinned device was unavailable (Chromium rotates IDs / device unplugged); fall back to the
     // system default for this capture without discarding the saved preference. See #900.
     if (forceDefaultMic) {
-      logger.debug("Using default microphone (pinned device unavailable)", {}, "audio");
+      logger.debug("Using system-default microphone for fallback", {}, "audio");
       return { audio: noProcessing };
     }
 
     if (preferBuiltIn) {
-      if (this.cachedMicDeviceId) {
+      if (this.cachedMicDeviceId && this.cachedMicDeviceId !== this.unavailableBuiltInMicDeviceId) {
         logger.debug(
           "Using cached microphone device ID",
           { deviceId: this.cachedMicDeviceId },
@@ -384,11 +386,17 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
 
       try {
-        const devices = await navigator.mediaDevices.enumerateDevices();
-        const audioInputs = devices.filter((d) => d.kind === "audioinput");
-        const builtInMic = audioInputs.find((d) => isBuiltInMicrophone(d.label));
+        const builtInMic = await findBuiltInMicrophone();
 
         if (builtInMic) {
+          if (builtInMic.deviceId === this.unavailableBuiltInMicDeviceId) {
+            logger.debug(
+              "Using default microphone (preferred built-in was unavailable)",
+              {},
+              "audio"
+            );
+            return { audio: noProcessing };
+          }
           this.cachedMicDeviceId = builtInMic.deviceId;
           logger.debug(
             "Using built-in microphone (cached for next time)",
@@ -415,16 +423,45 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return { audio: noProcessing };
   }
 
+  async acquireMicrophone(constraints) {
+    const audioConstraints =
+      typeof constraints.audio === "object" && constraints.audio !== null
+        ? constraints.audio
+        : null;
+    const deviceConstraint = audioConstraints?.deviceId;
+    const pinnedDeviceId =
+      typeof deviceConstraint === "string" ? deviceConstraint : deviceConstraint?.exact;
+    const isBuiltInPreference = Boolean(pinnedDeviceId && getSettings().preferBuiltInMic);
+
+    return reacquireIfDead(
+      navigator.mediaDevices.getUserMedia(constraints),
+      () => {
+        this.cachedMicDeviceId = null;
+        return this.getAudioConstraints(true);
+      },
+      logger,
+      {
+        fallbackOnAcquisitionError: Boolean(pinnedDeviceId),
+        onFallbackSuccess: ({ reason }) => {
+          // A health failure or stale ID is stable enough to avoid retrying the same auto-picked
+          // built-in on every recording. Generic acquisition failures may be transient, and an
+          // explicit user selection must remain retryable.
+          if (isBuiltInPreference && reason !== "acquisition-error") {
+            this.unavailableBuiltInMicDeviceId = pinnedDeviceId;
+          }
+        },
+      }
+    );
+  }
+
   async cacheMicrophoneDeviceId() {
     if (this.cachedMicDeviceId) return; // Already cached
 
     if (!getSettings().preferBuiltInMic) return; // Only needed for built-in mic detection
 
     try {
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const audioInputs = devices.filter((d) => d.kind === "audioinput");
-      const builtInMic = audioInputs.find((d) => isBuiltInMicrophone(d.label));
-      if (builtInMic) {
+      const builtInMic = await findBuiltInMicrophone();
+      if (builtInMic && builtInMic.deviceId !== this.unavailableBuiltInMicDeviceId) {
         this.cachedMicDeviceId = builtInMic.deviceId;
         logger.debug("Microphone device ID pre-cached", { deviceId: builtInMic.deviceId }, "audio");
       }
@@ -450,21 +487,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  async startRecording(forceDefaultMic = false) {
+  async startRecording() {
     try {
       if (this.isRecording || this.isProcessing || this.mediaRecorder?.state === "recording") {
         return false;
       }
 
-      const constraints = await this.getAudioConstraints(forceDefaultMic);
-      const micStream = await reacquireIfDead(
-        await navigator.mediaDevices.getUserMedia(constraints),
-        () => {
-          this.cachedMicDeviceId = null;
-          return this.getAudioConstraints();
-        },
-        logger
-      );
+      const constraints = await this.getAudioConstraints();
+      const micStream = await this.acquireMicrophone(constraints);
       const audioTrack = micStream.getAudioTracks()[0];
 
       if (audioTrack) {
@@ -620,17 +650,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       return true;
     } catch (error) {
-      if (isStaleDeviceError(error) && !forceDefaultMic) {
-        // Pinned mic is gone (Chromium rotates IDs / device unplugged). Retry once on the default mic. See #900.
-        logger.warn("Pinned microphone unavailable, retrying on default mic", {}, "audio");
-        this.cachedMicDeviceId = null;
-        return this.startRecording(true);
-      }
-
       let errorTitle = "Recording Error";
       let errorDescription = `Failed to access microphone: ${error.message}`;
 
-      if (error.name === "NotAllowedError" || error.name === "PermissionDeniedError") {
+      if (
+        error.name === "NotAllowedError" ||
+        error.name === "PermissionDeniedError" ||
+        error.name === "SecurityError"
+      ) {
         errorTitle = "Microphone Access Denied";
         errorDescription =
           "Please grant microphone permission in your system settings and try again.";
@@ -2648,7 +2675,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return this.persistentAudioContext;
   }
 
-  async startStreamingRecording(forceDefaultMic = false) {
+  async startStreamingRecording() {
     try {
       if (this.streamingStartInProgress) {
         return false;
@@ -2663,21 +2690,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.stopRequestedDuringStreamingStart = false;
 
       const t0 = performance.now();
-      const constraints = await this.getAudioConstraints(forceDefaultMic);
+      const constraints = await this.getAudioConstraints();
       const tConstraints = performance.now();
 
       // 1. Get mic stream (can take 10-15s on cold macOS mic driver)
-      const rawStream = await navigator.mediaDevices.getUserMedia(constraints);
+      const stream = await this.acquireMicrophone(constraints);
       const tMedia = performance.now();
-
-      const stream = await reacquireIfDead(
-        rawStream,
-        () => {
-          this.cachedMicDeviceId = null;
-          return this.getAudioConstraints();
-        },
-        logger
-      );
       const audioTrack = stream.getAudioTracks()[0];
 
       if (audioTrack) {
@@ -2870,31 +2888,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
       return true;
     } catch (error) {
-      const stopRequested = this.stopRequestedDuringStreamingStart;
       this.streamingStartInProgress = false;
       this.stopRequestedDuringStreamingStart = false;
-
-      if (isStaleDeviceError(error) && !forceDefaultMic && !stopRequested) {
-        // Pinned mic is gone (Chromium rotates IDs / device unplugged). Retry once on the default mic. See #900.
-        logger.warn(
-          "Pinned microphone unavailable, retrying streaming on default mic",
-          {},
-          "streaming"
-        );
-        this.cachedMicDeviceId = null;
-        await this.cleanupStreaming();
-        this.isRecording = false;
-        this.recordingStartTime = null;
-        this.onStateChange?.({ isRecording: false, isProcessing: false, isStreaming: false });
-        return this.startStreamingRecording(true);
-      }
 
       logger.error("Failed to start streaming recording", { error: error.message }, "streaming");
 
       let errorTitle = "Streaming Error";
       let errorDescription = `Failed to start streaming: ${error.message}`;
 
-      if (error.name === "NotAllowedError" || error.name === "PermissionDeniedError") {
+      if (
+        error.name === "NotAllowedError" ||
+        error.name === "PermissionDeniedError" ||
+        error.name === "SecurityError"
+      ) {
         errorTitle = "Microphone Access Denied";
         errorDescription =
           "Please grant microphone permission in your system settings and try again.";

--- a/src/helpers/micTrackHealth.js
+++ b/src/helpers/micTrackHealth.js
@@ -1,3 +1,5 @@
+import { isStaleDeviceError } from "./staleMicDevice.js";
+
 const TRACK_READY_TIMEOUT_MS = 600;
 
 // Waits until a capture track is actually delivering audio (wake-after-idle re-acquire).
@@ -54,26 +56,102 @@ export const waitForTrackReady = (track, timeoutMs) =>
     }, timeoutMs);
   });
 
-// Re-acquires the mic once if the first track never delivers audio (dead/muted after idle).
-// getFreshConstraints must drop any pinned device id so the retry re-resolves the device.
-// Returns a live stream — the original when it was healthy or the retry failed.
-export const reacquireIfDead = async (stream, getFreshConstraints, logger) => {
-  const track = stream.getAudioTracks()[0];
-  if (!track || (await waitForTrackReady(track, TRACK_READY_TIMEOUT_MS))) {
-    return stream;
+const stopStream = (stream) => {
+  stream?.getTracks?.().forEach((track) => {
+    try {
+      track.stop();
+    } catch {
+      // A track can end between the readiness check and cleanup.
+    }
+  });
+};
+
+const isPermissionError = (error) =>
+  error?.name === "NotAllowedError" ||
+  error?.name === "PermissionDeniedError" ||
+  error?.name === "SecurityError";
+
+const acquireReadyFallback = async (
+  getFallbackConstraints,
+  logger,
+  onFallbackSuccess,
+  fallbackContext
+) => {
+  let fallbackStream;
+  try {
+    fallbackStream = await navigator.mediaDevices.getUserMedia(await getFallbackConstraints());
+  } catch (error) {
+    logger.warn("Default microphone fallback failed", { error: error.message }, "audio");
+    throw error;
+  }
+
+  const fallbackTrack = fallbackStream.getAudioTracks()[0];
+  if (fallbackTrack?.muted) {
+    logger.debug("Fallback microphone track is muted; waiting for unmute", {}, "audio");
+  }
+
+  if (!fallbackTrack || !(await waitForTrackReady(fallbackTrack, TRACK_READY_TIMEOUT_MS))) {
+    stopStream(fallbackStream);
+    const error = new Error("System default microphone did not become ready");
+    error.name = "MicrophoneTrackError";
+    logger.warn("Default microphone fallback did not become ready", {}, "audio");
+    throw error;
   }
 
   try {
-    const retryStream = await navigator.mediaDevices.getUserMedia(await getFreshConstraints());
-    stream.getTracks().forEach((t) => t.stop());
-    logger.info("Re-acquired microphone after dead/muted track", {}, "audio");
-    return retryStream;
+    onFallbackSuccess?.(fallbackContext);
   } catch (error) {
+    stopStream(fallbackStream);
+    throw error;
+  }
+
+  logger.info("Fallback microphone acquired successfully", {}, "audio");
+  return fallbackStream;
+};
+
+// Re-acquires the mic once if the preferred capture cannot start or its track never delivers
+// audio. getFallbackConstraints must return system-default constraints with no pinned device ID.
+// The fallback is health-checked too; a failed fallback is surfaced rather than returning silence.
+export const reacquireIfDead = async (
+  streamOrPromise,
+  getFallbackConstraints,
+  logger,
+  { fallbackOnAcquisitionError = false, onFallbackSuccess } = {}
+) => {
+  let stream;
+  try {
+    stream = await streamOrPromise;
+  } catch (error) {
+    const canFallback =
+      !isPermissionError(error) && (fallbackOnAcquisitionError || isStaleDeviceError(error));
+    if (!canFallback) throw error;
+
     logger.warn(
-      "Microphone re-acquire failed, using original stream",
+      "Preferred microphone acquisition failed; falling back to system default",
       { error: error.message },
       "audio"
     );
+    return acquireReadyFallback(getFallbackConstraints, logger, onFallbackSuccess, {
+      reason: isStaleDeviceError(error) ? "stale-device" : "acquisition-error",
+      error,
+    });
+  }
+
+  const track = stream.getAudioTracks()[0];
+  if (track?.muted) {
+    logger.debug("Preferred microphone track is muted; waiting for unmute", {}, "audio");
+  }
+  if (track && (await waitForTrackReady(track, TRACK_READY_TIMEOUT_MS))) {
     return stream;
   }
+
+  const reason = !track ? "missing track" : track.readyState === "ended" ? "ended" : "muted";
+  logger.warn(
+    "Preferred microphone remained unavailable; falling back to system default",
+    { reason },
+    "audio"
+  );
+  logger.debug("Stopping unusable preferred microphone stream", {}, "audio");
+  stopStream(stream);
+  return acquireReadyFallback(getFallbackConstraints, logger, onFallbackSuccess, { reason });
 };

--- a/src/utils/audioDeviceUtils.ts
+++ b/src/utils/audioDeviceUtils.ts
@@ -38,3 +38,13 @@ export function isBuiltInMicrophone(label: string): boolean {
 
   return false;
 }
+
+/** Enumerates the first input matching the app's built-in microphone policy. */
+export async function findBuiltInMicrophone(
+  mediaDevices: Pick<MediaDevices, "enumerateDevices"> = navigator.mediaDevices
+): Promise<MediaDeviceInfo | undefined> {
+  const devices = await mediaDevices.enumerateDevices();
+  return devices.find(
+    (device) => device.kind === "audioinput" && isBuiltInMicrophone(device.label)
+  );
+}

--- a/test/helpers/audioDeviceUtils.test.js
+++ b/test/helpers/audioDeviceUtils.test.js
@@ -1,0 +1,53 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/audioDeviceUtils.ts");
+
+const input = (deviceId, label) => ({ kind: "audioinput", deviceId, label });
+
+test("enumerates Realtek as built-in while excluding the default Plantronics headset", async () => {
+  const { findBuiltInMicrophone } = await load();
+  const realtek = input("realtek-device", "Microphone Array (Realtek(R) Audio)");
+  let calls = 0;
+  const mediaDevices = {
+    async enumerateDevices() {
+      calls += 1;
+      return [
+        input(
+          "default",
+          "Default - Headset Microphone (Plantronics Blackwire 5220 Series) (047f:c053)"
+        ),
+        { kind: "audiooutput", deviceId: "speakers", label: "Speakers" },
+        input("plantronics", "Headset Microphone (Plantronics Blackwire 5220 Series)"),
+        realtek,
+      ];
+    },
+  };
+
+  assert.equal(await findBuiltInMicrophone(mediaDevices), realtek);
+  assert.equal(calls, 1);
+});
+
+test("returns undefined when enumeration contains only external microphones", async () => {
+  const { findBuiltInMicrophone } = await load();
+  const mediaDevices = {
+    enumerateDevices: async () => [
+      input("plantronics", "Headset Microphone (Plantronics Blackwire 5220 Series)"),
+      input("usb", "USB Microphone"),
+    ],
+  };
+
+  assert.equal(await findBuiltInMicrophone(mediaDevices), undefined);
+});
+
+test("surfaces enumerateDevices failures to the caller", async () => {
+  const { findBuiltInMicrophone } = await load();
+  const enumerationError = new Error("enumeration failed");
+  const mediaDevices = {
+    enumerateDevices: async () => {
+      throw enumerationError;
+    },
+  };
+
+  await assert.rejects(findBuiltInMicrophone(mediaDevices), (error) => error === enumerationError);
+});

--- a/test/helpers/micTrackHealth.test.js
+++ b/test/helpers/micTrackHealth.test.js
@@ -267,6 +267,51 @@ test("reacquireIfDead falls back once when preferred acquisition rejects", async
   }
 });
 
+test("reacquireIfDead surfaces a generic acquisition error when fallback is disabled", async () => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  let calls = 0;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+  });
+  try {
+    const preferredError = Object.assign(new Error("selected microphone is in use"), {
+      name: "NotReadableError",
+    });
+    await assert.rejects(
+      reacquireIfDead(Promise.reject(preferredError), () => ({ audio: true }), noopLogger),
+      (error) => error === preferredError
+    );
+    assert.equal(calls, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead still falls back for a stale device when generic fallback is disabled", async () => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  const fallback = new FakeStream(new FakeTrack());
+  let calls = 0;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+    return fallback;
+  });
+  try {
+    const staleDeviceError = Object.assign(new Error("saved microphone no longer exists"), {
+      name: "OverconstrainedError",
+      constraint: "deviceId",
+    });
+    const result = await reacquireIfDead(
+      Promise.reject(staleDeviceError),
+      () => ({ audio: true }),
+      noopLogger
+    );
+    assert.equal(result, fallback);
+    assert.equal(calls, 1);
+  } finally {
+    restore();
+  }
+});
+
 test("reacquireIfDead surfaces permission denial without retrying another device", async () => {
   const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
   let calls = 0;

--- a/test/helpers/micTrackHealth.test.js
+++ b/test/helpers/micTrackHealth.test.js
@@ -7,6 +7,7 @@ class FakeTrack extends EventTarget {
     super();
     this.muted = muted;
     this.readyState = readyState;
+    this.stopped = false;
     this._listenerCount = 0;
   }
 
@@ -22,6 +23,11 @@ class FakeTrack extends EventTarget {
 
   fire(type) {
     this.dispatchEvent(new Event(type));
+  }
+
+  stop() {
+    this.stopped = true;
+    this.readyState = "ended";
   }
 }
 
@@ -85,11 +91,10 @@ test("resolves true after timeout if the track quietly unmuted without firing", 
   assert.equal(track._listenerCount, 0);
 });
 
-// Fake MediaStream: one track plus a stop-tracking flag, matching the bits reacquireIfDead touches.
+// Fake MediaStream: one track, matching the browser surface reacquireIfDead touches.
 class FakeStream {
   constructor(track) {
     this.track = track;
-    this.stopped = false;
   }
 
   getAudioTracks() {
@@ -101,7 +106,7 @@ class FakeStream {
   }
 }
 
-const noopLogger = { info() {}, warn() {} };
+const noopLogger = { debug() {}, info() {}, warn() {} };
 
 function stubGetUserMedia(impl) {
   const original = globalThis.navigator;
@@ -124,64 +129,206 @@ test("reacquireIfDead returns the original stream and never retries a healthy tr
     const result = await reacquireIfDead(stream, () => ({}), noopLogger);
     assert.equal(result, stream);
     assert.equal(called, false);
-    assert.equal(stream.stopped, false);
+    assert.equal(stream.track.stopped, false);
   } finally {
     restore();
   }
 });
 
-test("reacquireIfDead returns the original stream for a trackless stream", async () => {
+test("reacquireIfDead falls back once for a trackless stream", async () => {
   const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
   const stream = new FakeStream(null);
-  let called = false;
+  const fallback = new FakeStream(new FakeTrack());
+  let calls = 0;
   const restore = stubGetUserMedia(async () => {
-    called = true;
+    calls += 1;
+    return fallback;
   });
   try {
-    assert.equal(await reacquireIfDead(stream, () => ({}), noopLogger), stream);
-    assert.equal(called, false);
+    assert.equal(await reacquireIfDead(stream, () => ({ audio: true }), noopLogger), fallback);
+    assert.equal(calls, 1);
   } finally {
     restore();
   }
 });
 
-test("reacquireIfDead re-acquires once and stops the dead stream", async () => {
+test("reacquireIfDead invalidates the pinned cache before one unpinned retry", async () => {
   const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
   const deadTrack = new FakeTrack({ readyState: "ended" });
-  deadTrack.stop = () => {
-    deadTrack._stopped = true;
-  };
   const stream = new FakeStream(deadTrack);
   const fresh = new FakeStream(new FakeTrack({ muted: false }));
-  let constraintsCleared = false;
-  const restore = stubGetUserMedia(async () => fresh);
+  const fallbackConstraints = { audio: { echoCancellation: false } };
+  let cachedDeviceId = "realtek-device";
+  let unavailableDeviceId = null;
+  const pinnedDeviceId = cachedDeviceId;
+  const calls = [];
+  const restore = stubGetUserMedia(async (constraints) => {
+    calls.push(constraints);
+    return fresh;
+  });
   try {
     const result = await reacquireIfDead(
       stream,
       () => {
-        constraintsCleared = true;
-        return {};
+        cachedDeviceId = null;
+        return fallbackConstraints;
       },
-      noopLogger
+      noopLogger,
+      {
+        onFallbackSuccess: () => {
+          unavailableDeviceId = pinnedDeviceId;
+        },
+      }
     );
     assert.equal(result, fresh);
-    assert.equal(constraintsCleared, true);
-    assert.equal(deadTrack._stopped, true);
+    assert.deepEqual(calls, [fallbackConstraints]);
+    assert.equal(cachedDeviceId, null);
+    assert.equal(unavailableDeviceId, "realtek-device");
+    assert.equal(deadTrack.stopped, true);
   } finally {
     restore();
   }
 });
 
-test("reacquireIfDead falls back to the original stream when the retry fails", async () => {
+test("reacquireIfDead waits for a muted preferred track before falling back", async (t) => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const mutedTrack = new FakeTrack({ muted: true });
+  const stream = new FakeStream(mutedTrack);
+  const fallback = new FakeStream(new FakeTrack());
+  let calls = 0;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+    return fallback;
+  });
+  try {
+    const pending = reacquireIfDead(stream, () => ({ audio: true }), noopLogger);
+    await Promise.resolve();
+    assert.equal(calls, 0);
+    t.mock.timers.tick(600);
+    assert.equal(await pending, fallback);
+    assert.equal(calls, 1);
+    assert.equal(mutedTrack.stopped, true);
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead retains a preferred track that unmutes within the grace period", async () => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  const mutedTrack = new FakeTrack({ muted: true });
+  const stream = new FakeStream(mutedTrack);
+  let calls = 0;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+  });
+  try {
+    const pending = reacquireIfDead(stream, () => ({ audio: true }), noopLogger);
+    await Promise.resolve();
+    mutedTrack.muted = false;
+    mutedTrack.fire("unmute");
+    assert.equal(await pending, stream);
+    assert.equal(calls, 0);
+    assert.equal(mutedTrack.stopped, false);
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead falls back once when preferred acquisition rejects", async () => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  const fallback = new FakeStream(new FakeTrack());
+  let calls = 0;
+  let fallbackReason = null;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+    return fallback;
+  });
+  try {
+    const preferredError = Object.assign(new Error("preferred device unavailable"), {
+      name: "NotReadableError",
+    });
+    const result = await reacquireIfDead(
+      Promise.reject(preferredError),
+      () => ({ audio: true }),
+      noopLogger,
+      {
+        fallbackOnAcquisitionError: true,
+        onFallbackSuccess: ({ reason }) => {
+          fallbackReason = reason;
+        },
+      }
+    );
+    assert.equal(result, fallback);
+    assert.equal(calls, 1);
+    assert.equal(fallbackReason, "acquisition-error");
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead surfaces permission denial without retrying another device", async () => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  let calls = 0;
+  const restore = stubGetUserMedia(async () => {
+    calls += 1;
+  });
+  try {
+    const permissionError = Object.assign(new Error("permission denied"), {
+      name: "NotAllowedError",
+    });
+    await assert.rejects(
+      reacquireIfDead(Promise.reject(permissionError), () => ({ audio: true }), noopLogger, {
+        fallbackOnAcquisitionError: true,
+      }),
+      (error) => error === permissionError
+    );
+    assert.equal(calls, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead surfaces a failed default fallback without retrying again", async () => {
   const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
   const deadTrack = new FakeTrack({ readyState: "ended" });
-  deadTrack.stop = () => {};
   const stream = new FakeStream(deadTrack);
+  let calls = 0;
+  let fallbackSucceeded = false;
   const restore = stubGetUserMedia(async () => {
+    calls += 1;
     throw new Error("device busy");
   });
   try {
-    assert.equal(await reacquireIfDead(stream, () => ({}), noopLogger), stream);
+    await assert.rejects(
+      reacquireIfDead(stream, () => ({ audio: true }), noopLogger, {
+        onFallbackSuccess: () => {
+          fallbackSucceeded = true;
+        },
+      }),
+      /device busy/
+    );
+    assert.equal(calls, 1);
+    assert.equal(fallbackSucceeded, false);
+    assert.equal(deadTrack.stopped, true);
+  } finally {
+    restore();
+  }
+});
+
+test("reacquireIfDead rejects and stops a persistently muted default fallback", async (t) => {
+  const { reacquireIfDead } = await import("../../src/helpers/micTrackHealth.js");
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const deadTrack = new FakeTrack({ readyState: "ended" });
+  const fallbackTrack = new FakeTrack({ muted: true });
+  const restore = stubGetUserMedia(async () => new FakeStream(fallbackTrack));
+  try {
+    const pending = reacquireIfDead(new FakeStream(deadTrack), () => ({ audio: true }), noopLogger);
+    // Flush the async constraints and getUserMedia steps so the readiness timer is registered.
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    t.mock.timers.tick(600);
+    await assert.rejects(pending, /default microphone.*ready/i);
+    assert.equal(fallbackTrack.stopped, true);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Problem

With Prefer Built-in Microphone enabled, OpenWhispr pins the built-in microphone using an exact device ID.

On the affected Windows system, Chromium returned a live but persistently muted Realtek track. The existing readiness check waited 600 ms, cleared the cached device ID, and requested fresh constraints.

Fresh constraint generation immediately rediscovered and pinned the same Realtek device. The retry stream was not health-checked, and a failed retry could return the original silent stream.

Fixes #1152.

## Fix

- Retain a healthy preferred microphone without adding latency.
- Give an initially muted track 600 ms to emit `unmute`.
- Stop a missing, ended, or persistently muted preferred stream.
- Retry exactly once with unpinned system-default constraints.
- Health-check the fallback before recording.
- Stop and surface an unusable fallback instead of continuing with silence.
- Avoid reopening a rejected automatically selected built-in on every subsequent recording in the stable session.
- Reconsider devices after a `devicechange` event.
- Share the acquisition path between regular and streaming dictation.
- Preserve permission errors and generic acquisition errors for explicit microphone selections.
- Retain the existing default fallback for stale explicit device IDs.

## Tests

Using Node 24.18:

- Focused microphone/device tests: 21 passed, 0 failed
- Full suite: 275 total, 267 passed, 8 skipped, 0 failed
- ESLint: passed
- Prettier: passed
- Type checking: passed
- i18n validation: passed
- Renderer production build: passed
- `git diff --check`: passed

On Windows:

- Focused tests on the hardware-tested core commit: 19 passed, 0 failed
- ESLint: passed
- The full Windows suite had one unrelated existing archive-extraction failure, which reproduced when run independently and is unchanged by this branch.

## Windows validation

Tested using the native Windows development build with both Realtek and Plantronics enabled.

With Plantronics configured as the Windows default:

- OpenWhispr detected that the preferred Realtek stream remained unavailable.
- It logged fallback to the system-default microphone.
- The fallback acquired Plantronics as a live, unmuted track.
- Four repeated recordings remained on Plantronics and contained audible voice.

With Plantronics disconnected:

- The system-default fallback resolved to Realtek.
- Realtek was live, unmuted, and produced audible recordings.
- Two repeated recordings also succeeded.

After reconnecting Plantronics:

- A device-change event caused OpenWhispr to reconsider Realtek.
- Realtek had recovered and was retained, matching the existing built-in preference.
- Physically muting Plantronics throughout a recording confirmed that the Realtek label matched the actual capture source.

After restarting the app, healthy Realtek continued recording successfully.

Audio capture and playback were validated. End-to-end local transcription was not completed because the development Whisper service failed after recording. The microphone capture had already completed successfully and the saved recordings contained audible speech.

## Scope

This change covers microphone acquisition for regular and streaming dictation startup.

It does not change the built-in microphone policy, device classification, microphone settings UI, meeting recording, or recovery from a device disappearing during an active recording.

Windows validation used the development build rather than a packaged installer.