### PR TITLE
fix(stt): match dictionary echo against truncated Groq prompt

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -49,7 +49,10 @@ import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
 import { evaluateFinishedRecording } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
-import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
+import {
+  matchesDictionaryPrompt,
+  truncateDictionaryPrompt,
+} from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
@@ -417,8 +420,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     return words.length > 0 ? words.join(", ") : null;
   }
 
-  isDictionaryEcho(text) {
-    return matchesDictionaryPrompt(text, this.getCustomDictionaryPrompt());
+  isDictionaryEcho(text, dictionaryPrompt = this.getCustomDictionaryPrompt()) {
+    // Prefer the prompt actually sent to STT (may be truncated for Groq).
+    return matchesDictionaryPrompt(text, dictionaryPrompt);
   }
 
   setCallbacks({
@@ -2412,9 +2416,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       if (dictionaryPrompt) {
         if (dictionaryPrompt.length > MAX_PROMPT_CHARS) {
           const originalLength = dictionaryPrompt.length;
-          const truncated = dictionaryPrompt.slice(0, MAX_PROMPT_CHARS);
-          const lastComma = truncated.lastIndexOf(",");
-          dictionaryPrompt = lastComma > 0 ? truncated.slice(0, lastComma) : truncated;
+          dictionaryPrompt = truncateDictionaryPrompt(dictionaryPrompt, MAX_PROMPT_CHARS);
           logger.debug(
             "Custom dictionary prompt truncated",
             {
@@ -2462,7 +2464,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         const proxyText = result?.text;
 
         if (proxyText && proxyText.trim().length > 0) {
-          if (this.isDictionaryEcho(proxyText)) {
+          if (this.isDictionaryEcho(proxyText, dictionaryPrompt)) {
             throw new Error("No audio detected");
           }
           timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
@@ -2676,7 +2678,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       // Check for text - handle both empty string and missing field
       if (result.text && result.text.trim().length > 0) {
-        if (this.isDictionaryEcho(result.text)) {
+        // Match against the prompt actually sent (truncated for Groq), not the full dict.
+        if (this.isDictionaryEcho(result.text, dictionaryPrompt)) {
           throw new Error("No audio detected");
         }
         timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -5,6 +5,14 @@ const normalize = (s) =>
     .replace(/\s+/g, " ")
     .trim();
 
+/** Truncate a dictionary prompt to maxChars, preferring a comma boundary. */
+export function truncateDictionaryPrompt(prompt, maxChars) {
+  if (!prompt || prompt.length <= maxChars) return prompt;
+  const truncated = prompt.slice(0, maxChars);
+  const lastComma = truncated.lastIndexOf(",");
+  return lastComma > 0 ? truncated.slice(0, lastComma) : truncated;
+}
+
 export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   if (!text || !dictionaryPrompt) return false;
 

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -116,3 +116,29 @@ test("does not flag completely unrelated text", async () => {
     false
   );
 });
+
+test("truncateDictionaryPrompt prefers a comma boundary under maxChars", async () => {
+  const { truncateDictionaryPrompt } = await import("../../src/utils/dictionaryEchoFilter.js");
+  const full = "Alpha, Bravo, Charlie, Delta, Echo, Foxtrot";
+  assert.equal(truncateDictionaryPrompt(full, 20), "Alpha, Bravo");
+  assert.equal(truncateDictionaryPrompt(full, 1000), full);
+  assert.equal(truncateDictionaryPrompt(null, 10), null);
+});
+
+test("echo filter matches the truncated prompt that Groq actually receives", async () => {
+  const { matchesDictionaryPrompt, truncateDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  // Large dict: enough unique terms that truncation drops a trailing chunk (>890 chars).
+  const words = Array.from({ length: 200 }, (_, i) => `DictionaryTerm${i}`);
+  const full = words.join(", ");
+  assert.ok(full.length > 890, `expected long dict, got length ${full.length}`);
+  const sent = truncateDictionaryPrompt(full, 890);
+  assert.ok(sent.length <= 890);
+  assert.notEqual(sent, full);
+
+  // Whisper often echoes the prompt that was sent, not the full dictionary.
+  assert.equal(matchesDictionaryPrompt(sent, sent), true);
+  // Comparing that echo against the full dict can miss (usage ratio drops).
+  assert.equal(matchesDictionaryPrompt(sent, full), false);
+});


### PR DESCRIPTION
## Summary

Groq (and custom Groq endpoints) truncate the custom dictionary prompt to about 890 characters before STT. The dictionary-echo filter still compared transcripts against the full dictionary, so a truncated echo could miss the filter and paste into the focused field.

This change:
- extracts `truncateDictionaryPrompt` next to the echo matcher
- lets `isDictionaryEcho` take the prompt that was actually sent
- uses that prompt on the BYOK / Groq transcription path after truncation

## AI assistance

Assisted by Cursor / Grok. Human author: Stan Shih (stantheman0128). I reviewed the diff and verification output.

## Verification / Evidence

`	ext
node --test test/helpers/dictionaryEchoFilter.test.js
# 18 pass, 0 fail (includes truncated-prompt echo case)

npx tsc --noEmit -p src
# exit 0

npm run lint
# exit 0
`

Live note: truncation logic was already present for Groq; the bug was echo matching against the unsent full dictionary.

## Test plan

- [x] Unit tests for truncate + echo against sent prompt
- [ ] Manual: large custom dictionary + silent dictation on Groq should not paste truncated dictionary text