### PR TITLE
fix(settings): fall back to /v1 when listing self-hosted models

### DIFF
--- a/src/components/OpenAICompatiblePanel.tsx
+++ b/src/components/OpenAICompatiblePanel.tsx
@@ -5,7 +5,7 @@ import { Input } from "./ui/input";
 import ApiKeyInput from "./ui/ApiKeyInput";
 import ModelCardList from "./ui/ModelCardList";
 import SearchableModelList, { MODEL_SEARCH_THRESHOLD } from "./ui/SearchableModelList";
-import { buildApiUrl, normalizeBaseUrl } from "../config/constants";
+import { buildApiUrl, getModelListBaseCandidates, normalizeBaseUrl } from "../config/constants";
 import { isSecureEndpoint } from "../utils/urlUtils";
 import { GetApiKeyLink } from "./ui/GetApiKeyLink";
 
@@ -111,6 +111,7 @@ export default function OpenAICompatiblePanel({
 
       const trimmedKey = apiKey?.trim();
       const effectiveKey = trimmedKey && trimmedKey.length > 0 ? trimmedKey : undefined;
+      let activeBase = normalized;
 
       try {
         if (!normalized.includes("://")) {
@@ -134,50 +135,79 @@ export default function OpenAICompatiblePanel({
           headers.Authorization = `Bearer ${effectiveKey}`;
         }
 
-        const modelsUrl = buildApiUrl(normalized, "/models");
-        const response = await fetch(modelsUrl, { method: "GET", headers });
+        const fetchModelOptions = async (base: string): Promise<ModelOption[]> => {
+          const response = await fetch(buildApiUrl(base, "/models"), { method: "GET", headers });
 
-        if (!response.ok) {
-          const errorText = await response.text().catch(() => "");
-          const summary = errorText
-            ? `${response.status} ${errorText.slice(0, 200)}`
-            : `${response.status} ${response.statusText}`;
-          throw new Error(summary.trim());
+          if (!response.ok) {
+            const errorText = await response.text().catch(() => "");
+            const summary = errorText
+              ? `${response.status} ${errorText.slice(0, 200)}`
+              : `${response.status} ${response.statusText}`;
+            throw new Error(summary.trim());
+          }
+
+          const payload = await response.json().catch(() => ({}));
+          const rawModels = Array.isArray(payload?.data)
+            ? payload.data
+            : Array.isArray(payload?.models)
+              ? payload.models
+              : [];
+
+          // Coerce fields defensively: non-conformant endpoints may return
+          // numeric ids or object descriptions, which would crash the render.
+          return (rawModels as Array<Record<string, unknown>>)
+            .map((item) => {
+              const rawValue = item?.id ?? item?.name;
+              if (rawValue === undefined || rawValue === null || rawValue === "") return null;
+              const value = String(rawValue);
+              const ownedBy = typeof item?.owned_by === "string" ? item.owned_by : undefined;
+              const description =
+                typeof item?.description === "string" && item.description
+                  ? item.description
+                  : ownedBy
+                    ? t("reasoning.custom.ownerLabel", { owner: ownedBy })
+                    : undefined;
+              return { value, label: value, description, ownedBy } as ModelOption;
+            })
+            .filter(Boolean) as ModelOption[];
+        };
+
+        // When the entered base yields no models, fall back through sibling
+        // bases and adopt the working one so inference targets it too.
+        const candidates = lockedBaseUrl ? [normalized] : getModelListBaseCandidates(normalized);
+        let mapped: ModelOption[] = [];
+        let resolvedBase = normalized;
+        let primaryError: Error | null = null;
+
+        for (const candidate of candidates) {
+          try {
+            const options = await fetchModelOptions(candidate);
+            if (options.length > 0) {
+              mapped = options;
+              resolvedBase = candidate;
+              break;
+            }
+          } catch (error) {
+            if (candidate === normalized) primaryError = error as Error;
+          }
         }
 
-        const payload = await response.json().catch(() => ({}));
-        const rawModels = Array.isArray(payload?.data)
-          ? payload.data
-          : Array.isArray(payload?.models)
-            ? payload.models
-            : [];
-
-        // Coerce fields defensively: non-conformant endpoints may return
-        // numeric ids or object descriptions, which would crash the render.
-        const mapped = (rawModels as Array<Record<string, unknown>>)
-          .map((item) => {
-            const rawValue = item?.id ?? item?.name;
-            if (rawValue === undefined || rawValue === null || rawValue === "") return null;
-            const value = String(rawValue);
-            const ownedBy = typeof item?.owned_by === "string" ? item.owned_by : undefined;
-            const description =
-              typeof item?.description === "string" && item.description
-                ? item.description
-                : ownedBy
-                  ? t("reasoning.custom.ownerLabel", { owner: ownedBy })
-                  : undefined;
-            return { value, label: value, description, ownedBy } as ModelOption;
-          })
-          .filter(Boolean) as ModelOption[];
+        if (mapped.length === 0 && primaryError) throw primaryError;
 
         if (isMountedRef.current && latestBaseRef.current === normalized) {
+          if (resolvedBase !== normalized) {
+            activeBase = resolvedBase;
+            latestBaseRef.current = resolvedBase;
+            setDraftBase(resolvedBase);
+            setBaseUrl(resolvedBase);
+          }
           setModelOptions(mapped);
           // `/models` is a discovery aid, not an allowlist — keep the user's
           // chosen id even if it's absent (it may still be valid, or belong to
           // a provider they're switching away from). Invalid ids surface a
           // clear API error at request time instead of being silently wiped.
           setModelsError(null);
-          lastLoadedBaseRef.current = normalized;
+          lastLoadedBaseRef.current = resolvedBase;
         }
       } catch (error) {
         if (isMountedRef.current && latestBaseRef.current === normalized) {
@@ -194,12 +224,12 @@ export default function OpenAICompatiblePanel({
         if (pendingBaseRef.current === normalized) {
           pendingBaseRef.current = null;
         }
-        if (isMountedRef.current && latestBaseRef.current === normalized) {
+        if (isMountedRef.current && latestBaseRef.current === activeBase) {
           setModelsLoading(false);
         }
       }
     },
-    [baseUrl, apiKey, t]
+    [baseUrl, apiKey, lockedBaseUrl, setBaseUrl, t]
   );
 
   useEffect(() => {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -43,6 +43,19 @@ export const ensureV1Suffix = (base: string): string => {
   return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
 };
 
+// Ordered bases to try when listing models from an OpenAI-compatible server.
+// Self-hosted servers (LM Studio, Ollama, vLLM) serve the API under /v1 even
+// when users enter the bare origin, and LM Studio's native REST base
+// (/api/v1 or /api/v0) has its OpenAI-compatible sibling at /v1.
+export const getModelListBaseCandidates = (base: string): string[] => {
+  const normalized = normalizeBaseUrl(base);
+  if (!normalized) return [];
+  const nativeApiMatch = normalized.match(/^(.+?)\/api\/v[01]$/i);
+  if (nativeApiMatch) return [normalized, `${nativeApiMatch[1]}/v1`];
+  const withV1 = ensureV1Suffix(normalized);
+  return withV1 === normalized ? [normalized] : [normalized, withV1];
+};
+
 const env = (typeof import.meta !== "undefined" && (import.meta as any).env) || {};
 
 const computeBaseUrl = (candidates: Array<string | undefined>, fallback: string): string => {

--- a/test/helpers/modelListBaseCandidates.test.js
+++ b/test/helpers/modelListBaseCandidates.test.js
@@ -1,0 +1,62 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+
+const load = () => import("../../src/config/constants.ts");
+
+test("bare origin falls back to /v1 (LM Studio, Ollama, vLLM)", async () => {
+  const { getModelListBaseCandidates } = await load();
+
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234"), [
+    "http://127.0.0.1:1234",
+    "http://127.0.0.1:1234/v1",
+  ]);
+});
+
+test("LM Studio native REST bases fall back to the OpenAI-compatible /v1", async () => {
+  const { getModelListBaseCandidates } = await load();
+
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234/api/v1"), [
+    "http://127.0.0.1:1234/api/v1",
+    "http://127.0.0.1:1234/v1",
+  ]);
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234/api/v0"), [
+    "http://127.0.0.1:1234/api/v0",
+    "http://127.0.0.1:1234/v1",
+  ]);
+});
+
+test("bases already ending in /v1 have no fallback", async () => {
+  const { getModelListBaseCandidates } = await load();
+
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234/v1"), [
+    "http://127.0.0.1:1234/v1",
+  ]);
+  assert.deepEqual(getModelListBaseCandidates("https://api.together.xyz/v1"), [
+    "https://api.together.xyz/v1",
+  ]);
+});
+
+test("hosted /api/v1 bases keep the entered base first so it wins when it serves models", async () => {
+  const { getModelListBaseCandidates } = await load();
+
+  assert.deepEqual(getModelListBaseCandidates("https://openrouter.ai/api/v1"), [
+    "https://openrouter.ai/api/v1",
+    "https://openrouter.ai/v1",
+  ]);
+});
+
+test("normalizes trailing slashes and endpoint suffixes before deriving candidates", async () => {
+  const { getModelListBaseCandidates } = await load();
+
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234/"), [
+    "http://127.0.0.1:1234",
+    "http://127.0.0.1:1234/v1",
+  ]);
+  assert.deepEqual(getModelListBaseCandidates("http://127.0.0.1:1234/v1/models"), [
+    "http://127.0.0.1:1234/v1",
+  ]);
+  assert.deepEqual(getModelListBaseCandidates(""), []);
+});


