### PR TITLE
fix(windows): resolve mic-listener linker errors so the binary actually ships

### DIFF
--- a/resources/windows-mic-listener.c
+++ b/resources/windows-mic-listener.c
@@ -7,13 +7,17 @@
  * Uses IAudioSessionManager2 to enumerate and monitor capture sessions.
  * Supports --exclude-pid to ignore OpenWhispr's own microphone usage.
  *
- * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe ole32.lib oleaut32.lib
- * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -lole32 -loleaut32
+ * Compile with: cl /O2 windows-mic-listener.c /Fe:windows-mic-listener.exe ole32.lib oleaut32.lib user32.lib
+ * Or with MinGW: gcc -O2 windows-mic-listener.c -o windows-mic-listener.exe -lole32 -loleaut32 -luser32
  */
 
 #define WIN32_LEAN_AND_MEAN
 #define COBJMACROS
 #define CINTERFACE
+
+#ifdef _MSC_VER
+#pragma comment(lib, "user32.lib")
+#endif
 
 #include <windows.h>
 #include <initguid.h>
@@ -22,6 +26,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* The SDK declares these IIDs via MIDL_INTERFACE for C++ __uuidof only —
+ * no import library defines them and <initguid.h> skips them in C — so
+ * they must be defined in-source to link. */
+DEFINE_GUID(CLSID_MMDeviceEnumerator,
+    0xbcde0395, 0xe52f, 0x467c, 0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e);
+DEFINE_GUID(IID_IMMDeviceEnumerator,
+    0xa95664d2, 0x9614, 0x4f35, 0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6);
+DEFINE_GUID(IID_IAudioSessionManager2,
+    0x77aa99a0, 0x1bd6, 0x484f, 0x8b, 0xc7, 0x2c, 0x65, 0x4c, 0x9a, 0x9b, 0x6f);
+DEFINE_GUID(IID_IAudioSessionControl2,
+    0xbfb7ff88, 0x7239, 0x4fc9, 0x8f, 0xa2, 0x07, 0xc9, 0x50, 0xbe, 0x9c, 0x6d);
+DEFINE_GUID(IID_IAudioSessionEvents,
+    0x24918acc, 0x64b3, 0x37c1, 0x8c, 0xa9, 0x74, 0xa6, 0x6e, 0x99, 0x57, 0xa8);
+DEFINE_GUID(IID_IAudioSessionNotification,
+    0x641dd20b, 0x4d41, 0x49cc, 0xab, 0xa3, 0x17, 0x4b, 0x94, 0x77, 0xbb, 0x08);
 
 static DWORD g_excludePid = 0;
 static volatile BOOL g_running = TRUE;


### PR DESCRIPTION
## Problem

The `build-windows-mic-listener.yml` workflow has run exactly once (on the #407 merge, 2026-03-10) and failed with 10 unresolved externals — so **no `windows-mic-listener-v*` release has ever been published**. Since `scripts/download-windows-mic-listener.js` is best-effort, every Windows build has silently shipped without the binary, and all Windows users fall back to 15s mic polling instead of event-driven WASAPI detection (`windows-mic-listener.exe not found, will use polling` in user debug logs).

## Fix

Two classes of linker errors, both fixed in-source so the workflow needs no changes:

1. **`GetMessageA` / `TranslateMessage` / `DispatchMessageA` / `PostThreadMessageA`** — the message loop needs user32; linked via `#pragma comment(lib, "user32.lib")` under MSVC (MinGW compile comment updated with `-luser32`).
2. **`CLSID_MMDeviceEnumerator`, `IID_IMMDeviceEnumerator`, `IID_IAudioSessionManager2`, `IID_IAudioSessionControl2`, `IID_IAudioSessionEvents`, `IID_IAudioSessionNotification`** — the SDK declares these for C++ `__uuidof` only; defined in-source with `DEFINE_GUID`, same pattern as `windows-system-audio-helper.c`. GUID values verified against the SDK headers.

## Verification

- Reproduced the original failure via `workflow_dispatch` on main: run 29369576963 (10 unresolved externals).
- Dispatched the workflow on this branch: run 29369946066 — **compile green, release `windows-mic-listener-v1.0.0` published** with `windows-mic-listener-win32-x64.zip` (78.8 KB), matching the tag prefix and asset name the download script expects.
- Merging this PR re-triggers the workflow on main (paths filter includes the `.c` file), which updates the same release from main's commit.