### PR TITLE
Override adm-zip to 0.6.0 (high-severity dependabot alert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5118,12 +5118,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "zustand": "^5.0.11"
   },
   "overrides": {
+    "adm-zip": "^0.6.0",
     "@tiptap/extension-blockquote": "3.22.5",
     "@tiptap/extension-bold": "3.22.5",
     "@tiptap/extension-bubble-menu": "3.22.5",


### PR DESCRIPTION
Clears the repo's one open high-severity dependabot alert: adm-zip < 0.6.0 (crafted ZIP triggers a 4GB memory allocation). It's a transitive dependency pinned by `onnxruntime-node`, so dependabot can't PR it — this adds an npm `overrides` entry forcing `^0.6.0`.

Verified locally on Node 24:
- `npm ls adm-zip` resolves 0.6.0 under onnxruntime-node
- adm-zip write/read round-trip works
- `require("onnxruntime-node")` loads (it only uses adm-zip for install-time archive extraction)
- full test suite passes