### PR TITLE
Isolate dev Qdrant storage from the production app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,8 @@ Always-on offline semantic search that finds notes by meaning, not just keywords
 
 **Storage**:
 
-- Qdrant data: `~/.cache/openwhispr/qdrant-data/`
-- Qdrant binary: `resources/bin/qdrant-{platform}-{arch}` (bundled — downloaded during `prebuild` / `predev`)
+- Qdrant data: `~/.cache/openwhispr/qdrant-data/` (`qdrant-data-dev/` in development)
+- Qdrant binary: `resources/bin/qdrant-{platform}-{arch}` (bundled — downloaded during `prebuild` / `predev:main`)
 - Embedding model: `~/.cache/openwhispr/embedding-models/all-MiniLM-L6-v2/` (auto-downloaded on first launch)
 
 **Dependencies**: `@qdrant/js-client-rest`, `onnxruntime-node`

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "compile:native": "npm run compile:globe && npm run compile:fast-paste && npm run compile:winkeys && npm run compile:linuxkeys && npm run compile:winpaste && npm run compile:linux-paste && npm run compile:linux-system-audio && npm run compile:text-monitor && npm run compile:media-remote && npm run compile:mediaremote-adapter && npm run compile:mic-listener && npm run compile:audio-tap",
     "prestart": "npm run compile:native && npm run download:meeting-aec-helper && npm run download:sherpa-onnx && npm run download:yt-dlp && npm run download:qdrant && npm run download:embedding-model && npm run download:whisper-vad-model",
     "start": "electron .",
-    "predev": "npm run compile:native && npm run download:meeting-aec-helper && npm run download:sherpa-onnx && npm run download:yt-dlp && npm run download:qdrant && npm run download:embedding-model && npm run download:whisper-vad-model",
     "dev": "concurrently -k -r \"npm:dev:renderer\" \"npm:dev:main\"",
     "predev:main": "npm run compile:native && npm run download:meeting-aec-helper && npm run download:sherpa-onnx && npm run download:yt-dlp && npm run download:qdrant && npm run download:embedding-model && npm run download:whisper-vad-model",
     "dev:main": "cross-env NODE_ENV=development node scripts/run-electron.js --dev",

--- a/scripts/download-qdrant.js
+++ b/scripts/download-qdrant.js
@@ -60,6 +60,14 @@ function getDownloadUrl(release, archiveName) {
   return asset?.url || null;
 }
 
