### PR TITLE
fix(gpu): keep GPU acceleration download state after the settings picker remounts

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -269,6 +269,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     "cuda-download-progress",
     (callback) => (_event, data) => callback(data)
   ),
+  onCudaDownloadComplete: registerListener(
+    "cuda-download-complete",
+    (callback) => (_event, data) => callback(data)
+  ),
   onCudaFallbackNotification: registerListener(
     "cuda-fallback-notification",
     (callback) => () => callback()
@@ -281,6 +285,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   deleteVulkanWhisperBinary: () => ipcRenderer.invoke("delete-vulkan-whisper-binary"),
   onVulkanWhisperDownloadProgress: registerListener(
     "vulkan-whisper-download-progress",
+    (callback) => (_event, data) => callback(data)
+  ),
+  onVulkanWhisperDownloadComplete: registerListener(
+    "vulkan-whisper-download-complete",
     (callback) => (_event, data) => callback(data)
   ),
   onGpuFallbackNotification: registerListener(

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -543,12 +543,16 @@ export default function TranscriptionModelPicker({
         if (cuda?.gpuInfo.hasNvidiaGpu) {
           setGpuBackend("cuda");
           setGpuDownloaded(cuda.downloaded);
+          // The download runs in the main process, so it survives this
+          // component unmounting; pick it back up after a remount.
+          setGpuDownloading(cuda.downloading === true);
           return;
         }
         const vulkan = await window.electronAPI?.getVulkanWhisperStatus?.();
         if (vulkan?.vulkan.available) {
           setGpuBackend("vulkan");
           setGpuDownloaded(vulkan.downloaded);
+          setGpuDownloading(vulkan.downloading === true);
         }
       } catch {}
     };
@@ -563,6 +567,20 @@ export default function TranscriptionModelPicker({
         : window.electronAPI?.onVulkanWhisperDownloadProgress;
     return subscribe?.((data) => setGpuProgress(data));
   }, [gpuDownloading, gpuBackend]);
+
+  // Settles a download this component did not start (it began before a
+  // remount), where no in-flight invoke resolves to update the state.
+  useEffect(() => {
+    if (!gpuBackend) return;
+    const subscribe =
+      gpuBackend === "cuda"
+        ? window.electronAPI?.onCudaDownloadComplete
+        : window.electronAPI?.onVulkanWhisperDownloadComplete;
+    return subscribe?.((result) => {
+      setGpuDownloading(false);
+      if (result?.success) setGpuDownloaded(true);
+    });
+  }, [gpuBackend]);
 
   const handleGpuDownload = async () => {
     setGpuDownloading(true);

--- a/src/helpers/gpuBinaryManager.js
+++ b/src/helpers/gpuBinaryManager.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const { promises: fsPromises } = require("fs");
 const { createHash } = require("crypto");
+const { EventEmitter } = require("events");
 const path = require("path");
 const { app } = require("electron");
 const debugLogger = require("./debugLogger");
@@ -42,8 +43,13 @@ function sha256File(filePath) {
 // assetPattern regex; optional libPattern for companion libs). Archives are
 // sha256-verified against expectedDigests, falling back to the digest the
 // GitHub API reports.
-class GpuBinaryManager {
+//
+// Emits "download-settled" with { success, error? } once a started download
+// finishes (install, failure, or cancel). The duplicate-download guard does
+// not emit: the original download is still running.
+class GpuBinaryManager extends EventEmitter {
   constructor(config) {
+    super();
     this.config = config;
     this._binDir = null;
     this._downloadSignal = null;
@@ -140,6 +146,7 @@ class GpuBinaryManager {
     const tempDir = getSafeTempDir();
     let archivePath = null;
     let extractDir = null;
+    let settledResult = null;
 
     try {
       await fsPromises.mkdir(this.binDir, { recursive: true });
@@ -193,7 +200,11 @@ class GpuBinaryManager {
       }
 
       debugLogger.info(`${this.config.name} binary installed`, { version, path: outputPath });
+      settledResult = { success: true };
       return { version };
+    } catch (error) {
+      settledResult = { success: false, error: error.message };
+      throw error;
     } finally {
       this._downloading = false;
       this._downloadSignal = null;
@@ -201,6 +212,7 @@ class GpuBinaryManager {
       if (extractDir) {
         await fsPromises.rm(extractDir, { recursive: true, force: true }).catch(() => {});
       }
+      this.emit("download-settled", settledResult);
     }
   }
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -455,6 +455,16 @@ class IPCHandlers {
         this.broadcastToWindows("gpu-fallback-notification", {});
       });
     }
+
+    // A GPU acceleration download keeps running when the settings picker
+    // unmounts; broadcast completion so a remounted picker can settle its
+    // rehydrated download UI (#1136).
+    this.whisperCudaManager?.on("download-settled", (result) => {
+      this.broadcastToWindows("cuda-download-complete", result);
+    });
+    this.whisperVulkanManager?.on("download-settled", (result) => {
+      this.broadcastToWindows("vulkan-whisper-download-complete", result);
+    });
   }
 
   _getWhisperVadSettings() {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -829,6 +829,9 @@ declare global {
           percentage: number;
         }) => void
       ) => () => void;
+      onCudaDownloadComplete: (
+        callback: (data: { success: boolean; error?: string }) => void
+      ) => () => void;
       onCudaFallbackNotification: (callback: () => void) => () => void;
 
       // Vulkan GPU acceleration (whisper on AMD/Intel GPUs)
@@ -842,6 +845,9 @@ declare global {
           totalBytes: number;
           percentage: number;
         }) => void
+      ) => () => void;
+      onVulkanWhisperDownloadComplete: (
+        callback: (data: { success: boolean; error?: string }) => void
       ) => () => void;
       onGpuFallbackNotification: (callback: () => void) => () => void;
 

--- a/test/helpers/gpuBinaryManager.test.js
+++ b/test/helpers/gpuBinaryManager.test.js
@@ -321,6 +321,47 @@ test("delete: removes binary + matching libs only; whisper Vulkan leaves shared 
   assert.deepEqual(llamaResult, { success: true, deletedCount: 1 });
 });
 
+test("settled event: emitted with success after install and with the error after a failure", async () => {
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "whisper-server-linux-x64-cuda": "binary" };
+
+  const manager = new WhisperCudaManager();
+  const settled = [];
+  manager.on("download-settled", (result) => settled.push(result));
+
+  await manager.download();
+  assert.deepEqual(settled, [{ success: true }]);
+
+  state.extractImpl = async () => {
+    throw new Error("Extraction failed: corrupt");
+  };
+  await assert.rejects(() => manager.download(), { message: /Extraction failed/ });
+  assert.deepEqual(settled[1], { success: false, error: "Extraction failed: corrupt" });
+  assert.equal(manager.isDownloading(), false, "state already reset when the event fires");
+});
+
+test("settled event: the duplicate-download guard does not emit", async () => {
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "whisper-server-linux-x64-cuda": "binary" };
+  let releaseDownload;
+  const gate = new Promise((resolve) => (releaseDownload = resolve));
+  state.downloadImpl = async (_url, dest) => {
+    await gate;
+    fs.writeFileSync(dest, state.archiveContent);
+  };
+
+  const manager = new WhisperCudaManager();
+  const settled = [];
+  manager.on("download-settled", (result) => settled.push(result));
+
+  const first = manager.download();
+  await assert.rejects(() => manager.download(), { message: "Download already in progress" });
+  assert.equal(settled.length, 0, "rejected duplicate must not look like a settled download");
+  releaseDownload();
+  await first;
+  assert.deepEqual(settled, [{ success: true }]);
+});
+
 test("getStatus reflects supported/downloaded/downloading", async () => {
   const manager = new WhisperVulkanManager();
   assert.deepEqual(manager.getStatus(), {


### PR DESCRIPTION
## Summary

The GPU acceleration download (Settings > Speech to Text > Local) runs in the main process, so it keeps going when the user navigates to another settings page. The picker's state does not survive that navigation. On return, the progress bar was gone and the "Enable GPU acceleration" button was back even though the download was still running. Clicking the button again hit the manager's "Download already in progress" guard and silently failed, and when the download eventually finished nothing told the remounted picker, so the UI never flipped to the active state. This is what #1136 reports: the button is back and does nothing while Task Manager still shows network traffic.

To reproduce on main: Settings > Speech to Text > Local > start the GPU acceleration download > open any other settings page > come back while the download is running.

The fix:

1. `GpuBinaryManager` extends `EventEmitter` and emits `download-settled` with `{ success, error? }` from the `finally` block of `download()`, so it fires exactly once per started download, whether it installs, fails, or is cancelled. The duplicate-download guard does not emit, since the original download is still in flight.
2. `ipcHandlers.js` forwards the event to all windows as `cuda-download-complete` and `vulkan-whisper-download-complete`, exposed in the preload as `onCudaDownloadComplete` / `onVulkanWhisperDownloadComplete`.
3. On mount, `TranscriptionModelPicker` restores the downloading flag from `get-cuda-whisper-status` / `get-vulkan-whisper-status` (both handlers already reported it, the renderer just never read it) and subscribes to the completion event. A remounted picker shows the progress bar again (progress events already reach the same webContents), keeps the cancel link working, and settles to "GPU acceleration active" once the install finishes.

No new polling and no renderer-side persistence, just the existing status call plus one new event.

Fixes #1136

## Changes

- `src/helpers/gpuBinaryManager.js`: emit `download-settled` once a started download settles
- `src/helpers/ipcHandlers.js`: broadcast the completion to all windows
- `preload.js`, `src/types/electron.ts`: renderer listeners for both backends
- `src/components/TranscriptionModelPicker.tsx`: rehydrate the downloading state on mount and settle it from the completion event
- `test/helpers/gpuBinaryManager.test.js`: regression tests for the settled event (success, failure, and the duplicate-download guard staying silent)

## Verification

The new tests fail without the manager change and pass with it:

```
$ git checkout origin/main -- src/helpers/gpuBinaryManager.js
$ node --test test/helpers/gpuBinaryManager.test.js
not ok 12 - settled event: emitted with success after install and with the error after a failure
not ok 13 - settled event: the duplicate-download guard does not emit
# pass 11
# fail 3

$ git checkout HEAD -- src/helpers/gpuBinaryManager.js
$ node --test test/helpers/gpuBinaryManager.test.js
# tests 14
# pass 13
# fail 1
```

The one remaining failure ("binary is executable") is a pre-existing artifact of running this file on a Windows checkout: the test pins `process.platform` to linux and the chmod execute bit does not survive on NTFS. It fails identically on origin/main; CI runs the suite on ubuntu-latest.

```
$ npm run typecheck
> cd src && tsc --noEmit
(clean)

$ npm run lint
> eslint . && cd src && eslint .
(clean)
```

Full suite on this Windows machine: 434 pass, 24 fail at HEAD, and the failing set is identical by name to a fresh run at origin/main (all pre-existing Windows-host environment failures), so the branch introduces no new failures.

This fix was developed with AI assistance (Claude Code) and verified locally as shown above.
