### PR TITLE
fix(parakeet): preserve newer partial after duplicate final

### DIFF
--- a/src/helpers/parakeetWsResult.js
+++ b/src/helpers/parakeetWsResult.js
@@ -13,6 +13,7 @@ function createOnlineAccumulator() {
   const finalizedSegments = new Set();
   let finalizedText = "";
   let partialText = "";
+  let partialSegment = null;
   let fallbackKey = 0;
 
   const text = () =>
@@ -33,6 +34,7 @@ function createOnlineAccumulator() {
 
       if (!parsed.is_final) {
         partialText = finalizedSegments.has(parsed.segment) ? "" : messageText;
+        partialSegment = parsed.segment ?? null;
         return text();
       }
 
@@ -41,7 +43,10 @@ function createOnlineAccumulator() {
         finalizedSegments.add(segment);
         finalizedText = finalizedText ? `${finalizedText} ${messageText}` : messageText;
       }
-      partialText = "";
+      if (partialSegment === null || partialSegment === segment) {
+        partialText = "";
+        partialSegment = null;
+      }
       return text();
     },
     text,

--- a/test/helpers/parakeetWsResult.test.js
+++ b/test/helpers/parakeetWsResult.test.js
@@ -19,6 +19,27 @@ test("online sherpa messages keep finalized segments and latest partial", () => 
   );
 });
 
+test("online sherpa duplicate final keeps a newer segment partial", () => {
+  assert.equal(
+    parseOnlineMessages([
+      JSON.stringify({ text: "hello", is_final: true, segment: 0 }),
+      JSON.stringify({ text: "new partial", is_final: false, segment: 1 }),
+      JSON.stringify({ text: "hello", is_final: true, segment: 0 }),
+    ]),
+    "hello new partial"
+  );
+});
+
+test("online sherpa matching final replaces its partial", () => {
+  assert.equal(
+    parseOnlineMessages([
+      JSON.stringify({ text: "hello", is_final: false, segment: 0 }),
+      JSON.stringify({ text: "hello world", is_final: true, segment: 0 }),
+    ]),
+    "hello world"
+  );
+});
+
 test("online sherpa parser keeps numeric final text as text", () => {
   assert.equal(
     parseOnlineMessages([JSON.stringify({ text: "2026", is_final: true, segment: 0 })]),


### PR DESCRIPTION
## Summary

- preserve the active Parakeet/Nemotron partial when a duplicate final arrives for an older segment
- continue clearing a partial when its own matching final arrives
- cover both message orderings with focused accumulator regressions

## Problem

The online accumulator deduplicates finalized messages by segment ID, but cleared `partialText` after every final message. When an older final was repeated after a newer segment had begun producing partial text, the newer live transcript disappeared from the preview and accumulated stream result.

## Root cause

The accumulator tracked the partial text but not the segment that owned it, so it could not distinguish a matching final from a stale final for another segment.

## Solution

Track the current partial's segment ID and clear the partial only when a final belongs to that segment. Finals without a segment ID retain the previous conservative behavior and clear the partial.

Fixes #1282

## Validation

- `node --test test/helpers/parakeetWsResult.test.js` — 8 passed
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` — 662 passed, 16 skipped, 0 failed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed
- `npx prettier --check src/helpers/parakeetWsResult.js test/helpers/parakeetWsResult.test.js` — passed
- `git diff --check` — passed

`npm run format:check` still reports pre-existing formatting differences in `src/locales/zh-CN/translation.json` and `src/locales/zh-TW/translation.json`; neither file is changed by this PR.

## Risk

Low. The change is confined to the online websocket result accumulator. Existing final-segment deduplication and fallback handling are unchanged, and focused tests cover both stale and matching final messages.
