### PR TITLE
fix(mic): persist microphone selection across Chromium device ID change

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -707,8 +707,9 @@ export default function SettingsPage({
     setActivationMode,
     preferBuiltInMic,
     selectedMicDeviceId,
+    selectedMicDeviceLabel,
     setPreferBuiltInMic,
-    setSelectedMicDeviceId,
+    setSelectedMicDevice,
     setUseLocalWhisper,
     setUiLanguage,
     setWhisperModel,
@@ -2703,8 +2704,9 @@ export default function SettingsPage({
                   <MicrophoneSettings
                     preferBuiltInMic={preferBuiltInMic}
                     selectedMicDeviceId={selectedMicDeviceId}
+                    selectedMicDeviceLabel={selectedMicDeviceLabel}
                     onPreferBuiltInChange={setPreferBuiltInMic}
-                    onDeviceSelect={setSelectedMicDeviceId}
+                    onDeviceSelect={setSelectedMicDevice}
                   />
                 </SettingsPanelRow>
               </SettingsPanel>

--- a/src/components/ui/MicrophoneSettings.tsx
+++ b/src/components/ui/MicrophoneSettings.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Button } from "./button";
 import { RefreshCw, Mic } from "lucide-react";
 import { isBuiltInMicrophone } from "../../utils/audioDeviceUtils";
+import { resolveMicDeviceSelection } from "../../helpers/micDeviceSelection";
 
 interface AudioDevice {
   deviceId: string;
@@ -16,13 +17,15 @@ interface AudioDevice {
 interface MicrophoneSettingsProps {
   preferBuiltInMic: boolean;
   selectedMicDeviceId: string;
+  selectedMicDeviceLabel: string;
   onPreferBuiltInChange: (value: boolean) => void;
-  onDeviceSelect: (deviceId: string) => void;
+  onDeviceSelect: (deviceId: string, label: string) => void;
 }
 
 export const MicrophoneSettings: React.FC<MicrophoneSettingsProps> = ({
   preferBuiltInMic,
   selectedMicDeviceId,
+  selectedMicDeviceLabel,
   onPreferBuiltInChange,
   onDeviceSelect,
 }) => {
@@ -34,14 +37,16 @@ export const MicrophoneSettings: React.FC<MicrophoneSettingsProps> = ({
   // Use refs to access current values without triggering re-renders
   const preferBuiltInRef = useRef(preferBuiltInMic);
   const selectedDeviceRef = useRef(selectedMicDeviceId);
+  const selectedDeviceLabelRef = useRef(selectedMicDeviceLabel);
   const onDeviceSelectRef = useRef(onDeviceSelect);
 
   // Keep refs in sync
   useEffect(() => {
     preferBuiltInRef.current = preferBuiltInMic;
     selectedDeviceRef.current = selectedMicDeviceId;
+    selectedDeviceLabelRef.current = selectedMicDeviceLabel;
     onDeviceSelectRef.current = onDeviceSelect;
-  }, [preferBuiltInMic, selectedMicDeviceId, onDeviceSelect]);
+  }, [preferBuiltInMic, selectedMicDeviceId, selectedMicDeviceLabel, onDeviceSelect]);
 
   const loadDevices = useCallback(async () => {
     setIsLoading(true);
@@ -68,9 +73,24 @@ export const MicrophoneSettings: React.FC<MicrophoneSettingsProps> = ({
 
       setDevices(audioInputs);
 
+      const resolvedSelection = resolveMicDeviceSelection(
+        audioInputs,
+        selectedDeviceRef.current,
+        selectedDeviceLabelRef.current
+      );
+      if (
+        resolvedSelection.device &&
+        (resolvedSelection.status === "remapped" || !selectedDeviceLabelRef.current)
+      ) {
+        onDeviceSelectRef.current(
+          resolvedSelection.device.deviceId,
+          resolvedSelection.device.label
+        );
+      }
+
       // If no device is selected and not preferring built-in, select the first device
       if (!preferBuiltInRef.current && !selectedDeviceRef.current && audioInputs.length > 0) {
-        onDeviceSelectRef.current(audioInputs[0].deviceId);
+        onDeviceSelectRef.current(audioInputs[0].deviceId, audioInputs[0].label);
       }
     } catch {
       setError(t("microphoneSettings.errors.unableToAccess"));
@@ -143,7 +163,14 @@ export const MicrophoneSettings: React.FC<MicrophoneSettingsProps> = ({
           ) : (
             <Select
               value={selectedMicDeviceId || "default"}
-              onValueChange={(value) => onDeviceSelect(value === "default" ? "" : value)}
+              onValueChange={(value) => {
+                if (value === "default") {
+                  onDeviceSelect("", "");
+                  return;
+                }
+                const device = devices.find((candidate) => candidate.deviceId === value);
+                onDeviceSelect(value, device?.label || "");
+              }}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={t("microphoneSettings.selectPlaceholder")}>

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -15,7 +15,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { reacquireIfDead } from "./micTrackHealth";
-import { resolveMicDeviceSelection } from "./micDeviceSelection";
+import { reconcileSavedMicSelection } from "./micSelectionRecovery";
 import { isStaleDeviceError } from "./staleMicDevice";
 import { shouldSaveDiscardedRecording } from "./discardedRecording";
 import {
@@ -417,43 +417,21 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       if (this.validatedSelectedMicDeviceId !== selectedDeviceId) {
         try {
-          const devices = await navigator.mediaDevices.enumerateDevices();
-          const resolvedSelection = resolveMicDeviceSelection(
-            devices,
+          const reconciled = await reconcileSavedMicSelection(
             selectedDeviceId,
-            selectedDeviceLabel
+            selectedDeviceLabel,
+            "audio"
           );
+          resolvedDeviceId = reconciled.deviceId;
 
-          if (resolvedSelection.device) {
-            resolvedDeviceId = resolvedSelection.device.deviceId;
+          if (reconciled.resolved) {
             this.validatedSelectedMicDeviceId = resolvedDeviceId;
-
-            if (
-              resolvedSelection.status === "remapped" ||
-              (!selectedDeviceLabel && resolvedSelection.device.label)
-            ) {
-              getSettings().setSelectedMicDevice(
-                resolvedSelection.device.deviceId,
-                resolvedSelection.device.label
-              );
-              logger.info(
-                resolvedSelection.status === "remapped"
-                  ? "Restored selected microphone after its device ID changed"
-                  : "Saved selected microphone label for future recovery",
-                {
-                  deviceId: resolvedSelection.device.deviceId,
-                  label: resolvedSelection.device.label,
-                },
-                "audio"
-              );
-            }
           } else {
             // Avoid enumerating on every recording while the saved device is
             // unplugged. A devicechange event clears this cache when it returns.
-            const labelsAreAvailable = devices.some(
-              (device) => device.kind === "audioinput" && device.label
-            );
-            this.validatedSelectedMicDeviceId = labelsAreAvailable ? selectedDeviceId : null;
+            this.validatedSelectedMicDeviceId = reconciled.labelsAvailable
+              ? selectedDeviceId
+              : null;
           }
         } catch (error) {
           logger.debug(

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -15,6 +15,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { reacquireIfDead } from "./micTrackHealth";
+import { resolveMicDeviceSelection } from "./micDeviceSelection";
 import { isStaleDeviceError } from "./staleMicDevice";
 import { shouldSaveDiscardedRecording } from "./discardedRecording";
 import {
@@ -212,6 +213,7 @@ class AudioManager {
     // Otherwise wake-after-idle keeps requesting a stale deviceId that yields silence.
     this._onDeviceChange = () => {
       this.cachedMicDeviceId = null;
+      this.validatedSelectedMicDeviceId = null;
       this.micDriverWarmedUp = false;
     };
     navigator.mediaDevices?.addEventListener?.("devicechange", this._onDeviceChange);
@@ -232,6 +234,7 @@ class AudioManager {
     this.streamingTextResolve = null;
     this.streamingTextDebounce = null;
     this.cachedMicDeviceId = null;
+    this.validatedSelectedMicDeviceId = null;
     this.persistentAudioContext = null;
     this.workletModuleLoaded = false;
     this.workletBlobUrl = null;
@@ -352,8 +355,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   }
 
   async getAudioConstraints(forceDefaultMic = false) {
-    const { preferBuiltInMic: preferBuiltIn, selectedMicDeviceId: selectedDeviceId } =
-      getSettings();
+    const {
+      preferBuiltInMic: preferBuiltIn,
+      selectedMicDeviceId: selectedDeviceId,
+      selectedMicDeviceLabel: selectedDeviceLabel,
+    } = getSettings();
 
     // All browser audio processing disabled to avoid OS-level side-effects.
     // AGC off: Chromium's AGC on Windows mutates the system mic volume via WASAPI (#476).
@@ -407,8 +413,59 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
 
     if (!preferBuiltIn && selectedDeviceId) {
-      logger.debug("Using selected microphone", { deviceId: selectedDeviceId }, "audio");
-      return { audio: { deviceId: { exact: selectedDeviceId }, ...noProcessing } };
+      let resolvedDeviceId = selectedDeviceId;
+
+      if (this.validatedSelectedMicDeviceId !== selectedDeviceId) {
+        try {
+          const devices = await navigator.mediaDevices.enumerateDevices();
+          const resolvedSelection = resolveMicDeviceSelection(
+            devices,
+            selectedDeviceId,
+            selectedDeviceLabel
+          );
+
+          if (resolvedSelection.device) {
+            resolvedDeviceId = resolvedSelection.device.deviceId;
+            this.validatedSelectedMicDeviceId = resolvedDeviceId;
+
+            if (
+              resolvedSelection.status === "remapped" ||
+              (!selectedDeviceLabel && resolvedSelection.device.label)
+            ) {
+              getSettings().setSelectedMicDevice(
+                resolvedSelection.device.deviceId,
+                resolvedSelection.device.label
+              );
+              logger.info(
+                resolvedSelection.status === "remapped"
+                  ? "Restored selected microphone after its device ID changed"
+                  : "Saved selected microphone label for future recovery",
+                {
+                  deviceId: resolvedSelection.device.deviceId,
+                  label: resolvedSelection.device.label,
+                },
+                "audio"
+              );
+            }
+          } else {
+            // Avoid enumerating on every recording while the saved device is
+            // unplugged. A devicechange event clears this cache when it returns.
+            const labelsAreAvailable = devices.some(
+              (device) => device.kind === "audioinput" && device.label
+            );
+            this.validatedSelectedMicDeviceId = labelsAreAvailable ? selectedDeviceId : null;
+          }
+        } catch (error) {
+          logger.debug(
+            "Failed to reconcile selected microphone",
+            { error: error.message },
+            "audio"
+          );
+        }
+      }
+
+      logger.debug("Using selected microphone", { deviceId: resolvedDeviceId }, "audio");
+      return { audio: { deviceId: { exact: resolvedDeviceId }, ...noProcessing } };
     }
 
     logger.debug("Using default microphone", {}, "audio");

--- a/src/helpers/micDeviceSelection.js
+++ b/src/helpers/micDeviceSelection.js
@@ -8,6 +8,7 @@ export function resolveMicDeviceSelection(devices, selectedDeviceId, selectedDev
     return { device: null, status: "default" };
   }
 
+  // Callers pass raw MediaDeviceInfo lists or pre-filtered inputs without a kind.
   const audioInputs = devices.filter(
     (device) => device.kind === undefined || device.kind === "audioinput"
   );

--- a/src/helpers/micDeviceSelection.js
+++ b/src/helpers/micDeviceSelection.js
@@ -1,0 +1,36 @@
+/**
+ * Reconcile a saved microphone preference with the devices Chromium currently
+ * exposes. deviceId is preferred while it remains valid; the label is only a
+ * recovery key when exactly one current input has that label.
+ */
+export function resolveMicDeviceSelection(devices, selectedDeviceId, selectedDeviceLabel) {
+  if (!selectedDeviceId) {
+    return { device: null, status: "default" };
+  }
+
+  const audioInputs = devices.filter(
+    (device) => device.kind === undefined || device.kind === "audioinput"
+  );
+  const exactMatch = audioInputs.find((device) => device.deviceId === selectedDeviceId);
+
+  if (exactMatch) {
+    return { device: exactMatch, status: "exact" };
+  }
+
+  if (!selectedDeviceLabel) {
+    return { device: null, status: "missing" };
+  }
+
+  const labelMatches = audioInputs.filter(
+    (device) => device.deviceId !== "default" && device.label === selectedDeviceLabel
+  );
+
+  if (labelMatches.length === 1) {
+    return { device: labelMatches[0], status: "remapped" };
+  }
+
+  return {
+    device: null,
+    status: labelMatches.length > 1 ? "ambiguous" : "missing",
+  };
+}

--- a/src/helpers/micSelectionRecovery.js
+++ b/src/helpers/micSelectionRecovery.js
@@ -1,0 +1,43 @@
+import { getSettings } from "../stores/settingsStore";
+import logger from "../utils/logger";
+import { resolveMicDeviceSelection } from "./micDeviceSelection";
+
+/**
+ * Resolve the saved mic selection against live devices, persisting a remap or
+ * label backfill so the preference survives Chromium device-ID rotation.
+ * `labelsAvailable` is false while device labels are hidden (no mic permission
+ * yet), in which case a failed resolution should not be treated as final.
+ */
+export async function reconcileSavedMicSelection(
+  selectedDeviceId,
+  selectedDeviceLabel,
+  logChannel
+) {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  const { device, status } = resolveMicDeviceSelection(
+    devices,
+    selectedDeviceId,
+    selectedDeviceLabel
+  );
+
+  if (!device) {
+    return {
+      deviceId: selectedDeviceId,
+      resolved: false,
+      labelsAvailable: devices.some((d) => d.kind === "audioinput" && d.label),
+    };
+  }
+
+  if (status === "remapped" || (!selectedDeviceLabel && device.label)) {
+    getSettings().setSelectedMicDevice(device.deviceId, device.label);
+    logger.info(
+      status === "remapped"
+        ? "Restored selected microphone after its device ID changed"
+        : "Saved selected microphone label for future recovery",
+      { deviceId: device.deviceId, label: device.label },
+      logChannel
+    );
+  }
+
+  return { deviceId: device.deviceId, resolved: true, labelsAvailable: true };
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -327,7 +327,6 @@ function useSettingsInternal() {
     selectedMicDeviceId: store.selectedMicDeviceId,
     selectedMicDeviceLabel: store.selectedMicDeviceLabel,
     setPreferBuiltInMic: store.setPreferBuiltInMic,
-    setSelectedMicDeviceId: store.setSelectedMicDeviceId,
     setSelectedMicDevice: store.setSelectedMicDevice,
     autoLearnCorrections,
     setAutoLearnCorrections,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -60,6 +60,7 @@ export interface OnboardingSettings {
 export interface MicrophoneSettings {
   preferBuiltInMic: boolean;
   selectedMicDeviceId: string;
+  selectedMicDeviceLabel: string;
 }
 
 export interface ApiKeySettings {
@@ -324,8 +325,10 @@ function useSettingsInternal() {
     setPanelStartPosition: store.setPanelStartPosition,
     preferBuiltInMic: store.preferBuiltInMic,
     selectedMicDeviceId: store.selectedMicDeviceId,
+    selectedMicDeviceLabel: store.selectedMicDeviceLabel,
     setPreferBuiltInMic: store.setPreferBuiltInMic,
     setSelectedMicDeviceId: store.setSelectedMicDeviceId,
+    setSelectedMicDevice: store.setSelectedMicDevice,
     autoLearnCorrections,
     setAutoLearnCorrections,
     showTranscriptionPreview: store.showTranscriptionPreview,

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { getSettings, selectResolvedMeetingTranscription } from "./settingsStore";
 import { useStreamingProvidersStore } from "./streamingProvidersStore";
 import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
-import { resolveMicDeviceSelection } from "../helpers/micDeviceSelection";
+import { reconcileSavedMicSelection } from "../helpers/micSelectionRecovery";
 import { getBaseLanguageCode } from "../utils/languageSupport";
 import type { SystemAudioAccessResult, SystemAudioStrategy } from "../types/electron";
 import {
@@ -326,35 +326,12 @@ const getMeetingMicConstraints = async (): Promise<MediaStreamConstraints> => {
     let resolvedDeviceId = selectedMicDeviceId;
 
     try {
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const resolvedSelection = resolveMicDeviceSelection(
-        devices,
+      const reconciled = await reconcileSavedMicSelection(
         selectedMicDeviceId,
-        selectedMicDeviceLabel
+        selectedMicDeviceLabel,
+        "meeting"
       );
-
-      if (resolvedSelection.device) {
-        resolvedDeviceId = resolvedSelection.device.deviceId;
-        if (
-          resolvedSelection.status === "remapped" ||
-          (!selectedMicDeviceLabel && resolvedSelection.device.label)
-        ) {
-          getSettings().setSelectedMicDevice(
-            resolvedSelection.device.deviceId,
-            resolvedSelection.device.label
-          );
-          logger.info(
-            resolvedSelection.status === "remapped"
-              ? "Restored selected meeting microphone after its device ID changed"
-              : "Saved selected meeting microphone label for future recovery",
-            {
-              deviceId: resolvedSelection.device.deviceId,
-              label: resolvedSelection.device.label,
-            },
-            "meeting"
-          );
-        }
-      }
+      resolvedDeviceId = reconciled.deviceId;
     } catch (err) {
       logger.debug(
         "Failed to reconcile selected microphone for meeting transcription",

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { getSettings, selectResolvedMeetingTranscription } from "./settingsStore";
 import { useStreamingProvidersStore } from "./streamingProvidersStore";
 import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
+import { resolveMicDeviceSelection } from "../helpers/micDeviceSelection";
 import { getBaseLanguageCode } from "../utils/languageSupport";
 import type { SystemAudioAccessResult, SystemAudioStrategy } from "../types/electron";
 import {
@@ -295,7 +296,7 @@ export const primeMeetingWorklet = () => {
 };
 
 const getMeetingMicConstraints = async (): Promise<MediaStreamConstraints> => {
-  const { preferBuiltInMic, selectedMicDeviceId } = getSettings();
+  const { preferBuiltInMic, selectedMicDeviceId, selectedMicDeviceLabel } = getSettings();
 
   if (preferBuiltInMic) {
     try {
@@ -322,9 +323,49 @@ const getMeetingMicConstraints = async (): Promise<MediaStreamConstraints> => {
   }
 
   if (selectedMicDeviceId && selectedMicDeviceId !== "default") {
+    let resolvedDeviceId = selectedMicDeviceId;
+
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const resolvedSelection = resolveMicDeviceSelection(
+        devices,
+        selectedMicDeviceId,
+        selectedMicDeviceLabel
+      );
+
+      if (resolvedSelection.device) {
+        resolvedDeviceId = resolvedSelection.device.deviceId;
+        if (
+          resolvedSelection.status === "remapped" ||
+          (!selectedMicDeviceLabel && resolvedSelection.device.label)
+        ) {
+          getSettings().setSelectedMicDevice(
+            resolvedSelection.device.deviceId,
+            resolvedSelection.device.label
+          );
+          logger.info(
+            resolvedSelection.status === "remapped"
+              ? "Restored selected meeting microphone after its device ID changed"
+              : "Saved selected meeting microphone label for future recovery",
+            {
+              deviceId: resolvedSelection.device.deviceId,
+              label: resolvedSelection.device.label,
+            },
+            "meeting"
+          );
+        }
+      }
+    } catch (err) {
+      logger.debug(
+        "Failed to reconcile selected microphone for meeting transcription",
+        { error: (err as Error).message },
+        "meeting"
+      );
+    }
+
     return {
       audio: {
-        deviceId: { exact: selectedMicDeviceId },
+        deviceId: { exact: resolvedDeviceId },
         ...MEETING_MIC_PRIMARY_AUDIO_CONSTRAINTS,
       },
     };

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -623,7 +623,6 @@ export interface SettingsState
   setActivationMode: (mode: "tap" | "push") => void;
 
   setPreferBuiltInMic: (value: boolean) => void;
-  setSelectedMicDeviceId: (value: string) => void;
   setSelectedMicDevice: (deviceId: string, label: string) => void;
 
   setTheme: (value: "light" | "dark" | "auto") => void;
@@ -704,8 +703,7 @@ function createRegisteredHotkeySetter(
   key: "chatAgentKey" | "voiceAgentKey",
   label: string,
   getRegisterFn: () =>
-    | ((hotkey: string) => Promise<{ success: boolean; message: string }>)
-    | undefined,
+    ((hotkey: string) => Promise<{ success: boolean; message: string }>) | undefined,
   fallbackSave?: (hotkey: string) => void
 ) {
   return async (hotkey: string): Promise<boolean> => {
@@ -793,8 +791,7 @@ function debouncedSaveSecret(provider: SecretProvider, key: string) {
   secretSaveTimers[provider] = setTimeout(() => {
     const api = window.electronAPI;
     const save = api?.[SECRET_IPC_SAVERS[provider]] as
-      | ((k: string) => Promise<unknown>)
-      | undefined;
+      ((k: string) => Promise<unknown>) | undefined;
     save?.(key)?.catch((err) => {
       logger.warn(
         "Failed to persist secret",
@@ -953,8 +950,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     ? "side-panel"
     : "full-width") as "side-panel" | "full-width",
   activationMode: (readString("activationMode", "tap") === "push" ? "push" : "tap") as
-    | "tap"
-    | "push",
+    "tap" | "push",
 
   preferBuiltInMic: readBoolean("preferBuiltInMic", true),
   selectedMicDeviceId: readString("selectedMicDeviceId", ""),
@@ -1474,13 +1470,6 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
 
   setPreferBuiltInMic: createBooleanSetter("preferBuiltInMic"),
-  setSelectedMicDeviceId: (deviceId: string) => {
-    if (isBrowser) {
-      localStorage.setItem("selectedMicDeviceLabel", "");
-      localStorage.setItem("selectedMicDeviceId", deviceId);
-    }
-    set({ selectedMicDeviceId: deviceId, selectedMicDeviceLabel: "" });
-  },
   setSelectedMicDevice: (deviceId: string, label: string) => {
     if (isBrowser) {
       localStorage.setItem("selectedMicDeviceLabel", label);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -624,6 +624,7 @@ export interface SettingsState
 
   setPreferBuiltInMic: (value: boolean) => void;
   setSelectedMicDeviceId: (value: string) => void;
+  setSelectedMicDevice: (deviceId: string, label: string) => void;
 
   setTheme: (value: "light" | "dark" | "auto") => void;
   setCloudBackupEnabled: (value: boolean) => void;
@@ -703,7 +704,8 @@ function createRegisteredHotkeySetter(
   key: "chatAgentKey" | "voiceAgentKey",
   label: string,
   getRegisterFn: () =>
-    ((hotkey: string) => Promise<{ success: boolean; message: string }>) | undefined,
+    | ((hotkey: string) => Promise<{ success: boolean; message: string }>)
+    | undefined,
   fallbackSave?: (hotkey: string) => void
 ) {
   return async (hotkey: string): Promise<boolean> => {
@@ -791,7 +793,8 @@ function debouncedSaveSecret(provider: SecretProvider, key: string) {
   secretSaveTimers[provider] = setTimeout(() => {
     const api = window.electronAPI;
     const save = api?.[SECRET_IPC_SAVERS[provider]] as
-      ((k: string) => Promise<unknown>) | undefined;
+      | ((k: string) => Promise<unknown>)
+      | undefined;
     save?.(key)?.catch((err) => {
       logger.warn(
         "Failed to persist secret",
@@ -950,10 +953,12 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     ? "side-panel"
     : "full-width") as "side-panel" | "full-width",
   activationMode: (readString("activationMode", "tap") === "push" ? "push" : "tap") as
-    "tap" | "push",
+    | "tap"
+    | "push",
 
   preferBuiltInMic: readBoolean("preferBuiltInMic", true),
   selectedMicDeviceId: readString("selectedMicDeviceId", ""),
+  selectedMicDeviceLabel: readString("selectedMicDeviceLabel", ""),
 
   theme: (() => {
     const v = readString("theme", "auto");
@@ -1469,7 +1474,20 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
 
   setPreferBuiltInMic: createBooleanSetter("preferBuiltInMic"),
-  setSelectedMicDeviceId: createStringSetter("selectedMicDeviceId"),
+  setSelectedMicDeviceId: (deviceId: string) => {
+    if (isBrowser) {
+      localStorage.setItem("selectedMicDeviceLabel", "");
+      localStorage.setItem("selectedMicDeviceId", deviceId);
+    }
+    set({ selectedMicDeviceId: deviceId, selectedMicDeviceLabel: "" });
+  },
+  setSelectedMicDevice: (deviceId: string, label: string) => {
+    if (isBrowser) {
+      localStorage.setItem("selectedMicDeviceLabel", label);
+      localStorage.setItem("selectedMicDeviceId", deviceId);
+    }
+    set({ selectedMicDeviceId: deviceId, selectedMicDeviceLabel: label });
+  },
 
   setTheme: (value: "light" | "dark" | "auto") => {
     if (isBrowser) localStorage.setItem("theme", value);

--- a/test/helpers/micDeviceSelection.test.js
+++ b/test/helpers/micDeviceSelection.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/micDeviceSelection.js");
+
+const mic = (deviceId, label) => ({ kind: "audioinput", deviceId, label });
+
+test("uses the saved device ID while it is still available", async () => {
+  const { resolveMicDeviceSelection } = await load();
+  const device = mic("saved-id", "Studio Mic");
+
+  assert.deepEqual(resolveMicDeviceSelection([device], "saved-id", "Studio Mic"), {
+    device,
+    status: "exact",
+  });
+});
+
+test("remaps a stale ID when exactly one microphone has the saved label", async () => {
+  const { resolveMicDeviceSelection } = await load();
+  const device = mic("new-id", "Studio Mic");
+
+  assert.deepEqual(resolveMicDeviceSelection([device], "old-id", "Studio Mic"), {
+    device,
+    status: "remapped",
+  });
+});
+
+test("does not guess when multiple microphones have the saved label", async () => {
+  const { resolveMicDeviceSelection } = await load();
+
+  assert.deepEqual(
+    resolveMicDeviceSelection(
+      [mic("first", "USB Audio"), mic("second", "USB Audio")],
+      "old-id",
+      "USB Audio"
+    ),
+    { device: null, status: "ambiguous" }
+  );
+});
+
+test("keeps an unplugged microphone preference unresolved", async () => {
+  const { resolveMicDeviceSelection } = await load();
+
+  assert.deepEqual(resolveMicDeviceSelection([], "old-id", "Studio Mic"), {
+    device: null,
+    status: "missing",
+  });
+});
+
+test("does not remap a stale ID without a saved label", async () => {
+  const { resolveMicDeviceSelection } = await load();
+
+  assert.deepEqual(resolveMicDeviceSelection([mic("new-id", "Studio Mic")], "old-id", ""), {
+    device: null,
+    status: "missing",
+  });
+});
+
+test("ignores non-input devices when remapping", async () => {
+  const { resolveMicDeviceSelection } = await load();
+  const output = { kind: "audiooutput", deviceId: "speaker", label: "Studio Mic" };
+
+  assert.deepEqual(resolveMicDeviceSelection([output], "old-id", "Studio Mic"), {
+    device: null,
+    status: "missing",
+  });
+});
+
+test("treats an empty saved ID as the system default", async () => {
+  const { resolveMicDeviceSelection } = await load();
+
+  assert.deepEqual(resolveMicDeviceSelection([mic("mic", "Studio Mic")], "", ""), {
+    device: null,
+    status: "default",
+  });
+});


### PR DESCRIPTION
## Summary
The saved microphone preference stored only Chromium's deviceId, which rotates over time (and changes on unplug/replug). When the ID went stale, recordings silently fell back to the default mic even though the user's chosen device was still connected (see #900 for the original stale-ID symptom).

This PR persists the device label alongside the ID and reconciles the saved preference against currently available devices at every acquisition point. The saved ID is used while valid; when it goes stale, the selection is remapped by label — but only when exactly one connected input matches, so we never guess between identical devices. If reconciliation can't resolve a device, behavior degrades to exactly what ships today (stale-ID → OverconstrainedError → existing default-mic retry). Existing users are migrated transparently: the label is backfilled the first time their saved ID resolves.

The reconcile-and-persist flow shared by dictation and meeting capture lives in `src/helpers/micSelectionRecovery.js`; the pure resolution logic (unit-tested) lives in `src/helpers/micDeviceSelection.js`. The caller-less `setSelectedMicDeviceId` setter was removed in favor of the label-aware `setSelectedMicDevice`.

Fixes #1171

## Verification
Full test suite passes: 272 tests, 0 failures (Node 24).
`tsc --noEmit`, ESLint, and `prettier --check` are clean across the repo.

## Known limitations
Two identical-model microphones (duplicate labels) intentionally do not remap — the user must re-pick. This is by design to avoid guessing wrong.
The integration paths (caching, persistence side effects) are verified by review only; a manual smoke test is recommended: select a non-default mic → restart → record → confirm the same mic is used.
