### PR TITLE
fix(notes): support Unicode note search

### DIFF
--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const { randomUUID } = require("crypto");
 const debugLogger = require("./debugLogger");
+const { buildNoteSearchQuery } = require("./noteSearch");
 const { app } = require("electron");
 
 // Server-enforced trigger cap (openwhispr-api); enforced here so one oversized
@@ -2097,11 +2098,8 @@ class DatabaseManager {
   searchNotes(query, limit = 50) {
     try {
       if (!this.db) throw new Error("Database not initialized");
-      const term = query
-        .trim()
-        .replace(/[^\w\s]/g, " ")
-        .trim();
-      if (!term) return [];
+      const ftsQuery = buildNoteSearchQuery(query);
+      if (!ftsQuery) return [];
       return this.db
         .prepare(
           `
@@ -2113,7 +2111,7 @@ class DatabaseManager {
         LIMIT ?
       `
         )
-        .all(term + "*", limit);
+        .all(ftsQuery, limit);
     } catch (error) {
       debugLogger.error("Error searching notes", { error: error.message }, "database");
       throw error;

--- a/src/helpers/noteSearch.js
+++ b/src/helpers/noteSearch.js
@@ -1,0 +1,14 @@
+function buildNoteSearchQuery(input) {
+  if (typeof input !== "string") return "";
+
+  const tokens = input
+    .normalize("NFC")
+    .match(/[\p{L}\p{N}_][\p{L}\p{M}\p{N}_]*/gu)
+    ?.filter((token) => /[\p{L}\p{N}]/u.test(token));
+
+  if (!tokens?.length) return "";
+
+  return tokens.map((token) => `"${token.replace(/"/g, '""')}"*`).join(" ");
+}
+
+module.exports = { buildNoteSearchQuery };

--- a/test/helpers/noteSearch.test.js
+++ b/test/helpers/noteSearch.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { DatabaseSync } = require("node:sqlite");
+const Module = require("node:module");
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "electron") {
+    return { app: {} };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+const DatabaseManager = require("../../src/helpers/database.js");
+Module._load = originalLoad;
+const { buildNoteSearchQuery } = require("../../src/helpers/noteSearch.js");
+
+test("buildNoteSearchQuery builds quoted prefix queries", () => {
+  for (const [input, expected] of [
+    ["hello", '"hello"*'],
+    ["hello world", '"hello"* "world"*'],
+    ["Привет мир", '"Привет"* "мир"*'],
+    ["中文", '"中文"*'],
+    ["東京", '"東京"*'],
+    ["مرحبا", '"مرحبا"*'],
+    ["café", '"café"*'],
+    ["cafe\u0301", '"café"*'],
+    ["2026", '"2026"*'],
+    ["résumé 2026", '"résumé"* "2026"*'],
+    ["  naïve  ", '"naïve"*'],
+    ["hello,world", '"hello"* "world"*'],
+    ["foo_bar", '"foo_bar"*'],
+  ]) {
+    assert.equal(buildNoteSearchQuery(input), expected, input);
+  }
+});
+
+test("buildNoteSearchQuery discards empty input and FTS5 syntax", () => {
+  for (const input of ["", "   ", "!!!", "***", '""', "___"]) {
+    assert.equal(buildNoteSearchQuery(input), "", input);
+  }
+
+  for (const [input, expected] of [
+    ["OR", '"OR"*'],
+    ["title:", '"title"*'],
+    ['foo"bar', '"foo"* "bar"*'],
+    ["hello -world", '"hello"* "world"*'],
+  ]) {
+    assert.equal(buildNoteSearchQuery(input), expected, input);
+  }
+});
+
+function createSearchDatabase() {
+  const sqlite = new DatabaseSync(":memory:");
+  sqlite.exec(`
+    CREATE TABLE notes (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      deleted_at TEXT
+    );
+    CREATE VIRTUAL TABLE notes_fts USING fts5(title, content);
+  `);
+
+  const insertNote = sqlite.prepare("INSERT INTO notes (title, content) VALUES (?, ?)");
+  const insertFts = sqlite.prepare(
+    "INSERT INTO notes_fts (rowid, title, content) VALUES (?, ?, ?)"
+  );
+
+  for (const [title, content] of [
+    ["Привет мир", "Заметка о проекте"],
+    ["中文测试", "项目计划"],
+    ["مرحبا بالعالم", "ملاحظات المشروع"],
+    ["café résumé", "naïve approach"],
+    ["hello world", "ordinary ASCII note"],
+    ["東京駅", "旅行計画"],
+    ["OR operation", "literal operator note"],
+  ]) {
+    const { lastInsertRowid } = insertNote.run(title, content);
+    insertFts.run(lastInsertRowid, title, content);
+  }
+
+  const manager = Object.create(DatabaseManager.prototype);
+  manager.db = sqlite;
+  return { manager, sqlite };
+}
+
+test("DatabaseManager.searchNotes matches Unicode and ASCII prefixes with SQLite FTS5", (t) => {
+  const { manager, sqlite } = createSearchDatabase();
+  t.after(() => sqlite.close());
+
+  for (const [query, expectedTitle] of [
+    ["Прив", "Привет мир"],
+    ["中文", "中文测试"],
+    ["مرح", "مرحبا بالعالم"],
+    ["caf rés", "café résumé"],
+    ["hel wor", "hello world"],
+    ["東京", "東京駅"],
+  ]) {
+    assert.equal(manager.searchNotes(query, 10)[0]?.title, expectedTitle, query);
+  }
+});
+
+test("DatabaseManager.searchNotes returns no rows for empty normalized queries", (t) => {
+  const { manager, sqlite } = createSearchDatabase();
+  t.after(() => sqlite.close());
+
+  assert.deepEqual(manager.searchNotes("!!!", 10), []);
+  assert.deepEqual(manager.searchNotes("   ", 10), []);
+});
+
+test("DatabaseManager.searchNotes treats FTS5 operators and punctuation as text", (t) => {
+  const { manager, sqlite } = createSearchDatabase();
+  t.after(() => sqlite.close());
+
+  assert.ok(manager.searchNotes("OR", 10).some((note) => note.title === "OR operation"));
+  assert.equal(manager.searchNotes("hello -world", 10)[0]?.title, "hello world");
+  assert.deepEqual(manager.searchNotes("title:", 10), []);
+  assert.deepEqual(manager.searchNotes('foo"bar', 10), []);
+});


### PR DESCRIPTION
## Summary

* Preserve Unicode letters, combining marks, and numbers when constructing
  SQLite FTS5 note-search queries.
* Quote every token and apply prefix matching independently without exposing
  raw FTS5 operators.
* Return no results for blank or punctuation-only input without executing an
  invalid or match-all expression.
* Preserve existing note filtering, ranking, limits, IPC, and UI behavior.

## Root cause

`DatabaseManager.searchNotes()` sanitized queries with `/[^\w\s]/g`.
JavaScript `\w` is ASCII-only, so Cyrillic, CJK, Arabic, and other scripts
were removed before SQLite was queried. Accented Latin terms were modified.

## Behavior

Each searchable token is normalized, safely quoted, and independently
prefix-matched using SQLite FTS5 syntax.

Representative verified searches include:

* `Прив` matching `Привет мир`
* `中文` matching `中文测试`
* `東京` matching `東京駅`
* `مرح` matching `مرحبا بالعالم`
* `caf rés` matching `café résumé`
* `hel wor` matching `hello world`

Blank or punctuation-only input returns an empty result set without executing
an invalid or match-all `MATCH` expression.

## Scope

This PR changes only local SQLite note-search query construction and its
regression tests.

It does not change:

* Command Search UI
* IPC or preload APIs
* semantic search or Qdrant
* database schema or FTS tokenizer configuration
* note ranking, ordering, filtering, or limits
* cloud synchronization
* dependencies or `package-lock.json`

## Testing

Passed:

* `node --test test/helpers/noteSearch.test.js`

  * 5 passed, 0 failed
* `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test`

  * 259 passed, 11 skipped, 0 failed
* `npm run typecheck`
* `npm run lint`
* `npm run format:check`
* `npm run i18n:check`
* `git diff --check`
* `node --check src/helpers/database.js`
* `node --check src/helpers/noteSearch.js`

The regression tests use Node 24's in-memory SQLite FTS5 support and require no
Electron startup, native rebuild, network access, model download, or API
credentials.

Fixes #1177