### PR TITLE
fix(ux): surface cloud-only STT posture in tray, settings, and errors

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -464,6 +464,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   saveAllKeysToEnv: () => ipcRenderer.invoke("save-all-keys-to-env"),
   syncStartupPreferences: (prefs) => ipcRenderer.invoke("sync-startup-preferences", prefs),
+  syncSttPosture: (payload) => ipcRenderer.invoke("sync-stt-posture", payload),
 
   // Local reasoning
   processLocalReasoning: (text, modelId, agentName, config) =>

--- a/src/components/CloudOnlyPostureSync.tsx
+++ b/src/components/CloudOnlyPostureSync.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "../stores/settingsStore";
+import { setSttPosture, type SttPosture } from "../stores/sttPostureStore";
+import {
+  hasDownloadedLocalModels,
+  isCloudTranscriptionActive,
+  resolveSttPosture,
+} from "../helpers/sttPosture.js";
+async function loadTranscriptionSecrets(api: Window["electronAPI"]) {
+  const [
+    openaiApiKey,
+    groqApiKey,
+    xaiApiKey,
+    mistralApiKey,
+    tinfoilApiKey,
+    cortiClientId,
+    cortiClientSecret,
+    cortiApiKey,
+    customTranscriptionApiKey,
+  ] = await Promise.all([
+    api?.getOpenAIKey?.().catch(() => ""),
+    api?.getGroqKey?.().catch(() => ""),
+    api?.getXaiKey?.().catch(() => ""),
+    api?.getMistralKey?.().catch(() => ""),
+    api?.getTinfoilKey?.().catch(() => ""),
+    api?.getCortiClientId?.().catch(() => ""),
+    api?.getCortiClientSecret?.().catch(() => ""),
+    api?.getCortiKey?.().catch(() => ""),
+    api?.getCustomTranscriptionKey?.().catch(() => ""),
+  ]);
+
+  return {
+    openaiApiKey: openaiApiKey || "",
+    groqApiKey: groqApiKey || "",
+    xaiApiKey: xaiApiKey || "",
+    mistralApiKey: mistralApiKey || "",
+    tinfoilApiKey: tinfoilApiKey || "",
+    cortiClientId: cortiClientId || "",
+    cortiClientSecret: cortiClientSecret || "",
+    cortiApiKey: cortiApiKey || "",
+    customTranscriptionApiKey: customTranscriptionApiKey || "",
+  };
+}
+
+/**
+ * Keeps tray tooltip + in-renderer posture cache aligned with local models / cloud config (#1082).
+ */
+export default function CloudOnlyPostureSync() {
+  const useLocalWhisper = useSettingsStore((s) => s.useLocalWhisper);
+  const cloudTranscriptionMode = useSettingsStore((s) => s.cloudTranscriptionMode);
+  const transcriptionMode = useSettingsStore((s) => s.transcriptionMode);
+  const isSignedIn = useSettingsStore((s) => s.isSignedIn);
+  const remoteTranscriptionUrl = useSettingsStore((s) => s.remoteTranscriptionUrl);
+  const cloudTranscriptionProvider = useSettingsStore((s) => s.cloudTranscriptionProvider);
+  const cloudTranscriptionBaseUrl = useSettingsStore((s) => s.cloudTranscriptionBaseUrl);
+  const openaiApiKey = useSettingsStore((s) => s.openaiApiKey);
+  const groqApiKey = useSettingsStore((s) => s.groqApiKey);
+  const xaiApiKey = useSettingsStore((s) => s.xaiApiKey);
+  const mistralApiKey = useSettingsStore((s) => s.mistralApiKey);
+  const tinfoilApiKey = useSettingsStore((s) => s.tinfoilApiKey);
+  const cortiClientId = useSettingsStore((s) => s.cortiClientId);
+  const cortiClientSecret = useSettingsStore((s) => s.cortiClientSecret);
+  const cortiApiKey = useSettingsStore((s) => s.cortiApiKey);
+  const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      const api = window.electronAPI;
+      if (!api?.listWhisperModels || !api?.listParakeetModels) return;
+
+      const [whisperResult, parakeetResult, secrets] = await Promise.all([
+        api.listWhisperModels().catch(() => ({ models: [] })),
+        api.listParakeetModels().catch(() => ({ models: [] })),
+        loadTranscriptionSecrets(api),
+      ]);
+      if (cancelled) return;
+
+      const settings = useSettingsStore.getState();
+      const next = resolveSttPosture({
+        hasLocalModels: hasDownloadedLocalModels(whisperResult?.models, parakeetResult?.models),
+        cloudActive: isCloudTranscriptionActive({
+          useLocalWhisper: settings.useLocalWhisper,
+          cloudTranscriptionMode: settings.cloudTranscriptionMode,
+          transcriptionMode: settings.transcriptionMode,
+          isSignedIn: settings.isSignedIn,
+          remoteTranscriptionUrl: settings.remoteTranscriptionUrl,
+          cloudTranscriptionProvider: settings.cloudTranscriptionProvider,
+          cloudTranscriptionBaseUrl: settings.cloudTranscriptionBaseUrl,
+          ...secrets,
+        }),
+      }) as SttPosture;
+
+      setSttPosture(next);
+      await api.syncSttPosture?.({ posture: next }).catch(() => {});
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    useLocalWhisper,
+    cloudTranscriptionMode,
+    transcriptionMode,
+    isSignedIn,
+    remoteTranscriptionUrl,
+    cloudTranscriptionProvider,
+    cloudTranscriptionBaseUrl,
+    openaiApiKey,
+    groqApiKey,
+    xaiApiKey,
+    mistralApiKey,
+    tinfoilApiKey,
+    cortiClientId,
+    cortiClientSecret,
+    cortiApiKey,
+    customTranscriptionApiKey,
+  ]);
+
+  return null;
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -45,6 +45,7 @@ import PasteToolsInfo from "./ui/PasteToolsInfo";
 import NixOsPasteInfo from "./ui/NixOsPasteInfo";
 import TranscriptionModelPicker from "./TranscriptionModelPicker";
 import SelfHostedPanel from "./SelfHostedPanel";
