### PR TITLE
fix(reasoning): route custom providers through Chat Completions, not the Responses API

### DIFF
--- a/src/services/ai/providers.ts
+++ b/src/services/ai/providers.ts
@@ -47,7 +47,8 @@ export async function getAIModel(
       // Corti's gateway is Chat Completions-compatible, not the OpenAI Responses API.
       return createOpenAI({ apiKey, baseURL: API_ENDPOINTS.CORTI_MODELS_BASE }).chat(model);
     case "custom":
-      return createOpenAI({ apiKey, baseURL })(model);
+      // Custom OpenAI-compatible servers implement Chat Completions, not the Responses API.
+      return createOpenAI({ apiKey, baseURL }).chat(model);
     case "openrouter":
       // OpenRouter implements Chat Completions, not the OpenAI Responses API.
       return createOpenAI({


### PR DESCRIPTION
The AI SDK's default `createOpenAI(...)(model)` factory returns a Responses API model (POST {baseURL}/responses), which custom OpenAI-compatible endpoints (LiteLLM, vLLM, DeepSeek, llama-server proxies) don't implement — custom BYOK chat agents got 404s or empty responses. Use `.chat(model)` like the corti, openrouter, and local cases already do.

Salvaged from #849, which is otherwise superseded; see the closing comment there for the per-item breakdown.