### PR TITLE
fix: show full raw transcript in history and add copy raw transcript action

### DIFF
--- a/src/components/ui/TranscriptionItem.tsx
+++ b/src/components/ui/TranscriptionItem.tsx
@@ -75,7 +75,8 @@ export default function TranscriptionItem({
     item.audio_duration_ms && item.audio_duration_ms > 0
       ? formatMmSs(Math.round(item.audio_duration_ms / 1000))
       : null;
-  const hasRawText = item.raw_text !== null;
+  const rawText = item.raw_text;
+  const hasRawText = rawText !== null;
   const hasAudio = item.has_audio === 1;
   const showUtilityGroup = hasRawText || hasAudio;
 
@@ -298,23 +299,38 @@ export default function TranscriptionItem({
         </div>
       </div>
 
-      {!isFailed && !isDiscarded && (
+      {!isFailed && !isDiscarded && rawText !== null && (
         <div
+          inert={!isExpanded}
           className={cn(
-            "overflow-hidden transition-all duration-200",
-            isExpanded ? "max-h-96" : "max-h-0"
+            "grid transition-[grid-template-rows] duration-200",
+            isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
           )}
         >
-          <div className="border-t border-border/20 mt-2 pt-2">
-            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-              {t("controlPanel.history.rawTranscript")}
-            </span>
-            <p className="text-xs text-muted-foreground/80 leading-relaxed mt-1">{item.raw_text}</p>
-            {item.raw_text === item.text && (
-              <p className="text-[10px] text-muted-foreground/50 italic mt-1">
-                {t("controlPanel.history.noAiProcessing")}
-              </p>
-            )}
+          <div className="min-h-0 overflow-hidden">
+            <div className="border-t border-border/20 mt-2 pt-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                  {t("controlPanel.history.rawTranscript")}
+                </span>
+                <Tooltip content={t("controlPanel.history.copyRawTranscript")}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => onCopy(rawText)}
+                    className="h-5 w-5 rounded-sm text-muted-foreground hover:text-foreground hover:bg-foreground/10"
+                  >
+                    <Copy size={10} />
+                  </Button>
+                </Tooltip>
+              </div>
+              <p className="text-xs text-muted-foreground/80 leading-relaxed mt-1">{rawText}</p>
+              {rawText === item.text && (
+                <p className="text-[10px] text-muted-foreground/50 italic mt-1">
+                  {t("controlPanel.history.noAiProcessing")}
+                </p>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "Verlauf konnte nicht gelöscht werden",
       "clearAllErrorDescription": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
       "copyText": "Text kopieren",
+      "copyRawTranscript": "Rohtranskript kopieren",
       "deleteItem": "Löschen",
       "viewRawTranscript": "Rohtranskript anzeigen",
       "showInFolder": "Im Finder anzeigen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -367,6 +367,7 @@
         "yesterday": "Yesterday"
       },
       "copyText": "Copy text",
+      "copyRawTranscript": "Copy raw transcript",
       "deleteItem": "Delete",
       "viewRawTranscript": "View raw transcript",
       "showInFolder": "Reveal in Finder",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -388,6 +388,7 @@
       "clearAllErrorTitle": "No se pudo borrar el historial",
       "clearAllErrorDescription": "Algo salió mal. Inténtalo de nuevo.",
       "copyText": "Copiar texto",
+      "copyRawTranscript": "Copiar transcripción sin procesar",
       "deleteItem": "Eliminar",
       "viewRawTranscript": "Ver transcripción sin procesar",
       "showInFolder": "Mostrar en Finder",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "Impossible d'effacer l'historique",
       "clearAllErrorDescription": "Une erreur est survenue. Veuillez réessayer.",
       "copyText": "Copier le texte",
+      "copyRawTranscript": "Copier la transcription brute",
       "deleteItem": "Supprimer",
       "viewRawTranscript": "Voir la transcription brute",
       "showInFolder": "Afficher dans le Finder",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "Impossibile cancellare la cronologia",
       "clearAllErrorDescription": "Qualcosa è andato storto. Riprova.",
       "copyText": "Copia testo",
+      "copyRawTranscript": "Copia trascrizione grezza",
       "deleteItem": "Elimina",
       "viewRawTranscript": "Visualizza trascrizione grezza",
       "showInFolder": "Mostra nel Finder",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "履歴を削除できませんでした",
       "clearAllErrorDescription": "問題が発生しました。もう一度お試しください。",
       "copyText": "テキストをコピー",
+      "copyRawTranscript": "生の文字起こしをコピー",
       "deleteItem": "削除",
       "viewRawTranscript": "生の文字起こしを表示",
       "showInFolder": "Finderで表示",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -358,6 +358,7 @@
       "clearAllErrorTitle": "Não foi possível limpar o histórico",
       "clearAllErrorDescription": "Algo deu errado. Tente novamente.",
       "copyText": "Copiar texto",
+      "copyRawTranscript": "Copiar transcrição bruta",
       "deleteItem": "Excluir",
       "viewRawTranscript": "Ver transcrição bruta",
       "showInFolder": "Mostrar no Finder",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "Не удалось очистить историю",
       "clearAllErrorDescription": "Что-то пошло не так. Попробуйте ещё раз.",
       "copyText": "Копировать текст",
+      "copyRawTranscript": "Копировать исходную расшифровку",
       "deleteItem": "Удалить",
       "viewRawTranscript": "Показать исходную расшифровку",
       "showInFolder": "Показать в Finder",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "无法清除历史记录",
       "clearAllErrorDescription": "出了点问题，请重试。",
       "copyText": "复制文本",
+      "copyRawTranscript": "复制原始转录",
       "deleteItem": "删除",
       "viewRawTranscript": "查看原始转录",
       "showInFolder": "在访达中显示",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -379,6 +379,7 @@
       "clearAllErrorTitle": "無法清除歷史紀錄",
       "clearAllErrorDescription": "發生錯誤，請重試。",
       "copyText": "複製文字",
+      "copyRawTranscript": "複製原始轉錄",
       "deleteItem": "刪除",
       "viewRawTranscript": "檢視原始轉錄",
       "showInFolder": "在 Finder 中顯示",


### PR DESCRIPTION
## Problem

Expanding the raw transcript on a history item clips it at a fixed 384px (`max-h-96` + `overflow-hidden`). Long dictations are cut off mid-sentence with no scrollbar, no way to read the rest, and drag-selection can't reach it. Reported by a subscriber who records long, detailed messages and needs to review the full transcript when the AI-processed output misses details.

## Changes

- Expand/collapse now animates `grid-template-rows` (`0fr` ↔ `1fr`) instead of a capped `max-height`, so the panel opens to the transcript's full height and the page scrolls naturally — consistent with the processed text above, which was never clamped
- Added a copy button to the raw transcript panel header; the existing copy action only copies the processed text
- Collapsed panel is `inert`, so the hidden copy button can't take keyboard focus
- Panel only renders when the item has raw text
- New `controlPanel.history.copyRawTranscript` key in all 10 locales

No data changes — full raw transcripts were always stored; this was purely a presentation clip, so existing history benefits immediately.