+import { useSttPostureStore } from "../stores/sttPostureStore";
 import {
   ConfirmDialog,
   AlertDialog,
@@ -258,6 +259,8 @@ function TranscriptionSection({
   toast,
 }: TranscriptionSectionProps) {
   const { t } = useTranslation();
+  const sttPosture = useSttPostureStore((s) => s.posture);
+  const showCloudOnlyBadge = sttPosture === "cloud-only";
 
   const transcriptionModes: InferenceModeOption[] = [
     {
@@ -366,6 +369,14 @@ function TranscriptionSection({
 
   return (
     <div className="space-y-4">
+      {showCloudOnlyBadge && (
+        <div className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+          <Badge variant="outline">{t("settingsPage.transcription.cloudOnlyBadge")}</Badge>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            {t("settingsPage.transcription.cloudOnlyHint")}
+          </p>
+        </div>
+      )}
       <InferenceModeSelector
         modes={transcriptionModes}
         activeMode={transcriptionMode}

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -27,6 +27,8 @@ import {
   isCloudTranslationMode,
 } from "../stores/settingsStore";
 import { recordCleanupFailure } from "../stores/cleanupFailureStore";
+import { getSttPosture } from "../stores/sttPostureStore";
+import { resolveCloudOnlyFailureMessageKey } from "./sttPosture";
 import {
   getBatchTranscriptionModel,
   getTranscriptionProvider,
@@ -1326,11 +1328,16 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       );
 
       if (error.message !== "No audio detected") {
+        const cloudOnlyMessageKey = resolveCloudOnlyFailureMessageKey(getSttPosture());
         this.onError?.({
-          title: "Transcription Error",
-          description: `Transcription failed: ${error.message}`,
-          code: error.code,
-          messageKey: error.messageKey,
+          title: cloudOnlyMessageKey
+            ? "hooks.audioRecording.cloudOnlyFailure.title"
+            : "Transcription Error",
+          description: cloudOnlyMessageKey
+            ? undefined
+            : `Transcription failed: ${error.message}`,
+          code: cloudOnlyMessageKey ? error.code || "CLOUD_ONLY_FAILURE" : error.code,
+          messageKey: cloudOnlyMessageKey || error.messageKey,
         });
 
         // Save failed transcription with audio so the user can retry later
@@ -3609,8 +3616,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         errorDescription =
           "Your OpenWhispr Cloud session is unavailable. Please sign in again from Settings.";
       } else if (error.code === "NETWORK_ERROR") {
-        errorTitle = "streaming.errors.cloudUnreachable.title";
-        errorDescription = error.messageKey || "streaming.errors.cloudUnreachable.generic";
+        const cloudOnlyMessageKey = resolveCloudOnlyFailureMessageKey(getSttPosture());
+        if (cloudOnlyMessageKey) {
+          errorTitle = "hooks.audioRecording.cloudOnlyFailure.title";
+          errorDescription = cloudOnlyMessageKey;
+          error.messageKey = cloudOnlyMessageKey;
+        } else {
+          errorTitle = "streaming.errors.cloudUnreachable.title";
+          errorDescription = error.messageKey || "streaming.errors.cloudUnreachable.generic";
+        }
       } else if (error.name === "MicUnusableError") {
         errorTitle = "Microphone Muted";
         errorDescription =

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3516,6 +3516,12 @@ class IPCHandlers {
       return this.environmentManager.saveAllKeysToEnvFile();
     });
 
+    ipcMain.handle("sync-stt-posture", async (_event, payload) => {
+      const posture = typeof payload?.posture === "string" ? payload.posture : "unknown";
+      this.getTrayManager?.()?.setSttPosture?.(posture);
+      return { success: true, posture };
+    });
+
     ipcMain.handle("sync-startup-preferences", async (event, prefs) => {
       const setVars = {};
       const clearVars = [];

--- a/src/helpers/sttPosture.js
+++ b/src/helpers/sttPosture.js
@@ -1,0 +1,77 @@
+/**
+ * STT readiness posture for startup UX (#1079 / #1082).
+ *
+ * - local-ready: at least one Whisper/Parakeet model is on disk
+ * - cloud-only: no local models, but a cloud/self-hosted provider is active
+ * - unconfigured: no local models and no usable cloud/self-hosted provider
+ */
+
+export function hasDownloadedLocalModels(whisperModels = [], parakeetModels = []) {
+  const anyDownloaded = (models) =>
+    Array.isArray(models) && models.some((m) => m && (m.downloaded === true || m.isDownloaded === true));
+  return anyDownloaded(whisperModels) || anyDownloaded(parakeetModels);
+}
+
+export function hasTranscriptionProviderKey(settings = {}) {
+  const provider = settings.cloudTranscriptionProvider || "openai";
+  const trim = (v) => (typeof v === "string" ? v.trim() : "");
+
+  switch (provider) {
+    case "groq":
+      return !!trim(settings.groqApiKey);
+    case "xai":
+      return !!trim(settings.xaiApiKey);
+    case "mistral":
+      return !!trim(settings.mistralApiKey);
+    case "tinfoil":
+      return !!trim(settings.tinfoilApiKey);
+    case "corti":
+      return (
+        (!!trim(settings.cortiClientId) && !!trim(settings.cortiClientSecret)) ||
+        !!trim(settings.cortiApiKey)
+      );
+    case "custom":
+      return !!trim(settings.customTranscriptionApiKey) || !!trim(settings.cloudTranscriptionBaseUrl);
+    case "openai":
+    default:
+      return !!trim(settings.openaiApiKey);
+  }
+}
+
+export function isCloudTranscriptionActive(settings = {}) {
+  if (settings.useLocalWhisper) return false;
+
+  const transcriptionMode =
+    typeof settings.transcriptionMode === "string" ? settings.transcriptionMode.trim() : "";
+  const cloudMode =
+    typeof settings.cloudTranscriptionMode === "string"
+      ? settings.cloudTranscriptionMode.trim()
+      : "";
+  const remoteUrl =
+    typeof settings.remoteTranscriptionUrl === "string"
+      ? settings.remoteTranscriptionUrl.trim()
+      : "";
+
+  if (transcriptionMode === "self-hosted" && remoteUrl.length > 0) return true;
+
+  if (cloudMode === "openwhispr" || transcriptionMode === "openwhispr") {
+    return !!settings.isSignedIn;
+  }
+
+  if (cloudMode === "byok" || transcriptionMode === "providers") {
+    return hasTranscriptionProviderKey(settings);
+  }
+
+  return false;
+}
+
+export function resolveSttPosture({ hasLocalModels, cloudActive }) {
+  if (hasLocalModels) return "local-ready";
+  if (cloudActive) return "cloud-only";
+  return "unconfigured";
+}
+
+/** i18n messageKey used when a cloud STT call fails with no local fallback (#1082). */
+export function resolveCloudOnlyFailureMessageKey(posture) {
+  return posture === "cloud-only" ? "hooks.audioRecording.cloudOnlyFailure.description" : null;
+}

--- a/src/helpers/tray.js
+++ b/src/helpers/tray.js
@@ -12,6 +12,12 @@ class TrayManager {
     this.controlPanelWindow = null;
     this.windowManager = null;
     this.attachedControlPanels = new WeakSet();
+    this.sttPosture = "unknown";
+  }
+
+  setSttPosture(posture) {
+    this.sttPosture = typeof posture === "string" && posture ? posture : "unknown";
+    this.updateTrayMenu?.();
   }
 
   setWindows(mainWindow, controlPanelWindow) {
@@ -292,7 +298,9 @@ class TrayManager {
     if (!this.tray) return;
 
     const contextMenu = Menu.buildFromTemplate(this.buildContextMenuTemplate());
-    this.tray.setToolTip(i18nMain.t("tray.tooltip"));
+    const tooltipKey =
+      this.sttPosture === "cloud-only" ? "tray.tooltipCloudOnly" : "tray.tooltip";
+    this.tray.setToolTip(i18nMain.t(tooltipKey));
     this.tray.setContextMenu(contextMenu);
   }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,7 +35,8 @@
     "openControlPanel": "Open Control Panel",
     "hideControlPanel": "Hide Control Panel",
     "quit": "Quit OpenWhispr",
-    "tooltip": "OpenWhispr - Voice Dictation"
+    "tooltip": "OpenWhispr - Voice Dictation",
+    "tooltipCloudOnly": "OpenWhispr - Cloud only"
   },
   "menu": {
     "appLabel": "OpenWhispr",
@@ -583,6 +584,10 @@
       "partialTranscription": {
         "title": "Partial Transcription",
         "description": "Part of the recording couldn't be transcribed."
+      },
+      "cloudOnlyFailure": {
+        "title": "Cloud provider unreachable",
+        "description": "Cloud provider unreachable — add a local model as fallback in Settings → Models."
       },
       "errorDescriptions": {
         "sessionExpired": "Your OpenWhispr Cloud session is unavailable. Please sign in again from Settings.",
@@ -1891,6 +1896,8 @@
       "openwhisprCloud": "OpenWhispr Cloud",
       "openwhisprCloudDescription": "Reliable accuracy. No setup needed.",
       "title": "Speech to Text",
+      "cloudOnlyBadge": "Cloud only",
+      "cloudOnlyHint": "No local model downloaded. Dictation depends on your cloud provider.",
       "toasts": {
         "switchedCloud": {
           "description": "Transcription will use OpenWhispr's cloud service.",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import AppRouter from "./AppRouter.jsx";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 import CleanupFailureToastListener from "./components/CleanupFailureToastListener.tsx";
 import TinfoilModelSwitchToastListener from "./components/TinfoilModelSwitchToastListener.tsx";
+import CloudOnlyPostureSync from "./components/CloudOnlyPostureSync.tsx";
 import { ToastProvider } from "./components/ui/Toast.tsx";
 import { SettingsProvider } from "./hooks/useSettings";
 
@@ -20,6 +21,7 @@ root.render(
           <ToastProvider>
             <TinfoilModelSwitchToastListener />
             <CleanupFailureToastListener />
+            <CloudOnlyPostureSync />
             <AppRouter />
           </ToastProvider>
         </SettingsProvider>

--- a/src/stores/sttPostureStore.ts
+++ b/src/stores/sttPostureStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+export type SttPosture = "unknown" | "unconfigured" | "cloud-only" | "local-ready";
+
+interface SttPostureState {
+  posture: SttPosture;
+}
+
+export const useSttPostureStore = create<SttPostureState>(() => ({
+  posture: "unknown",
+}));
+
+export function setSttPosture(posture: SttPosture): void {
+  useSttPostureStore.setState({ posture });
+}
+
+export function getSttPosture(): SttPosture {
+  return useSttPostureStore.getState().posture;
+}
+
+export function isCloudOnlyPosture(): boolean {
+  return getSttPosture() === "cloud-only";
+}

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -829,6 +829,7 @@ declare global {
         dictationAgentProvider: string;
         dictationAgentModel?: string;
       }) => Promise<void>;
+      syncSttPosture: (payload: { posture: string }) => Promise<{ success: boolean; posture: string }>;
 
       // Clipboard operations
       checkAccessibilityPermission: (silent?: boolean) => Promise<boolean>;

--- a/src/utils/recordingErrors.ts
+++ b/src/utils/recordingErrors.ts
@@ -8,7 +8,12 @@ type RecordingError = {
 };
 
 export function getRecordingErrorTitle(error: RecordingError, t: TFunction): string {
-  if (error.code === "NETWORK_ERROR") return t(error.title);
+  if (error.code === "NETWORK_ERROR" || error.code === "CLOUD_ONLY_FAILURE") {
+    return t(error.title);
+  }
+  if (error.title === "hooks.audioRecording.cloudOnlyFailure.title") {
+    return t(error.title);
+  }
   if (error.code === "AUTH_EXPIRED" || error.code === "AUTH_REQUIRED") {
     return t("hooks.audioRecording.errorTitles.sessionExpired");
   }

--- a/test/helpers/sttPosture.test.js
+++ b/test/helpers/sttPosture.test.js
@@ -1,0 +1,114 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/sttPosture.js");
+
+test("hasDownloadedLocalModels is false when both lists are empty", async () => {
+  const { hasDownloadedLocalModels } = await load();
+  assert.equal(hasDownloadedLocalModels([], []), false);
+  assert.equal(hasDownloadedLocalModels(undefined, undefined), false);
+});
+
+test("hasDownloadedLocalModels is true when Whisper or Parakeet has a download", async () => {
+  const { hasDownloadedLocalModels } = await load();
+  assert.equal(hasDownloadedLocalModels([{ model: "base", downloaded: true }], []), true);
+  assert.equal(hasDownloadedLocalModels([], [{ id: "nemo", isDownloaded: true }]), true);
+  assert.equal(hasDownloadedLocalModels([{ downloaded: false }], [{ downloaded: false }]), false);
+});
+
+test("isCloudTranscriptionActive: OpenWhispr Cloud requires sign-in", async () => {
+  const { isCloudTranscriptionActive } = await load();
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: "openwhispr",
+      transcriptionMode: "openwhispr",
+      isSignedIn: false,
+    }),
+    false
+  );
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: "openwhispr",
+      transcriptionMode: "openwhispr",
+      isSignedIn: true,
+    }),
+    true
+  );
+});
+
+test("isCloudTranscriptionActive: BYOK requires a provider key", async () => {
+  const { isCloudTranscriptionActive } = await load();
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: "byok",
+      transcriptionMode: "providers",
+      cloudTranscriptionProvider: "groq",
+      groqApiKey: "",
+    }),
+    false
+  );
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: "byok",
+      transcriptionMode: "providers",
+      cloudTranscriptionProvider: "groq",
+      groqApiKey: "gsk_test",
+    }),
+    true
+  );
+});
+
+test("isCloudTranscriptionActive: self-hosted needs a URL", async () => {
+  const { isCloudTranscriptionActive } = await load();
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "",
+    }),
+    false
+  );
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: false,
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "http://localhost:8080/v1",
+    }),
+    true
+  );
+});
+
+test("isCloudTranscriptionActive: local mode is never cloud-active", async () => {
+  const { isCloudTranscriptionActive } = await load();
+  assert.equal(
+    isCloudTranscriptionActive({
+      useLocalWhisper: true,
+      cloudTranscriptionMode: "openwhispr",
+      isSignedIn: true,
+      openaiApiKey: "sk-test",
+    }),
+    false
+  );
+});
+
+test("resolveSttPosture maps the three UX states (#1079)", async () => {
+  const { resolveSttPosture } = await load();
+  assert.equal(resolveSttPosture({ hasLocalModels: true, cloudActive: false }), "local-ready");
+  assert.equal(resolveSttPosture({ hasLocalModels: true, cloudActive: true }), "local-ready");
+  assert.equal(resolveSttPosture({ hasLocalModels: false, cloudActive: true }), "cloud-only");
+  assert.equal(resolveSttPosture({ hasLocalModels: false, cloudActive: false }), "unconfigured");
+});
+
+test("resolveCloudOnlyFailureMessageKey only fires in cloud-only posture (#1082)", async () => {
+  const { resolveCloudOnlyFailureMessageKey } = await load();
+  assert.equal(
+    resolveCloudOnlyFailureMessageKey("cloud-only"),
+    "hooks.audioRecording.cloudOnlyFailure.description"
+  );
+  assert.equal(resolveCloudOnlyFailureMessageKey("local-ready"), null);
+  assert.equal(resolveCloudOnlyFailureMessageKey("unconfigured"), null);
+});


