### PR TITLE
fix: prevent Parakeet install hanging behind an old PATH tar on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Parakeet installation no longer hangs behind an old PATH `tar` on Windows.** Model extraction now invokes Windows' built-in `tar.exe` directly and times out a stuck native extractor so the existing JavaScript fallback can finish the installation. The same hardened extraction path is used for diarization model setup and for CUDA whisper / Vulkan llama.cpp runtime archive extraction.
+
 ## [1.7.5] - 2026-07-10
 
 A model-breadth and reliability release on top of 1.7.4: the latest cloud reasoning models (OpenAI GPT-5.6 and Anthropic Claude Fable 5 / Sonnet 5), Corti as a private clinical reasoning provider with in-region routing that keeps transcribed medical text off third-party LLMs, Tinfoil confidential transcription extended to uploaded audio and every batch path, OpenRouter as a first-class LLM provider with a searchable model picker, enterprise Agent Mode chat with region-aware Bedrock and a live model catalog, multiple hotkeys per action, and a broad stack of meeting-notes, notes, transcription, and platform fixes.

--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -3,6 +3,7 @@ const fsPromises = require("fs").promises;
 const path = require("path");
 const { spawn } = require("child_process");
 const debugLogger = require("./debugLogger");
+const { runSystemTar } = require("./systemTar");
 const { downloadFile, createDownloadSignal, checkDiskSpace } = require("./downloadUtils");
 const { resolveBinaryPath, gracefulStopProcess } = require("../utils/serverUtils");
 const { getModelsDirForService } = require("./modelDirUtils");
@@ -264,34 +265,7 @@ class DiarizationManager {
   }
 
   _runSystemTar(archivePath, destDir) {
-    return new Promise((resolve, reject) => {
-      // Use relative paths from archive dir as cwd so neither -f nor -C args
-      // contain Windows drive letter colons (GNU tar treats C: as remote host)
-      const cwd = path.dirname(archivePath);
-      const tarProcess = spawn(
-        "tar",
-        ["-xjf", path.basename(archivePath), "-C", path.relative(cwd, destDir)],
-        { stdio: ["ignore", "pipe", "pipe"], cwd }
-      );
-
-      let stderr = "";
-
-      tarProcess.stderr.on("data", (data) => {
-        stderr += data.toString();
-      });
-
-      tarProcess.on("close", (code) => {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(new Error(`tar extraction failed with code ${code}: ${stderr}`));
-        }
-      });
-
-      tarProcess.on("error", (err) => {
-        reject(new Error(`Failed to start tar process: ${err.message}`));
-      });
-    });
+    return runSystemTar(archivePath, destDir);
   }
 
   async cancelDownload() {

--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -5,6 +5,7 @@ const { net } = require("electron");
 const { execFile } = require("child_process");
 const { pipeline } = require("stream");
 const debugLogger = require("./debugLogger");
+const { runSystemTar } = require("./systemTar");
 
 const USER_AGENT = "OpenWhispr/1.0";
 const PROGRESS_THROTTLE_MS = 100;
@@ -412,37 +413,45 @@ async function checkDiskSpace(directory, requiredBytes) {
   }
 }
 
