### PR TITLE
fix(macos): resolve ffmpeg/ffprobe on Nix-managed setups (#912)

### DIFF
--- a/main.js
+++ b/main.js
@@ -341,24 +341,19 @@ const AUTH_BRIDGE_HOST = "127.0.0.1";
 const AUTH_BRIDGE_PORT = parseAuthBridgePort();
 const AUTH_BRIDGE_PATH = "/oauth/callback";
 
-// Set up PATH for production builds to find system tools (whisper.cpp, ffmpeg)
+// Set up PATH for production builds to find system tools (whisper.cpp, ffmpeg,
+// and the ffprobe that yt-dlp shells out to). GUI apps on macOS/Linux are
+// launched by launchd/systemd with a minimal PATH that never sources the user's
+// shell profile, so tools installed by Homebrew or Nix are invisible. Rebuild
+// PATH from the real login-shell PATH plus known extra locations so child
+// processes inherit somewhere they can actually find these binaries.
 function setupProductionPath() {
-  if (process.platform === "darwin" && process.env.NODE_ENV !== "development") {
-    const commonPaths = [
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-      "/usr/bin",
-      "/bin",
-      "/usr/sbin",
-      "/sbin",
-    ];
+  if (process.platform === "win32" || process.env.NODE_ENV === "development") return;
 
-    const currentPath = process.env.PATH || "";
-    const pathsToAdd = commonPaths.filter((p) => !currentPath.includes(p));
-
-    if (pathsToAdd.length > 0) {
-      process.env.PATH = `${currentPath}:${pathsToAdd.join(":")}`;
-    }
+  const { buildAugmentedPath } = require("./src/helpers/systemBinaryPath");
+  const augmented = buildAugmentedPath();
+  if (augmented) {
+    process.env.PATH = augmented;
   }
 }
 

--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { app } = require("electron");
 
@@ -323,6 +324,10 @@ class DebugLogger {
         "/usr/local/bin/ffmpeg",
         "/opt/homebrew/bin/ffmpeg",
         "/usr/bin/ffmpeg",
+        // Nix / nix-darwin install locations, which a launchd PATH never sees.
+        "/run/current-system/sw/bin/ffmpeg",
+        path.join(os.homedir(), ".nix-profile", "bin", "ffmpeg"),
+        "/nix/var/nix/profiles/default/bin/ffmpeg",
       ].filter(Boolean);
     }
 

--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -2,6 +2,7 @@ const { spawn } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const debugLogger = require("./debugLogger");
+const { findSystemBinary } = require("./systemBinaryPath");
 
 let cachedFFmpegPath = null;
 
@@ -55,38 +56,13 @@ function getFFmpegPath() {
     debugLogger.debug("Bundled FFmpeg not available", { error: err.message });
   }
 
-  const systemCandidates =
-    process.platform === "darwin"
-      ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-      : process.platform === "win32"
-        ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-        : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
-
-  for (const candidate of systemCandidates) {
-    if (fs.existsSync(candidate)) {
-      cachedFFmpegPath = candidate;
-      return candidate;
-    }
-  }
-
-  const pathEnv = process.env.PATH || "";
-  const pathSep = process.platform === "win32" ? ";" : ":";
-  const pathDirs = pathEnv.split(pathSep).map((entry) => entry.replace(/^"|"$/g, ""));
-  const pathBinary = process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
-
-  for (const dir of pathDirs) {
-    if (!dir) continue;
-    const candidate = path.join(dir, pathBinary);
-    if (!fs.existsSync(candidate)) continue;
-    if (process.platform !== "win32") {
-      try {
-        fs.accessSync(candidate, fs.constants.X_OK);
-      } catch {
-        continue;
-      }
-    }
-    cachedFFmpegPath = candidate;
-    return candidate;
+  // Fall back to a system FFmpeg. findSystemBinary probes the inherited PATH,
+  // the login-shell PATH, and known extra locations (Homebrew, Nix), so this
+  // works even when the app was launched by launchd/systemd with a minimal PATH.
+  const systemFFmpeg = findSystemBinary("ffmpeg");
+  if (systemFFmpeg) {
+    cachedFFmpegPath = systemFFmpeg;
+    return systemFFmpeg;
   }
 
   debugLogger.debug("FFmpeg not found");

--- a/src/helpers/systemBinaryPath.js
+++ b/src/helpers/systemBinaryPath.js
@@ -1,0 +1,153 @@
+// Resolving system tools (ffmpeg, ffprobe, whisper.cpp, ...) on macOS and Linux
+// is more than checking a couple of hardcoded paths. GUI apps are launched by
+// launchd/systemd with a minimal PATH that never sources the user's shell
+// profile, so anything installed by Homebrew or Nix is invisible to
+// process.env.PATH. This resolver combines the inherited PATH, the real
+// login-shell PATH, and known extra install locations, and keeps the resolution
+// logic injectable so it can be unit-tested without a real filesystem.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const childProcess = require("child_process");
+
+// Common non-standard bin directories a GUI-launched app would otherwise miss.
+// Nix (including nix-darwin) installs here, which is why ffmpeg/ffprobe are not
+// found at the usual Homebrew/system locations on those machines.
+function extraBinDirs(platform, homedir) {
+  if (platform === "win32") return ["C:\\ffmpeg\\bin"];
+
+  const nix = [
+    "/run/current-system/sw/bin", // nix-darwin / NixOS system profile
+    path.posix.join(homedir, ".nix-profile", "bin"), // per-user nix profile
+    "/nix/var/nix/profiles/default/bin", // default nix profile
+  ];
+
+  const base =
+    platform === "darwin"
+      ? ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+      : ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+  return [...base, ...nix];
+}
+
+function splitPath(value, sep) {
+  return String(value || "")
+    .split(sep)
+    .map((entry) => entry.replace(/^"|"$/g, "").trim())
+    .filter(Boolean);
+}
+
+let cachedShellDirs;
+
+// Ask the user's login shell for the PATH it would actually use. This is the
+// standard Electron-on-macOS fix for launchd's minimal PATH. Best-effort:
+// returns [] on Windows, on error, or if nothing usable comes back. Cached
+// because spawning a login shell is relatively expensive.
+function loginShellPathDirs(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const env = opts.env || process.env;
+  const exec = opts.exec || childProcess.execFileSync;
+
+  if (opts.clearCache) cachedShellDirs = undefined;
+  if (cachedShellDirs !== undefined) return cachedShellDirs;
+  if (platform === "win32") {
+    cachedShellDirs = [];
+    return cachedShellDirs;
+  }
+
+  const shell = env.SHELL || "/bin/zsh";
+  try {
+    // A sentinel keeps us from being fooled by banners or rc-file chatter that
+    // an interactive login shell may print before the PATH line.
+    const out = exec(shell, ["-lic", 'printf "__OW_PATH__=%s\\n" "$PATH"'], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const match = /__OW_PATH__=(.*)/.exec(String(out || ""));
+    cachedShellDirs = match ? splitPath(match[1], ":") : [];
+  } catch {
+    cachedShellDirs = [];
+  }
+  return cachedShellDirs;
+}
+
+// Reset the login-shell PATH cache. Exposed for tests and for callers that know
+// the environment changed.
+function clearShellPathCache() {
+  cachedShellDirs = undefined;
+}
+
+// Ordered, de-duplicated directories to search for a system binary: inherited
+// PATH first, then the login-shell PATH, then the known extra locations.
+function systemBinDirs(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const env = opts.env || process.env;
+  const homedir = opts.homedir || os.homedir();
+  const sep = platform === "win32" ? ";" : ":";
+
+  const dirs = [
+    ...splitPath(env.PATH, sep),
+    ...loginShellPathDirs({ ...opts, platform, env }),
+    ...extraBinDirs(platform, homedir),
+  ];
+
+  const seen = new Set();
+  const out = [];
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    out.push(dir);
+  }
+  return out;
+}
+
+function defaultIsExecutable(candidate) {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Resolve an executable by name across systemBinDirs. Returns the absolute path
+// or null. Filesystem access is injectable so the ordering/matching logic is
+// unit-testable without touching the real disk.
+function findSystemBinary(binaryName, opts = {}) {
+  const platform = opts.platform || process.platform;
+  const existsSync = opts.existsSync || fs.existsSync;
+  const isExecutable = opts.isExecutable || defaultIsExecutable;
+
+  const name =
+    platform === "win32" && !binaryName.endsWith(".exe") ? `${binaryName}.exe` : binaryName;
+  const join = platform === "win32" ? path.win32.join : path.posix.join;
+
+  for (const dir of systemBinDirs(opts)) {
+    const candidate = join(dir, name);
+    if (!existsSync(candidate)) continue;
+    if (platform !== "win32" && !isExecutable(candidate)) continue;
+    return candidate;
+  }
+  return null;
+}
+
+// Build a PATH string that includes the login-shell PATH and the known extra
+// dirs, so child processes (yt-dlp -> ffprobe, whisper.cpp) inherit a PATH that
+// can actually find system tools even when the app was launched with a minimal
+// one.
+function buildAugmentedPath(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const sep = platform === "win32" ? ";" : ":";
+  return systemBinDirs(opts).join(sep);
+}
+
+module.exports = {
+  extraBinDirs,
+  loginShellPathDirs,
+  clearShellPathCache,
+  systemBinDirs,
+  findSystemBinary,
+  buildAugmentedPath,
+};

--- a/src/helpers/whisper.js
+++ b/src/helpers/whisper.js
@@ -11,6 +11,7 @@ const {
 } = require("./downloadUtils");
 const WhisperServerManager = require("./whisperServer");
 const { getModelsDirForService } = require("./modelDirUtils");
+const { findSystemBinary } = require("./systemBinaryPath");
 
 const modelRegistryData = require("../models/modelRegistryData.json");
 
@@ -745,22 +746,14 @@ class WhisperManager {
       debugLogger.warn("Bundled FFmpeg not available", { error: err.message });
     }
 
-    // Try system FFmpeg paths
-    const systemCandidates =
-      process.platform === "darwin"
-        ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-        : process.platform === "win32"
-          ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-          : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
-
-    debugLogger.debug("Trying system FFmpeg candidates", { candidates: systemCandidates });
-
-    for (const candidate of systemCandidates) {
-      if (fs.existsSync(candidate)) {
-        debugLogger.debug("Found system FFmpeg", { path: candidate });
-        this.cachedFFmpegPath = candidate;
-        return candidate;
-      }
+    // Fall back to a system FFmpeg. findSystemBinary probes the inherited PATH,
+    // the login-shell PATH, and known extra locations (Homebrew, Nix), so this
+    // works even when launchd/systemd started the app with a minimal PATH.
+    const systemFFmpeg = findSystemBinary("ffmpeg");
+    if (systemFFmpeg) {
+      debugLogger.debug("Found system FFmpeg", { path: systemFFmpeg });
+      this.cachedFFmpegPath = systemFFmpeg;
+      return systemFFmpeg;
     }
 
     debugLogger.error("FFmpeg not found anywhere");

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -10,6 +10,7 @@ const { killProcess } = require("../utils/process");
 const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { convertToWav } = require("./ffmpegUtils");
+const { findSystemBinary } = require("./systemBinaryPath");
 const sidecarPidFile = require("./sidecarPidFile");
 const { sanitizeWhisperVadConfig, DEFAULT_WHISPER_VAD_CONFIG } = require("./whisperVadConfig");
 
@@ -270,39 +271,13 @@ class WhisperServerManager extends EventEmitter {
       debugLogger.debug("Bundled FFmpeg not available", { error: err.message });
     }
 
-    // Try system FFmpeg locations
-    const systemCandidates =
-      process.platform === "darwin"
-        ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-        : process.platform === "win32"
-          ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-          : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
-
-    for (const candidate of systemCandidates) {
-      if (fs.existsSync(candidate)) {
-        this.cachedFFmpegPath = candidate;
-        return candidate;
-      }
-    }
-
-    const pathEnv = process.env.PATH || "";
-    const pathSep = process.platform === "win32" ? ";" : ":";
-    const pathDirs = pathEnv.split(pathSep).map((entry) => entry.replace(/^"|"$/g, ""));
-    const pathBinary = process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
-
-    for (const dir of pathDirs) {
-      if (!dir) continue;
-      const candidate = path.join(dir, pathBinary);
-      if (!fs.existsSync(candidate)) continue;
-      if (process.platform !== "win32") {
-        try {
-          fs.accessSync(candidate, fs.constants.X_OK);
-        } catch {
-          continue;
-        }
-      }
-      this.cachedFFmpegPath = candidate;
-      return candidate;
+    // Fall back to a system FFmpeg. findSystemBinary probes the inherited PATH,
+    // the login-shell PATH, and known extra locations (Homebrew, Nix), so this
+    // works even when launchd/systemd started the app with a minimal PATH.
+    const systemFFmpeg = findSystemBinary("ffmpeg");
+    if (systemFFmpeg) {
+      this.cachedFFmpegPath = systemFFmpeg;
+      return systemFFmpeg;
     }
 
     debugLogger.debug("FFmpeg not found");

--- a/test/helpers/systemBinaryPath.test.js
+++ b/test/helpers/systemBinaryPath.test.js
@@ -1,0 +1,141 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  extraBinDirs,
+  findSystemBinary,
+  systemBinDirs,
+  buildAugmentedPath,
+} = require("../../src/helpers/systemBinaryPath");
+
+const NIX_FFMPEG = "/run/current-system/sw/bin/ffmpeg";
+const NIX_FFPROBE = "/run/current-system/sw/bin/ffprobe";
+
+// A minimal PATH is exactly what launchd hands a GUI-launched Electron app on
+// macOS: no Homebrew, no Nix, no user profile.
+const LAUNCHD_MINIMAL_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+// exec stub standing in for a login shell that reports a Nix-augmented PATH.
+function loginShellReturning(pathValue) {
+  return () => `__OW_PATH__=${pathValue}\n`;
+}
+
+// existsSync stub: only the listed absolute paths exist.
+function existsAmong(...present) {
+  const set = new Set(present);
+  return (candidate) => set.has(candidate);
+}
+
+test("regression: the old hardcoded darwin list misses a Nix ffmpeg", () => {
+  // This mirrors the exact detection the code used before the fix.
+  const oldDarwinCandidates = ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
+  const oldPathScanDirs = LAUNCHD_MINIMAL_PATH.split(":");
+  const exists = existsAmong(NIX_FFMPEG, NIX_FFPROBE);
+
+  const foundViaOldList = oldDarwinCandidates.find((c) => exists(c)) || null;
+  const foundViaOldPathScan =
+    oldPathScanDirs.map((d) => `${d}/ffmpeg`).find((c) => exists(c)) || null;
+
+  assert.equal(foundViaOldList, null, "old hardcoded list should not find the Nix ffmpeg");
+  assert.equal(foundViaOldPathScan, null, "scanning launchd's minimal PATH should not find it");
+});
+
+test("findSystemBinary finds a Nix ffmpeg via the extra bin dirs", () => {
+  const found = findSystemBinary("ffmpeg", {
+    platform: "darwin",
+    env: { PATH: LAUNCHD_MINIMAL_PATH },
+    homedir: "/Users/nixuser",
+    exec: () => {
+      throw new Error("no login shell available");
+    },
+    existsSync: existsAmong(NIX_FFMPEG),
+    isExecutable: () => true,
+    clearCache: true,
+  });
+
+  assert.equal(found, NIX_FFMPEG);
+});
+
+test("findSystemBinary finds ffprobe via the login-shell PATH", () => {
+  // The bundled ffmpeg-static ships no ffprobe, so this is the binary yt-dlp
+  // actually fails on. A login shell that exposes the Nix profile fixes it.
+  const found = findSystemBinary("ffprobe", {
+    platform: "darwin",
+    env: { PATH: LAUNCHD_MINIMAL_PATH, SHELL: "/bin/zsh" },
+    homedir: "/Users/nixuser",
+    exec: loginShellReturning("/run/current-system/sw/bin:/usr/bin:/bin"),
+    existsSync: existsAmong(NIX_FFPROBE),
+    isExecutable: () => true,
+    clearCache: true,
+  });
+
+  assert.equal(found, NIX_FFPROBE);
+});
+
+test("findSystemBinary skips a match that is not executable", () => {
+  const found = findSystemBinary("ffmpeg", {
+    platform: "darwin",
+    env: { PATH: LAUNCHD_MINIMAL_PATH },
+    homedir: "/Users/nixuser",
+    exec: () => {
+      throw new Error("no login shell");
+    },
+    existsSync: existsAmong(NIX_FFMPEG),
+    isExecutable: () => false,
+    clearCache: true,
+  });
+
+  assert.equal(found, null);
+});
+
+test("findSystemBinary appends .exe and honors the win32 fallback dir", () => {
+  const winFfmpeg = "C:\\ffmpeg\\bin\\ffmpeg.exe";
+  const found = findSystemBinary("ffmpeg", {
+    platform: "win32",
+    env: { PATH: "C:\\Windows\\system32" },
+    homedir: "C:\\Users\\me",
+    existsSync: existsAmong(winFfmpeg),
+    clearCache: true,
+  });
+
+  assert.equal(found, winFfmpeg);
+});
+
+test("extraBinDirs lists the common Nix locations on darwin", () => {
+  const dirs = extraBinDirs("darwin", "/Users/nixuser");
+  assert.ok(dirs.includes("/run/current-system/sw/bin"));
+  assert.ok(dirs.includes("/Users/nixuser/.nix-profile/bin"));
+  assert.ok(dirs.includes("/nix/var/nix/profiles/default/bin"));
+  assert.ok(dirs.includes("/opt/homebrew/bin"));
+});
+
+test("systemBinDirs de-duplicates while preserving priority order", () => {
+  const dirs = systemBinDirs({
+    platform: "darwin",
+    env: { PATH: "/usr/bin:/bin", SHELL: "/bin/zsh" },
+    homedir: "/Users/nixuser",
+    exec: loginShellReturning("/usr/bin:/run/current-system/sw/bin"),
+    clearCache: true,
+  });
+
+  // Inherited PATH entries come first and are not repeated by the login shell.
+  assert.equal(dirs.indexOf("/usr/bin"), 0);
+  assert.equal(dirs.filter((d) => d === "/usr/bin").length, 1);
+  assert.ok(dirs.includes("/run/current-system/sw/bin"));
+});
+
+test("buildAugmentedPath injects Nix dirs a launchd PATH is missing", () => {
+  const augmented = buildAugmentedPath({
+    platform: "darwin",
+    env: { PATH: LAUNCHD_MINIMAL_PATH, SHELL: "/bin/zsh" },
+    homedir: "/Users/nixuser",
+    exec: loginShellReturning("/run/current-system/sw/bin:/usr/bin"),
+    clearCache: true,
+  });
+
+  const dirs = augmented.split(":");
+  assert.ok(dirs.includes("/run/current-system/sw/bin"));
+  assert.ok(dirs.includes("/Users/nixuser/.nix-profile/bin"));
+  // The original minimal entries survive.
+  assert.ok(dirs.includes("/usr/bin"));
+});


### PR DESCRIPTION
# fix(macos): resolve ffmpeg/ffprobe on Nix-managed setups (#912)

## Summary

Fixes #912. On macOS managed via nix-darwin, transcription fails with
`ffprobe not found (usually installed with ffmpeg)`. This makes ffmpeg/ffprobe
resolution robust instead of relying on a fixed list of Homebrew/system paths.

## Root cause

The reporter diagnosed this precisely, and the code confirms it:

1. ffmpeg detection checked only a hardcoded list (macOS: `/opt/homebrew/bin`,
   `/usr/local/bin`) and then scanned `process.env.PATH`.
2. Electron apps on macOS are launched by launchd, not a shell, so they never
   source `~/.zshrc`/`~/.zshenv`. `process.env.PATH` is a minimal system PATH
   with no Nix profile, so the PATH scan finds nothing either.
3. `setupProductionPath()` in `main.js` only prepended the usual
   Homebrew/system dirs, never the Nix location where ffmpeg actually lives
   (`/run/current-system/sw/bin`).

Because `process.env.PATH` stays minimal, the yt-dlp sidecar that URL audio
download shells out to also cannot find `ffprobe`, which is the binary the
error message names (the bundled `ffmpeg-static` ships ffmpeg only, no ffprobe).

## Changes

- New `src/helpers/systemBinaryPath.js`: a shared resolver that probes, in
  priority order, the inherited PATH, the real login-shell PATH (obtained by
  spawning `$SHELL -lic` once, cached, best-effort), and known extra install
  locations including Homebrew and the common Nix paths
  (`/run/current-system/sw/bin`, `~/.nix-profile/bin`,
  `/nix/var/nix/profiles/default/bin`). Filesystem and shell access are
  injectable so the logic is unit-testable.
- The three existing ffmpeg resolvers (`ffmpegUtils.js`, `whisper.js`,
  `whisperServer.js`) now delegate their system fallback to
  `findSystemBinary("ffmpeg")` instead of their own hardcoded lists. Bundled
  `ffmpeg-static` resolution is unchanged and still takes priority.
- `setupProductionPath()` in `main.js` rebuilds `process.env.PATH` from the
  login-shell PATH plus those extra locations, so child processes
  (yt-dlp then ffprobe, whisper.cpp) inherit a PATH they can actually resolve
  tools from. Still a no-op on Windows and in development.
- `debugLogger.js` ffmpeg diagnostics now also probe the Nix paths, so debug
  logs attached to future reports show whether a Nix ffmpeg is present.

The Windows `C:\ffmpeg\bin` fallback and the executable-bit check on Unix are
preserved by the resolver.

## Verification / Evidence

Added `test/helpers/systemBinaryPath.test.js`, run with the repo's harness
(`node --test`). It reproduces the bug at the logic level: with a launchd-style
minimal PATH, the old hardcoded darwin list and PATH scan miss a Nix ffmpeg,
while the new resolver finds ffmpeg (and ffprobe) via the extra dirs and the
login-shell PATH.

```
node --test test/helpers/systemBinaryPath.test.js

ok 1 - regression: the old hardcoded darwin list misses a Nix ffmpeg
ok 2 - findSystemBinary finds a Nix ffmpeg via the extra bin dirs
ok 3 - findSystemBinary finds ffprobe via the login-shell PATH
ok 4 - findSystemBinary skips a match that is not executable
ok 5 - findSystemBinary appends .exe and honors the win32 fallback dir
ok 6 - extraBinDirs lists the common Nix locations on darwin
ok 7 - systemBinDirs de-duplicates while preserving priority order
ok 8 - buildAugmentedPath injects Nix dirs a launchd PATH is missing
# tests 8
# pass 8
# fail 0
```

`node --check` passes on every touched file.

### What I could not verify

I do not have access to a macOS or Nix machine, so I could not live-reproduce
the original failure or confirm the fix end to end on a real nix-darwin install.
Verification is at the logic level via the unit test above. The remaining
resolver files import `electron`, which is not installed in my environment, so I
did not run the full `npm test`/lint/build suite; the new resolver and its test
have no electron dependency and run clean. A maintainer on macOS/Nix should
confirm a real transcription and URL download once merged.

## AI assistance disclosure

This change was prepared with AI assistance (Claude) and reviewed before
submission.
