### PR TITLE
fix(windows): quote Expand-Archive paths for apostrophes

### DIFF
--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -413,6 +413,11 @@ async function checkDiskSpace(directory, requiredBytes) {
   }
 }
 
+/** Escape a path for embedding in a PowerShell single-quoted string. */
+function escapePowerShellSingleQuoted(value) {
+  return String(value).replace(/'/g, "''");
+}
+
 async function extractZipWindows(zipPath, destDir) {
   try {
     await runSystemTar(zipPath, destDir);
@@ -421,14 +426,17 @@ async function extractZipWindows(zipPath, destDir) {
     debugLogger.info("tar extraction failed, trying PowerShell", { error: error.message });
   }
 
+  // Use -LiteralPath + single-quoted embedding (apostrophes doubled) so paths
+  // with spaces, brackets, or apostrophes (e.g. C:\Users\O'Brien\...) work.
+  // Double-quoted -Path embedding breaks on apostrophes when routed via cmd.
+  const command =
+    `Expand-Archive -Force -LiteralPath '${escapePowerShellSingleQuoted(zipPath)}' ` +
+    `-DestinationPath '${escapePowerShellSingleQuoted(destDir)}'`;
+
   return new Promise((resolve, reject) => {
     execFile(
-      "powershell",
-      [
-        "-NoProfile",
-        "-Command",
-        `Expand-Archive -Force -Path '${zipPath}' -DestinationPath '${destDir}'`,
-      ],
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", command],
       (psError) => {
         if (psError) reject(new Error(`Zip extraction failed: ${psError.message}`));
         else resolve();
@@ -513,4 +521,5 @@ module.exports = {
   extractArchive,
   findFile,
   findFiles,
+  escapePowerShellSingleQuoted,
 };

--- a/test/helpers/extractArchive.test.js
+++ b/test/helpers/extractArchive.test.js
@@ -176,13 +176,63 @@ test("extractArchive falls back to PowerShell when Windows tar rejects a zip arc
     assert.deepEqual(systemTarCalls, [[archivePath, destDir]]);
     assert.deepEqual(execCalls, [
       {
-        command: "powershell",
+        command: "powershell.exe",
         args: [
           "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
           "-Command",
-          "Expand-Archive -Force -Path 'C:\\cache\\binary.zip' -DestinationPath 'C:\\cache\\extract'",
+          "Expand-Archive -Force -LiteralPath 'C:\\cache\\binary.zip' -DestinationPath 'C:\\cache\\extract'",
         ],
       },
+    ]);
+  } finally {
+    cp.execFile = originalExecFile;
+    Object.defineProperty(process, "platform", originalPlatform);
+    delete require.cache[downloadUtilsPath];
+  }
+});
+
+test("escapePowerShellSingleQuoted doubles apostrophes for Expand-Archive paths", () => {
+  delete require.cache[downloadUtilsPath];
+  const { escapePowerShellSingleQuoted } = freshRequire();
+  assert.equal(
+    escapePowerShellSingleQuoted("C:\\Users\\O'Brien\\cache\\binary.zip"),
+    "C:\\Users\\O''Brien\\cache\\binary.zip"
+  );
+});
+
+test("extractArchive PowerShell fallback quotes apostrophe paths safely", async () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalExecFile = cp.execFile;
+  const execCalls = [];
+
+  Object.defineProperty(process, "platform", { value: "win32" });
+  cp.execFile = (command, args, callback) => {
+    execCalls.push({ command, args });
+    callback(null);
+  };
+
+  const archivePath = "C:\\Users\\O'Brien\\cache\\binary.zip";
+  const destDir = "C:\\Users\\O'Brien\\cache\\extract";
+  const { extractArchive } = freshRequire({
+    runSystemTar: async () => {
+      throw new Error("tar extraction timed out");
+    },
+  });
+
+  try {
+    await extractArchive(archivePath, destDir);
+    assert.equal(execCalls.length, 1);
+    assert.equal(execCalls[0].command, "powershell.exe");
+    assert.deepEqual(execCalls[0].args, [
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "Expand-Archive -Force -LiteralPath 'C:\\Users\\O''Brien\\cache\\binary.zip' -DestinationPath 'C:\\Users\\O''Brien\\cache\\extract'",
     ]);
   } finally {
     cp.execFile = originalExecFile;


### PR DESCRIPTION
## Summary

On Windows, `extractZipWindows` fell back to PowerShell `Expand-Archive` with paths embedded in single quotes via `-Path`. Paths containing an apostrophe (for example `C:\Users\O'Brien\...`) break that command, so binary/model zip extraction fails after tar fallback.

This switches to `powershell.exe` with `-LiteralPath` and doubles apostrophes for PowerShell single-quoted strings.

## AI assistance

Assisted by Cursor / Grok. Human author: Stan Shih (stantheman0128). I reviewed the diff and verification output.

## Verification / Evidence

```
node --test --test-name-pattern "PowerShell|escapePowerShell|falls back to PowerShell|falls back to JS tar|extracts a zip|unzipper" test/helpers/extractArchive.test.js
# 6 pass, 0 fail

# Live Win11 smoke: Expand-Archive -LiteralPath with O''Brien-escaped paths extracts OK
# (pre-existing corrupt-zip test still fails on Windows on origin/main; A/B confirmed)
```

## Test plan

- [x] Unit tests for Expand-Archive argv + apostrophe escaping
- [x] Live PowerShell Expand-Archive with apostrophe path (escaped)
- [ ] Manual: download a zip into a user profile path that contains an apostrophe
