### PR TITLE
feat(models): centralize temperature support in model registry

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3280,7 +3280,7 @@ class IPCHandlers {
             messages: [{ role: "user", content: userPrompt }],
             system: systemPrompt,
             max_tokens: config?.maxTokens || Math.max(100, Math.min(text.length * 2, 4096)),
-            temperature: config?.temperature || 0.3,
+            ...(config?.supportsTemperature ? { temperature: config?.temperature ?? 0.3 } : {}),
           };
 
           const response = await proxyFetch("https://api.anthropic.com/v1/messages", {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -42,7 +42,7 @@ export interface CloudModelDefinition {
   disableThinking?: boolean;
   supportsThinking?: boolean;
   tokenParam?: "max_tokens" | "max_completion_tokens";
-  supportsTemperature?: boolean;
+  supportsTemperature: boolean;
 }
 
 export interface CloudProviderData {
@@ -440,26 +440,33 @@ export function getLocalModel(modelId: string): ModelDefinition | undefined {
 
 export interface OpenAiApiConfig {
   tokenParam: "max_tokens" | "max_completion_tokens";
-  supportsTemperature: boolean;
+}
+
+export function supportsTemperature(modelId: string): boolean {
+  const model = getCloudModel(modelId);
+  if (model) return model.supportsTemperature;
+
+  // Model not in the registry -- apply known prefix heuristics for
+  // unregistered models (custom providers, OpenRouter).
+  if (modelId.includes("claude")) return false;
+  if (modelId.startsWith("gpt-5")) return false;
+  return true;
 }
 
 export function getOpenAiApiConfig(modelId: string, provider?: string): OpenAiApiConfig {
   const model = getCloudModel(modelId);
   if (model?.tokenParam) {
-    return {
-      tokenParam: model.tokenParam,
-      supportsTemperature: model.supportsTemperature ?? true,
-    };
+    return { tokenParam: model.tokenParam };
   }
 
   // OpenRouter's vendor-prefixed ids (openai/gpt-4o, anthropic/claude-…) speak
   // standard Chat Completions. Scoped to the provider so vendor-prefixed ids on
   // custom endpoints keep the request shape they had before OpenRouter landed.
   if (provider === "openrouter" && modelId.includes("/")) {
-    return { tokenParam: "max_tokens", supportsTemperature: true };
+    return { tokenParam: "max_tokens" };
   }
 
-  // Fallback for models not in the registry (custom model IDs, etc.)
+  // Model not in registry — infer token param from ID prefix.
   const isLegacy =
     modelId.startsWith("gpt-3") ||
     modelId.startsWith("gpt-4o") ||
@@ -467,24 +474,10 @@ export function getOpenAiApiConfig(modelId: string, provider?: string): OpenAiAp
     modelId === "gpt-4";
 
   if (isLegacy) {
-    return { tokenParam: "max_tokens", supportsTemperature: true };
+    return { tokenParam: "max_tokens" };
   }
 
-  // gpt-4.1* supports temperature but uses max_completion_tokens
-  if (modelId.startsWith("gpt-4.1")) {
-    return { tokenParam: "max_completion_tokens", supportsTemperature: true };
-  }
-
-  // gpt-5* reasoning models: no temperature
-  return { tokenParam: "max_completion_tokens", supportsTemperature: false };
-}
-
-export interface AnthropicApiConfig {
-  supportsTemperature: boolean;
-}
-
-export function getAnthropicApiConfig(modelId: string): AnthropicApiConfig {
-  return { supportsTemperature: getCloudModel(modelId)?.supportsTemperature };
+  return { tokenParam: "max_completion_tokens" };
 }
 
 export function getParakeetModels(): ParakeetModelsMap {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -479,6 +479,14 @@ export function getOpenAiApiConfig(modelId: string, provider?: string): OpenAiAp
   return { tokenParam: "max_completion_tokens", supportsTemperature: false };
 }
 
+export interface AnthropicApiConfig {
+  supportsTemperature: boolean;
+}
+
+export function getAnthropicApiConfig(modelId: string): AnthropicApiConfig {
+  return { supportsTemperature: getCloudModel(modelId)?.supportsTemperature };
+}
+
 export function getParakeetModels(): ParakeetModelsMap {
   return modelData.parakeetModels;
 }

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -400,37 +400,43 @@
           "name": "Gemini 3.5 Flash",
           "description": "Latest fast, high-capability Gemini model",
           "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_5_flash",
+          "supportsTemperature": true,
           "supportsThinking": true
         },
         {
           "id": "gemini-3.1-pro-preview",
           "name": "Gemini 3.1 Pro",
           "description": "Next-gen flagship model for complex reasoning",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_1_pro_preview"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_1_pro_preview",
+          "supportsTemperature": true
         },
         {
           "id": "gemini-3-flash-preview",
           "name": "Gemini 3 Flash",
           "description": "Ultra-fast, high-capability next-gen model",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_flash_preview"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemini_3_flash_preview",
+          "supportsTemperature": true
         },
         {
           "id": "gemini-2.5-flash-lite",
           "name": "Gemini 2.5 Flash Lite",
           "description": "Lowest latency and cost",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemini_2_5_flash_lite"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemini_2_5_flash_lite",
+          "supportsTemperature": true
         },
         {
           "id": "gemma-4-31b-it",
           "name": "Gemma 4 31B",
           "description": "Google's largest Gemma 4, 31B dense, 256K context",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemma_4_31b_it"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemma_4_31b_it",
+          "supportsTemperature": true
         },
         {
           "id": "gemma-4-26b-a4b-it",
           "name": "Gemma 4 26B MoE",
           "description": "Google's Gemma 4 MoE, 4B active params, 256K context",
-          "descriptionKey": "models.descriptions.cloud.gemini_gemma_4_26b_a4b_it"
+          "descriptionKey": "models.descriptions.cloud.gemini_gemma_4_26b_a4b_it",
+          "supportsTemperature": true
         }
       ]
     },
@@ -444,57 +450,66 @@
           "description": "Powerful reasoning model, 131K context",
           "disableThinking": true,
           "supportsThinking": true,
-          "descriptionKey": "models.descriptions.cloud.groq_qwen_qwen3_32b"
+          "descriptionKey": "models.descriptions.cloud.groq_qwen_qwen3_32b",
+          "supportsTemperature": true
         },
         {
           "id": "openai/gpt-oss-120b",
           "name": "GPT-OSS 120B",
           "description": "OpenAI's open-source flagship, 500 T/sec",
           "supportsThinking": true,
-          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_120b"
+          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_120b",
+          "supportsTemperature": true
         },
         {
           "id": "openai/gpt-oss-20b",
           "name": "GPT-OSS 20B",
           "description": "Fast open-source model, 1000 T/sec",
           "supportsThinking": true,
-          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_20b"
+          "descriptionKey": "models.descriptions.cloud.groq_openai_gpt_oss_20b",
+          "supportsTemperature": true
         },
         {
           "id": "llama-3.3-70b-versatile",
           "name": "LLaMA 3.3 70B",
           "description": "Meta's versatile model, 280 T/sec",
-          "descriptionKey": "models.descriptions.cloud.groq_llama_3_3_70b_versatile"
+          "descriptionKey": "models.descriptions.cloud.groq_llama_3_3_70b_versatile",
+          "supportsTemperature": true
         },
         {
           "id": "llama-3.1-8b-instant",
           "name": "LLaMA 3.1 8B",
           "description": "Ultra-fast 560 T/sec, 131K context",
-          "descriptionKey": "models.descriptions.cloud.groq_llama_3_1_8b_instant"
+          "descriptionKey": "models.descriptions.cloud.groq_llama_3_1_8b_instant",
+          "supportsTemperature": true
         },
         {
           "id": "meta-llama/llama-4-scout-17b-16e-instruct",
           "name": "Llama 4 Scout",
           "description": "Meta's efficient multimodal, 750 T/sec",
-          "descriptionKey": "models.descriptions.cloud.groq_llama_4_scout"
+          "descriptionKey": "models.descriptions.cloud.groq_llama_4_scout",
+          "supportsTemperature": true
         },
         {
           "id": "groq/compound",
           "name": "Compound",
           "description": "Groq's compound system, 450 T/sec",
-          "descriptionKey": "models.descriptions.cloud.groq_compound"
+          "descriptionKey": "models.descriptions.cloud.groq_compound",
+          "supportsTemperature": true
         },
         {
           "id": "groq/compound-mini",
           "name": "Compound Mini",
           "description": "Fast compound system, 3x lower latency",
-          "descriptionKey": "models.descriptions.cloud.groq_compound_mini"
+          "descriptionKey": "models.descriptions.cloud.groq_compound_mini",
+          "supportsTemperature": true
         },
         {
           "id": "moonshotai/kimi-k2-instruct-0905",
           "name": "Kimi K2 0905",
           "description": "Moonshot AI's 1T MoE, 256K context",
-          "descriptionKey": "models.descriptions.cloud.groq_kimi_k2_0905"
+          "descriptionKey": "models.descriptions.cloud.groq_kimi_k2_0905",
+          "supportsTemperature": true
         }
       ]
     },
