### PR TITLE
fix(downloads): wait for stream close before cleanup

### DIFF
--- a/src/helpers/urlAudioDownloader.js
+++ b/src/helpers/urlAudioDownloader.js
@@ -8,6 +8,7 @@ const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { finished } = require("node:stream/promises");
 const debugLogger = require("./debugLogger");
 const { getSafeTempDir } = require("./safeTempDir");
 const { getFFmpegPath } = require("./ffmpegUtils");
@@ -1064,11 +1065,27 @@ function streamToFile(
       bail(Object.assign(new Error("Download stalled"), { code: "DOWNLOAD_FAILED" }));
     });
 
-    const cleanupFile = () => {
+    const cleanupFile = async () => {
+      const closed = finished(fileStream, { cleanup: true });
       fileStream.destroy();
       try {
-        fs.unlinkSync(tempPath);
+        await closed;
       } catch {}
+      try {
+        fs.unlinkSync(tempPath);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    };
+
+    const rejectAfterCleanup = (err) => {
+      cleanupFile().then(
+        () => reject(err),
+        (cleanupError) => {
+          if (err.cause === undefined) err.cause = cleanupError;
+          reject(err);
+        }
+      );
     };
 
     const bail = (err) => {
@@ -1076,8 +1093,7 @@ function streamToFile(
       settled = true;
       stall.clear();
       if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
-      cleanupFile();
-      reject(err);
+      rejectAfterCleanup(err);
     };
 
     // React to cancel even while stalled (no data events arriving).
@@ -1132,8 +1148,7 @@ function streamToFile(
         const sizeBytes = fs.statSync(tempPath).size;
         resolve(sizeBytes);
       } catch {
-        cleanupFile();
-        reject(
+        rejectAfterCleanup(
           Object.assign(new Error("Download produced no output"), { code: "DOWNLOAD_FAILED" })
         );
       }

--- a/test/helpers/urlAudioDownloader.test.js
+++ b/test/helpers/urlAudioDownloader.test.js
@@ -701,6 +701,95 @@ async function withFakeHttps(handler, fn) {
   }
 }
 
+async function withDelayedWriteOpen(fn) {
+  const originalCreateWriteStream = fs.createWriteStream;
+  let delayedPath = null;
+  let openArgs = null;
+  let released = false;
+  let resolveOpenRequested;
+  const openRequested = new Promise((resolve) => {
+    resolveOpenRequested = resolve;
+  });
+
+  fs.createWriteStream = (filePath) => {
+    delayedPath = filePath;
+    return originalCreateWriteStream(filePath, {
+      fs: {
+        open(...args) {
+          openArgs = args;
+          resolveOpenRequested();
+        },
+        write: fs.write.bind(fs),
+        writev: fs.writev.bind(fs),
+        close: fs.close.bind(fs),
+      },
+    });
+  };
+
+  const releaseOpen = () => {
+    if (released || !openArgs) return;
+    released = true;
+    fs.open(...openArgs);
+  };
+
+  try {
+    return await fn({ openRequested, releaseOpen, getPath: () => delayedPath });
+  } finally {
+    releaseOpen();
+    fs.createWriteStream = originalCreateWriteStream;
+  }
+}
+
+async function withCapturedWriteStream(fn) {
+  const originalCreateWriteStream = fs.createWriteStream;
+  let resolveCaptured;
+  const captured = new Promise((resolve) => {
+    resolveCaptured = resolve;
+  });
+
+  fs.createWriteStream = (...args) => {
+    const stream = originalCreateWriteStream(...args);
+    resolveCaptured({ stream, filePath: args[0] });
+    return stream;
+  };
+
+  try {
+    return await fn(captured);
+  } finally {
+    fs.createWriteStream = originalCreateWriteStream;
+  }
+}
+
+async function withFailingWriteOpen(fn) {
+  const originalCreateWriteStream = fs.createWriteStream;
+  let resolveOpenAttempted;
+  const openAttempted = new Promise((resolve) => {
+    resolveOpenAttempted = resolve;
+  });
+
+  fs.createWriteStream = (filePath) =>
+    originalCreateWriteStream(filePath, {
+      fs: {
+        open(...args) {
+          const callback = args[args.length - 1];
+          resolveOpenAttempted(filePath);
+          setImmediate(() => {
+            callback(Object.assign(new Error("open denied"), { code: "EACCES" }));
+          });
+        },
+        write: fs.write.bind(fs),
+        writev: fs.writev.bind(fs),
+        close: fs.close.bind(fs),
+      },
+    });
+
+  try {
+    return await fn(openAttempted);
+  } finally {
+    fs.createWriteStream = originalCreateWriteStream;
+  }
+}
+
 function listOwUrlTempFiles() {
   const { getSafeTempDir } = require("../../src/helpers/safeTempDir");
   return new Set(fs.readdirSync(getSafeTempDir()).filter((f) => f.startsWith("ow-url-")));
@@ -870,6 +959,257 @@ test("downloadDirect rejects with DOWNLOAD_CANCELLED on mid-stream abort and cle
     }
   );
   assert.deepEqual(listOwUrlTempFiles(), before, "cancelled download must remove its temp file");
+});
+
+test("downloadDirect waits for a delayed file open to close before reporting cancellation", async () => {
+  const ac = new AbortController();
+  let downloadPromise;
+  let downloadResponse;
+
+  await withDelayedWriteOpen(async ({ openRequested, releaseOpen, getPath }) => {
+    try {
+      await withFakeHttps(
+        (parsed, options) =>
+          options.method === "HEAD"
+            ? { response: makeDirectResponse({ statusCode: 405 }) }
+            : {
+                response: (downloadResponse = makeDirectResponse({
+                  headers: { "content-type": "audio/mpeg" },
+                })),
+                after: () => ac.abort(),
+              },
+        async () => {
+          let settlementCount = 0;
+          let rejection;
+          downloadPromise = downloader.download(
+            "https://93.184.216.34/file.mp3",
+            null,
+            ac.signal
+          );
+          downloadPromise.then(
+            () => {
+              settlementCount += 1;
+            },
+            (error) => {
+              rejection = error;
+              settlementCount += 1;
+            }
+          );
+
+          await openRequested;
+          if (!ac.signal.aborted) {
+            await new Promise((resolve) => ac.signal.addEventListener("abort", resolve, { once: true }));
+          }
+          await new Promise((resolve) => setImmediate(resolve));
+          downloadResponse.emit("error", new Error("late source error"));
+          await new Promise((resolve) => setImmediate(resolve));
+
+          assert.equal(
+            settlementCount,
+            0,
+            "download must not settle before the delayed write stream closes"
+          );
+
+          releaseOpen();
+          await assert.rejects(downloadPromise, { code: "DOWNLOAD_CANCELLED" });
+          assert.equal(settlementCount, 1);
+          assert.equal(rejection.code, "DOWNLOAD_CANCELLED");
+          assert.equal(fs.existsSync(getPath()), false, "cancelled download must remove its file");
+        }
+      );
+    } finally {
+      releaseOpen();
+      await downloadPromise?.catch(() => {});
+      const delayedPath = getPath();
+      if (delayedPath) {
+        try {
+          fs.unlinkSync(delayedPath);
+        } catch {}
+      }
+    }
+  });
+});
+
+test("downloadDirect removes a partial file when cancelled after the stream opens", async () => {
+  const ac = new AbortController();
+  let tempPath;
+
+  try {
+    await withCapturedWriteStream(async (captured) => {
+      await withFakeHttps(
+        (parsed, options) =>
+          options.method === "HEAD"
+            ? { response: makeDirectResponse({ statusCode: 405 }) }
+            : { response: makeDirectResponse({ headers: { "content-type": "audio/mpeg" } }) },
+        async () => {
+          const downloadPromise = downloader.download(
+            "https://93.184.216.34/file.mp3",
+            null,
+            ac.signal
+          );
+          const capturedStream = await captured;
+          tempPath = capturedStream.filePath;
+          if (capturedStream.stream.pending) {
+            await new Promise((resolve) => capturedStream.stream.once("open", resolve));
+          }
+
+          fs.writeFileSync(tempPath, "partial");
+          ac.abort();
+
+          await assert.rejects(downloadPromise, { code: "DOWNLOAD_CANCELLED" });
+          assert.equal(fs.existsSync(tempPath), false, "cancelled download must remove its file");
+        }
+      );
+    });
+  } finally {
+    if (tempPath) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {}
+    }
+  }
+});
+
+test("downloadDirect rejects once and leaves no file when the destination cannot open", async () => {
+  let tempPath;
+  let settlementCount = 0;
+
+  await withFailingWriteOpen(async (openAttempted) => {
+    await withFakeHttps(
+      (parsed, options) =>
+        options.method === "HEAD"
+          ? { response: makeDirectResponse({ statusCode: 405 }) }
+          : { response: makeDirectResponse({ headers: { "content-type": "audio/mpeg" } }) },
+      async () => {
+        const downloadPromise = downloader.download(
+          "https://93.184.216.34/file.mp3",
+          null,
+          null
+        );
+        downloadPromise.then(
+          () => {
+            settlementCount += 1;
+          },
+          () => {
+            settlementCount += 1;
+          }
+        );
+        tempPath = await openAttempted;
+
+        await assert.rejects(downloadPromise, {
+          code: "DOWNLOAD_FAILED",
+          message: "open denied",
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+
+        assert.equal(settlementCount, 1);
+        assert.equal(fs.existsSync(tempPath), false);
+      }
+    );
+  });
+});
+
+test("downloadDirect tolerates an already-missing destination during cleanup", async () => {
+  const ac = new AbortController();
+  const originalUnlinkSync = fs.unlinkSync;
+  let tempPath;
+
+  try {
+    await withCapturedWriteStream(async (captured) => {
+      await withFakeHttps(
+        (parsed, options) =>
+          options.method === "HEAD"
+            ? { response: makeDirectResponse({ statusCode: 405 }) }
+            : { response: makeDirectResponse({ headers: { "content-type": "audio/mpeg" } }) },
+        async () => {
+          const downloadPromise = downloader.download(
+            "https://93.184.216.34/file.mp3",
+            null,
+            ac.signal
+          );
+          const capturedStream = await captured;
+          tempPath = capturedStream.filePath;
+          if (capturedStream.stream.pending) {
+            await new Promise((resolve) => capturedStream.stream.once("open", resolve));
+          }
+
+          fs.unlinkSync = (filePath) => {
+            if (filePath === tempPath) {
+              originalUnlinkSync(filePath);
+              throw Object.assign(new Error("already removed"), { code: "ENOENT" });
+            }
+            return originalUnlinkSync(filePath);
+          };
+          ac.abort();
+
+          await assert.rejects(downloadPromise, (error) => {
+            assert.equal(error.code, "DOWNLOAD_CANCELLED");
+            assert.equal(error.cause, undefined);
+            return true;
+          });
+          assert.equal(fs.existsSync(tempPath), false);
+        }
+      );
+    });
+  } finally {
+    fs.unlinkSync = originalUnlinkSync;
+    if (tempPath) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {}
+    }
+  }
+});
+
+test("downloadDirect preserves cancellation and exposes unexpected cleanup errors", async () => {
+  const ac = new AbortController();
+  const originalUnlinkSync = fs.unlinkSync;
+  let tempPath;
+
+  try {
+    await withCapturedWriteStream(async (captured) => {
+      await withFakeHttps(
+        (parsed, options) =>
+          options.method === "HEAD"
+            ? { response: makeDirectResponse({ statusCode: 405 }) }
+            : { response: makeDirectResponse({ headers: { "content-type": "audio/mpeg" } }) },
+        async () => {
+          const downloadPromise = downloader.download(
+            "https://93.184.216.34/file.mp3",
+            null,
+            ac.signal
+          );
+          const capturedStream = await captured;
+          tempPath = capturedStream.filePath;
+          if (capturedStream.stream.pending) {
+            await new Promise((resolve) => capturedStream.stream.once("open", resolve));
+          }
+
+          fs.unlinkSync = (filePath) => {
+            if (filePath === tempPath) {
+              throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+            }
+            return originalUnlinkSync(filePath);
+          };
+          ac.abort();
+
+          await assert.rejects(downloadPromise, (error) => {
+            assert.equal(error.code, "DOWNLOAD_CANCELLED");
+            assert.equal(error.cause?.code, "EACCES");
+            return true;
+          });
+          assert.equal(fs.existsSync(tempPath), true);
+        }
+      );
+    });
+  } finally {
+    fs.unlinkSync = originalUnlinkSync;
+    if (tempPath) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {}
+    }
+  }
 });
 
 // --- selectYtDlpOutput: finished-file selection + transient cleanup ---


