### PR TITLE
fix(url-download): remove partial file only after the write stream closes

### DIFF
--- a/src/helpers/urlAudioDownloader.js
+++ b/src/helpers/urlAudioDownloader.js
@@ -1064,20 +1064,37 @@ function streamToFile(
       bail(Object.assign(new Error("Download stalled"), { code: "DOWNLOAD_FAILED" }));
     });
 
-    const cleanupFile = () => {
-      fileStream.destroy();
-      try {
-        fs.unlinkSync(tempPath);
-      } catch {}
-    };
+    // destroy() returns before the stream's async open finishes, so unlinking
+    // right away can race a pending open into recreating the file. Wait for 'close'.
+    const cleanupFile = () =>
+      new Promise((done) => {
+        const unlink = () =>
+          fs.unlink(tempPath, (e) => {
+            try {
+              if (e && e.code !== "ENOENT") {
+                debugLogger.warn("Failed to remove partial download", {
+                  tempPath,
+                  error: e.message,
+                });
+              }
+            } finally {
+              done();
+            }
+          });
+        if (fileStream.closed) {
+          unlink();
+          return;
+        }
+        fileStream.once("close", unlink);
+        fileStream.destroy();
+      });
 
     const bail = (err) => {
       if (settled) return;
       settled = true;
       stall.clear();
       if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
-      cleanupFile();
-      reject(err);
+      cleanupFile().then(() => reject(err));
     };
 
     // React to cancel even while stalled (no data events arriving).
@@ -1132,9 +1149,10 @@ function streamToFile(
         const sizeBytes = fs.statSync(tempPath).size;
         resolve(sizeBytes);
       } catch {
-        cleanupFile();
-        reject(
-          Object.assign(new Error("Download produced no output"), { code: "DOWNLOAD_FAILED" })
+        cleanupFile().then(() =>
+          reject(
+            Object.assign(new Error("Download produced no output"), { code: "DOWNLOAD_FAILED" })
+          )
         );
       }
     });

--- a/test/helpers/urlAudioDownloader.test.js
+++ b/test/helpers/urlAudioDownloader.test.js
@@ -872,6 +872,78 @@ test("downloadDirect rejects with DOWNLOAD_CANCELLED on mid-stream abort and cle
   assert.deepEqual(listOwUrlTempFiles(), before, "cancelled download must remove its temp file");
 });
 
+test("downloadDirect defers a cancelled download's rejection until the write stream closed", async () => {
+  const before = listOwUrlTempFiles();
+  const ac = new AbortController();
+  const order = [];
+  let releaseOpen;
+  const openGate = new Promise((r) => (releaseOpen = r));
+  let onAborted;
+  const aborted = new Promise((r) => (onAborted = r));
+  const realCreate = fs.createWriteStream;
+
+  // Hold the stream's async open past cancellation: the window where cleanup
+  // used to unlink before the file existed, orphaning it.
+  fs.createWriteStream = (p, opts) => {
+    const ws = realCreate(p, {
+      ...opts,
+      fs: {
+        open: (...args) => {
+          const cb = args[args.length - 1];
+          openGate.then(() => fs.open(...args.slice(0, -1), cb));
+        },
+        write: fs.write.bind(fs),
+        writev: fs.writev.bind(fs),
+        close: fs.close.bind(fs),
+      },
+    });
+    ws.once("close", () => order.push("close"));
+    return ws;
+  };
+
+  try {
+    await withFakeHttps(
+      (parsed, options) =>
+        options.method === "HEAD"
+          ? { response: makeDirectResponse({ statusCode: 405 }) }
+          : {
+              response: makeDirectResponse({ headers: { "content-type": "audio/mpeg" } }),
+              after: (response) => {
+                response.emit("data", { length: 1024 });
+                ac.abort();
+                onAborted();
+              },
+            },
+      async () => {
+        let settled = null;
+        const done = downloader
+          .download("https://93.184.216.34/file.mp3", null, ac.signal)
+          .then(
+            () => (settled = "resolved"),
+            (err) => {
+              order.push("rejected");
+              settled = err;
+            }
+          );
+
+        await aborted;
+        for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+        assert.equal(settled, null, "cancel must not settle while the open is still pending");
+
+        releaseOpen();
+        await done;
+        assert.equal(settled.code, "DOWNLOAD_CANCELLED");
+        assert.deepEqual(order, ["close", "rejected"]);
+      }
+    );
+  } finally {
+    fs.createWriteStream = realCreate;
+    releaseOpen();
+  }
+
+  assert.deepEqual(listOwUrlTempFiles(), before, "a late open must not orphan a temp file");
+});
+
 // --- selectYtDlpOutput: finished-file selection + transient cleanup ---
 
 function mkSelectDir() {


### PR DESCRIPTION
## Summary
Cancelling a URL audio download could leave an orphan `ow-url-*` file in the temp dir. `fs.createWriteStream()` opens its destination asynchronously, and the cleanup path in `streamToFile` (`src/helpers/urlAudioDownloader.js`) called `destroy()` and unlinked the file right away: if cancellation landed before the open completed, the unlink hit ENOENT and the pending open then created the file after cleanup had already run. Cancellation also settled before the stream was actually closed.

Cleanup now waits for the stream's `close` event (Node defers destruction until a pending open completes, and `close` only fires after the fd is closed), then unlinks the file, ignoring ENOENT and logging any other unlink error, and only then rejects with the original error. A regression test reproduces the race deterministically by gating the stream's open through the `fs` option override of `createWriteStream`; it fails on the previous code.

Fixes #1197

## Changes
- src/helpers/urlAudioDownloader.js: `cleanupFile` in `streamToFile` is now async — destroys the stream, waits for `close`, then unlinks (ENOENT ignored, other errors logged); `bail` and the `finish` stat-failure path reject only after cleanup completes.
- test/helpers/urlAudioDownloader.test.js: regression test that holds the write stream's open past cancellation and asserts the rejection happens only after `close`, with no leftover temp file.