@@ -507,8 +522,8 @@
           "name": "Kimi K2.6",
           "description": "Private long-horizon coding and multimodal model, 256K context",
           "tokenParam": "max_tokens",
-          "supportsTemperature": true,
           "descriptionKey": "models.descriptions.cloud.tinfoil_kimi_k2_6",
+          "supportsTemperature": true,
           "supportsThinking": true
         },
         {
@@ -516,8 +531,8 @@
           "name": "GLM-5.2",
           "description": "Private agentic engineering model in secure enclaves, 384K context",
           "tokenParam": "max_tokens",
-          "supportsTemperature": true,
           "descriptionKey": "models.descriptions.cloud.tinfoil_glm_5_2",
+          "supportsTemperature": true,
           "supportsThinking": true
         },
         {
@@ -525,8 +540,8 @@
           "name": "GPT-OSS 120B",
           "description": "Private open-weight reasoning model with tool use, 131K context",
           "tokenParam": "max_tokens",
-          "supportsTemperature": true,
           "descriptionKey": "models.descriptions.cloud.tinfoil_gpt_oss_120b",
+          "supportsTemperature": true,
           "supportsThinking": true
         },
         {
@@ -534,8 +549,8 @@
           "name": "Gemma 4 31B",
           "description": "Private multilingual reasoning model with tool calling, 256K context",
           "tokenParam": "max_tokens",
-          "supportsTemperature": true,
           "descriptionKey": "models.descriptions.cloud.tinfoil_gemma4_31b",
+          "supportsTemperature": true,
           "supportsThinking": true
         }
       ]
