### PR TITLE
test: run all test directories, not just test/helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "format": "npm run format:js",
     "format:check": "eslint . && cd src && eslint . && prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "lint": "eslint . && cd src && eslint .",
-    "test": "node --test \"test/helpers/*.test.js\"",
+    "test": "node --test \"test/**/*.test.js\"",
     "typecheck": "cd src && tsc --noEmit",
     "quality-check": "npm run format:check && npm run typecheck",
     "i18n:check": "node scripts/check-i18n.js",


### PR DESCRIPTION
## Summary
- `npm test` only globbed `test/helpers/*.test.js`, so the tests in `test/utils/` (bedrockRegions, snippets, and the new gpuDetection windowsHide regression test from #1233) never ran in CI.
- Widen the glob to `test/**/*.test.js` so every test directory runs.

## Verification
`npm test` now picks up 578 tests (was 564): 563 pass, 15 skipped, 0 fail.