### PR DESCRIPTION
## Summary

Fixes #1082: cloud STT with no local model downloaded worked, but the tray, Settings, and failure toasts looked the same as a hybrid setup. When the cloud provider dropped, there was no clear path to add a local fallback.

## Changes

- Classify STT posture (`cloud-only` when models are empty and a cloud/self-hosted provider is active)
- Tray tooltip becomes `OpenWhispr - Cloud only` in that mode
- Settings → Speech to Text shows a Cloud only badge and short hint
- On cloud transcription / streaming network failure in cloud-only mode, show an actionable error pointing at Settings → Models

## AI assistance

This PR was prepared with AI assistance (Cursor / Grok). I reviewed the diff, ran the tests below, and take responsibility for the change.

## Evidence

```text
$ node --test test/helpers/sttPosture.test.js
✔ hasDownloadedLocalModels is false when both lists are empty
✔ hasDownloadedLocalModels is true when Whisper or Parakeet has a download
✔ isCloudTranscriptionActive: OpenWhispr Cloud requires sign-in
✔ isCloudTranscriptionActive: BYOK requires a provider key
✔ isCloudTranscriptionActive: self-hosted needs a URL
✔ isCloudTranscriptionActive: local mode is never cloud-active
✔ resolveSttPosture maps the three UX states (#1079)
✔ resolveCloudOnlyFailureMessageKey only fires in cloud-only posture (#1082)
ℹ tests 8
ℹ pass 8
ℹ fail 0
```

No open covering PR for #1082 at publish time. Claim VERIFY_OK for session cursor-20260718-033202034.

## Test plan

- [x] Unit tests for posture + cloud-only failure message key
- [ ] Manual: BYOK with no local models shows Cloud only tray tooltip and Settings badge
- [ ] Manual: download a local model and confirm badge/tooltip clear after restart or settings change
- [ ] Manual: disconnect network and dictate in cloud-only mode; error mentions Settings → Models

Made with [Cursor](https://cursor.com)