@@ -589,43 +604,50 @@
           "id": "us.anthropic.claude-fable-5",
           "name": "Claude Fable 5",
           "description": "Most capable Claude model, Mythos-class. Best for the hardest Agent Mode tasks.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_fable_5"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_fable_5",
+          "supportsTemperature": false
         },
         {
           "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
           "name": "Claude Haiku 4.5",
           "description": "Fast and cheap. Great default for text cleanup.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_haiku_4_5"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_haiku_4_5",
+          "supportsTemperature": true
         },
         {
           "id": "us.anthropic.claude-sonnet-5",
           "name": "Claude Sonnet 5",
           "description": "Balanced workhorse. Best default for Agent Mode.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_sonnet_5"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_sonnet_5",
+          "supportsTemperature": false
         },
         {
           "id": "us.anthropic.claude-opus-4-8",
           "name": "Claude Opus 4.8",
           "description": "Max intelligence. Best for complex Agent Mode tasks.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_opus_4_8"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_claude_opus_4_8",
+          "supportsTemperature": false
         },
         {
           "id": "openai.gpt-oss-120b-1:0",
           "name": "GPT-OSS 120B",
           "description": "Open-weight OpenAI model. Strong reasoning at low cost.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_gpt_oss_120b"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_gpt_oss_120b",
+          "supportsTemperature": true
         },
         {
           "id": "deepseek.v3.2",
           "name": "DeepSeek V3.2",
           "description": "Open-weight frontier model. Great value for Agent Mode.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_deepseek_v3_2"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_deepseek_v3_2",
+          "supportsTemperature": true
         },
         {
           "id": "qwen.qwen3-next-80b-a3b",
           "name": "Qwen3 Next 80B",
           "description": "Sparse open-weight model. Fast and multilingual.",
-          "descriptionKey": "models.descriptions.enterprise.bedrock_qwen3_next_80b"
+          "descriptionKey": "models.descriptions.enterprise.bedrock_qwen3_next_80b",
+          "supportsTemperature": true
         }
       ]
     },
