### PR TITLE
fix(linux): harden deb maintainer scripts

### DIFF
--- a/resources/linux/after-install.sh
+++ b/resources/linux/after-install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Post-install script for OpenWhispr (deb/rpm)
-# Sets up chrome-sandbox permissions and ydotool daemon prerequisites
+# Sets up chrome-sandbox permissions and ydotool daemon prerequisites.
+# Best-effort: nothing here may fail the package install.
 
-set -euo pipefail
+set -uo pipefail
 
 # 0. Set SUID bit on chrome-sandbox (required by Electron for Linux sandboxing)
 #    Find it wherever dpkg placed the package files, rather than hardcoding /opt/...
@@ -12,25 +13,33 @@ if [ -z "$CHROME_SANDBOX" ]; then
   CHROME_SANDBOX="/opt/OpenWhispr/chrome-sandbox"
 fi
 if [ -f "$CHROME_SANDBOX" ]; then
-  chown root:root "$CHROME_SANDBOX"
-  chmod 4755 "$CHROME_SANDBOX"
+  chown root:root "$CHROME_SANDBOX" 2>/dev/null || true
+  chmod 4755 "$CHROME_SANDBOX" 2>/dev/null || true
 fi
 
 UDEV_RULE='KERNEL=="uinput", GROUP="input", MODE="0660", TAG+="uaccess"'
 UDEV_RULE_PATH="/etc/udev/rules.d/70-uinput.rules"
 SERVICE_PATH="/usr/lib/systemd/user/ydotoold.service"
 
-# Detect the real user (not root) who triggered the install
+# Detect the real user (not root) who triggered the install.
+# No SUDO_USER and no tty (GUI installers, D-Bus backed ones like Aptkit) is fine:
+# the user-specific steps below are simply skipped.
 REAL_USER="${SUDO_USER:-}"
 if [ -z "$REAL_USER" ] || [ "$REAL_USER" = "root" ]; then
   REAL_USER=$(logname 2>/dev/null || echo "")
 fi
+if [ "$REAL_USER" = "root" ]; then
+  REAL_USER=""
+fi
 
-# 1. udev rule for /dev/uinput
-if [ ! -f "$UDEV_RULE_PATH" ] || ! grep -q uinput "$UDEV_RULE_PATH" 2>/dev/null; then
-  echo "$UDEV_RULE" > "$UDEV_RULE_PATH"
-  udevadm control --reload-rules 2>/dev/null || true
-  udevadm trigger /dev/uinput 2>/dev/null || true
+# 1. udev rule for /dev/uinput — only where udev actually exists (skipped in
+#    containers, chroots and minimal systems, where the rule is useless anyway)
+if [ -d /etc/udev/rules.d ]; then
+  if [ ! -f "$UDEV_RULE_PATH" ] || ! grep -q uinput "$UDEV_RULE_PATH" 2>/dev/null; then
+    echo "$UDEV_RULE" > "$UDEV_RULE_PATH" 2>/dev/null || true
+    udevadm control --reload-rules 2>/dev/null || true
+    udevadm trigger /dev/uinput 2>/dev/null || true
+  fi
 fi
 
 # 2. Add user to input group
@@ -42,11 +51,13 @@ fi
 
 # 3. systemd user service for ydotoold
 # Skip if a service already exists (e.g. Fedora ships one with the ydotool package)
-if [ ! -f "$SERVICE_PATH" ] && [ ! -f "/usr/lib/systemd/user/ydotool.service" ]; then
+# or if systemd is not present on this system at all.
+if [ -d /usr/lib/systemd ] && [ ! -f "$SERVICE_PATH" ] && [ ! -f "/usr/lib/systemd/user/ydotool.service" ]; then
   YDOTOOLD_BIN=$(command -v ydotoold 2>/dev/null || echo "/usr/bin/ydotoold")
   if [ -x "$YDOTOOLD_BIN" ] || [ -f "$YDOTOOLD_BIN" ]; then
