### PR TITLE
fix: control panel navigates to external links instead of opening them in the browser

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -631,10 +631,9 @@ class WindowManager {
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
-      const controlPanelUrl = appUrl.startsWith("http") ? appUrl : `file://${appUrl}`;
 
       if (
-        url.startsWith(controlPanelUrl) ||
+        (appUrl && url.startsWith(appUrl)) ||
         url.startsWith("file://") ||
         url.startsWith("devtools://")
       ) {


### PR DESCRIPTION
## Summary
- In production builds, `DevServerManager.getAppUrl(true)` returns `null` (production loads via `loadFile()`, not `loadURL()`).
- The control panel's `will-navigate` guard in `src/helpers/windowManager.js` called `appUrl.startsWith("http")` on that value without a null check, throwing before `event.preventDefault()` ran.
- Net effect: the external-link guard silently no-ops in every packaged build. Clicking any external link inside the control panel (e.g. the changelog link in Settings → System → Software Updates) replaces the entire window's content with that page instead of opening it in the OS browser — with no way to navigate back.
- The bug only reproduces in packaged builds; in dev mode `getAppUrl(true)` returns the dev-server URL string, so `.startsWith` never throws and the issue is invisible under `npm run dev`.
- `main.js` already null-checks `getAppUrl()` before use elsewhere (see `applySessionTokenAndRefresh`), so this fix follows the same existing pattern.

## Fix
Null-guard `appUrl` before calling `.startsWith` on it, and drop the now-unreachable `file://${appUrl}` reconstruction (dead code — `getAppUrl` never returns a bare path; it's either an `http(s)` URL or `null`). The pre-existing `url.startsWith("file://")` check already covers all production navigation.

## Test plan
- [ ] `npm run pack` a build, open Settings → System, trigger an update-available state (or point release notes HTML at any external link), click a link, and confirm it opens in the default OS browser instead of navigating the control panel window away.
- [ ] Confirm internal navigation (dev server / packaged `file://` content) still loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)