+function isCurrentVersion(markerPath, version) {
+  try {
+    return JSON.parse(fs.readFileSync(markerPath, "utf8")).version === version;
+  } catch {
+    return false;
+  }
+}
+
 async function downloadBinary(platformArch, config, release, isForce = false) {
   if (!config) {
     console.log(`  [qdrant] ${platformArch}: Not supported`);
@@ -67,9 +75,10 @@ async function downloadBinary(platformArch, config, release, isForce = false) {
   }
 
   const outputPath = path.join(BIN_DIR, config.outputName);
+  const markerPath = path.join(BIN_DIR, `.qdrant-${platformArch}.json`);
 
-  if (fs.existsSync(outputPath) && !isForce) {
-    console.log(`  [qdrant] ${platformArch}: Already exists (use --force to re-download)`);
+  if (fs.existsSync(outputPath) && !isForce && isCurrentVersion(markerPath, release.tag)) {
+    console.log(`  [qdrant] ${platformArch}: Already up to date (${release.tag})`);
     return true;
   }
 
@@ -93,6 +102,7 @@ async function downloadBinary(platformArch, config, release, isForce = false) {
     if (binaryPath) {
       fs.copyFileSync(binaryPath, outputPath);
       setExecutable(outputPath);
+      fs.writeFileSync(markerPath, JSON.stringify({ version: release.tag }));
       console.log(`  [qdrant] ${platformArch}: Extracted to ${config.outputName}`);
     } else {
       console.error(

--- a/src/helpers/qdrantManager.js
+++ b/src/helpers/qdrantManager.js
@@ -18,7 +18,12 @@ const STARTUP_POLL_INTERVAL_MS = 100;
 const HEALTH_CHECK_INTERVAL_MS = 5000;
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 
-const STORAGE_DIR = path.join(os.homedir(), ".cache", "openwhispr", "qdrant-data");
+const STORAGE_DIR = path.join(
+  os.homedir(),
+  ".cache",
+  "openwhispr",
+  process.env.NODE_ENV === "development" ? "qdrant-data-dev" : "qdrant-data"
+);
 
 class QdrantManager {
   constructor() {
@@ -98,10 +103,14 @@ class QdrantManager {
     sidecarPidFile.write("qdrant", this.process.pid);
 
     let stderrBuffer = "";
+    let lastErrorLine = "";
     let exitCode = null;
 
     this.process.stdout.on("data", (data) => {
-      debugLogger.debug("qdrant stdout", { data: data.toString().trim() });
+      const text = data.toString();
+      debugLogger.debug("qdrant stdout", { data: text.trim() });
+      const errorLine = text.split("\n").findLast((line) => line.includes(" ERROR "));
+      if (errorLine) lastErrorLine = errorLine.trim();
     });
 
     this.process.stderr.on("data", (data) => {
@@ -123,7 +132,7 @@ class QdrantManager {
       sidecarPidFile.clear("qdrant");
     });
 
-    await this._waitForReady(() => ({ stderr: stderrBuffer, exitCode }));
+    await this._waitForReady(() => ({ stderr: stderrBuffer, lastErrorLine, exitCode }));
     this._startHealthCheck();
 
     debugLogger.info("qdrant started successfully", { port: this.port });
@@ -136,9 +145,13 @@ class QdrantManager {
     while (Date.now() - startTime < STARTUP_TIMEOUT_MS) {
       if (!this.process || this.process.killed) {
         const info = getProcessInfo ? getProcessInfo() : {};
-        const stderr = info.stderr ? info.stderr.trim().slice(0, 200) : "";
-        const details = stderr || (info.exitCode !== null ? `exit code: ${info.exitCode}` : "");
-        throw new Error(`qdrant process died during startup${details ? `: ${details}` : ""}`);
+        const details =
+          info.lastErrorLine ||
+          (info.stderr ? info.stderr.trim() : "") ||
+          (info.exitCode !== null ? `exit code: ${info.exitCode}` : "");
+        throw new Error(
+          `qdrant process died during startup${details ? `: ${details.slice(0, 400)}` : ""}`
+        );
       }
 
       pollCount++;


### PR DESCRIPTION
## Problem

Dev (`npm run dev`) and the installed production app both point Qdrant at `~/.cache/openwhispr/qdrant-data`. Whichever instance starts second panics on the WAL file lock (`Wal error: Can't init WAL: Resource temporarily unavailable`), silently killing local vector search for that session.

## Changes

- **Dev storage isolation**: development now uses `qdrant-data-dev`, following the existing `transcriptions-dev.db` convention. Production path is unchanged, so existing users are unaffected.
- **Accurate crash reporting**: the startup death message now surfaces Qdrant's actual panic line (stdout `ERROR`) instead of the first stderr line (a harmless jemalloc warning).
- **Version-aware binary download**: `download-qdrant.js` writes a `.qdrant-<platform>.json` marker (same pattern as sherpa-onnx) and re-downloads when the installed binary doesn't match the release tag — previously a stale binary was kept forever unless `--force`.
- **Single prep run**: removed the `predev` hook that duplicated `predev:main` verbatim; the compile/download chain now runs once per `npm run dev` instead of twice.

## Verification

- Prod vs dev path resolution tested for both `NODE_ENV` values
- Download script exercised end-to-end: fresh install pulls v1.18.3 and writes the marker; re-run skips with "Already up to date"; missing marker (the stale-binary case) triggers re-download
- Error-line extraction tested against the real crash output
- Marker never ships in builds (`extraResources` filter `qdrant-*` doesn't match dotfiles); no docs/CI reference `predev`; the only qdrant error consumer just logs `err.message`