@@ -644,13 +666,15 @@
           "id": "gemini-2.5-flash",
           "name": "Gemini 2.5 Flash",
           "description": "Fast multimodal model via Vertex",
-          "descriptionKey": "models.descriptions.enterprise.vertex_gemini_2_5_flash"
+          "descriptionKey": "models.descriptions.enterprise.vertex_gemini_2_5_flash",
+          "supportsTemperature": true
         },
         {
           "id": "gemini-2.5-pro",
           "name": "Gemini 2.5 Pro",
           "description": "Advanced reasoning via Vertex",
-          "descriptionKey": "models.descriptions.enterprise.vertex_gemini_2_5_pro"
+          "descriptionKey": "models.descriptions.enterprise.vertex_gemini_2_5_pro",
+          "supportsTemperature": true
         }
       ]
     }

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -330,55 +330,64 @@
           "id": "claude-fable-5",
           "name": "Claude Fable 5",
           "description": "Anthropic's most capable model, Mythos-class, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_fable_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_fable_5",
+          "supportsTemperature": false
         },
         {
           "id": "claude-sonnet-5",
           "name": "Claude Sonnet 5",
           "description": "Fast, capable agentic model at lower cost",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_5",
+          "supportsTemperature": false
         },
         {
           "id": "claude-sonnet-4-6",
           "name": "Claude Sonnet 4.6",
           "description": "Balanced performance",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_6"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_6",
+          "supportsTemperature": true
         },
         {
           "id": "claude-haiku-4-5",
           "name": "Claude Haiku 4.5",
           "description": "Fast with near-frontier intelligence",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5",
+          "supportsTemperature": true
         },
         {
           "id": "claude-opus-4-8",
           "name": "Claude Opus 4.8",
           "description": "Powerful Opus model tuned for honesty and reliability, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_8"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_8",
+          "supportsTemperature": false
         },
         {
           "id": "claude-opus-4-7",
           "name": "Claude Opus 4.7",
           "description": "Powerful Opus model, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_7"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_7",
+          "supportsTemperature": false
         },
         {
           "id": "claude-opus-4-6",
           "name": "Claude Opus 4.6",
           "description": "Previous Opus generation, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_6"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_6",
+          "supportsTemperature": true
         },
         {
           "id": "claude-sonnet-4-5",
           "name": "Claude Sonnet 4.5",
           "description": "Previous Sonnet generation",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_5",
+          "supportsTemperature": true
         },
         {
           "id": "claude-opus-4-5",
           "name": "Claude Opus 4.5",
           "description": "Earlier Opus model",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_5",
+          "supportsTemperature": true
         }
       ]
     },

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -21,12 +21,10 @@ export function readCachedTinfoilModels(): CachedTinfoilModels {
 
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed?.models) || typeof parsed.fetchedAt !== "number") return EMPTY;
-    const models: CloudModelDefinition[] = parsed.models.map(
-      (raw: CloudModelDefinition) => ({
-        ...raw,
-        supportsTemperature: raw.supportsTemperature ?? true,
-      })
-    );
+    const models: CloudModelDefinition[] = parsed.models.map((raw: CloudModelDefinition) => ({
+      ...raw,
+      supportsTemperature: raw.supportsTemperature ?? true,
+    }));
     return { models, fetchedAt: parsed.fetchedAt };
   } catch {
     return EMPTY;

--- a/src/models/tinfoilModelCache.ts
+++ b/src/models/tinfoilModelCache.ts
@@ -21,7 +21,13 @@ export function readCachedTinfoilModels(): CachedTinfoilModels {
 
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed?.models) || typeof parsed.fetchedAt !== "number") return EMPTY;
-    return { models: parsed.models, fetchedAt: parsed.fetchedAt };
+    const models: CloudModelDefinition[] = parsed.models.map(
+      (raw: CloudModelDefinition) => ({
+        ...raw,
+        supportsTemperature: raw.supportsTemperature ?? true,
+      })
+    );
+    return { models, fetchedAt: parsed.fetchedAt };
   } catch {
     return EMPTY;
   }

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,5 +1,5 @@
 import {
-  getAnthropicApiConfig,
+  supportsTemperature,
   getModelProvider,
   getCloudModel,
   getOpenAiApiConfig,
@@ -439,7 +439,7 @@ class ReasoningService extends BaseReasoningService {
       requestBody.max_tokens = maxTokens;
     } else {
       requestBody[apiConfig.tokenParam] = maxTokens;
-      if (apiConfig.supportsTemperature) {
+      if (supportsTemperature(model)) {
         requestBody.temperature = config.temperature ?? 0.3;
       }
     }
@@ -641,7 +641,6 @@ class ReasoningService extends BaseReasoningService {
           disableThinking: openrouterDisableThinking,
         });
 
-    const apiConfig = getOpenAiApiConfig(model, provider);
     const modelDef = getCloudModel(model);
     const userSuppressesThinking = config.disableThinking === true && !!modelDef?.supportsThinking;
     const needsGroqDisableThinking =
@@ -663,12 +662,7 @@ class ReasoningService extends BaseReasoningService {
       messageCount: messages.length,
     });
 
