### PR TITLE
fix(audio): re-warm mic driver after idle instead of once per session

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -15,6 +15,7 @@ import {
   recordLocalSpeechWindow,
 } from "./localSpeechGate";
 import { reacquireIfDead } from "./micTrackHealth";
+import { isMicWarm, MIC_WARM_TTL_MS } from "./micWarmState";
 import { ActiveMicRecoveryController } from "./activeMicRecovery";
 import { followsSystemDefaultMic, reconcileSavedMicSelection } from "./micSelectionRecovery";
 import { isStaleDeviceError } from "./staleMicDevice";
@@ -299,7 +300,7 @@ class AudioManager {
     this._onDeviceChange = () => {
       this.cachedMicDeviceId = null;
       this.validatedSelectedMicDeviceId = null;
-      this.micDriverWarmedUp = false;
+      this._micWarmedAt = 0;
       this.rejectedMicDeviceId = null;
     };
     navigator.mediaDevices?.addEventListener?.("devicechange", this._onDeviceChange);
@@ -322,6 +323,7 @@ class AudioManager {
     this.cachedMicDeviceId = null;
     this.validatedSelectedMicDeviceId = null;
     this.rejectedMicDeviceId = null;
+    this._micWarmedAt = 0;
     this.persistentAudioContext = null;
     this.workletModuleLoaded = false;
     this.workletBlobUrl = null;
@@ -688,21 +690,40 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
+  // Warm the mic driver at most once per TTL. Shared by the batch and streaming
+  // sites so they can't drift or latch each other permanently off.
+  async _warmMicDriverOnce(logCategory) {
+    if (isMicWarm(this._micWarmedAt, Date.now())) return;
+    try {
+      const constraints = await this.getAudioConstraints();
+      const streamPromise = navigator.mediaDevices.getUserMedia(constraints);
+      // Stop the mic whenever it resolves, so a stream that arrives after the
+      // timeout is still released instead of leaking open.
+      streamPromise
+        .then((stream) => stream.getTracks().forEach((track) => track.stop()))
+        .catch(() => {});
+      let timer = null;
+      const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error("mic warmup timed out")), MIC_WARM_TTL_MS);
+      });
+      try {
+        await Promise.race([streamPromise, timeout]);
+      } finally {
+        if (timer !== null) clearTimeout(timer);
+      }
+      this._micWarmedAt = Date.now();
+      logger.debug("Microphone driver pre-warmed", {}, logCategory);
+    } catch (e) {
+      logger.debug("Mic driver warmup failed (non-critical)", { error: e.message }, logCategory);
+    }
+  }
+
   // Briefly acquire and release the mic so the OS audio driver is warm before
   // the first real recording, reducing cold-start empty captures. See #871.
   async warmupMicDriver() {
-    if (this.micDriverWarmedUp) return;
     // Skip while a recording is active so we don't double-acquire the mic. See #871.
     if (this.isRecording || this.isProcessing || this.mediaRecorder?.state === "recording") return;
-    try {
-      const constraints = await this.getAudioConstraints();
-      const tempStream = await navigator.mediaDevices.getUserMedia(constraints);
-      tempStream.getTracks().forEach((track) => track.stop());
-      this.micDriverWarmedUp = true;
-      logger.debug("Microphone driver pre-warmed", {}, "audio");
-    } catch (e) {
-      logger.debug("Mic driver warmup failed (non-critical)", { error: e.message }, "audio");
-    }
+    await this._warmMicDriverOnce("audio");
   }
 
   // Recovers a dead/muted capture: retries the same device, then hops to the OS default,
@@ -3253,21 +3274,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         // Warm up the OS audio driver by briefly acquiring the mic, then releasing.
         // This forces macOS to initialize the audio subsystem so subsequent
         // getUserMedia calls resolve in ~100-200ms instead of ~500-1000ms.
-        if (!this.micDriverWarmedUp) {
-          try {
-            const constraints = await this.getAudioConstraints();
-            const tempStream = await navigator.mediaDevices.getUserMedia(constraints);
-            tempStream.getTracks().forEach((track) => track.stop());
-            this.micDriverWarmedUp = true;
-            logger.debug("Microphone driver pre-warmed", {}, "streaming");
-          } catch (e) {
-            logger.debug(
-              "Mic driver warmup failed (non-critical)",
-              { error: e.message },
-              "streaming"
-            );
-          }
-        }
+        await this._warmMicDriverOnce("streaming");
 
         logger.info(
           "Streaming connection warmed up",
@@ -3563,7 +3570,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           wsConnectMs: Math.round(tWs - tPipeline),
           totalMs: Math.round(tWs - t0),
           usedWarmConnection: result.usedWarmConnection,
-          micDriverWarmedUp: !!this.micDriverWarmedUp,
+          micWarm: isMicWarm(this._micWarmedAt, Date.now()),
         },
         "streaming"
       );

