### PR TITLE
fix(windows): restore pre-recording input focus before dictation paste (#859)

### DIFF
--- a/resources/windows-fast-paste.c
+++ b/resources/windows-fast-paste.c
@@ -10,6 +10,14 @@
  *   1. Window class name (fast, works for native terminals)
  *   2. Executable name (fallback, catches Electron-based terminals like Termius)
  *
+ * Focus restore (issue #859): the caller captures the target window handle at
+ * record start with --print-foreground, then passes it back as
+ * --restore-window <hwnd> at paste time. We re-activate that window before
+ * sending the keystroke so dictation lands in the field the user was in, even
+ * when something (a subprocess console flash, Chromium moving focus to its
+ * toolbar) stole the foreground during transcription. This mirrors the macOS
+ * PID capture/activate path and the Linux --window path.
+ *
  * Compile with: cl /O2 windows-fast-paste.c /Fe:windows-fast-paste.exe user32.lib
  * Or with MinGW: gcc -O2 windows-fast-paste.c -o windows-fast-paste.exe -luser32
  */
@@ -17,6 +25,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 static const char* TERMINAL_CLASSES[] = {
@@ -144,6 +154,45 @@ static int SendPasteNormal(void) {
     return (sent == 4) ? 0 : 1;
 }
 
+/* Bring a captured target window back to the foreground before pasting.
+   SetForegroundWindow alone is blocked by Windows' foreground lock when the
+   calling process isn't the current foreground owner, so we attach this
+   thread's input queue to both the current foreground thread and the target
+   thread first — the standard workaround, and what nircmd's "win activate"
+   does internally. Returns TRUE if the target ended up foreground. */
+static BOOL RestoreForegroundWindow(HWND target) {
+    if (!target || !IsWindow(target)) return FALSE;
+
+    if (GetForegroundWindow() == target) return TRUE;
+
+    if (IsIconic(target)) {
+        ShowWindow(target, SW_RESTORE);
+    }
+
+    HWND fg = GetForegroundWindow();
+    DWORD thisThread = GetCurrentThreadId();
+    DWORD targetThread = GetWindowThreadProcessId(target, NULL);
+    DWORD fgThread = fg ? GetWindowThreadProcessId(fg, NULL) : 0;
+
+    BOOL attachedTarget = FALSE;
+    BOOL attachedFg = FALSE;
+    if (targetThread && targetThread != thisThread) {
+        attachedTarget = AttachThreadInput(thisThread, targetThread, TRUE);
+    }
+    if (fgThread && fgThread != thisThread && fgThread != targetThread) {
+        attachedFg = AttachThreadInput(thisThread, fgThread, TRUE);
+    }
+
+    BringWindowToTop(target);
+    BOOL ok = SetForegroundWindow(target);
+    SetFocus(target);
+
+    if (attachedFg) AttachThreadInput(thisThread, fgThread, FALSE);
+    if (attachedTarget) AttachThreadInput(thisThread, targetThread, FALSE);
+
+    return ok && GetForegroundWindow() == target;
+}
+
 static int SendPasteTerminal(void) {
     INPUT inputs[6];
     ZeroMemory(inputs, sizeof(inputs));
@@ -161,11 +210,33 @@ static int SendPasteTerminal(void) {
 
 int main(int argc, char* argv[]) {
     BOOL detectOnly = FALSE;
+    BOOL printForeground = FALSE;
+    HWND restoreWindow = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--detect-only") == 0) {
             detectOnly = TRUE;
+        } else if (strcmp(argv[i], "--print-foreground") == 0) {
+            printForeground = TRUE;
+        } else if (strcmp(argv[i], "--restore-window") == 0 && i + 1 < argc) {
+            restoreWindow = (HWND)(uintptr_t)strtoull(argv[++i], NULL, 10);
         }
+    }
+
+    /* Capture mode: report the current foreground window handle so the caller
+       can stash it before the overlay/transcription can change focus. */
+    if (printForeground) {
+        HWND fg = GetForegroundWindow();
+        printf("FOREGROUND %llu\n", (unsigned long long)(uintptr_t)fg);
+        fflush(stdout);
+        return fg ? 0 : 2;
+    }
+
+    /* Restore the captured target to the foreground before pasting. If it is
+       gone or can't be restored we fall through to whatever is foreground now,
+       which is the pre-#859 behavior. */
+    if (restoreWindow && RestoreForegroundWindow(restoreWindow)) {
+        Sleep(20);
     }
 
     HWND hwnd = GetForegroundWindow();

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -812,7 +812,10 @@ class ClipboardManager {
           const nircmdPath = this.getNircmdPath();
           method = nircmdPath ? "nircmd" : "powershell";
         }
-        pasteResult = await this.pasteWindows(originalClipboard, { expectedClipboardText: text });
+        pasteResult = await this.pasteWindows(originalClipboard, {
+          expectedClipboardText: text,
+          targetWindow: options.targetWindow,
+        });
       } else {
         pasteResult = await this.pasteLinux(originalClipboard, {
           ...options,
@@ -994,9 +997,18 @@ class ClipboardManager {
         let hasTimedOut = false;
         const startTime = Date.now();
 
-        this.safeLog("⚡ Windows fast-paste starting");
+        // Restore the window captured at record start (issue #859) so the paste
+        // lands where the user was typing, even if focus drifted during
+        // transcription. An older binary ignores the unknown flag and pastes
+        // into the current foreground, matching the previous behavior.
+        const args =
+          options.targetWindow != null
+            ? ["--restore-window", String(options.targetWindow)]
+            : [];
 
-        const pasteProcess = spawn(fastPastePath, [], {
+        this.safeLog("⚡ Windows fast-paste starting", { targetWindow: options.targetWindow });
+
+        const pasteProcess = spawn(fastPastePath, args, {
           stdio: ["ignore", "pipe", "pipe"],
           windowsHide: true,
         });

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1872,9 +1872,17 @@ class IPCHandlers {
       // too slow for the paste hot path.
       const textToPaste = applySmartSpacing({ text, mode: "append" });
 
+      // Windows: restore the foreground window captured at record start so the
+      // paste lands in the field the user was in, not wherever focus drifted
+      // during transcription (issue #859). macOS handles this via activateTargetPid
+      // above; Linux re-detects the target window inside pasteLinux.
+      const targetWindow =
+        process.platform === "win32" ? this.textEditMonitor?.lastForegroundWindow || null : null;
+
       const result = await this.clipboardManager.pasteText(textToPaste, {
         ...options,
         webContents: event.sender,
+        targetWindow,
       });
       debugLogger.debug("[AutoLearn] Paste completed", {
         autoLearnEnabled: this._autoLearnEnabled,

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -82,20 +82,53 @@ class TextEditMonitor extends EventEmitter {
     this._lastValue = null;
     this._stdoutBuffer = "";
     this.lastTargetPid = null;
+    this.lastForegroundWindow = null;
   }
 
   /**
-   * macOS: capture the active app's PID via NSWorkspace before the overlay steals focus.
+   * Capture the active target before the overlay/transcription can steal focus.
    * Must be called at hotkey press time, BEFORE showDictationPanel()/mainWindow.show().
-   * NSWorkspace.frontmostApplication correctly identifies the key window owner,
-   * ignoring panel-type windows like the OpenWhispr overlay.
+   * macOS: the frontmost app's PID via NSWorkspace (re-activated by PID before paste).
+   * Windows: the foreground window handle via windows-fast-paste (restored before
+   * paste, issue #859). NSWorkspace.frontmostApplication and GetForegroundWindow
+   * both ignore the focusable:false OpenWhispr overlay, so they name the real target.
    */
   captureTargetPid() {
-    if (process.platform !== "darwin") return;
-    this._readFrontmostPid().then((pid) => {
-      this.lastTargetPid = pid;
-      debugLogger.debug("[TextEditMonitor] Captured target PID", { pid });
-    });
+    if (process.platform === "darwin") {
+      this._readFrontmostPid().then((pid) => {
+        this.lastTargetPid = pid;
+        debugLogger.debug("[TextEditMonitor] Captured target PID", { pid });
+      });
+      return;
+    }
+    if (process.platform === "win32") {
+      this._captureWindowsForegroundWindow();
+    }
+  }
+
+  /**
+   * Windows: read the current foreground window handle via the fast-paste helper
+   * so it can be restored before the paste keystroke. Best-effort: if the binary
+   * is missing or fails, we clear the handle and the paste falls back to whatever
+   * is foreground at paste time (the pre-#859 behavior).
+   */
+  _captureWindowsForegroundWindow() {
+    const binary = this._findFile("windows-fast-paste.exe");
+    if (!binary) {
+      this.lastForegroundWindow = null;
+      return;
+    }
+    execFile(
+      binary,
+      ["--print-foreground"],
+      { timeout: 2000, windowsHide: true },
+      (err, stdout) => {
+        const match = err ? null : /FOREGROUND\s+(\d+)/.exec(stdout || "");
+        const handle = match && match[1] !== "0" ? match[1] : null;
+        this.lastForegroundWindow = handle;
+        debugLogger.debug("[TextEditMonitor] Captured foreground window", { handle });
+      }
+    );
   }
 
   /**

--- a/src/helpers/textEditMonitor.js
+++ b/src/helpers/textEditMonitor.js
@@ -111,6 +111,16 @@ class TextEditMonitor extends EventEmitter {
    * so it can be restored before the paste keystroke. Best-effort: if the binary
    * is missing or fails, we clear the handle and the paste falls back to whatever
    * is foreground at paste time (the pre-#859 behavior).
+   *
+   * We pass BOTH --detect-only and --print-foreground. A current binary checks
+   * --print-foreground first and prints "FOREGROUND <hwnd>". An OLD binary
+   * (shipped before #859, commonly cached from a separate release) does not know
+   * --print-foreground, but it does know --detect-only, so it takes its detect
+   * early-return and prints window-class info WITHOUT injecting a paste. Without
+   * --detect-only the old binary would ignore the unknown flag and fall through
+   * to Ctrl+V, pasting the clipboard at record start. The extra flag makes the
+   * old binary degrade to no capture (no FOREGROUND line -> null handle -> no
+   * restore) instead of pasting.
    */
   _captureWindowsForegroundWindow() {
     const binary = this._findFile("windows-fast-paste.exe");
@@ -120,7 +130,7 @@ class TextEditMonitor extends EventEmitter {
     }
     execFile(
       binary,
-      ["--print-foreground"],
+      ["--detect-only", "--print-foreground"],
       { timeout: 2000, windowsHide: true },
       (err, stdout) => {
         const match = err ? null : /FOREGROUND\s+(\d+)/.exec(stdout || "");

--- a/test/helpers/clipboardRestore.test.js
+++ b/test/helpers/clipboardRestore.test.js
@@ -237,6 +237,62 @@ test("pasteWithFastPaste sends no window arg when nothing was captured", async (
   assert.deepEqual(spawnCalls[0].args, []);
 });
 
+const textEditMonitorPath = require.resolve("../../src/helpers/textEditMonitor");
+
+function loadTextEditMonitor({ execFile } = {}) {
+  delete require.cache[textEditMonitorPath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "child_process" && execFile) {
+      return { ...childProcess, execFile };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../../src/helpers/textEditMonitor");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test("windows capture uses the old-binary-safe detect-only flag (no premature paste, #859 regression)", () => {
+  const execFileCalls = [];
+  const TextEditMonitor = loadTextEditMonitor({
+    execFile: (command, args, options, cb) => {
+      execFileCalls.push({ command, args });
+      // Simulate a current binary answering in capture mode.
+      cb(null, "FOREGROUND 4242\n");
+    },
+  });
+
+  const monitor = new TextEditMonitor();
+  monitor._findFile = () => "/tmp/windows-fast-paste.exe";
+  monitor._captureWindowsForegroundWindow();
+
+  assert.equal(execFileCalls.length, 1);
+  assert.equal(execFileCalls[0].command, "/tmp/windows-fast-paste.exe");
+  // --detect-only makes an OLD binary hit its detect early-return instead of
+  // pasting; --print-foreground makes a current binary report the handle.
+  assert.deepEqual(execFileCalls[0].args, ["--detect-only", "--print-foreground"]);
+  assert.equal(monitor.lastForegroundWindow, "4242");
+});
+
+test("windows capture yields no handle when the binary prints no FOREGROUND line (old-binary degradation)", () => {
+  const TextEditMonitor = loadTextEditMonitor({
+    execFile: (command, args, options, cb) => {
+      // An OLD binary in --detect-only mode prints window-class info, not FOREGROUND.
+      cb(null, "WINDOW_CLASS Notepad\nIS_TERMINAL false\n");
+    },
+  });
+
+  const monitor = new TextEditMonitor();
+  monitor._findFile = () => "/tmp/windows-fast-paste.exe";
+  monitor._captureWindowsForegroundWindow();
+
+  assert.equal(monitor.lastForegroundWindow, null);
+});
+
 test("pasteMacOS restores clipboard after the short macOS delay on successful fast paste", async () => {
   const spawnCalls = [];
   const TestClipboardManager = loadClipboardManager({

--- a/test/helpers/clipboardRestore.test.js
+++ b/test/helpers/clipboardRestore.test.js
@@ -198,6 +198,45 @@ test("pasteText waits for prior clipboard restoration before starting the next p
   assert.deepEqual(events, ["start:first", "end:first", "start:second", "end:second"]);
 });
 
+test("pasteWithFastPaste restores the captured target window before pasting (#859)", async () => {
+  const spawnCalls = [];
+  const TestClipboardManager = loadClipboardManager({
+    spawn: createSuccessfulSpawn(spawnCalls),
+  });
+  const manager = new TestClipboardManager();
+  manager._restoreClipboardAfterDelay = () => Promise.resolve();
+
+  const result = await manager.pasteWithFastPaste(
+    "/tmp/windows-fast-paste.exe",
+    { type: "text", data: "previous clipboard" },
+    { expectedClipboardText: "dictated text", targetWindow: "12345" }
+  );
+  await result.restoreComplete;
+
+  assert.equal(spawnCalls.length, 1);
+  assert.equal(spawnCalls[0].command, "/tmp/windows-fast-paste.exe");
+  assert.deepEqual(spawnCalls[0].args, ["--restore-window", "12345"]);
+});
+
+test("pasteWithFastPaste sends no window arg when nothing was captured", async () => {
+  const spawnCalls = [];
+  const TestClipboardManager = loadClipboardManager({
+    spawn: createSuccessfulSpawn(spawnCalls),
+  });
+  const manager = new TestClipboardManager();
+  manager._restoreClipboardAfterDelay = () => Promise.resolve();
+
+  const result = await manager.pasteWithFastPaste(
+    "/tmp/windows-fast-paste.exe",
+    { type: "text", data: "previous clipboard" },
+    { expectedClipboardText: "dictated text" }
+  );
+  await result.restoreComplete;
+
+  assert.equal(spawnCalls.length, 1);
+  assert.deepEqual(spawnCalls[0].args, []);
+});
+
 test("pasteMacOS restores clipboard after the short macOS delay on successful fast paste", async () => {
   const spawnCalls = [];
   const TestClipboardManager = loadClipboardManager({


### PR DESCRIPTION
# fix(windows): restore the focused window before paste (#859)

## Why

Fixes #859. On Windows, starting a dictation from a focused input field and then
letting it transcribe often drops the result in the wrong place. The moment
processing begins, focus leaves the original field and the transcript lands
somewhere else (the reporter saw it hit Brave's settings button), so they have
to re-click the field or paste by hand. SuperWhisper keeps focus, so this is a
clear gap.

## Root cause

The Windows paste helper sends its keystroke to whatever window is foreground at
paste time. `resources/windows-fast-paste.c` calls `GetForegroundWindow()` right
before `SendInput`, with no memory of the field the user recorded from. Nothing
captures the pre-recording target and nothing restores it.

macOS and Linux already handle this. On macOS `TextEditMonitor.captureTargetPid()`
grabs the frontmost app's PID at record start and `activateTargetPid()`
re-activates it before the paste (added in #668, for exactly this Brave and
Claude Desktop focus loss). On Linux `pasteLinux()` re-detects the target window
and passes it to the paste tool with `--window`. Windows had no equivalent, so
if anything takes the foreground during the record to transcribe to paste window
(a subprocess console flash, or Chromium moving focus into its own toolbar), the
paste follows the wrong window.

The dictation overlay itself is `focusable: false` and shown with
`showInactive`, so it is not the thief. The problem is the missing capture and
restore, not the overlay stealing focus.

## The fix

Mirror the macOS capture and restore design on Windows, reusing the native
helper that already ships in the paste path (no new dependency):

- `resources/windows-fast-paste.c` gains two modes:
  - `--print-foreground` reports the current foreground window handle, so the
    caller can stash it at record start.
  - `--restore-window <hwnd>` re-activates that window before pasting, using the
    standard `AttachThreadInput` foreground-lock workaround (the same technique
    nircmd's `win activate` uses), then sends the paste keystroke to it.
- `src/helpers/textEditMonitor.js`: `captureTargetPid()` now also captures the
  foreground HWND on Windows, at the same record-start seams that already
  capture the macOS PID (they run before the overlay shows). It invokes the
  binary with both `--detect-only` and `--print-foreground` so that an old
  binary that predates these flags takes its existing non-pasting detect
  early-return instead of injecting a paste (see the old-binary safety note
  below).
- `src/helpers/ipcHandlers.js`: the `paste-text` handler passes the captured
  handle through to the clipboard manager on Windows.
- `src/helpers/clipboard.js`: `pasteWithFastPaste` forwards it to the binary as
  `--restore-window <hwnd>`.

Whole feature is gated on the fast-paste binary. If it is missing, capture
returns nothing and paste behaves exactly as before.

### Old-binary safety

`windows-fast-paste.exe` is downloaded as a prebuilt binary from a separate
GitHub release and cached, so new JS commonly runs against an OLD exe built
before this change. Both new invocations are safe on that old binary, and
neither triggers a premature paste:

- Restore (paste time): the old `main()` has no `--restore-window` handler, so
  it ignores the flag and falls through to its normal paste. That is exactly the
  pre-#859 behavior (paste into the current foreground), which is correct for
  the paste stage.
- Capture (record start): the old `main()` recognizes only `--detect-only` in
  its arg loop. Passing `--detect-only --print-foreground` sets `detectOnly`
  true; the old binary then reaches `if (detectOnly) { print class info;
  return 0; }` and returns BEFORE `SendPasteNormal`/`SendPasteTerminal`, so no
  Ctrl+V is injected. Its output has no `FOREGROUND <hwnd>` line, so capture
  yields null, no restore happens, and behavior falls back to exactly pre-#859.

  Passing `--print-foreground` alone would be unsafe on the old binary: the flag
  is unknown, `detectOnly` stays false, and control falls through to the paste,
  injecting the clipboard at record start. The added `--detect-only` is what
  prevents that. A current binary checks `--print-foreground` before
  `--detect-only`, so it still reports the handle as `FOREGROUND <hwnd>`.

## Verification

This was verified at the code level. Interactive GUI focus behavior (recording
from a real input field and watching where the transcript lands) was not
exercised. A headless agent cannot drive that flow, so a maintainer should
confirm the end to end behavior on a real Windows desktop.

Control flow, before and after:

- Before: record starts, overlay shows inactive, transcription runs, paste
  spawns `windows-fast-paste.exe` which pastes into `GetForegroundWindow()` at
  that instant. If focus drifted during transcription, the transcript lands in
  the wrong window.
- After: record starts and the foreground HWND is captured first. At paste time
  the binary re-activates that captured window, waits briefly for the activation
  to land, then pastes into it.

What was run:

- Targeted unit tests for the clipboard module pass, including cases asserting
  the captured handle is threaded to the binary as `--restore-window <hwnd>`,
  that no window argument is sent when nothing was captured, and that the
  capture path invokes the binary with the old-binary-safe
  `--detect-only --print-foreground` form (yielding null when no `FOREGROUND`
  line is printed):
  `node --test test/helpers/clipboardRestore.test.js` -> 10 passed, 0 failed.
- `node --check` on the three changed JS files: clean.

Not run in this environment, please run in CI or locally:

- `npm run lint` / `npm run format` and `npm run build`: this worktree does not
  have `node_modules` installed (no `electron`), so the Electron-dependent
  suites and the linter could not run here. The clipboard test runs because it
  mocks `electron`.
- `test/helpers/textEditMonitorPrecedingChar.test.js` requires `electron`
  (via `debugLogger`) and cannot run without an install; the change to
  `textEditMonitor.js` only adds a Windows branch and leaves the existing
  macOS-only `activateTargetPid` path untouched.

## Note on the prebuilt binary

`windows-fast-paste.exe` is downloaded as a prebuilt binary during
`prebuild:win` (with a local compile fallback). The new `--print-foreground`
and `--restore-window` modes take effect once the binary is rebuilt from this
updated source (the `build-windows-fast-paste.yml` workflow does this on
release). Until then, as detailed in the old-binary safety section above, both
new invocations are safe against the still-cached old exe: neither injects a
premature paste, and the app falls back to exactly pre-#859 behavior.

## Scope check

The gap was confirmed against the actual code at this branch's base
(HEAD `fa6dd8cf`): `windows-fast-paste.c` pastes into `GetForegroundWindow()`
with no restore, and `pasteWithFastPaste` spawned the binary with no arguments.
The capture and restore added here are additive and gated on the captured handle
being present.

---

This change was written with AI assistance (Claude) and reviewed before
submission.
