### PR TITLE
fix(linux): settle modifiers before key press in portal paste

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -91,6 +91,8 @@ static void portal_send_paste(PortalData *app)
 {
     if (app->mode == PASTE_MODE_SHIFT_INSERT) {
         portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 1, "Shift press");
+        /* let the compositor register the modifier before the key arrives */
+        usleep(20000);
         portal_emit_key(app, PORTAL_KEY_INSERT,    1, "Insert press");
         usleep(20000);
         portal_emit_key(app, PORTAL_KEY_INSERT,    0, "Insert release");
@@ -101,6 +103,7 @@ static void portal_send_paste(PortalData *app)
         portal_emit_key(app, PORTAL_KEY_LEFTCTRL, 1, "Ctrl press");
         if (use_shift)
             portal_emit_key(app, PORTAL_KEY_LEFTSHIFT, 1, "Shift press");
+        usleep(20000);
         portal_emit_key(app, PORTAL_KEY_V, 1, "V press");
         usleep(20000);
         portal_emit_key(app, PORTAL_KEY_V, 0, "V release");


### PR DESCRIPTION
## Summary

On KDE Wayland, auto-paste into terminals intermittently fails even though `linux-fast-paste --portal` exits 0. `portal_send_paste()` in `resources/linux-fast-paste.c` emits the modifier press and the key press back to back, with the only `usleep` sitting between key press and key release. The D-Bus call is synchronous, but the portal reply only means the daemon dispatched the event: KWin applies it asynchronously, so the target sometimes receives a bare Insert or V before the modifier registers. GUI apps tolerate that; terminals drop it. Holding Shift physically while the paste fires makes it work every time, which is what pointed at the race.

The fix adds a 20 ms settle after the modifier press on both paths (Shift+Insert and Ctrl(+Shift)+V), before the key press. That matches the value the reporter verified on KWin and brings the portal path in line with the uinput and XTest backends in the same file, which already delay after the modifier press. Release order is unchanged, cost is +20 ms per paste.

Fixes #1230

## Changes

- resources/linux-fast-paste.c: add a 20 ms settle between modifier press and key press in both branches of `portal_send_paste()`