### PR TITLE
feat: open notes from cloud deep links

### DIFF
--- a/main.js
+++ b/main.js
@@ -323,6 +323,9 @@ let ipcHandlers = null;
 let cliBridge = null;
 let globeKeyAlertShown = false;
 let authBridgeServer = null;
+let pendingNoteCloudId = null;
+let pendingNoteRetryTimer = null;
+let pendingNoteRetryCount = 0;
 const WHISPER_WAKE_REWARM_DELAY_MS = 3000;
 let wakeRewarmTimer = null;
 
@@ -517,6 +520,11 @@ app.on("open-url", (event, url) => {
     return;
   }
 
+  if (isNoteDeepLink(url)) {
+    void handleNoteDeepLink(url);
+    return;
+  }
+
   if (isInvitationDeepLink(url)) {
     handleInvitationDeepLink(url);
     return;
@@ -533,6 +541,79 @@ app.on("open-url", (event, url) => {
 
 function isInvitationDeepLink(url) {
   return url.slice(`${OAUTH_PROTOCOL}://`.length).startsWith("invitations/");
+}
+
+function isNoteDeepLink(url) {
+  return url.slice(`${OAUTH_PROTOCOL}://`.length).startsWith("notes/");
+}
+
+function parseNoteCloudId(deepLinkUrl) {
+  try {
+    const match = deepLinkUrl.match(/notes\/([^/?#]+)/);
+    const cloudId = match?.[1] ? decodeURIComponent(match[1]) : "";
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(cloudId)
+      ? cloudId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearPendingNoteDeepLink() {
+  clearTimeout(pendingNoteRetryTimer);
+  pendingNoteRetryTimer = null;
+  pendingNoteCloudId = null;
+  pendingNoteRetryCount = 0;
+}
+
+async function flushPendingNoteDeepLink() {
+  if (!pendingNoteCloudId || !windowManager || !databaseManager) return;
+
+  try {
+    // Surface the panel on the first attempt only; retries just poll the
+    // database so they can't repeatedly steal focus.
+    if (pendingNoteRetryCount === 0) {
+      await windowManager.createControlPanelWindow();
+    }
+
+    const note = databaseManager.getNoteByCloudId(pendingNoteCloudId);
+    if (!note) {
+      // Cloud sync may still be hydrating during a cold launch. Retry briefly so
+      // the handoff can resolve a note pulled after the protocol event arrived.
+      pendingNoteRetryCount += 1;
+      if (pendingNoteRetryCount <= 10) {
+        clearTimeout(pendingNoteRetryTimer);
+        pendingNoteRetryTimer = setTimeout(() => {
+          void flushPendingNoteDeepLink();
+        }, 1000);
+      } else {
+        console.warn("Note deep link could not resolve a local note", {
+          cloudId: pendingNoteCloudId,
+        });
+        clearPendingNoteDeepLink();
+      }
+      return;
+    }
+
+    const payload = { noteId: note.id, folderId: note.folder_id ?? null };
+    clearPendingNoteDeepLink();
+    await windowManager.queueNoteNavigation(payload);
+  } catch (error) {
+    console.error("Note deep link failed:", error);
+    clearPendingNoteDeepLink();
+  }
+}
+
+async function handleNoteDeepLink(deepLinkUrl) {
+  const cloudId = parseNoteCloudId(deepLinkUrl);
+  if (!cloudId) {
+    console.warn("Invalid note deep link");
+    return;
+  }
+
+  clearPendingNoteDeepLink();
+  pendingNoteCloudId = cloudId;
+  await flushPendingNoteDeepLink();
 }
 
 function handleInvitationDeepLink(deepLinkUrl) {
@@ -861,6 +942,13 @@ async function startApp() {
   await windowManager.createMainWindow();
   if (!startMinimized) {
     await windowManager.createControlPanelWindow();
+  }
+
+  const initialProtocolUrl = process.argv.find((arg) => arg.startsWith(`${OAUTH_PROTOCOL}://`));
+  if (initialProtocolUrl && isNoteDeepLink(initialProtocolUrl)) {
+    await handleNoteDeepLink(initialProtocolUrl);
+  } else {
+    await flushPendingNoteDeepLink();
   }
 
   // Create agent window (hidden) and set up agent hotkey
@@ -1557,6 +1645,8 @@ if (gotSingleInstanceLock) {
     if (url) {
       if (url.includes("upgrade-success")) {
         handleUpgradeDeepLink();
+      } else if (isNoteDeepLink(url)) {
+        await handleNoteDeepLink(url);
       } else if (isInvitationDeepLink(url)) {
         handleInvitationDeepLink(url);
       } else {
@@ -1677,6 +1767,7 @@ function performSyncTeardown() {
     clearTimeout(wakeRewarmTimer);
     wakeRewarmTimer = null;
   }
+  clearPendingNoteDeepLink();
   if (authBridgeServer) {
     authBridgeServer.close();
     authBridgeServer = null;

--- a/preload.js
+++ b/preload.js
@@ -981,9 +981,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     "meeting-note-navigation-pending",
     (callback) => () => callback()
   ),
-  onNavigateToNote: registerListener(
-    "navigate-to-note",
-    (callback) => (_event, data) => callback(data)
+  getPendingNoteNavigation: () => ipcRenderer.invoke("get-pending-note-navigation"),
+  onNoteNavigationPending: registerListener(
+    "note-navigation-pending",
+    (callback) => () => callback()
   ),
 
   onUpdateNotificationData: registerListener(

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -372,14 +372,18 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   }, []);
 
   useEffect(() => {
-    const cleanup = window.electronAPI?.onNavigateToNote?.((data) => {
+    const drain = async () => {
+      const data = await window.electronAPI?.getPendingNoteNavigation?.();
+      if (!data) return;
       if (data.folderId) {
         setActiveFolderId(data.folderId);
         initializeNotes(null, 50, data.folderId);
       }
       setActiveNoteId(data.noteId);
       setActiveView("personal-notes");
-    });
+    };
+    drain();
+    const cleanup = window.electronAPI?.onNoteNavigationPending?.(drain);
     return () => cleanup?.();
   }, []);
 

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -1464,6 +1464,21 @@ class DatabaseManager {
     }
   }
 
+  getNoteByCloudId(cloudId) {
+    try {
+      if (!this.db) {
+        throw new Error("Database not initialized");
+      }
+      const stmt = this.db.prepare(
+        "SELECT * FROM notes WHERE cloud_id = ? AND deleted_at IS NULL LIMIT 1"
+      );
+      return stmt.get(cloudId) || null;
+    } catch (error) {
+      debugLogger.error("Error getting note by cloud_id", { error: error.message }, "notes");
+      throw error;
+    }
+  }
+
   getNotes(noteType = null, limit = 100, folderId = null) {
     try {
       if (!this.db) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6947,8 +6947,7 @@ class IPCHandlers {
     ipcMain.handle("agent-open-note", async (_event, noteId) => {
       try {
         const note = this.databaseManager.getNote(noteId);
-        await this.windowManager.createControlPanelWindow();
-        this.windowManager.sendToControlPanel("navigate-to-note", {
+        await this.windowManager.queueNoteNavigation({
           noteId,
           folderId: note?.folder_id ?? null,
         });
@@ -8804,6 +8803,10 @@ class IPCHandlers {
 
     ipcMain.handle("get-pending-meeting-note-navigation", async () => {
       return this.windowManager?.consumePendingMeetingNoteNavigation() ?? null;
+    });
+
+    ipcMain.handle("get-pending-note-navigation", async () => {
+      return this.windowManager?.consumePendingNoteNavigation() ?? null;
     });
 
     ipcMain.handle("meeting-notification-ready", async () => {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -48,6 +48,7 @@ class WindowManager {
     this._panelStartPosition = "bottom-right";
     this._isDictatingToggle = false;
     this._pendingMeetingNoteNavigation = null;
+    this._pendingNoteNavigation = null;
 
     app.on("before-quit", () => {
       this.isQuitting = true;
@@ -1374,6 +1375,18 @@ class WindowManager {
   consumePendingMeetingNoteNavigation() {
     const payload = this._pendingMeetingNoteNavigation;
     this._pendingMeetingNoteNavigation = null;
+    return payload;
+  }
+
+  async queueNoteNavigation(payload) {
+    this._pendingNoteNavigation = payload;
+    await this.createControlPanelWindow();
+    this.sendToControlPanel("note-navigation-pending");
+  }
+
+  consumePendingNoteNavigation() {
+    const payload = this._pendingNoteNavigation;
+    this._pendingNoteNavigation = null;
     return payload;
   }
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -2001,9 +2001,11 @@ declare global {
         trigger?: "hotkey" | "manual" | "calendar-join";
       } | null>;
       onMeetingNoteNavigationPending?: (callback: () => void) => () => void;
-      onNavigateToNote?: (
-        callback: (data: { noteId: number; folderId: number | null }) => void
-      ) => () => void;
+      getPendingNoteNavigation?: () => Promise<{
+        noteId: number;
+        folderId: number | null;
+      } | null>;
+      onNoteNavigationPending?: (callback: () => void) => () => void;
       onUpdateNotificationData?: (
         callback: (data: { version: string; releaseDate?: string }) => void
       ) => () => void;


### PR DESCRIPTION
## What & why

Adds a notes/<cloud-id> deep link so links from the cloud app (e.g. openwhispr://notes/<uuid>) open the matching local note in the control panel. Handles all three arrival paths — macOS open-url, Windows/Linux cold launch via argv, and second-instance — and tolerates the cold-start case where cloud sync hasn't hydrated the note yet by retrying the lookup for up to 10 seconds.

As part of this, note navigation delivery was reworked from a push IPC event (navigate-to-note) to a store-then-drain pull pattern (same mechanism as meeting-note navigation): the main process queues the payload and pings; the renderer drains on mount and on ping. This closes a race where a freshly created control panel window could miss the push event before its React listener mounted — the existing agent-open-note flow had the same latent race and was migrated to the shared queue too.