### PR DESCRIPTION
## Problem

Pointing dictation cleanup at LM Studio fails in both Self-Hosted and Cloud → Custom (#1187):

- `http://127.0.0.1:1234` → the panel fetches `{base}/models`, which 404s because LM Studio (like Ollama and vLLM) serves the OpenAI-compatible API under `/v1`.
- `http://127.0.0.1:1234/api/v1` → this is LM Studio's native REST API. Its `/api/v1/models` responds `{"models": [{"key": ...}]}` — no `id`/`name` fields — so every entry mapped to null and the panel showed "No models returned" even though LM Studio returned 19. Inference can't use that base anyway (there is no `/api/v1/chat/completions`).

The working base was `http://127.0.0.1:1234/v1` all along, but nothing guided the user there. Inference already applies `ensureV1Suffix` for the LAN provider; the model-list UI never got the same forgiveness.

## Fix

- New `getModelListBaseCandidates(base)` in `constants.ts`: entered base first, then its `/v1` sibling (bare origin → `origin/v1`; native `/api/v1` or `/api/v0` → `origin/v1`). Bases already ending in `/v1` get no fallback.
- `OpenAICompatiblePanel` walks the candidates and adopts the first base that returns models, updating the saved URL (and the input field) so inference targets the same working endpoint. The entered base always wins when it serves models, `lockedBaseUrl` (OpenRouter) never falls back, and error semantics are unchanged — the entered endpoint's error is what surfaces if nothing works.

## Testing

- New `test/helpers/modelListBaseCandidates.test.js` (5 cases); full suite 542 pass / 0 fail; typecheck, lint, prettier clean.
- Verified end-to-end against a mock server replicating LM Studio's exact surface (`/v1/models` with `data[].id`, `/api/v1/models` with `models[].key`, 404 elsewhere): bare origin, `/api/v1`, and `/v1` inputs all resolve to `/v1` and list models.

Fixes #1187
