### PR TITLE
fix(updater): forward update events to live window refs

### DIFF
--- a/main.js
+++ b/main.js
@@ -1043,7 +1043,6 @@ async function startApp() {
   trayManager.setCreateControlPanelCallback(() => windowManager.createControlPanelWindow());
   await trayManager.createTray();
 
-  updateManager.setWindows(windowManager.mainWindow, windowManager.controlPanelWindow);
   updateManager.checkForUpdatesOnStartup();
 
   if (process.platform === "darwin") {

--- a/src/updater.js
+++ b/src/updater.js
@@ -2,8 +2,6 @@ const { autoUpdater } = require("electron-updater");
 
 class UpdateManager {
   constructor() {
-    this.mainWindow = null;
-    this.controlPanelWindow = null;
     this.updateAvailable = false;
     this.updateDownloaded = false;
     this.lastUpdateInfo = null;
@@ -17,11 +15,6 @@ class UpdateManager {
     this._suppressNotification = false;
 
     this.setupAutoUpdater();
-  }
-
-  setWindows(mainWindow, controlPanelWindow) {
-    this.mainWindow = mainWindow;
-    this.controlPanelWindow = controlPanelWindow;
   }
 
   setWindowManager(windowManager) {
@@ -158,15 +151,13 @@ class UpdateManager {
   }
 
   notifyRenderers(channel, data) {
-    if (this.mainWindow && !this.mainWindow.isDestroyed() && this.mainWindow.webContents) {
-      this.mainWindow.webContents.send(channel, data);
-    }
-    if (
-      this.controlPanelWindow &&
-      !this.controlPanelWindow.isDestroyed() &&
-      this.controlPanelWindow.webContents
-    ) {
-      this.controlPanelWindow.webContents.send(channel, data);
+    // Read window refs live from windowManager: cached refs go stale when the
+    // control panel is created after boot (start minimized) or recreated.
+    const { mainWindow, controlPanelWindow } = this.windowManager ?? {};
+    for (const win of [mainWindow, controlPanelWindow]) {
+      if (win && !win.isDestroyed() && win.webContents) {
+        win.webContents.send(channel, data);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Clicking Update shows a percent indicator that never moves past 0%, yet after restarting the app the new version is installed. `UpdateManager.notifyRenderers` (`src/updater.js`) sends updater events to window references captured once at boot via `setWindows(...)` in `main.js`. With "Start minimized" enabled the control panel doesn't exist at that point (and a window recreated later is never re-registered), so `update-download-progress` and `update-downloaded` silently never reach the UI. The stuck 0% comes from the optimistic downloading state in `useUpdater.ts`, and `autoInstallOnAppQuit` still applies the update on the next restart, which matches the report exactly.

The fix makes `notifyRenderers` read `mainWindow`/`controlPanelWindow` live from `windowManager` (already injected right after construction) at send time, and drops the one-shot `setWindows` snapshot. Progress now also reaches a control panel opened while a download is already running.

## Changes

- `src/updater.js`: `notifyRenderers` reads window refs live from `windowManager`; removed the `setWindows` method and the cached `mainWindow`/`controlPanelWindow` fields.
- `main.js`: removed the `updateManager.setWindows(...)` call.