--- a/src/helpers/micWarmState.js
+++ b/src/helpers/micWarmState.js
@@ -1,0 +1,11 @@
+// Warm state is a timestamp, not a latch: mic drivers go cold again after idle,
+// so a permanent "warmed" flag would never re-warm a driver that has since slept.
+export const MIC_WARM_TTL_MS = 5000;
+
+// True only when the mic was warmed within the TTL. A negative elapsed (clock
+// jumped backwards) returns false so we err on the side of re-warming.
+export const isMicWarm = (lastWarmedAt, now, ttlMs = MIC_WARM_TTL_MS) => {
+  if (typeof lastWarmedAt !== "number" || lastWarmedAt <= 0) return false;
+  const elapsed = now - lastWarmedAt;
+  return elapsed >= 0 && elapsed < ttlMs;
+};

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -230,6 +230,9 @@ export const useAudioRecording = (toast, options = {}) => {
 
           if (audioManagerRef.current.shouldUseStreaming()) {
             audioManagerRef.current.warmupStreamingConnection();
+          } else {
+            // Batch path: a dictation soon after this one should also find a warm driver.
+            audioManagerRef.current?.warmupMicDriver?.();
           }
         }
       },

--- a/test/helpers/micWarmState.test.js
+++ b/test/helpers/micWarmState.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isMicWarm, MIC_WARM_TTL_MS } = require("../../src/helpers/micWarmState");
+
+test("MIC_WARM_TTL_MS is 5000", () => {
+  assert.equal(MIC_WARM_TTL_MS, 5000);
+});
+
+test("is not warm for a zero timestamp", () => {
+  assert.equal(isMicWarm(0, 1000), false);
+});
+
+test("is not warm for a missing timestamp", () => {
+  assert.equal(isMicWarm(undefined, 1000), false);
+  assert.equal(isMicWarm(null, 1000), false);
+});
+
+test("is not warm for a non-number timestamp", () => {
+  assert.equal(isMicWarm("1000", 2000), false);
+  assert.equal(isMicWarm(NaN, 2000), false);
+});
+
+test("is warm when the elapsed time is below the TTL", () => {
+  assert.equal(isMicWarm(1000, 1000 + MIC_WARM_TTL_MS - 1), true);
+  // Zero elapsed still counts as warm.
+  assert.equal(isMicWarm(1000, 1000), true);
+});
+
+test("is not warm at exactly the TTL", () => {
+  assert.equal(isMicWarm(1000, 1000 + MIC_WARM_TTL_MS), false);
+});
+
+test("is not warm beyond the TTL", () => {
+  assert.equal(isMicWarm(1000, 1000 + MIC_WARM_TTL_MS + 1), false);
+});
+
+test("is not warm when the clock jumped backwards", () => {
+  assert.equal(isMicWarm(5000, 4000), false);
+});
+
+test("honors a custom ttlMs argument", () => {
+  assert.equal(isMicWarm(1000, 1500, 1000), true);
+  // Exactly the custom TTL is not warm.
+  assert.equal(isMicWarm(1000, 2000, 1000), false);
+  assert.equal(isMicWarm(1000, 2001, 1000), false);
+});


### PR DESCRIPTION
## Summary

The mic warm-up was a one-shot: `micDriverWarmedUp` got latched true by whichever of the two warm-up sites in `audioManager.js` ran first, and the only reset was the `devicechange` handler. An idle pause never fires that event, so after the first dictation the warm-up was a permanent no-op and a driver that had gone back to sleep was never re-warmed, which matches the report: clipped on the first dictation, fine back-to-back, clipped again after a pause. The fix turns the latch into a timestamp with a 5s TTL (`isMicWarm` in the new `micWarmState.js`) and routes both sites through one shared `_warmMicDriverOnce()` so they can't disable each other. The warm-up `getUserMedia` is capped by a timeout (a late stream still gets released), the batch path now re-warms after each transcription like the streaming path already did, and the hotkey call sites stay fire-and-forget, so no latency is added and the mic is never held open longer than the existing brief acquire-and-release.

Verified by reading and by the unit tests, not by reproducing on Windows (I don't have a Windows machine), so a confirmation from a Windows user before merge would be worth having. Worth saying too: this makes the clip much less likely but won't fully cover someone who starts speaking the exact instant they hit the hotkey after a long idle; closing that gap needs a pre-roll buffer along the lines of #742. The cause is shared across platforms (the warm-up was originally written for macOS cold starts and the code has no platform branches), so the fix isn't gated to Windows.

Fixes #845

## Changes

- src/helpers/micWarmState.js: new pure helper, `MIC_WARM_TTL_MS` and `isMicWarm(lastWarmedAt, now, ttlMs)`, warm state as a timestamp with expiry instead of a permanent flag.
- src/helpers/audioManager.js: both warm-up sites call a shared `_warmMicDriverOnce()` gated on the TTL; `_micWarmedAt` is initialized in the constructor and reset on `devicechange`; the warm-up `getUserMedia` is capped by a timeout and a late-resolving stream is still stopped.
- src/hooks/useAudioRecording.js: the batch path re-warms the driver after a transcription completes, mirroring what the streaming path already did.
- test/helpers/micWarmState.test.js: unit tests for the TTL logic, including expiry at the boundary and a clock that jumps backwards.
