### PR TITLE
fix(llama): bound local LLM context size to prevent macOS watchdog panic

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2120,10 +2120,10 @@ class IPCHandlers {
                 { from: oldUuid, to: uuid },
                 "gpu"
               );
-              const modelPath = modelManager.serverManager.modelPath;
+              const modelId = modelManager.currentServerModelId;
               await modelManager.serverManager.stop();
-              if (modelPath) {
-                await modelManager.serverManager.start(modelPath);
+              if (modelId) {
+                await modelManager.prewarmServer(modelId);
               }
             }
           }
@@ -3661,7 +3661,7 @@ class IPCHandlers {
 
         const modelPath = require("path").join(modelManager.modelsDir, modelInfo.model.fileName);
 
-        await modelManager.serverManager.start(modelPath, { threads: 4 });
+        await modelManager.serverManager.start(modelPath, modelManager.serverOptions(modelInfo));
         modelManager.currentServerModelId = modelId;
 
         this.environmentManager.saveAllKeysToEnvFile().catch(() => {});

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -19,6 +19,7 @@ const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const STARTUP_POLL_INTERVAL_MS = 500;
 const HEALTH_CHECK_FAILURE_THRESHOLD = 3;
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_CONTEXT_SIZE = 4096;
 
 class LlamaServerManager {
   constructor() {
@@ -137,11 +138,15 @@ class LlamaServerManager {
       String(this.port),
       "--threads",
       String(options.threads || 4),
+      // Unset, this defaults to the model's full trained context (128K+),
+      // whose KV cache can exceed total RAM with --fit disabled. See #1203.
+      "--ctx-size",
+      String(options.contextSize || DEFAULT_CONTEXT_SIZE),
       "--jinja",
     ];
 
     if (process.platform === "darwin") {
-      const args = [...baseArgs, "--n-gpu-layers", "99"];
+      const args = [...baseArgs, "--n-gpu-layers", String(options.gpuLayers ?? 99)];
       await this._startWithBinary(
         binaryPaths.default,
         args,
@@ -163,7 +168,7 @@ class LlamaServerManager {
   }
 
   async _startWithGpuFallback(binaryPaths, baseArgs, options) {
-    const gpuArgs = [...baseArgs, "--n-gpu-layers", "99"];
+    const gpuArgs = [...baseArgs, "--n-gpu-layers", String(options.gpuLayers ?? 99)];
     const cpuArgs = baseArgs;
 
     if (binaryPaths.vulkan) {

--- a/src/helpers/modelManagerBridge.js
+++ b/src/helpers/modelManagerBridge.js
@@ -15,6 +15,11 @@ const debugLogger = require("./debugLogger");
 
 const MIN_FILE_SIZE = 1_000_000; // 1MB minimum for valid model files
 
+// Bounds the KV cache — registry contextLength is the full trained context
+// (128K+), which can exceed total RAM (#1203). Uniform for all start paths:
+// start() won't restart a ready server when only options change.
+const SERVER_CONTEXT_SIZE = 16384;
+
 function getLocalProviders() {
   return modelRegistryData.localProviders || [];
 }
@@ -165,6 +170,17 @@ class ModelManager {
       }
     }
     return null;
+  }
+
+  serverOptions(modelInfo) {
+    return {
+      contextSize: Math.min(
+        SERVER_CONTEXT_SIZE,
+        modelInfo.model.contextLength || SERVER_CONTEXT_SIZE
+      ),
+      threads: 4,
+      gpuLayers: 99,
+    };
   }
 
   async downloadModel(modelId, onProgress) {
@@ -366,11 +382,7 @@ class ModelManager {
         serverReady: this.serverManager.ready,
       });
 
-      await this.serverManager.start(modelPath, {
-        contextSize: options.contextSize || modelInfo.model.contextLength || 4096,
-        threads: options.threads || 4,
-        gpuLayers: 99,
-      });
+      await this.serverManager.start(modelPath, this.serverOptions(modelInfo));
       this.currentServerModelId = modelId;
 
       debugLogger.logReasoning("INFERENCE_SERVER_STARTED", {
@@ -440,11 +452,7 @@ class ModelManager {
     if (!this.serverManager.isAvailable()) return false;
 
     try {
-      await this.serverManager.start(modelPath, {
-        contextSize: modelInfo.model.contextLength || 4096,
-        threads: 4,
-        gpuLayers: 99,
-      });
+      await this.serverManager.start(modelPath, this.serverOptions(modelInfo));
       this.currentServerModelId = modelId;
       debugLogger.info("llama-server pre-warmed", { modelId });
       return true;

--- a/src/services/localReasoningBridge.js
+++ b/src/services/localReasoningBridge.js
@@ -37,8 +37,6 @@ class LocalReasoningService {
         topK: config.topK || 40,
         topP: config.topP || 0.9,
         repeatPenalty: config.repeatPenalty || 1.1,
-        contextSize: config.contextSize || 4096,
-        threads: config.threads || 4,
         systemPrompt: config.systemPrompt || "",
         disableThinking: config.disableThinking !== false,
       };


### PR DESCRIPTION
## Problem

Starting local LLM cleanup/polishing could freeze the entire machine — on 16 GB Macs it escalated to a watchdog kernel panic (#1203). This reproduced with a 2 GB Llama-3.2-3B model, so it was never about model size.

`llama-server` was spawned with no `--ctx-size` and with `LLAMA_ARG_FIT=off`. On the bundled llama.cpp (b9763), an unset context size means **the model's full trained context** (131,072 tokens for Llama-3.2-3B), and `--fit off` disables the auto-shrink that would have bounded it. The resulting KV cache (~15 GB for the 3B model, on top of weights, fully Metal-offloaded via `-ngl 99`) wires more unified memory than the machine has. Wired memory can't be compressed or swapped, so userspace starves until `watchdogd` misses check-ins — matching the panic report (compressor at 18%, `kernel_task` panic).

How it regressed: `--ctx-size` was removed in an earlier commit to let llama.cpp's `--fit` auto-size the context; the b9763 bump later set `LLAMA_ARG_FIT=off` to skip its ~70 s startup probe — unknowingly removing the only remaining bound. The `contextSize` option callers pass into `serverManager.start()` had been silently ignored since the first change.

## Fix

- `llamaServer.js`: pass `--ctx-size` (and honor `gpuLayers`) instead of dropping those options. `baseArgs` is shared by the Metal, Vulkan, and CPU paths, so all backends are bounded — the CPU path had the same unbounded allocation in system RAM on Windows/Linux.
- `modelManagerBridge.js`: one `serverOptions()` policy — context 16384, capped at the model's trained context — used by inference, prewarm, and the `llama-server-start` IPC path. Uniformity matters because `start()` won't restart a ready server when only options change, so mixed sizes would silently keep whichever came first.
- `ipcHandlers.js`: the GPU-change restart now goes through `prewarmServer()` (same pattern as `llama-gpu-reset`) so restarts keep proper options instead of bare defaults.
- `localReasoningBridge.js`: drop the now-dead `contextSize`/`threads` pass-through fields.

For the reporter's setup (Llama-3.2-3B on a 16 GB M4 Air) this drops the allocation from ~17 GB to ~4 GB. 16384 tokens leaves ample room for cleanup prompts and agent/note flows (`max_tokens` tops out at 4096), while keeping the KV cache ≤ ~2.5 GB for the largest registry models. If a model's weights alone don't fit (e.g. gpt-oss-20b on 16 GB), llama-server now fails during startup and the existing error path surfaces it instead of taking down the OS.

## Verification

- Ran the bundled `llama-server` binary directly with the exact spawn args: without `--ctx-size` it logs `n_ctx = 32768` (gemma-3-1b's full trained context); with the fix it logs `n_ctx = 16384`. Confirmed `--parallel` defaults to auto with a unified KV cache, so the bound is the total budget.
- Confirmed no UI or stored setting exposes `contextSize`/`threads`, and traced all four live `serverManager.start()` call sites to the single policy.
- `npm run lint` and `npm test` (542 passing) are green.

Fixes #1203