### PR TITLE
fix(transcription): honor self-hosted settings on audio upload

### DIFF
--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -102,7 +102,11 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     cloudTranscriptionModel,
     cloudTranscriptionBaseUrl,
     cloudTranscriptionMode,
+    transcriptionMode,
   } = useSettingsStore(useShallow(selectResolvedUploadTranscription));
+
+  const remoteTranscriptionUrl = useSettingsStore((s) => s.remoteTranscriptionUrl);
+  const remoteTranscriptionModel = useSettingsStore((s) => s.remoteTranscriptionModel);
 
   const setUploadTranscriptionMode = useSettingsStore((s) => s.setUploadTranscriptionMode);
   const setUploadCloudTranscriptionMode = useSettingsStore(
@@ -125,6 +129,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     isSignedIn && cloudTranscriptionMode === "openwhispr" && !useLocalWhisper;
 
   // Mode detection
+  const isSelfHosted = transcriptionMode === "self-hosted" && !useLocalWhisper;
   const isByok = !useLocalWhisper && !isOpenWhisprCloud;
 
   // Mode-aware file size validation
@@ -141,8 +146,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
   if (file) {
     if (useLocalWhisper) {
       // Local transcription: no file size restrictions
-    } else if (cloudTranscriptionProvider === "custom") {
-      // Custom endpoints (e.g. local whisper.cpp): no file size restrictions
+    } else if (isSelfHosted || cloudTranscriptionProvider === "custom") {
+      // Self-hosted / custom endpoints (e.g. local whisper.cpp): no file size restrictions
     } else if (isByok) {
       byokTooLarge = file.sizeBytes > BYOK_MAX_FILE_SIZE;
       if (byokTooLarge && !isSignedIn) {
@@ -178,7 +183,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         return;
       }
       if (!useLocalWhisper) {
-        if (cloudTranscriptionProvider === "custom") {
+        if (isSelfHosted) {
+          if (!cancelled) setProviderReady(!!remoteTranscriptionUrl?.trim());
+        } else if (cloudTranscriptionProvider === "custom") {
           // Custom providers only need a base URL; API key is truly optional
           if (!cancelled) setProviderReady(!!cloudTranscriptionBaseUrl?.trim());
         } else if (cloudTranscriptionProvider === "corti") {
@@ -220,6 +227,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     };
   }, [
     isOpenWhisprCloud,
+    isSelfHosted,
+    remoteTranscriptionUrl,
     useLocalWhisper,
     localTranscriptionProvider,
     cloudTranscriptionProvider,
@@ -240,6 +249,10 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
       if (localTranscriptionProvider === "nvidia")
         return `Parakeet · ${parakeetModel || "default"}`;
       return `Whisper · ${whisperModel || "base"}`;
+    }
+    if (isSelfHosted) {
+      const name = t("settingsPage.transcription.modes.selfHosted");
+      return remoteTranscriptionModel ? `${name} · ${remoteTranscriptionModel}` : name;
     }
     const name =
       cloudTranscriptionProvider === "custom"
@@ -380,6 +393,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           model: localTranscriptionProvider === "nvidia" ? parakeetModel : whisperModel,
         });
       } else {
+        // Self-hosted fields make the handler route to the configured server
+        // (fail-closed on misconfiguration) instead of stale BYOK settings.
         res = await window.electronAPI.transcribeAudioFileByok!({
           filePath: file.path,
           apiKey: getActiveApiKey(),
@@ -389,6 +404,9 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           language: getBaseLanguageCode(preferredLanguage) || "en",
           environment: cortiEnvironment,
           tenant: cortiTenant,
+          transcriptionMode,
+          remoteTranscriptionUrl,
+          remoteTranscriptionModel,
         });
       }
 
@@ -481,6 +499,11 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
   const getTranscribingLabel = (): string => {
     if (isOpenWhisprCloud) return t("notes.upload.transcribingCloud");
     if (useLocalWhisper) return t("notes.upload.transcribingLocal");
+    if (isSelfHosted) {
+      return t("notes.upload.transcribingProvider", {
+        provider: t("settingsPage.transcription.modes.selfHosted"),
+      });
+    }
     return t("notes.upload.transcribingProvider", { provider: cloudTranscriptionProvider });
   };
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6976,11 +6976,55 @@ class IPCHandlers {
       "transcribe-audio-file-byok",
       async (
         event,
-        { filePath, apiKey, baseUrl, model, provider, language, environment, tenant }
+        {
+          filePath,
+          apiKey,
+          baseUrl,
+          model,
+          provider,
+          language,
+          environment,
+          tenant,
+          transcriptionMode,
+          remoteTranscriptionUrl,
+          remoteTranscriptionModel,
+        }
       ) => {
         const fs = require("fs");
         const BYOK_FILE_SIZE_LIMIT = 25 * 1024 * 1024; // 25 MB
         try {
+          const { resolveSelfHostedRetryRoute } = await import("./retryTranscriptionRouting.js");
+          const selfHostedRoute = resolveSelfHostedRetryRoute({
+            transcriptionMode,
+            remoteTranscriptionUrl,
+            remoteTranscriptionModel,
+          });
+
+          // Fail closed: a misconfigured self-hosted setup must never fall through to BYOK.
+          if (selfHostedRoute?.kind === "configuration-error") {
+            return { success: false, error: selfHostedRoute.error };
+          }
+
+          if (selfHostedRoute?.kind === "self-hosted") {
+            // User's own server, so the 25 MB third-party cap does not apply.
+            const ext = path.extname(filePath).toLowerCase().replace(".", "");
+            const { body, boundary } = buildMultipartBody(
+              fs.readFileSync(filePath),
+              path.basename(filePath),
+              AUDIO_MIME_TYPES[ext] || "audio/mpeg",
+              { model: selfHostedRoute.model, language }
+            );
+            const data = await postMultipart(new URL(selfHostedRoute.endpoint), body, boundary);
+            if (data.statusCode !== 200) {
+              throw new Error(
+                data.data?.error?.message ||
+                  data.data?.error ||
+                  `Self-hosted API Error: ${data.statusCode}`
+              );
+            }
+            return { success: true, text: data.data.text };
+          }
+
           const fileSize = fs.statSync(filePath).size;
           if (fileSize > BYOK_FILE_SIZE_LIMIT) {
             return {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1320,6 +1320,9 @@ declare global {
         language?: string;
         environment?: string;
         tenant?: string;
+        transcriptionMode?: string;
+        remoteTranscriptionUrl?: string;
+        remoteTranscriptionModel?: string;
       }) => Promise<{
         success: boolean;
         text?: string;


### PR DESCRIPTION
The audio upload path routed only three ways (OpenWhispr cloud, local, BYOK), so transcriptionMode=self-hosted fell into the BYOK branch with stale cloud provider settings — uploads either 401'd or sent audio to a cloud provider the user had switched away from.

The transcribe-audio-file-byok handler now resolves the self-hosted route first, reusing resolveSelfHostedRetryRoute from the retry fix (#1154): a misconfigured URL fails closed with a clear error instead of falling through, and a valid one posts to the configured server via the handler's existing multipart transport (no 25 MB third-party cap — it's the user's own server, matching the retry path). UploadAudioView forwards the self-hosted settings, exempts self-hosted from the BYOK size limit like custom endpoints, gates readiness on a configured URL, and reuses existing i18n keys for labels.

Closes #970