### PR TITLE
Control panel navigates to external links instead of opening them in the browser

### DIFF
--- a/src/helpers/navigationPolicy.js
+++ b/src/helpers/navigationPolicy.js
@@ -1,17 +1,3 @@
-// Control panel navigation policy.
-//
-// The control panel is the only window that renders arbitrary HTML from
-// outside the app (e.g. update release notes via dangerouslySetInnerHTML),
-// so its will-navigate handler must tell the app's own content apart from
-// anything else and hand the "anything else" off to the OS browser instead
-// of navigating the window itself.
-
-// Whether a navigation target is the app's own content and should be left
-// alone (return true) rather than redirected to the OS browser.
-//
-// appUrl is the control panel's own URL, and is only non-null in development
-// (loadURL() against the dev server). Production loads via loadFile(), so
-// appUrl is null there and only the file:// branch matters.
 export function isInternalNavigation(url, appUrl) {
   return Boolean(
     (appUrl && url.startsWith(appUrl)) ||

--- a/src/helpers/navigationPolicy.js
+++ b/src/helpers/navigationPolicy.js
@@ -1,0 +1,21 @@
+// Control panel navigation policy.
+//
+// The control panel is the only window that renders arbitrary HTML from
+// outside the app (e.g. update release notes via dangerouslySetInnerHTML),
+// so its will-navigate handler must tell the app's own content apart from
+// anything else and hand the "anything else" off to the OS browser instead
+// of navigating the window itself.
+
+// Whether a navigation target is the app's own content and should be left
+// alone (return true) rather than redirected to the OS browser.
+//
+// appUrl is the control panel's own URL, and is only non-null in development
+// (loadURL() against the dev server). Production loads via loadFile(), so
+// appUrl is null there and only the file:// branch matters.
+export function isInternalNavigation(url, appUrl) {
+  return Boolean(
+    (appUrl && url.startsWith(appUrl)) ||
+      url.startsWith("file://") ||
+      url.startsWith("devtools://")
+  );
+}

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -6,6 +6,7 @@ const DragManager = require("./dragManager");
 const MenuManager = require("./menuManager");
 const DevServerManager = require("./devServerManager");
 const dockManager = require("./dockManager");
+const { isInternalNavigation } = require("./navigationPolicy");
 const { i18nMain } = require("./i18nMain");
 const { DEV_SERVER_PORT } = DevServerManager;
 const {
@@ -632,11 +633,7 @@ class WindowManager {
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
 
-      if (
-        (appUrl && url.startsWith(appUrl)) ||
-        url.startsWith("file://") ||
-        url.startsWith("devtools://")
-      ) {
+      if (isInternalNavigation(url, appUrl)) {
         return;
       }
 

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -631,10 +631,9 @@ class WindowManager {
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
-      const controlPanelUrl = appUrl.startsWith("http") ? appUrl : `file://${appUrl}`;
 
       if (
-        url.startsWith(controlPanelUrl) ||
+        (appUrl && url.startsWith(appUrl)) ||
         url.startsWith("file://") ||
         url.startsWith("devtools://")
       ) {

--- a/test/helpers/navigationPolicy.test.js
+++ b/test/helpers/navigationPolicy.test.js
@@ -6,7 +6,6 @@ const load = () => import("../../src/helpers/navigationPolicy.js");
 test("production navigation to the app's own file:// content is internal", async () => {
   const { isInternalNavigation } = await load();
 
-  // appUrl is null in production (loadFile() is used, not loadURL()).
   assert.equal(
     isInternalNavigation("file:///Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html", null),
     true
@@ -26,10 +25,6 @@ test("devtools navigation is always internal", async () => {
 test("an external link in production is not internal", async () => {
   const { isInternalNavigation } = await load();
 
-  // Regression guard: appUrl is null in production, and this must not throw —
-  // a throw here used to skip event.preventDefault() entirely, letting the
-  // control panel window navigate straight to the external page with no way
-  // back (e.g. the changelog link in Settings -> System -> Software Updates).
   assert.equal(isInternalNavigation("https://github.com/OpenWhispr/openwhispr/releases", null), false);
 });
 

--- a/test/helpers/navigationPolicy.test.js
+++ b/test/helpers/navigationPolicy.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/navigationPolicy.js");
+
+test("production navigation to the app's own file:// content is internal", async () => {
+  const { isInternalNavigation } = await load();
+
+  // appUrl is null in production (loadFile() is used, not loadURL()).
+  assert.equal(
+    isInternalNavigation("file:///Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html", null),
+    true
+  );
+});
+
+test("devtools navigation is always internal", async () => {
+  const { isInternalNavigation } = await load();
+
+  assert.equal(isInternalNavigation("devtools://devtools/bundled/inspector.html", null), true);
+  assert.equal(
+    isInternalNavigation("devtools://devtools/bundled/inspector.html", "http://localhost:5183/?panel=true"),
+    true
+  );
+});
+
+test("an external link in production is not internal", async () => {
+  const { isInternalNavigation } = await load();
+
+  // Regression guard: appUrl is null in production, and this must not throw —
+  // a throw here used to skip event.preventDefault() entirely, letting the
+  // control panel window navigate straight to the external page with no way
+  // back (e.g. the changelog link in Settings -> System -> Software Updates).
+  assert.equal(isInternalNavigation("https://github.com/OpenWhispr/openwhispr/releases", null), false);
+});
+
+test("dev server navigation matches the control panel's own URL", async () => {
+  const { isInternalNavigation } = await load();
+
+  const appUrl = "http://localhost:5183/?panel=true";
+  assert.equal(isInternalNavigation(appUrl, appUrl), true);
+  assert.equal(isInternalNavigation("https://github.com/OpenWhispr/openwhispr/releases", appUrl), false);
+});


### PR DESCRIPTION
## Summary

Clicking an external link in the release notes opens the link in Electron.

- In production builds, `DevServerManager.getAppUrl(true)` returns `null` (production loads via `loadFile()`, not `loadURL()`).
- The control panel's `will-navigate` guard in `src/helpers/windowManager.js` called `appUrl.startsWith("http")` on that value without a null check, throwing before `event.preventDefault()` ran.
- Net effect: the external-link guard silently no-ops in every packaged build. Clicking any external link inside the control panel (e.g. the changelog link in Settings -> System -> Software Updates) replaces the entire window's content with that page instead of opening it in the OS browser -- with no way to navigate back.
- The bug only reproduces in packaged builds; in dev mode `getAppUrl(true)` returns the dev-server URL string, so `.startsWith` never throws and the issue is invisible under `npm run dev`.
- `main.js` already null-checks `getAppUrl()` before use elsewhere (see `applySessionTokenAndRefresh`), so this fix follows the same existing pattern.

## Screenshots

Visual context on where the issue is:
<img width="1205" height="802" alt="Control_Panel_and_npm_run_dev_and_fix__control_panel_navigates_to_external_links_instead_of_opening_them_in_the_browser_by_dakotahp_·_Pull_Request__1_·_dakotahp_openwhispr" src="https://github.com/user-attachments/assets/bf0b0176-3f9e-4f47-8958-2d739b9ce200" />

Before a fix:
<img width="1211" height="812" alt="Control_Panel_and_npm_run_dev_and_fix__control_panel_navigates_to_external_links_instead_of_opening_them_in_the_browser_by_dakotahp_·_Pull_Request__1_·_dakotahp_openwhispr" src="https://github.com/user-attachments/assets/3e04d81f-6e47-4eb5-a340-fdb5479f4250" />


## Fix
- Null-guard `appUrl` before calling `.startsWith` on it, and drop the now-unreachable `file://${appUrl}` reconstruction (dead code -- `getAppUrl` never returns a bare path; it's either an `http(s)` URL or `null`). The pre-existing `url.startsWith("file://")` check already covers all production navigation.
- Extracted the decision logic into `src/helpers/navigationPolicy.js` (pure `isInternalNavigation(url, appUrl)`), mirroring the existing `dockManager.js`/`dockPolicy.js` split in this repo. `windowManager.js` keeps the Electron side effects; the policy module is unit-tested directly.
- Added `test/helpers/navigationPolicy.test.js`, including a regression test for the exact null-`appUrl` production case that caused the bug.

## Test plan
- [x] `node --test test/helpers/navigationPolicy.test.js` -- 4/4 passing
- [x] `npm test` -- no new failures (pre-existing sandbox-unrelated failures only)
- [ ] `npm run pack` a build, open Settings -> System, trigger an update-available state (or point release notes HTML at any external link), click a link, and confirm it opens in the default OS browser instead of navigating the control panel window away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)