### PR TITLE
fix(logging): keep main-process logs off stdout in packaged builds

### DIFF
--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -31,6 +31,12 @@ const readArgLogLevel = () => {
   return null;
 };
 
+// True when the user explicitly asked for a log level (CLI arg or env). We treat
+// that as opt-in to console output even in packaged builds, so the app stays
+// debuggable from a terminal on demand.
+const hasExplicitLogLevel = () =>
+  readArgLogLevel() != null || Boolean(process.env.OPENWHISPR_LOG_LEVEL || process.env.LOG_LEVEL);
+
 class DebugLogger {
   constructor() {
     this.logLevel = this.resolveLogLevel();
@@ -40,6 +46,7 @@ class DebugLogger {
     this.logStream = null;
     this.fileLoggingEnabled = false;
     this.fileLoggingPending = this.debugMode; // Track if we need to initialize file logging later
+    this.consoleLoggingEnabled = this.resolveConsoleLogging();
 
     // IMPORTANT: Do NOT call initializeFileLogging() here!
     // It uses app.getPath() which is unsafe before app.whenReady().
@@ -110,8 +117,29 @@ class DebugLogger {
     return "info";
   }
 
+  // Decide whether logs may go to the console (stdout/stderr). Packaged builds
+  // must not: when the app is launched from a terminal, or spawned by one (a
+  // shell, VS Code, Claude Code), the main process inherits that console's stdio
+  // and every log line pollutes it. Users read that noise as dictation text
+  // typed into the focused window (#1075) or as CLI-session spam (#1058). File
+  // logging is unaffected. Dev builds keep console output, and an explicit
+  // --log-level or OPENWHISPR_LOG_LEVEL opts a packaged build back in for
+  // on-demand debugging.
+  resolveConsoleLogging() {
+    if (hasExplicitLogLevel()) return true;
+    try {
+      if (app && typeof app.isPackaged === "boolean") {
+        return !app.isPackaged;
+      }
+    } catch {}
+    // app state unavailable (unit tests, very early boot): mirror the dev signals
+    // main.js uses so development console output is never accidentally silenced.
+    return process.env.NODE_ENV === "development" || Boolean(process.defaultApp);
+  }
+
   refreshLogLevel() {
     const nextLevel = this.resolveLogLevel();
+    this.consoleLoggingEnabled = this.resolveConsoleLogging();
     if (nextLevel === this.logLevel) return;
 
     this.logLevel = nextLevel;
@@ -191,18 +219,20 @@ class DebugLogger {
     const metaText = this.formatMeta(meta);
     const logLine = metaText ? `${baseLine} ${metaText}\n` : `${baseLine}\n`;
 
-    const consoleFn =
-      normalized === "error" || normalized === "fatal"
-        ? console.error
-        : normalized === "warn"
-          ? console.warn
-          : console.log;
+    if (this.consoleLoggingEnabled) {
+      const consoleFn =
+        normalized === "error" || normalized === "fatal"
+          ? console.error
+          : normalized === "warn"
+            ? console.warn
+            : console.log;
 
-    if (meta !== undefined) {
-      // Pass the prefix as a %s arg, not as a format string. See CodeQL js/tainted-format-string.
-      consoleFn("%s", `${levelTag}${scopeTag}${sourceTag} ${message}`, meta);
-    } else {
-      consoleFn(`${levelTag}${scopeTag}${sourceTag} ${message}`);
+      if (meta !== undefined) {
+        // Pass the prefix as a %s arg, not as a format string. See CodeQL js/tainted-format-string.
+        consoleFn("%s", `${levelTag}${scopeTag}${sourceTag} ${message}`, meta);
+      } else {
+        consoleFn(`${levelTag}${scopeTag}${sourceTag} ${message}`);
+      }
     }
 
     if (this.logStream) {

--- a/test/helpers/debugLoggerConsoleGate.test.js
+++ b/test/helpers/debugLoggerConsoleGate.test.js
@@ -1,0 +1,107 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const loggerPath = require.resolve("../../src/helpers/debugLogger.js");
+const originalLoad = Module._load;
+
+// Load a fresh debugLogger singleton with electron's `app` mocked and the
+// process/env shaped for the scenario under test.
+function loadLogger({ isPackaged, argv = [], env = {} } = {}) {
+  const prevArgv = process.argv;
+  const prevEnv = {
+    OPENWHISPR_LOG_LEVEL: process.env.OPENWHISPR_LOG_LEVEL,
+    LOG_LEVEL: process.env.LOG_LEVEL,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  // Start from a clean slate so a debug-level shell running the suite can't
+  // force console logging on and mask a regression.
+  delete process.env.OPENWHISPR_LOG_LEVEL;
+  delete process.env.LOG_LEVEL;
+  delete process.env.NODE_ENV;
+  Object.assign(process.env, env);
+  process.argv = ["node", "main.js", ...argv];
+
+  delete require.cache[loggerPath];
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return { app: { isPackaged } };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(loggerPath);
+  } finally {
+    Module._load = originalLoad;
+    process.argv = prevArgv;
+    delete process.env.OPENWHISPR_LOG_LEVEL;
+    delete process.env.LOG_LEVEL;
+    delete process.env.NODE_ENV;
+    for (const [key, value] of Object.entries(prevEnv)) {
+      if (value !== undefined) process.env[key] = value;
+    }
+  }
+}
+
+function captureConsole(fn) {
+  const calls = [];
+  const original = { log: console.log, warn: console.warn, error: console.error };
+  console.log = (...args) => calls.push(["log", ...args]);
+  console.warn = (...args) => calls.push(["warn", ...args]);
+  console.error = (...args) => calls.push(["error", ...args]);
+  try {
+    fn();
+  } finally {
+    Object.assign(console, original);
+  }
+  return calls;
+}
+
+test("packaged build keeps main-process logs off the console (#1075/#1058)", () => {
+  const logger = loadLogger({ isPackaged: true });
+  assert.equal(logger.consoleLoggingEnabled, false);
+
+  const streamed = [];
+  logger.logStream = { write: (line) => streamed.push(line) };
+
+  // The exact line the reporter saw leaking into the focused window.
+  const calls = captureConsole(() => {
+    logger.info("CLI bridge started", { port: 8200 }, "cli-bridge");
+    logger.warn("something", {}, "meeting");
+    logger.error("boom");
+  });
+
+  assert.deepEqual(calls, [], "nothing reaches stdout/stderr in a packaged build");
+  assert.equal(streamed.length, 3, "logs still go to the file stream");
+  assert.match(streamed[0], /\[INFO\]\[cli-bridge\] CLI bridge started/);
+});
+
+test("dev build still writes logs to the console", () => {
+  const logger = loadLogger({ isPackaged: false });
+  assert.equal(logger.consoleLoggingEnabled, true);
+
+  const calls = captureConsole(() => {
+    logger.info("CLI bridge started", { port: 8200 }, "cli-bridge");
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "log");
+});
+
+test("explicit --log-level re-enables console in a packaged build", () => {
+  const logger = loadLogger({ isPackaged: true, argv: ["--log-level=info"] });
+  assert.equal(logger.consoleLoggingEnabled, true);
+
+  const calls = captureConsole(() => {
+    logger.info("opted in");
+  });
+
+  assert.equal(calls.length, 1);
+});
+
+test("explicit OPENWHISPR_LOG_LEVEL re-enables console in a packaged build", () => {
+  const logger = loadLogger({ isPackaged: true, env: { OPENWHISPR_LOG_LEVEL: "debug" } });
+  assert.equal(logger.consoleLoggingEnabled, true);
+});


### PR DESCRIPTION
Closes #1075
Closes #1058

## What was broken

With a cloud STT provider selected and no local model downloaded, main-process
startup log lines were showing up in the user's active window and reading as
dictation text, for example:

```
[INFO][cli-bridge] CLI bridge started { port: 8200 }
[DEBUG] [HotkeyManager] Setting up hotkey: "Control+Super" for slot "dictation"
[INFO][meeting] Meeting detection engine started { ... }
[INFO] qdrant started successfully { port: 6333 }
```

## Verified root cause

The reporter's hypothesis was that the port-8200 CLI bridge reads stdout and
forwards it to the dictation channel. That mechanism does not exist. At this
HEAD `src/helpers/cliBridge.js` is a loopback REST server whose routes are
notes, folders, and transcriptions CRUD; it never reads stdout and never
touches the paste/type path. The dictation "type into the focused app" path
(`ipcHandlers.js` `paste-text` to `clipboardManager.pasteText`) only ever
receives the renderer's transcription result text, never a log line.

The real vector is the logger. `debugLogger.write()` mirrored every INFO and
higher line to `console.log` / `console.warn` / `console.error` unconditionally,
in addition to the optional log file. A packaged Electron app normally has no
console attached, so this is invisible when the app is double-clicked. But when
the packaged app is launched from, or spawned by, a terminal (a shell, VS Code,
Claude Code), the main process inherits that console's stdio, so those lines
print into whatever window has focus. The exact formatting the reporter saw is
produced by `debugLogger.write()` (`[LEVEL][scope][source] message` plus the
meta object), which confirms the source.

This is the same defect described in #1058 ("main-process INFO logs written to
parent stdout on Windows, pollutes CLI sessions"), viewed from two angles.

## The fix

Gate the logger's console output on packaged state, in `src/helpers/debugLogger.js`:

- Dev builds keep console output (developers expect it).
- Packaged builds write to the log file only, so nothing reaches stdout/stderr.
- An explicit `--log-level` argument or `OPENWHISPR_LOG_LEVEL` / `LOG_LEVEL`
  env var opts a packaged build back in, so the app stays debuggable from a
  terminal on demand.

File logging is unchanged. The gate lives entirely in the logger, so it also
covers the identical stdout pollution in #1058.

## Sibling issue #1058

Recommendation: this PR resolves #1058 as well. Both issues are the same root
cause, the unconditional console output in `debugLogger`. Every routine
startup line the two reports mention flows through `debugLogger.info` /
`debugLogger.debug`, and the gate suppresses all of it in packaged builds.

A handful of direct `console.error` / `console.log` calls remain in the main
process (uncaught-exception and unhandled-rejection handlers in `main.js`,
failure branches in `dragManager.js` and `modelManagerBridge.js`). These are
error-path or user-interaction events, not routine startup logging, and most
target stderr. They do not reproduce either reported symptom, so I left them in
place to preserve crash diagnostics. Fully detaching stdio (the freopen / spawn
detached approach floated in #1058) is not needed to fix either issue and would
sacrifice those diagnostics, so I do not recommend it.

## Verification

Windows 11. Local Node is 22 while the repo pins 24, and dependencies were
installed with `--ignore-scripts`, so the Electron binary, native
`better-sqlite3`, and the TypeScript test loader are absent in this sandbox.
That does not affect the changed file, which is plain JS.

New focused unit test (`test/helpers/debugLoggerConsoleGate.test.js`) asserts
the gate directly: no console output in a packaged build while the file stream
still receives the line, console output preserved in dev, and the explicit
opt-in re-enabling console in a packaged build.

```
$ node --test test/helpers/debugLoggerConsoleGate.test.js
# tests 4
# pass 4
# fail 0
```

```
$ npm run lint
> eslint . && cd src && eslint .
(exit 0)

$ npm run typecheck
> cd src && tsc --noEmit
(exit 0)
```

Full helper suite for context:

```
$ npm test   (node --test "test/helpers/*.test.js")
# tests 396
# pass 307
# fail 74
# skipped 15
```

The 74 failures are all environmental in this sandbox, not from this change:
`Unknown file extension ".ts"` (tests importing `.ts` sources with no TS
loader), `Electron failed to install correctly` (installed with
`--ignore-scripts`), and `better-sqlite3` / `no such module: fts5` (native
module not built). None touch `debugLogger` or console behavior, and the four
new tests pass inside this same run. The gate function is wrapped in try/catch
and always returns a boolean, so it cannot make a previously passing test throw.

## AI-assisted disclosure

This change was investigated and implemented with the help of Claude (Claude
Code). A human reviewed the diff and is submitting the PR.