### PR DESCRIPTION
## Summary

* Wait for the destination write stream to close before deleting an incomplete
  URL audio download.
* Prevent cancellation from settling while a pending asynchronous open can
  still recreate the destination.
* Preserve the original download or cancellation error.
* Ignore an already-missing destination while retaining visibility into
  unexpected unlink failures.

## Root cause

`fs.createWriteStream()` opens its destination asynchronously. The previous
cleanup path called `destroy()` and immediately attempted to unlink the
destination.

When cancellation occurred before `open`, unlink could observe `ENOENT` and
return. The pending open could then create the destination after cleanup and
after the download promise rejected.

## Corrected lifecycle

Cleanup now:

1. starts waiting for terminal stream completion;
2. requests destination-stream destruction;
3. waits for the stream to close;
4. removes the incomplete destination;
5. rejects with the original error.

This prevents retry callers from proceeding while the previous destination
stream may still open or write.

## Behavior

The deterministic delayed-open regression proves that:

* cancellation does not settle before the destination stream closes;
* the incomplete destination is removed after closure;
* late source errors do not cause duplicate settlement;
* the original `DOWNLOAD_CANCELLED` code is preserved.

## Scope

This PR changes only incomplete-destination cleanup in the shared URL audio
download stream helper.

It does not change:

* retry policy
* progress reporting
* URL validation
* download sources
* successful-download handling
* model or runtime binary downloads
* dependencies or `package-lock.json`

## Testing

Passed:

* `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/urlAudioDownloader.test.js`

  * 83 passed, 0 failed, 0 skipped
* `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test`

  * 437 total, 426 passed, 11 skipped, 0 failed
* `npm run typecheck`
* `npm run lint`
* `npm run format:check`
* `npm run i18n:check`
* `git diff --check`
* `node --check src/helpers/urlAudioDownloader.js`
* `node --check test/helpers/urlAudioDownloader.test.js`

A supporting real-filesystem stress run completed 500 isolated iterations with
zero failures and no observed leaked files. This stress result supplements the
deterministic regression test rather than replacing it.

Fixes #1197