### PR TITLE
fix(windows): settle clipboard before fast-paste for long text

### DIFF
--- a/resources/windows-fast-paste.c
+++ b/resources/windows-fast-paste.c
@@ -200,7 +200,11 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    Sleep(10);
+    /* Give the clipboard a moment to settle after Electron's writeText.
+       Long Unicode payloads previously raced SendInput on some Windows 11
+       setups (#829). A short floor here complements the length-scaled delay
+       in clipboard.js; keep it small so short dictation stays snappy. */
+    Sleep(40);
 
     /* Release any modifier keys held by the user's hotkey so they don't
        contaminate the paste keystroke (e.g. Ctrl+Win held → Ctrl+Win+V). */

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -61,6 +61,23 @@ const RESTORE_DELAYS = {
   linux_kde_wayland: 1200,
 };
 
+// Long Unicode payloads need more clipboard settle time before SendInput Ctrl+V
+// on Windows. Without this, windows-fast-paste.exe can report PASTE_OK while the
+// focused app still sees the previous clipboard (#829).
+function windowsPasteSettleMs(textLength) {
+  const len = Number.isFinite(textLength) ? textLength : 0;
+  if (len <= 150) return PASTE_DELAYS.win32_fast;
+  if (len <= 400) return 80;
+  return 120;
+}
+
+function windowsRestoreDelayMs(textLength) {
+  const len = Number.isFinite(textLength) ? textLength : 0;
+  if (len <= 150) return RESTORE_DELAYS.win32_nircmd;
+  if (len <= 400) return 800;
+  return 1000;
+}
+
 function writeClipboardInRenderer(webContents, text) {
   if (!webContents || !webContents.executeJavaScript) {
     return Promise.reject(new Error("Invalid webContents for clipboard write"));
@@ -771,6 +788,10 @@ class ClipboardManager {
       }
       this.safeLog("📋 Text copied to clipboard:", text.substring(0, 50) + "...");
 
+      if (platform === "win32") {
+        await this._ensureClipboardText(text);
+      }
+
       let pasteResult = { restoreComplete: Promise.resolve() };
 
       if (platform === "darwin") {
@@ -978,23 +999,67 @@ class ClipboardManager {
     });
   }
 
+  async _ensureClipboardText(text, { attempts = 8, gapMs = 15 } = {}) {
+    for (let i = 0; i < attempts; i++) {
+      try {
+        if (clipboard.readText() === text) return true;
+      } catch {
+        // Clipboard can briefly throw while another process owns it.
+      }
+      if (i + 1 >= attempts) break;
+      try {
+        clipboard.writeText(text);
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, gapMs));
+    }
+    try {
+      return clipboard.readText() === text;
+    } catch {
+      return false;
+    }
+  }
+
+  _windowsTextLength(options = {}) {
+    return typeof options.expectedClipboardText === "string"
+      ? options.expectedClipboardText.length
+      : 0;
+  }
+
   async pasteWindows(originalClipboard, options = {}) {
+    const textLength = this._windowsTextLength(options);
+    const pasteDelayMs = windowsPasteSettleMs(textLength);
+    const restoreDelayMs = windowsRestoreDelayMs(textLength);
+    const winOptions = { ...options, pasteDelayMs, restoreDelayMs };
+
     const fastPastePath = this.resolveWindowsFastPasteBinary();
 
     if (fastPastePath) {
-      return this.pasteWithFastPaste(fastPastePath, originalClipboard, options);
+      return this.pasteWithFastPaste(fastPastePath, originalClipboard, winOptions);
     }
 
-    return this.pasteWithNircmdOrPowerShell(originalClipboard, options);
+    return this.pasteWithNircmdOrPowerShell(originalClipboard, winOptions);
   }
 
   async pasteWithFastPaste(fastPastePath, originalClipboard, options = {}) {
+    const pasteDelayMs =
+      typeof options.pasteDelayMs === "number"
+        ? options.pasteDelayMs
+        : windowsPasteSettleMs(this._windowsTextLength(options));
+    const restoreDelayMs =
+      typeof options.restoreDelayMs === "number"
+        ? options.restoreDelayMs
+        : windowsRestoreDelayMs(this._windowsTextLength(options));
+
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         let hasTimedOut = false;
         const startTime = Date.now();
 
-        this.safeLog("⚡ Windows fast-paste starting");
+        this.safeLog("⚡ Windows fast-paste starting", {
+          pasteDelayMs,
+          restoreDelayMs,
+          textLength: this._windowsTextLength(options),
+        });
 
         const pasteProcess = spawn(fastPastePath, [], {
           stdio: ["ignore", "pipe", "pipe"],
@@ -1027,7 +1092,7 @@ class ClipboardManager {
             if (originalClipboard != null) {
               resolve({
                 restoreComplete: this._restoreClipboardAfterDelay(originalClipboard, {
-                  delayMs: RESTORE_DELAYS.win32_nircmd,
+                  delayMs: restoreDelayMs,
                   expectedText: options.expectedClipboardText,
                 }),
               });
@@ -1062,7 +1127,7 @@ class ClipboardManager {
           pasteProcess.removeAllListeners();
           this.pasteWithNircmdOrPowerShell(originalClipboard, options).then(resolve).catch(reject);
         }, 2000);
-      }, PASTE_DELAYS.win32_fast);
+      }, pasteDelayMs);
     });
   }
 