-function extractZipWindows(zipPath, destDir) {
+async function extractZipWindows(zipPath, destDir) {
+  try {
+    await runSystemTar(zipPath, destDir);
+    return;
+  } catch (error) {
+    debugLogger.info("tar extraction failed, trying PowerShell", { error: error.message });
+  }
+
   return new Promise((resolve, reject) => {
-    execFile("tar", ["-xf", zipPath, "-C", destDir], (error) => {
-      if (error) {
-        debugLogger.info("tar extraction failed, trying PowerShell", { error: error.message });
-        execFile(
-          "powershell",
-          [
-            "-NoProfile",
-            "-Command",
-            `Expand-Archive -Force -Path '${zipPath}' -DestinationPath '${destDir}'`,
-          ],
-          (psError) => {
-            if (psError) reject(new Error(`Zip extraction failed: ${psError.message}`));
-            else resolve();
-          }
-        );
-      } else {
-        resolve();
+    execFile(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -Force -Path '${zipPath}' -DestinationPath '${destDir}'`,
+      ],
+      (psError) => {
+        if (psError) reject(new Error(`Zip extraction failed: ${psError.message}`));
+        else resolve();
       }
-    });
+    );
   });
+}
+
+async function extractTarGz(archivePath, destDir) {
+  try {
+    await runSystemTar(archivePath, destDir);
+    return;
+  } catch (error) {
+    debugLogger.info("system tar failed, using JS extraction", { error: error.message });
+  }
+
+  const tar = require("tar");
+  await tar.x({ file: archivePath, cwd: destDir });
 }
 
 function extractArchive(archivePath, destDir) {
   if (archivePath.endsWith(".tar.gz") || archivePath.endsWith(".tgz")) {
-    return new Promise((resolve, reject) => {
-      execFile("tar", ["-xzf", archivePath, "-C", destDir], (err) => {
-        err ? reject(new Error(`Extraction failed: ${err.message}`)) : resolve();
-      });
-    });
+    return extractTarGz(archivePath, destDir);
   }
 
   if (process.platform === "win32") {

--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -1,9 +1,9 @@
 const fs = require("fs");
 const fsPromises = require("fs").promises;
 const path = require("path");
-const { spawn } = require("child_process");
 const { pipeline } = require("stream/promises");
 const debugLogger = require("./debugLogger");
+const { runSystemTar } = require("./systemTar");
 const {
   downloadFile,
   createDownloadSignal,
@@ -449,29 +449,7 @@ class ParakeetManager {
   }
 
   _runSystemTar(archivePath, extractDir) {
-    return new Promise((resolve, reject) => {
-      const tarProcess = spawn("tar", ["-xjf", archivePath, "-C", extractDir], {
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-
-      let stderr = "";
-
-      tarProcess.stderr.on("data", (data) => {
-        stderr += data.toString();
-      });
-
-      tarProcess.on("close", (code) => {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(new Error(`tar extraction failed with code ${code}: ${stderr}`));
-        }
-      });
-
-      tarProcess.on("error", (err) => {
-        reject(new Error(`Failed to start tar process: ${err.message}`));
-      });
-    });
+    return runSystemTar(archivePath, extractDir);
   }
 
   async cancelDownload() {

--- a/src/helpers/systemTar.js
+++ b/src/helpers/systemTar.js
@@ -1,0 +1,114 @@
+const path = require("path");
+const { spawn } = require("child_process");
+const { TIMEOUTS, killProcess } = require("../utils/process");
+
+const TAR_KILL_GRACE_MS = 1000;
+
+function tarExtractionFlags(archivePath) {
+  const lower = archivePath.toLowerCase();
+  if (lower.endsWith(".tar.bz2") || lower.endsWith(".tbz2")) return "-xjf";
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return "-xzf";
+  // bsdtar and modern GNU tar auto-detect the format on extraction (zip included).
+  return "-xf";
+}
+
+function resolveSystemTarExecutable({
+  platform = process.platform,
+  arch = process.arch,
+  env = process.env,
+} = {}) {
+  if (platform !== "win32") return "tar";
+
+  const windowsDir = env.SystemRoot || env.SYSTEMROOT || env.WINDIR || env.windir || "C:\\Windows";
+  // A 32-bit process is redirected from System32 to SysWOW64, where tar.exe
+  // is not normally present. Sysnative is Windows' alias for the native
+  // system directory in that situation.
+  const systemDir = arch === "ia32" && env.PROCESSOR_ARCHITEW6432 ? "Sysnative" : "System32";
+  return path.win32.join(windowsDir, systemDir, "tar.exe");
+}
+
+function runSystemTar(
+  archivePath,
+  destDir,
+  {
+    platform = process.platform,
+    arch = process.arch,
+    env = process.env,
+    timeoutMs = TIMEOUTS.INSTALL,
+    killGraceMs = TAR_KILL_GRACE_MS,
+    spawnImpl = spawn,
+  } = {}
+) {
+  return new Promise((resolve, reject) => {
+    const executable = resolveSystemTarExecutable({ platform, arch, env });
+    // Relative arguments avoid GNU tar interpreting a Windows drive-letter
+    // colon as a remote archive separator on non-standard PATH tar builds.
+    const pathApi = platform === "win32" ? path.win32 : path;
+    const cwd = pathApi.dirname(archivePath);
+    const archiveArg = pathApi.basename(archivePath);
+    const destArg = pathApi.relative(cwd, destDir) || ".";
+    let tarProcess;
+
+    try {
+      tarProcess = spawnImpl(
+        executable,
+        [tarExtractionFlags(archivePath), archiveArg, "-C", destArg],
+        {
+          cwd,
+          stdio: ["ignore", "ignore", "pipe"],
+          windowsHide: true,
+        }
+      );
+    } catch (err) {
+      reject(new Error(`Failed to start tar process: ${err.message}`));
+      return;
+    }
+
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let killGraceTimer = null;
+
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      if (killGraceTimer) clearTimeout(killGraceTimer);
+      callback(value);
+    };
+
+    const timeoutError = () => new Error(`tar extraction timed out after ${timeoutMs}ms`);
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      killProcess(tarProcess, "SIGKILL");
+
+      // Normally close follows kill immediately. Do not let a broken process
+      // implementation turn the safety timeout into another indefinite wait.
+      killGraceTimer = setTimeout(() => finish(reject, timeoutError()), killGraceMs);
+    }, timeoutMs);
+
+    tarProcess.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    tarProcess.on("close", (code) => {
+      if (timedOut) {
+        finish(reject, timeoutError());
+      } else if (code === 0) {
+        finish(resolve);
+      } else {
+        finish(reject, new Error(`tar extraction failed with code ${code}: ${stderr}`));
+      }
+    });
+
+    tarProcess.on("error", (err) => {
+      finish(reject, new Error(`Failed to start tar process: ${err.message}`));
+    });
+  });
+}
+
+module.exports = {
+  resolveSystemTarExecutable,
+  runSystemTar,
+};

--- a/test/helpers/extractArchive.test.js
+++ b/test/helpers/extractArchive.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const Module = require("node:module");
 const cp = require("child_process");
 
 // Minimal valid zip: single file "test-file.txt" containing "hello from test\n"
@@ -22,9 +23,36 @@ function writeZip(dir, name, buf) {
   return p;
 }
 
-function freshRequire() {
-  delete require.cache[require.resolve("../../src/helpers/downloadUtils.js")];
-  return require("../../src/helpers/downloadUtils.js");
+const downloadUtilsPath = require.resolve("../../src/helpers/downloadUtils.js");
+const originalLoad = Module._load;
+
+function freshRequire({ runSystemTar } = {}) {
+  delete require.cache[downloadUtilsPath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") return { net: {} };
+    if (request === "./systemTar" && runSystemTar) return { runSystemTar };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../../src/helpers/downloadUtils.js");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+async function withModuleMock(requestToMock, mock, callback) {
+  Module._load = function loadWithMock(request, parent, isMain) {
+    if (request === requestToMock) return mock;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return await callback();
+  } finally {
+    Module._load = originalLoad;
+  }
 }
 
 test("extractArchive extracts a zip file on Linux", async () => {
@@ -96,5 +124,69 @@ test("extractArchive rejects on corrupt zip when both extraction methods fail", 
     cp.execFile = origExecFile;
     freshRequire();
     fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("extractArchive falls back to JS tar when system tar rejects a tar.gz archive", async () => {
+  const tarCalls = [];
+  const systemTarCalls = [];
+  const archivePath = "/cache/model.tar.gz";
+  const destDir = "/cache/extract";
+  const { extractArchive } = freshRequire({
+    runSystemTar: async (...args) => {
+      systemTarCalls.push(args);
+      throw new Error("tar extraction timed out");
+    },
+  });
+
+  try {
+    await withModuleMock("tar", { x: async (options) => tarCalls.push(options) }, () =>
+      extractArchive(archivePath, destDir)
+    );
+    assert.deepEqual(systemTarCalls, [[archivePath, destDir]]);
+    assert.deepEqual(tarCalls, [{ file: archivePath, cwd: destDir }]);
+  } finally {
+    delete require.cache[downloadUtilsPath];
+  }
+});
+
+test("extractArchive falls back to PowerShell when Windows tar rejects a zip archive", async () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalExecFile = cp.execFile;
+  const execCalls = [];
+  const systemTarCalls = [];
+
+  Object.defineProperty(process, "platform", { value: "win32" });
+  cp.execFile = (command, args, callback) => {
+    execCalls.push({ command, args });
+    callback(null);
+  };
+
+  const archivePath = "C:\\cache\\binary.zip";
+  const destDir = "C:\\cache\\extract";
+  const { extractArchive } = freshRequire({
+    runSystemTar: async (...args) => {
+      systemTarCalls.push(args);
+      throw new Error("tar extraction timed out");
+    },
+  });
+
+  try {
+    await extractArchive(archivePath, destDir);
+    assert.deepEqual(systemTarCalls, [[archivePath, destDir]]);
+    assert.deepEqual(execCalls, [
+      {
+        command: "powershell",
+        args: [
+          "-NoProfile",
+          "-Command",
+          "Expand-Archive -Force -Path 'C:\\cache\\binary.zip' -DestinationPath 'C:\\cache\\extract'",
+        ],
+      },
+    ]);
+  } finally {
+    cp.execFile = originalExecFile;
+    Object.defineProperty(process, "platform", originalPlatform);
+    delete require.cache[downloadUtilsPath];
   }
 });

--- a/test/helpers/systemTar.test.js
+++ b/test/helpers/systemTar.test.js
@@ -1,0 +1,115 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { resolveSystemTarExecutable, runSystemTar } = require("../../src/helpers/systemTar");
+
+function makeChild({ closeOnKill = true } = {}) {
+  const child = new EventEmitter();
+  child.stderr = new EventEmitter();
+  // killProcess() treats a non-null exitCode as an already-dead process
+  child.exitCode = null;
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+    if (closeOnKill) setImmediate(() => child.emit("close", null, "SIGKILL"));
+    return true;
+  };
+  return child;
+}
+
+test("resolves Windows tar from System32 instead of PATH", () => {
+  assert.equal(
+    resolveSystemTarExecutable({
+      platform: "win32",
+      arch: "x64",
+      env: { SystemRoot: "D:\\Windows" },
+    }),
+    "D:\\Windows\\System32\\tar.exe"
+  );
+});
+
+test("uses Sysnative when a 32-bit process needs the 64-bit Windows tar", () => {
+  assert.equal(
+    resolveSystemTarExecutable({
+      platform: "win32",
+      arch: "ia32",
+      env: { SystemRoot: "C:\\Windows", PROCESSOR_ARCHITEW6432: "AMD64" },
+    }),
+    "C:\\Windows\\Sysnative\\tar.exe"
+  );
+});
+
+test("keeps PATH tar resolution on non-Windows platforms", () => {
+  assert.equal(resolveSystemTarExecutable({ platform: "linux" }), "tar");
+});
+
+test("runs the explicit Windows tar with drive-colon-free arguments", async () => {
+  const child = makeChild();
+  let invocation;
+  const promise = runSystemTar("C:\\cache\\model.tar.bz2", "C:\\cache\\extract", {
+    platform: "win32",
+    arch: "x64",
+    env: { SystemRoot: "C:\\Windows" },
+    timeoutMs: 100,
+    spawnImpl: (command, args, options) => {
+      invocation = { command, args, options };
+      setImmediate(() => child.emit("close", 0));
+      return child;
+    },
+  });
+
+  await promise;
+  assert.equal(invocation.command, "C:\\Windows\\System32\\tar.exe");
+  assert.deepEqual(invocation.args, ["-xjf", "model.tar.bz2", "-C", "extract"]);
+  assert.equal(invocation.options.cwd, "C:\\cache");
+  assert.equal(child.killed, false);
+});
+
+test("derives tar flags from the archive extension", async () => {
+  for (const [archive, flags] of [
+    ["model.tar.gz", "-xzf"],
+    ["binary.zip", "-xf"],
+  ]) {
+    const child = makeChild();
+    let args;
+    await runSystemTar(`/cache/${archive}`, "/cache/extract", {
+      platform: "linux",
+      spawnImpl: (_command, spawnArgs) => {
+        args = spawnArgs;
+        setImmediate(() => child.emit("close", 0));
+        return child;
+      },
+    });
+    assert.equal(args[0], flags);
+  }
+});
+
+test("kills and rejects a tar process that does not exit before the timeout", async () => {
+  const child = makeChild();
+
+  await assert.rejects(
+    runSystemTar("/cache/model.tar.bz2", "/cache/extract", {
+      platform: "linux",
+      timeoutMs: 10,
+      spawnImpl: () => child,
+    }),
+    /tar extraction timed out after 10ms/
+  );
+  assert.equal(child.killed, true);
+});
+
+test("rejects after the kill grace period when the killed process never closes", async () => {
+  const child = makeChild({ closeOnKill: false });
+
+  await assert.rejects(
+    runSystemTar("/cache/model.tar.bz2", "/cache/extract", {
+      platform: "linux",
+      timeoutMs: 10,
+      killGraceMs: 20,
+      spawnImpl: () => child,
+    }),
+    /tar extraction timed out after 10ms/
+  );
+  assert.equal(child.killed, true);
+});


### PR DESCRIPTION
## Summary

Installing a Parakeet model could hang forever on Windows when a third-party tar (Git/MSYS/GnuWin32) shadows the built-in one on PATH: GNU tar interprets the drive colon in -f C:\... as a host:file remote-archive spec and blocks indefinitely. Extraction had no timeout, so the existing JavaScript fallback was never reached.

Extraction now goes through a shared runSystemTar helper that invokes %SystemRoot%\System32\tar.exe directly on Windows (bypassing PATH entirely), uses relative -f/-C arguments as defense-in-depth against the drive-colon parsing, and enforces a 5-minute timeout that SIGKILLs a stuck extractor — guaranteeing the promise settles and the JS fallback can finish the install. The same hardened path now also covers diarization model setup and the CUDA whisper / Vulkan llama.cpp runtime archive downloads, which had the identical bug.

Fixes [1159](https://github.com/OpenWhispr/openwhispr/issues/1159)

## Follow-ups / known limitations
Not yet reproduced/verified on a real Windows machine with a hostile PATH tar — unit tests cover binary resolution and arguments; a manual smoke test of a Parakeet install on Windows is recommended before release.
Pre-1803 Windows has no System32\tar.exe; those installs go straight to the (slower) JS fallback by design.
Worst case on a pathologically slow disk: a legitimate extraction exceeding 5 minutes gets killed and redone by the JS fallback — slow, but never hung.