### PR TITLE
fix(translation): guard empty translation chain results

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -37,7 +37,11 @@ import {
   resolveSelfHostedTranscriptionModel,
 } from "./selfHostedTranscription";
 import { resolveStreamingFallbackTarget } from "./transcriptionFallback";
-import { executeTranslationChain, shouldRunTranslateStep } from "./translationChain";
+import {
+  executeTranslationChain,
+  resolveTranslatedText,
+  shouldRunTranslateStep,
+} from "./translationChain";
 import { detectAgentName } from "../config/agentDetection";
 import {
   resolveDictationRouteKind,
@@ -2020,7 +2024,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
                     log: { level: "error", channel: "transcription" },
                   },
           });
-          processedText = chainResult.text;
+          processedText = resolveTranslatedText(processedText, chainResult);
         }
       } catch (reasonError) {
         logger.error(
@@ -3562,7 +3566,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
                     log: { level: "error", channel: "streaming" },
                   },
           });
-          finalText = chainResult.text;
+          finalText = resolveTranslatedText(finalText, chainResult);
           usedCloudReasoning = chainResult.usedCloudReasoning || usedCloudReasoning;
         }
       } catch (reasonError) {

--- a/src/helpers/translationChain.js
+++ b/src/helpers/translationChain.js
@@ -47,3 +47,9 @@ export async function executeTranslationChain({
 
   return { text: out, usedCloudReasoning };
 }
+
+// Keep the chain result only when it produced text; an empty/missing result
+// preserves the input so a dictation is never overwritten with nothing.
+export function resolveTranslatedText(previousText, chainResult) {
+  return chainResult?.text ? chainResult.text : previousText;
+}

--- a/test/helpers/translationChain.test.js
+++ b/test/helpers/translationChain.test.js
@@ -274,3 +274,32 @@ test("shouldRunTranslateStep matrix", async () => {
   assert.equal(shouldRunTranslateStep("", "en"), true);
   assert.equal(shouldRunTranslateStep(undefined, "it"), true);
 });
+
+// Guard used at the batch/cloud call site (processedText): an empty chain result
+// must leave the transcription intact; a real result replaces it.
+test("resolveTranslatedText: empty chain result keeps processedText", async () => {
+  const { resolveTranslatedText } = await load();
+
+  assert.equal(resolveTranslatedText("raw dictation", { text: "" }), "raw dictation");
+  assert.equal(resolveTranslatedText("raw dictation", { text: null }), "raw dictation");
+  assert.equal(resolveTranslatedText("raw dictation", {}), "raw dictation");
+});
+
+test("resolveTranslatedText: non-empty chain result replaces processedText", async () => {
+  const { resolveTranslatedText } = await load();
+
+  assert.equal(resolveTranslatedText("raw dictation", { text: "translated" }), "translated");
+});
+
+// Guard used at the streaming call site (finalText): same preservation semantics.
+test("resolveTranslatedText: empty chain result keeps finalText", async () => {
+  const { resolveTranslatedText } = await load();
+
+  assert.equal(resolveTranslatedText("streamed text", { text: "" }), "streamed text");
+});
+
+test("resolveTranslatedText: non-empty chain result replaces finalText", async () => {
+  const { resolveTranslatedText } = await load();
+
+  assert.equal(resolveTranslatedText("streamed text", { text: "traducido" }), "traducido");
+});


### PR DESCRIPTION
## Summary

While reviewing #938 I noticed the translation path shipped in #1189 has the same unguarded shape at its two call sites: in `audioManager.js`, `processedText = chainResult.text` (batch) and `finalText = chainResult.text` (streaming) assign the chain result without checking it, while the cleanup path a few lines above already guards with `reasonResult.success && reasonResult.text`. Today the assignments are safe only because `executeTranslationChain` never returns empty text for non-empty input, an invariant that lives in a different file. This guards the call sites themselves, so an empty chain result can never blank a dictation even if the chain internals change.

## Changes

- `src/helpers/translationChain.js`: new `resolveTranslatedText(previousText, chainResult)` helper that returns the chain text only when non-empty.
- `src/helpers/audioManager.js`: both translation call sites assign through the helper; `usedCloudReasoning` bookkeeping unchanged.
- `test/helpers/translationChain.test.js`: four tests covering both behaviors (empty, null, or missing result keeps the previous text; a real result replaces it).