-    const useTemperature =
-      isLocalProvider ||
-      isLanCleanup ||
-      (provider === "anthropic"
-        ? getAnthropicApiConfig(model).supportsTemperature
-        : apiConfig.supportsTemperature);
+    const useTemperature = isLocalProvider || isLanCleanup || supportsTemperature(model);
 
     // cancelActiveStream() aborts this controller; streamText propagates it
     // into doStream, cancelling the enterprise IPC proxy's request in main.

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,4 +1,5 @@
 import {
+  getAnthropicApiConfig,
   getModelProvider,
   getCloudModel,
   getOpenAiApiConfig,
@@ -662,7 +663,12 @@ class ReasoningService extends BaseReasoningService {
       messageCount: messages.length,
     });
 
-    const useTemperature = isLocalProvider || isLanCleanup || apiConfig.supportsTemperature;
+    const useTemperature =
+      isLocalProvider ||
+      isLanCleanup ||
+      (provider === "anthropic"
+        ? getAnthropicApiConfig(model).supportsTemperature
+        : apiConfig.supportsTemperature);
 
     // cancelActiveStream() aborts this controller; streamText propagates it
     // into doStream, cancelling the enterprise IPC proxy's request in main.

--- a/src/services/ai/inferenceProviders/anthropic.ts
+++ b/src/services/ai/inferenceProviders/anthropic.ts
@@ -1,6 +1,6 @@
 import type { InferenceProvider } from "./types";
 import { wrapCleanupTranscript } from "../../../config/prompts";