-    mkdir -p "$(dirname "$SERVICE_PATH")"
-    cat > "$SERVICE_PATH" << SERVICEEOF
+    mkdir -p "$(dirname "$SERVICE_PATH")" 2>/dev/null || true
+    if [ -d "$(dirname "$SERVICE_PATH")" ]; then
+      cat > "$SERVICE_PATH" 2>/dev/null << SERVICEEOF || true
 [Unit]
 Description=ydotoold - ydotool daemon
 After=graphical-session.target
@@ -61,6 +72,7 @@ RestartSec=1s
 [Install]
 WantedBy=graphical-session.target
 SERVICEEOF
+    fi
   fi
 fi
 

--- a/resources/linux/after-remove.sh
+++ b/resources/linux/after-remove.sh
@@ -1,25 +1,42 @@
 #!/bin/bash
-set -euo pipefail
+# Post-remove script for OpenWhispr (deb)
+# Best-effort: must never fail package removal, and must never run on upgrade.
+
+set -uo pipefail
+
+# dpkg also invokes the old version's postrm during upgrades (arg: upgrade /
+# failed-upgrade). Only clean up when the package is really going away.
+case "${1:-remove}" in
+  remove|purge) ;;
+  *) exit 0 ;;
+esac
 
 REAL_USER="${SUDO_USER:-}"
 if [ -z "$REAL_USER" ] || [ "$REAL_USER" = "root" ]; then
   REAL_USER=$(logname 2>/dev/null || echo "")
 fi
+if [ "$REAL_USER" = "root" ]; then
+  REAL_USER=""
+fi
 
+REAL_HOME=""
 if [ -n "$REAL_USER" ]; then
-  REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
-else
-  REAL_HOME="$HOME"
+  REAL_HOME=$(getent passwd "$REAL_USER" 2>/dev/null | cut -d: -f6 || echo "")
+fi
+if [ -z "$REAL_HOME" ]; then
+  exit 0
 fi
 
 CACHE_DIR="$REAL_HOME/.cache/openwhispr"
 MODELS_DIR="$CACHE_DIR/models"
 
 if [ -d "$MODELS_DIR" ]; then
-  rm -rf "$MODELS_DIR"
+  rm -rf "$MODELS_DIR" 2>/dev/null || true
   echo "Removed OpenWhispr cached models"
 fi
 
 if [ -d "$CACHE_DIR" ]; then
   rmdir "$CACHE_DIR" 2>/dev/null || true
 fi
+
+exit 0


### PR DESCRIPTION
## Summary

Installing the deb in any environment without `/etc/udev/rules.d` (Distrobox, chroots, minimal systems) dies with `postinst: line 31: /etc/udev/rules.d/70-uinput.rules: No such file or directory`, because `after-install.sh` runs under `set -euo pipefail` with unguarded writes, leaving the package half-configured. Upgrades have a second failure mode: Mint's double-click installer (Captain/Aptkit) runs maintainer scripts from a D-Bus service with a sterile environment (no HOME, no SUDO_USER, no tty), which kills `after-remove.sh` at `REAL_HOME="$HOME"`. And since the postrm never checks `$1`, every deb upgrade also wipes `~/.cache/openwhispr/models`, the locally downloaded LLM models.

The postinst now treats every step as best effort and skips the udev rule where the directory doesn't exist; the postrm cleans up only on remove/purge and exits 0 for upgrade/failed-upgrade/abort. The failed-upgrade path also unblocks users stuck on 1.7.x: when their old postrm fails mid-upgrade, dpkg falls back to the new postrm and continues. Verified in a Distrobox Ubuntu 24.04 container with gdebi: install completes, upgrades keep models, remove/purge still clean up.

Fixes OpenWhispr/openwhispr#1097

## Changes

* resources/linux/after-install.sh: guard every operation, gate the udev rule on `/etc/udev/rules.d` existing, gate the systemd service block on `/usr/lib/systemd`, filter root from the logname fallback too
* resources/linux/after-remove.sh: clean the model cache only on remove/purge, exit 0 on upgrade/failed-upgrade/abort, drop the bare `$HOME` fallback