### PR TITLE
fix(models): normalize self-hosted model discovery URL to /v1 (#1187)

### DIFF
--- a/src/components/OpenAICompatiblePanel.tsx
+++ b/src/components/OpenAICompatiblePanel.tsx
@@ -5,7 +5,7 @@ import { Input } from "./ui/input";
 import ApiKeyInput from "./ui/ApiKeyInput";
 import ModelCardList from "./ui/ModelCardList";
 import SearchableModelList, { MODEL_SEARCH_THRESHOLD } from "./ui/SearchableModelList";
-import { buildApiUrl, normalizeBaseUrl } from "../config/constants";
+import { buildModelsUrl, normalizeBaseUrl } from "../config/constants";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { GetApiKeyLink } from "./ui/GetApiKeyLink";
 
@@ -134,7 +134,7 @@ export default function OpenAICompatiblePanel({
           headers.Authorization = `Bearer ${effectiveKey}`;
         }
 
-        const modelsUrl = buildApiUrl(normalized, "/models");
+        const modelsUrl = buildModelsUrl(normalized);
         const response = await fetch(modelsUrl, { method: "GET", headers });
 
         if (!response.ok) {
@@ -249,7 +249,7 @@ export default function OpenAICompatiblePanel({
   }, [applyBase, isDraftDirty, trimmedDraft, loadRemoteModels]);
 
   const displayedModels = isDraftDirty ? [] : modelOptions;
-  const queryUrl = hasBase ? `${normalizedBase}/models` : `${baseUrlPlaceholder}/models`;
+  const queryUrl = buildModelsUrl(hasBase ? normalizedBase : baseUrlPlaceholder);
 
   return (
     <>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -43,6 +43,13 @@ export const ensureV1Suffix = (base: string): string => {
   return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
 };
 
+// The OpenAI-compatible model list lives at `<base>/v1/models`. A user who
+// enters just the server root (e.g. LM Studio's `http://127.0.0.1:1234`) needs
+// the `/v1` added, while an explicit `/v1` or `/api/v1` must be kept as-is.
+// Mirrors ensureV1Suffix so discovery targets the same endpoint inference does.
+export const buildModelsUrl = (base: string): string =>
+  buildApiUrl(ensureV1Suffix(base), "/models");
+
 const env = (typeof import.meta !== "undefined" && (import.meta as any).env) || {};
 
 const computeBaseUrl = (candidates: Array<string | undefined>, fallback: string): string => {

--- a/test/helpers/openaiCompatibleModelsUrl.test.js
+++ b/test/helpers/openaiCompatibleModelsUrl.test.js
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+
+// Regression for #1187: the OpenAI-compatible model list (Self-Hosted / Custom
+// providers, e.g. LM Studio) must be discovered at `<base>/v1/models`. A user
+// who enters only the server root (`http://127.0.0.1:1234`) previously hit
+// `/models` with no version segment, so LM Studio never returned its list and
+// the UI showed "No models returned". The inference path already runs the base
+// through ensureV1Suffix; model discovery has to do the same.
+
+test("buildModelsUrl appends /v1 for a bare host:port", async () => {
+  const { buildModelsUrl } = await import("../../src/config/constants.ts");
+  assert.equal(buildModelsUrl("http://127.0.0.1:1234"), "http://127.0.0.1:1234/v1/models");
+  assert.equal(buildModelsUrl("http://127.0.0.1:1234/"), "http://127.0.0.1:1234/v1/models");
+});
+
+test("buildModelsUrl keeps an explicit /v1 without duplicating it", async () => {
+  const { buildModelsUrl } = await import("../../src/config/constants.ts");
+  assert.equal(buildModelsUrl("http://127.0.0.1:1234/v1"), "http://127.0.0.1:1234/v1/models");
+});
+
+test("buildModelsUrl respects an explicit /api/v1 path", async () => {
+  const { buildModelsUrl } = await import("../../src/config/constants.ts");
+  assert.equal(
+    buildModelsUrl("http://127.0.0.1:1234/api/v1"),
+    "http://127.0.0.1:1234/api/v1/models"
+  );
+});
+
+test("buildModelsUrl matches the endpoint the inference layer targets (ensureV1Suffix)", async () => {
+  const { buildModelsUrl, ensureV1Suffix, buildApiUrl } = await import(
+    "../../src/config/constants.ts"
+  );
+  for (const base of [
+    "http://127.0.0.1:1234",
+    "http://127.0.0.1:1234/v1",
+    "http://127.0.0.1:1234/api/v1",
+  ]) {
+    assert.equal(buildModelsUrl(base), buildApiUrl(ensureV1Suffix(base), "/models"));
+  }
+});


### PR DESCRIPTION
# fix(reasoning): discover custom models at `<base>/v1/models` for bare endpoints

Closes #1187

## What was wrong

When you point Dictation Cleanup at a self-hosted OpenAI-compatible server (LM Studio, Ollama, etc.) and enter just the server root, for example `http://127.0.0.1:1234`, the model list never loads. The panel shows "No models returned. Check your endpoint URL." even though the server is running and reachable. You only get a list if you spell the version segment out yourself (`.../v1` or `.../api/v1`).

## Root cause

`OpenAICompatiblePanel` built the discovery URL with `buildApiUrl(base, "/models")`. For a bare host that produces `http://127.0.0.1:1234/models`, with no `/v1` segment, which is not where an OpenAI-compatible server exposes its model list. The request comes back empty, the parser maps zero models, and the UI falls through to the "No models returned" hint.

The inference path does not have this problem: it already runs the base through `ensureV1Suffix` (see `lan.ts`, `openaiBase.ts`, `ReasoningService.ts`), so dictation cleanup requests succeed against a bare host. Model discovery was the one place that skipped that normalization, so a bare base could run cleanup but never populate its own model picker. This is a URL-construction bug, not a response-parsing bug: the existing parser handles the standard `{ "data": [ { "id": ... } ] }` shape correctly.

## The fix

Add a small `buildModelsUrl` helper in `config/constants.ts` that mirrors `ensureV1Suffix` and use it for both the fetch and the query URL shown in the panel:

- bare `http://127.0.0.1:1234` -> `http://127.0.0.1:1234/v1/models`
- explicit `http://127.0.0.1:1234/v1` -> `http://127.0.0.1:1234/v1/models` (kept, not duplicated)
- explicit `http://127.0.0.1:1234/api/v1` -> `http://127.0.0.1:1234/api/v1/models` (respected)

Discovery now targets the same endpoint the inference layer already uses.

## Files changed

- `src/config/constants.ts` - new `buildModelsUrl` helper
- `src/components/OpenAICompatiblePanel.tsx` - use it for the fetch and the displayed query URL
- `test/helpers/openaiCompatibleModelsUrl.test.js` - new unit test

## Verification

New unit test (`node --test`), added first and watched fail before the fix (`buildModelsUrl is not a function`), then pass after:

```
ok 1 - buildModelsUrl appends /v1 for a bare host:port
ok 2 - buildModelsUrl keeps an explicit /v1 without duplicating it
ok 3 - buildModelsUrl respects an explicit /api/v1 path
ok 4 - buildModelsUrl matches the endpoint the inference layer targets (ensureV1Suffix)
# tests 4
# pass 4
# fail 0
```

Runtime check of the shipped helper against the three reported inputs:

```
"http://127.0.0.1:1234"        -> http://127.0.0.1:1234/v1/models
"http://127.0.0.1:1234/v1"     -> http://127.0.0.1:1234/v1/models
"http://127.0.0.1:1234/api/v1" -> http://127.0.0.1:1234/api/v1/models
```

The change is limited to URL construction, so no behavior changes for endpoints that already included the version segment.

## Note on AI assistance

This change was prepared with AI assistance (Claude) and reviewed before submission.
