### PR TITLE
Fix Opus audio uploads failing cloud transcription

### DIFF
--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -57,7 +57,7 @@ import { getBaseLanguageCode } from "../../utils/languageSupport";
 
 type UploadState = "idle" | "selected" | "downloading" | "transcribing" | "complete" | "error";
 
-const SUPPORTED_EXTENSIONS = ["mp3", "wav", "m4a", "webm", "ogg", "oga", "flac", "aac"];
+const SUPPORTED_EXTENSIONS = ["mp3", "wav", "m4a", "webm", "ogg", "oga", "flac", "aac", "opus"];
 
 const BYOK_MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB — hard limit for bring-your-own-key
 const CLOUD_FREE_MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB — free plan cloud limit
@@ -1385,7 +1385,7 @@ function IdleView({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".mp3,.wav,.m4a,.webm,.ogg,.oga,.flac,.aac"
+        accept=".mp3,.wav,.m4a,.webm,.ogg,.oga,.flac,.aac,.opus"
         onChange={handleFileInputChange}
         className="sr-only"
         tabIndex={-1}

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -124,6 +124,7 @@ const AUDIO_MIME_TYPES = {
   oga: "audio/ogg",
   flac: "audio/flac",
   aac: "audio/aac",
+  opus: "audio/ogg",
 };
 
 const CLOUD_INLINE_LIMIT = 4 * 1024 * 1024;
@@ -1705,7 +1706,7 @@ class IPCHandlers {
         filters: [
           {
             name: "Audio Files",
-            extensions: ["mp3", "wav", "m4a", "webm", "ogg", "oga", "flac", "aac"],
+            extensions: ["mp3", "wav", "m4a", "webm", "ogg", "oga", "flac", "aac", "opus"],
           },
         ],
       });

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2147,7 +2147,7 @@
       "title": "Audio hochladen",
       "using": "Verwendet {{model}}",
       "dropOrBrowse": "Audiodatei ablegen oder klicken zum Durchsuchen",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Zum Hochladen ablegen",
       "transcribe": "Transkribieren",
       "cancel": "Abbrechen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2348,7 +2348,7 @@
       "title": "Upload Audio",
       "using": "Using {{model}}",
       "dropOrBrowse": "Drop audio file or click to browse",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Drop to upload",
       "transcribe": "Transcribe",
       "cancel": "Cancel",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2195,7 +2195,7 @@
       "title": "Subir audio",
       "using": "Usando {{model}}",
       "dropOrBrowse": "Arrastra un archivo de audio o haz clic para explorar",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Suelta para subir",
       "transcribe": "Transcribir",
       "cancel": "Cancelar",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2260,7 +2260,7 @@
       "title": "Téléverser un fichier audio",
       "using": "Utilisation de {{model}}",
       "dropOrBrowse": "Déposez un fichier audio ou cliquez pour parcourir",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Déposez pour téléverser",
       "transcribe": "Transcrire",
       "cancel": "Annuler",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2147,7 +2147,7 @@
       "title": "Carica audio",
       "using": "Utilizzando {{model}}",
       "dropOrBrowse": "Trascina un file audio o clicca per sfogliare",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Rilascia per caricare",
       "transcribe": "Trascrivi",
       "cancel": "Annulla",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2131,7 +2131,7 @@
       "title": "音声をアップロード",
       "using": "{{model}} を使用中",
       "dropOrBrowse": "音声ファイルをドロップまたはクリックして選択",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "ドロップしてアップロード",
       "transcribe": "文字起こし",
       "cancel": "キャンセル",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2147,7 +2147,7 @@
       "title": "Enviar áudio",
       "using": "Usando {{model}}",
       "dropOrBrowse": "Arraste um arquivo de áudio ou clique para procurar",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Solte para enviar",
       "transcribe": "Transcrever",
       "cancel": "Cancelar",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2147,7 +2147,7 @@
       "title": "Загрузить аудио",
       "using": "Используется {{model}}",
       "dropOrBrowse": "Перетащите аудиофайл или нажмите для выбора",
-      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC",
+      "supportedFormats": "MP3, WAV, M4A, WebM, OGG, FLAC, AAC, Opus",
       "dropToUpload": "Отпустите для загрузки",
       "transcribe": "Транскрибировать",
       "cancel": "Отмена",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2142,7 +2142,7 @@
       "title": "上传音频",
       "using": "使用 {{model}}",
       "dropOrBrowse": "拖放音频文件或点击浏览",
-      "supportedFormats": "MP3、WAV、M4A、WebM、OGG、FLAC、AAC",
+      "supportedFormats": "MP3、WAV、M4A、WebM、OGG、FLAC、AAC、Opus",
       "dropToUpload": "拖放以上传",
       "transcribe": "转录",
       "cancel": "取消",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2142,7 +2142,7 @@
       "title": "上傳音訊",
       "using": "使用 {{model}}",
       "dropOrBrowse": "拖放音訊檔案或點擊瀏覽",
-      "supportedFormats": "MP3、WAV、M4A、WebM、OGG、FLAC、AAC",
+      "supportedFormats": "MP3、WAV、M4A、WebM、OGG、FLAC、AAC、Opus",
       "dropToUpload": "拖放以上傳",
       "transcribe": "轉錄",
       "cancel": "取消",


### PR DESCRIPTION
## Problem

Adding a YouTube link with OpenWhispr Cloud fails with an OpenAI "format not supported" error for short videos.

yt-dlp (`-x --audio-format best`) keeps YouTube's native Opus codec, producing a `.opus` file. `AUDIO_MIME_TYPES` had no `opus` entry, so the upload fell back to `Content-Type: audio/mpeg`. The cloud API trusts a recognized content type over the filename and forwarded Opus bytes to OpenAI labeled `audio.mp3`, which fails to decode.

Files over 4 MB were unaffected because the chunked path re-encodes to MP3 — only short videos hit the inline path with the raw `.opus` file. Same mislabel applied to the BYOK and self-hosted file paths, which share the map.

## Fix

- Map `opus` → `audio/ogg` in `AUDIO_MIME_TYPES` (OpenAI accepts Ogg Opus)
- Accept `.opus` in the file dialog filter, upload view extension gate, and file input, so manually uploading the same file the YouTube flow produces also works
- Add Opus to the supported-formats string in all locales

## Testing

- `npm test` — 563 pass
- `npm run typecheck` — clean