-import { getAnthropicApiConfig } from "../../../models/ModelRegistry";
+import { supportsTemperature } from "../../../models/ModelRegistry";
 import logger from "../../../utils/logger";
 
 export const anthropicProvider: InferenceProvider = {
@@ -24,7 +24,7 @@ export const anthropicProvider: InferenceProvider = {
       {
         ...config,
         systemPrompt,
-        supportsTemperature: getAnthropicApiConfig(model).supportsTemperature,
+        supportsTemperature: supportsTemperature(model),
       }
     );
 

--- a/src/services/ai/inferenceProviders/anthropic.ts
+++ b/src/services/ai/inferenceProviders/anthropic.ts
@@ -1,5 +1,6 @@
 import type { InferenceProvider } from "./types";
 import { wrapCleanupTranscript } from "../../../config/prompts";
+import { getAnthropicApiConfig } from "../../../models/ModelRegistry";
 import logger from "../../../utils/logger";
 
 export const anthropicProvider: InferenceProvider = {
@@ -23,6 +24,7 @@ export const anthropicProvider: InferenceProvider = {
       {
         ...config,
         systemPrompt,
+        supportsTemperature: getAnthropicApiConfig(model).supportsTemperature,
       }
     );
 

--- a/src/services/ai/inferenceProviders/enterprise.ts
+++ b/src/services/ai/inferenceProviders/enterprise.ts
@@ -1,7 +1,7 @@
 import type { InferenceProvider } from "./types";
 import {
-  getOpenAiApiConfig,
   isEnterpriseProvider,
+  supportsTemperature as supportsTemp,
   type EnterpriseProvider as EnterpriseProviderId,
 } from "../../../models/ModelRegistry";
 import { getSettings } from "../../../stores/settingsStore";
@@ -26,7 +26,7 @@ export const enterpriseProvider: InferenceProvider = {
 
     const systemPrompt = config.systemPrompt || ctx.getSystemPrompt(agentName);
     const userContent = config.systemPrompt ? text : wrapCleanupTranscript(text);
-    const { supportsTemperature } = getOpenAiApiConfig(model);
+    const supportsTemperature = supportsTemp(model);
 
     const startTime = Date.now();
     const result = await window.electronAPI.processEnterpriseReasoning(

--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -1,6 +1,6 @@
 import type { InferenceProvider } from "./types";
 import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl } from "../../../config/constants";
-import { getOpenAiApiConfig } from "../../../models/ModelRegistry";
+import { getOpenAiApiConfig, supportsTemperature } from "../../../models/ModelRegistry";
 import { getSettings } from "../../../stores/settingsStore";
 import { withRetry, createApiRetryStrategy } from "../../../utils/retry";
 import logger from "../../../utils/logger";
@@ -214,7 +214,7 @@ export const openaiProvider: InferenceProvider = {
             applyThinkingSuppression(requestBody, model, resolvedProvider, config);
           }
 
-          if (apiConfig.supportsTemperature) {
+          if (supportsTemperature(model)) {
             requestBody.temperature = config.temperature ?? (config.systemPrompt ? 0.3 : 0);
           }
 

--- a/test/helpers/modelRegistry.test.js
+++ b/test/helpers/modelRegistry.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const modelData = require("../../src/models/modelRegistryData.json");
+
+const providers = [
+  ...modelData.cloudProviders,
+  ...modelData.enterpriseProviders,
+];
+
+const REQUIRED = [
+  { field: "id", type: "string" },
+  { field: "name", type: "string" },
+  { field: "description", type: "string" },
+  { field: "descriptionKey", type: "string" },
+  { field: "supportsTemperature", type: "boolean" },
+];
+
+for (const provider of providers) {
+  for (const model of provider.models) {
+    for (const { field, type } of REQUIRED) {
+      test(`${provider.id}/${model.id} has ${field}`, () => {
+        assert.equal(
+          typeof model[field],
+          type,
+          `Expected ${field} to be ${type} for ${provider.id}/${model.id}, got ${typeof model[field]}`
+        );
+      });
+    }
+  }
+}


### PR DESCRIPTION
Temperature support is now a first-class, required field on every model in the registry -- the single source of truth replacing scattered, inconsistent per-provider checks. Unknown models get sensible fallback heuristics (Claude and GPT-5 --> no, everything else --> yes). This eliminates provider-level drift and guarantees every new model added to the registry carries accurate temperature support information.