@@ -1076,8 +1141,14 @@ class ClipboardManager {
 
   async pasteWithNircmd(nircmdPath, originalClipboard, options = {}) {
     return new Promise((resolve, reject) => {
-      const pasteDelay = PASTE_DELAYS.win32_nircmd;
-      const restoreDelay = RESTORE_DELAYS.win32_nircmd;
+      const pasteDelay =
+        typeof options.pasteDelayMs === "number"
+          ? Math.max(options.pasteDelayMs, PASTE_DELAYS.win32_nircmd)
+          : PASTE_DELAYS.win32_nircmd;
+      const restoreDelay =
+        typeof options.restoreDelayMs === "number"
+          ? options.restoreDelayMs
+          : RESTORE_DELAYS.win32_nircmd;
 
       setTimeout(() => {
         let hasTimedOut = false;
@@ -1148,8 +1219,14 @@ class ClipboardManager {
 
   async pasteWithPowerShell(originalClipboard, options = {}) {
     return new Promise((resolve, reject) => {
-      const pasteDelay = PASTE_DELAYS.win32_pwsh;
-      const restoreDelay = RESTORE_DELAYS.win32_pwsh;
+      const pasteDelay =
+        typeof options.pasteDelayMs === "number"
+          ? Math.max(options.pasteDelayMs, PASTE_DELAYS.win32_pwsh)
+          : PASTE_DELAYS.win32_pwsh;
+      const restoreDelay =
+        typeof options.restoreDelayMs === "number"
+          ? options.restoreDelayMs
+          : RESTORE_DELAYS.win32_pwsh;
 
       setTimeout(() => {
         let hasTimedOut = false;
@@ -2163,5 +2240,8 @@ Would you like to open System Settings now?`;
     };
   }
 }
+
+ClipboardManager.windowsPasteSettleMs = windowsPasteSettleMs;
+ClipboardManager.windowsRestoreDelayMs = windowsRestoreDelayMs;
 
 module.exports = ClipboardManager;

--- a/test/helpers/clipboardRestore.test.js
+++ b/test/helpers/clipboardRestore.test.js
@@ -259,3 +259,88 @@ test("pasteMacOSWithOsascript fallback uses the short macOS restore delay", asyn
     expectedText: "dictated text",
   });
 });
+
+test("windows paste settle and restore delays scale with transcript length (#829)", () => {
+  assert.equal(ClipboardManager.windowsPasteSettleMs(50), 10);
+  assert.equal(ClipboardManager.windowsPasteSettleMs(150), 10);
+  assert.equal(ClipboardManager.windowsPasteSettleMs(151), 80);
+  assert.equal(ClipboardManager.windowsPasteSettleMs(400), 80);
+  assert.equal(ClipboardManager.windowsPasteSettleMs(401), 120);
+  assert.equal(ClipboardManager.windowsPasteSettleMs(520), 120);
+
+  assert.equal(ClipboardManager.windowsRestoreDelayMs(50), 500);
+  assert.equal(ClipboardManager.windowsRestoreDelayMs(151), 800);
+  assert.equal(ClipboardManager.windowsRestoreDelayMs(520), 1000);
+});
+
+test("pasteWithFastPaste uses length-scaled settle and restore delays (#829)", async () => {
+  const spawnCalls = [];
+  const TestClipboardManager = loadClipboardManager({
+    spawn: createSuccessfulSpawn(spawnCalls),
+  });
+  const manager = new TestClipboardManager();
+  const originalClipboard = { type: "text", data: "previous clipboard" };
+  const longText = "x".repeat(520);
+  let restoreCall;
+  let observedPasteDelayMs;
+
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn, ms, ...args) => {
+    if (typeof ms === "number" && ms >= 10 && ms <= 200 && observedPasteDelayMs === undefined) {
+      observedPasteDelayMs = ms;
+    }
+    return originalSetTimeout(fn, ms, ...args);
+  };
+
+  manager._restoreClipboardAfterDelay = (original, options) => {
+    restoreCall = { original, options };
+    return Promise.resolve();
+  };
+
+  try {
+    const result = await manager.pasteWithFastPaste("/tmp/windows-fast-paste.exe", originalClipboard, {
+      expectedClipboardText: longText,
+      pasteDelayMs: TestClipboardManager.windowsPasteSettleMs(longText.length),
+      restoreDelayMs: TestClipboardManager.windowsRestoreDelayMs(longText.length),
+    });
+    await result.restoreComplete;
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].command, "/tmp/windows-fast-paste.exe");
+  assert.equal(observedPasteDelayMs, 120);
+  assert.equal(restoreCall.original, originalClipboard);
+  assert.deepEqual(restoreCall.options, {
+    delayMs: 1000,
+    expectedText: longText,
+  });
+});
+
+test("_ensureClipboardText retries until the clipboard matches (#829)", async () => {
+  resetClipboard();
+  const manager = new ClipboardManager();
+  let writes = 0;
+  const originalWrite = fakeClipboard.writeText.bind(fakeClipboard);
+  fakeClipboard.writeText = (text) => {
+    writes += 1;
+    if (writes < 3) {
+      fakeClipboard.text = "stale";
+      return;
+    }
+    originalWrite(text);
+  };
+
+  try {
+    const ok = await manager._ensureClipboardText("fresh dictation", {
+      attempts: 5,
+      gapMs: 0,
+    });
+    assert.equal(ok, true);
+    assert.equal(fakeClipboard.text, "fresh dictation");
+    assert.ok(writes >= 3);
+  } finally {
+    fakeClipboard.writeText = originalWrite;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #829: on Windows, long transcriptions (~150+ chars) could report a successful auto-paste while the focused app never received the text. Short dictation still worked; manual Ctrl+V worked when Keep transcription in clipboard was on.

Root cause matched a clipboard vs SendInput race: `clipboard.writeText` succeeded, then `windows-fast-paste.exe` fired Ctrl+V after only ~10ms. Larger Unicode payloads need more settle time before the target app reads CF_UNICODETEXT.

## Changes

- Scale Windows paste settle delay by transcript length (10ms / 80ms / 120ms)
- Scale clipboard restore delay the same way (500ms / 800ms / 1000ms)
- After writing the clipboard, retry readback until the expected text is visible
- Raise the native helper's settle floor from 10ms to 40ms in `windows-fast-paste.c` (ships when a new `windows-fast-paste-v*` release is cut; the JS delays apply with the current downloaded binary)

## AI assistance

This PR was prepared with AI assistance (Cursor / Grok). I reviewed the diff, ran the tests below, and take responsibility for the change.

## Evidence

```text
$ node --test test/helpers/clipboardRestore.test.js
✔ restore preserves rich clipboard formats atomically
✔ restore runs when clipboard still contains the pasted text
✔ restore is skipped when another clipboard write wins the race
✔ pasteText waits for prior clipboard restoration before starting the next paste
✔ pasteMacOS restores clipboard after the short macOS delay on successful fast paste
✔ pasteMacOSWithOsascript fallback uses the short macOS restore delay
✔ windows paste settle and restore delays scale with transcript length (#829)
✔ pasteWithFastPaste uses length-scaled settle and restore delays (#829)
✔ _ensureClipboardText retries until the clipboard matches (#829)
ℹ tests 9
ℹ pass 9
ℹ fail 0
ℹ duration_ms 885.8777
```

HEAD still used `PASTE_DELAYS.win32_fast = 10` with no length scaling before this change. No open covering PR for #829 at publish time.

## Test plan

- [x] Unit tests for settle/restore scaling and clipboard readback retry
- [ ] Manual: Windows 11, dictate >200 chars into Notepad with keep-in-clipboard off; confirm auto-paste lands
- [ ] Manual: short dictation (<100 chars) still feels snappy
- [ ] After merging, cut `windows-fast-paste-v1.0.1` so the C settle floor ships in the downloaded binary
