### PR TITLE
fix: stop cloud sync from wiping locally-edited notes with stale empty cloud copies

### DIFF
--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -25,6 +25,10 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Build better-sqlite3 for the runner's node
+        # --ignore-scripts skips the native build; DB-backed tests silently
+        # skip without it. This job is the only test gate on push to main.
+        run: npm rebuild better-sqlite3
       - name: Run tests
         run: npm test
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Build better-sqlite3 for the runner's node
+        # --ignore-scripts skips the native build, so every DB-backed test
+        # (snippetsDatabase, noteCloudUpsertGuard, …) silently skips without this.
+        run: npm rebuild better-sqlite3
+      - name: Typecheck
+        run: npm run typecheck
       - name: Run tests
         run: npm test
         env:

--- a/src/helpers/cloudSyncGuards.js
+++ b/src/helpers/cloudSyncGuards.js
@@ -1,0 +1,49 @@
+// Sync-pull ordering and push-payload helpers shared by SyncService and the
+// node --test suite (#1290).
+
+// SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
+// the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
+// millis-precision ISO so the pull loop's lexical greater-than compares
+// correctly — without the ".000" pad a whole-second local value sorts after a
+// sub-second cloud value at the same instant ('Z' > '.').
+export function normalizeTimestamp(value) {
+  if (!value) return "";
+  const iso = value.replace(" ", "T").replace(/Z$/, "");
+  return (/\.\d+$/.test(iso) ? iso : `${iso}.000`) + "Z";
+}
+
+// The pull loops' last-writer-wins gate. Comparing the raw values instead
+// silently hands every same-UTC-day conflict to the cloud copy — 'T' (0x54)
+// sorts after ' ' (0x20) at index 10 — which is how a staler, still-empty
+// cloud shell overwrote fresh local meeting notes (#1290).
+export function isCloudEntryNewer(cloudUpdatedAt, localUpdatedAt) {
+  return normalizeTimestamp(cloudUpdatedAt) > normalizeTimestamp(localUpdatedAt);
+}
+
+// Full-content PATCH payload for an existing cloud note. Both the debounced
+// editor push and the pushPendingNotes migration branch must send this same
+// shape: a content-less PATCH still bumps the cloud row's updated_at, so the
+// next pull elects a copy that never received the local edit (#1290).
+// Deliberately NO client_note_id: pre-client_note_id-era cloud notes carry a
+// different backfilled UUID per device, so PATCHing it from every push would
+// flip the cloud row's identity between devices on each edit and fork
+// duplicate local notes. Only the one-shot migration branch sends it.
+export function buildNoteUpdatePayload(note, folderMap) {
+  return {
+    title: note.title,
+    content: note.content,
+    enhanced_content: note.enhanced_content,
+    enhancement_prompt: note.enhancement_prompt,
+    enhanced_at_content_hash: note.enhanced_at_content_hash,
+    note_type: note.note_type,
+    source_file: note.source_file,
+    audio_duration_seconds: note.audio_duration_seconds,
+    transcript: note.transcript,
+    participants: note.participants,
+    calendar_event_id: note.calendar_event_id,
+    diarization_enabled: note.diarization_enabled,
+    expected_speaker_count: note.expected_speaker_count,
+    folder_id: note.folder_id ? (folderMap.get(note.folder_id) ?? null) : null,
+    updated_at: note.updated_at,
+  };
+}

--- a/src/helpers/cloudSyncGuards.js
+++ b/src/helpers/cloudSyncGuards.js
@@ -1,5 +1,4 @@
-// Sync-pull ordering and push-payload helpers shared by SyncService and the
-// node --test suite (#1290).
+// Sync guards shared by SyncService and the node --test suite (#1290).
 
 // SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
 // the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
@@ -12,22 +11,19 @@ export function normalizeTimestamp(value) {
   return (/\.\d+$/.test(iso) ? iso : `${iso}.000`) + "Z";
 }
 
-// The pull loops' last-writer-wins gate. Comparing the raw values instead
-// silently hands every same-UTC-day conflict to the cloud copy — 'T' (0x54)
-// sorts after ' ' (0x20) at index 10 — which is how a staler, still-empty
-// cloud shell overwrote fresh local meeting notes (#1290).
+// Last-writer-wins gate for the pull loops. A raw compare hands every
+// same-UTC-day conflict to the cloud copy ('T' > ' ' at index 10), which is
+// how a staler empty cloud shell overwrote fresh local notes (#1290).
 export function isCloudEntryNewer(cloudUpdatedAt, localUpdatedAt) {
   return normalizeTimestamp(cloudUpdatedAt) > normalizeTimestamp(localUpdatedAt);
 }
 
-// Full-content PATCH payload for an existing cloud note. Both the debounced
-// editor push and the pushPendingNotes migration branch must send this same
-// shape: a content-less PATCH still bumps the cloud row's updated_at, so the
-// next pull elects a copy that never received the local edit (#1290).
-// Deliberately NO client_note_id: pre-client_note_id-era cloud notes carry a
-// different backfilled UUID per device, so PATCHing it from every push would
-// flip the cloud row's identity between devices on each edit and fork
-// duplicate local notes. Only the one-shot migration branch sends it.
+// Full-content PATCH payload for an existing cloud note — a content-less
+// PATCH still bumps the cloud row's updated_at, so the next pull elects a
+// copy that never received the local edit (#1290). No client_note_id here:
+// legacy cloud notes carry a different backfilled UUID per device, so
+// PATCHing it on every push would fork duplicate notes; only the one-shot
+// migration branch sends it.
 export function buildNoteUpdatePayload(note, folderMap) {
   return {
     title: note.title,

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -2714,6 +2714,12 @@ class DatabaseManager {
   upsertNoteFromCloud(cloudNote, localFolderId) {
     try {
       if (!this.db) throw new Error("Database not initialized");
+      // Content columns keep the local value when the cloud copy is empty:
+      // sync must never replace non-empty local content/enhanced_content/
+      // transcript with an empty cloud value (#1290, the #938 invariant).
+      // enhancement_prompt/enhanced_at_content_hash travel with
+      // enhanced_content — a preserved enhancement must keep its hash or
+      // staleness detection breaks.
       const stmt = this.db.prepare(`
         INSERT INTO notes (client_note_id, cloud_id, title, content, enhanced_content,
           enhancement_prompt, enhanced_at_content_hash, note_type, source_file,
@@ -2723,11 +2729,21 @@ class DatabaseManager {
         ON CONFLICT(client_note_id) DO UPDATE SET
           cloud_id = excluded.cloud_id,
           title = excluded.title,
-          content = excluded.content,
-          enhanced_content = excluded.enhanced_content,
-          enhancement_prompt = excluded.enhancement_prompt,
-          enhanced_at_content_hash = excluded.enhanced_at_content_hash,
-          transcript = excluded.transcript,
+          content = CASE
+            WHEN COALESCE(excluded.content, '') = '' AND COALESCE(content, '') <> ''
+            THEN content ELSE excluded.content END,
+          enhanced_content = CASE
+            WHEN COALESCE(excluded.enhanced_content, '') = '' AND COALESCE(enhanced_content, '') <> ''
+            THEN enhanced_content ELSE excluded.enhanced_content END,
+          enhancement_prompt = CASE
+            WHEN COALESCE(excluded.enhanced_content, '') = '' AND COALESCE(enhanced_content, '') <> ''
+            THEN enhancement_prompt ELSE excluded.enhancement_prompt END,
+          enhanced_at_content_hash = CASE
+            WHEN COALESCE(excluded.enhanced_content, '') = '' AND COALESCE(enhanced_content, '') <> ''
+            THEN enhanced_at_content_hash ELSE excluded.enhanced_at_content_hash END,
+          transcript = CASE
+            WHEN COALESCE(excluded.transcript, '') = '' AND COALESCE(transcript, '') <> ''
+            THEN transcript ELSE excluded.transcript END,
           folder_id = excluded.folder_id,
           participants = COALESCE(excluded.participants, participants),
           calendar_event_id = COALESCE(excluded.calendar_event_id, calendar_event_id),

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -2714,12 +2714,9 @@ class DatabaseManager {
   upsertNoteFromCloud(cloudNote, localFolderId) {
     try {
       if (!this.db) throw new Error("Database not initialized");
-      // Content columns keep the local value when the cloud copy is empty:
-      // sync must never replace non-empty local content/enhanced_content/
+      // Sync must never replace non-empty local content/enhanced_content/
       // transcript with an empty cloud value (#1290, the #938 invariant).
-      // enhancement_prompt/enhanced_at_content_hash travel with
-      // enhanced_content — a preserved enhancement must keep its hash or
-      // staleness detection breaks.
+      // The enhancement prompt/hash travel with enhanced_content.
       const stmt = this.db.prepare(`
         INSERT INTO notes (client_note_id, cloud_id, title, content, enhanced_content,
           enhancement_prompt, enhanced_at_content_hash, note_type, source_file,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -11,6 +11,11 @@ import { TranscriptionsService } from "./TranscriptionsService.js";
 import { DictionaryService } from "./DictionaryService.js";
 import { SnippetService, type CloudSnippetEntry } from "./SnippetService.js";
 import { CloudApiError } from "./cloudApi.js";
+import {
+  normalizeTimestamp,
+  isCloudEntryNewer,
+  buildNoteUpdatePayload,
+} from "../helpers/cloudSyncGuards.js";
 
 function isHttpStatus(err: unknown, status: number): boolean {
   return err instanceof CloudApiError && err.status === status;
@@ -31,17 +36,6 @@ const SYNC_ALL_LOCK = "openwhispr-sync-all";
 // localStorage keys gating canSync(); a change in another window means sync
 // may have just become possible (sign-in, subscription, backup enabled).
 const CAN_SYNC_KEYS = ["isSignedIn", "cloudBackupEnabled", "isSubscribed"];
-
-// SQLite `datetime('now')` yields "YYYY-MM-DD HH:MM:SS" (no T, no millis, no Z);
-// the cloud sends ISO 8601 "YYYY-MM-DDTHH:MM:SS.sssZ". Normalize both to
-// millis-precision ISO so the pull loop's lexical greater-than compares
-// correctly — without the ".000" pad a whole-second local value sorts after a
-// sub-second cloud value at the same instant ('Z' > '.').
-function normalizeTimestamp(value: string | null | undefined): string {
-  if (!value) return "";
-  const iso = value.replace(" ", "T").replace(/Z$/, "");
-  return (/\.\d+$/.test(iso) ? iso : `${iso}.000`) + "Z";
-}
 
 class SyncService {
   private syncing = false;
@@ -241,23 +235,7 @@ class SyncService {
     const cloudFolderId = note.folder_id ? (folderMap.get(note.folder_id) ?? null) : null;
 
     if (note.cloud_id) {
-      await NotesService.update(note.cloud_id, {
-        title: note.title,
-        content: note.content,
-        enhanced_content: note.enhanced_content,
-        enhancement_prompt: note.enhancement_prompt,
-        enhanced_at_content_hash: note.enhanced_at_content_hash,
-        note_type: note.note_type,
-        source_file: note.source_file,
-        audio_duration_seconds: note.audio_duration_seconds,
-        transcript: note.transcript,
-        participants: note.participants,
-        calendar_event_id: note.calendar_event_id,
-        diarization_enabled: note.diarization_enabled,
-        expected_speaker_count: note.expected_speaker_count,
-        folder_id: cloudFolderId,
-        updated_at: note.updated_at,
-      });
+      await NotesService.update(note.cloud_id, buildNoteUpdatePayload(note, folderMap));
     } else {
       const cloud = await NotesService.create({
         client_note_id: note.client_note_id,
@@ -480,7 +458,7 @@ class SyncService {
         }
 
         if (local?.deleted_at) continue;
-        if (!local || cloudFolder.updated_at > local.updated_at) {
+        if (!local || isCloudEntryNewer(cloudFolder.updated_at, local.updated_at)) {
           await window.electronAPI.upsertFolderFromCloud?.(
             cloudFolder as unknown as Record<string, unknown>
           );
@@ -509,7 +487,13 @@ class SyncService {
 
     for (const note of migration) {
       try {
-        await NotesService.update(note.cloud_id!, { client_note_id: note.client_note_id });
+        // Full content, not just { client_note_id }: a content-less PATCH bumps
+        // the cloud row's updated_at without uploading the local edit, and the
+        // pull in this same pass then elects the still-empty cloud copy (#1290).
+        await NotesService.update(note.cloud_id!, {
+          client_note_id: note.client_note_id,
+          ...buildNoteUpdatePayload(note, folderMap),
+        });
         await window.electronAPI.markNoteSynced?.(note.id, note.cloud_id!);
       } catch {
         await window.electronAPI.markNoteSyncError?.(note.id);
@@ -583,7 +567,7 @@ class SyncService {
             continue;
           }
 
-          if (!local || cloudNote.updated_at > local.updated_at) {
+          if (!local || isCloudEntryNewer(cloudNote.updated_at, local.updated_at)) {
             const localFolderId = cloudNote.folder_id
               ? (cloudToLocal.get(cloudNote.folder_id) ?? defaultFolderId)
               : defaultFolderId;
@@ -689,7 +673,7 @@ class SyncService {
             continue;
           }
 
-          if (!local || cloudConv.updated_at > local.updated_at) {
+          if (!local || isCloudEntryNewer(cloudConv.updated_at, local.updated_at)) {
             await window.electronAPI.upsertConversationFromCloud?.(
               cloudConv as unknown as Record<string, unknown>,
               (cloudConv.messages ?? []) as unknown as Array<Record<string, unknown>>

--- a/test/helpers/cloudSyncGuards.test.js
+++ b/test/helpers/cloudSyncGuards.test.js
@@ -1,0 +1,117 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/cloudSyncGuards.js");
+
+// Regression for the sync data-loss in #1290: local rows carry SQLite
+// `CURRENT_TIMESTAMP` format ("2026-07-22 08:47:00", space at index 10) while
+// cloud rows are ISO 8601 ("2026-07-22T08:18:27.790Z", 'T' at index 10). A raw
+// lexical `>` makes any same-UTC-day cloud timestamp beat any local one
+// ('T' 0x54 > ' ' 0x20), so a staler empty cloud copy wins the pull and wipes
+// the local edit.
+
+test("a 29-minute-older cloud copy is not judged newer than a local edit", async () => {
+  const { isCloudEntryNewer } = await load();
+  // Raw lexical compare (the old gate) elects the older cloud copy:
+  assert.equal("2026-07-22T08:18:00.000Z" > "2026-07-22 08:47:00", true);
+  // The normalized gate must not:
+  assert.equal(isCloudEntryNewer("2026-07-22T08:18:00.000Z", "2026-07-22 08:47:00"), false);
+});
+
+test("a whole-day-staler cloud copy is not judged newer", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-22T00:00:00.000Z", "2026-07-22 23:59:59"), false);
+});
+
+test("a previous-day cloud copy still loses (control)", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-21T23:59:59.000Z", "2026-07-22 08:47:00"), false);
+});
+
+test("a genuinely newer cloud copy still wins (last-writer-wins intact)", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-22T08:47:01.000Z", "2026-07-22 08:47:00"), true);
+  assert.equal(isCloudEntryNewer("2026-07-23T00:00:00.000Z", "2026-07-22 23:59:59"), true);
+});
+
+test("the same instant across formats is a tie, not a cloud win", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-22T08:47:00.000Z", "2026-07-22 08:47:00"), false);
+});
+
+test("sub-second cloud precision beats a whole-second local value at the same second", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-22T08:47:00.500Z", "2026-07-22 08:47:00"), true);
+});
+
+test("a missing local timestamp always yields to the cloud value", async () => {
+  const { isCloudEntryNewer } = await load();
+  assert.equal(isCloudEntryNewer("2026-07-22T08:47:00.000Z", ""), true);
+  assert.equal(isCloudEntryNewer("2026-07-22T08:47:00.000Z", null), true);
+});
+
+// Regression for the wipe engine in #1290: the migration branch of
+// pushPendingNotes PATCHed only { client_note_id } for cloud_id-bearing pending
+// notes — bumping the cloud row's updated_at without ever uploading the local
+// content, so the same sync pass pulled the still-empty-but-now-"newer" cloud
+// row back down over the local edit. The update payload must carry the full
+// note content.
+
+const localNote = {
+  id: 7,
+  client_note_id: "client-uuid-1",
+  cloud_id: "cloud-1",
+  title: "Vision, Values, and Product Priorities",
+  content: "REAL MEETING NOTES",
+  enhanced_content: "ENHANCED NOTES",
+  enhancement_prompt: "prompt",
+  enhanced_at_content_hash: "hash-1",
+  note_type: "meeting",
+  source_file: null,
+  audio_duration_seconds: 3130,
+  transcript: '[{"text":"hello"}]',
+  participants: '[{"email":"a@b.c"}]',
+  calendar_event_id: "cal-ev-1",
+  diarization_enabled: 1,
+  expected_speaker_count: 2,
+  folder_id: 3,
+  sync_status: "pending",
+  created_at: "2026-07-21 19:31:00",
+  updated_at: "2026-07-22 08:47:00",
+};
+
+test("the note update payload carries the full content, not just identifiers", async () => {
+  const { buildNoteUpdatePayload } = await load();
+  const payload = buildNoteUpdatePayload(localNote, new Map([[3, "cloud-folder-3"]]));
+
+  // client_note_id stays OUT of the shared payload: pre-client_note_id-era
+  // cloud notes carry a different backfilled UUID per device, so PATCHing it
+  // from the debounced push would flip the cloud row's identity between
+  // devices on every edit. Only the one-shot migration branch may send it.
+  assert.equal("client_note_id" in payload, false);
+  assert.equal(payload.title, "Vision, Values, and Product Priorities");
+  assert.equal(payload.content, "REAL MEETING NOTES");
+  assert.equal(payload.enhanced_content, "ENHANCED NOTES");
+  assert.equal(payload.transcript, '[{"text":"hello"}]');
+  assert.equal(payload.enhancement_prompt, "prompt");
+  assert.equal(payload.enhanced_at_content_hash, "hash-1");
+  assert.equal(payload.note_type, "meeting");
+  assert.equal(payload.audio_duration_seconds, 3130);
+  assert.equal(payload.participants, '[{"email":"a@b.c"}]');
+  assert.equal(payload.calendar_event_id, "cal-ev-1");
+  assert.equal(payload.diarization_enabled, 1);
+  assert.equal(payload.expected_speaker_count, 2);
+  assert.equal(payload.updated_at, "2026-07-22 08:47:00");
+});
+
+test("the note update payload maps the local folder to its cloud id", async () => {
+  const { buildNoteUpdatePayload } = await load();
+  const mapped = buildNoteUpdatePayload(localNote, new Map([[3, "cloud-folder-3"]]));
+  assert.equal(mapped.folder_id, "cloud-folder-3");
+
+  const unmapped = buildNoteUpdatePayload(localNote, new Map());
+  assert.equal(unmapped.folder_id, null);
+
+  const folderless = buildNoteUpdatePayload({ ...localNote, folder_id: null }, new Map());
+  assert.equal(folderless.folder_id, null);
+});

--- a/test/helpers/cloudSyncGuards.test.js
+++ b/test/helpers/cloudSyncGuards.test.js
@@ -3,12 +3,9 @@ const assert = require("node:assert/strict");
 
 const load = () => import("../../src/helpers/cloudSyncGuards.js");
 
-// Regression for the sync data-loss in #1290: local rows carry SQLite
-// `CURRENT_TIMESTAMP` format ("2026-07-22 08:47:00", space at index 10) while
-// cloud rows are ISO 8601 ("2026-07-22T08:18:27.790Z", 'T' at index 10). A raw
-// lexical `>` makes any same-UTC-day cloud timestamp beat any local one
-// ('T' 0x54 > ' ' 0x20), so a staler empty cloud copy wins the pull and wipes
-// the local edit.
+// Regression for #1290: local rows carry SQLite format ("2026-07-22 08:47:00")
+// while cloud rows are ISO ("2026-07-22T08:18:27.790Z"), so a raw lexical `>`
+// let any same-UTC-day cloud copy beat any local edit and wipe it on pull.
 
 test("a 29-minute-older cloud copy is not judged newer than a local edit", async () => {
   const { isCloudEntryNewer } = await load();
@@ -50,12 +47,9 @@ test("a missing local timestamp always yields to the cloud value", async () => {
   assert.equal(isCloudEntryNewer("2026-07-22T08:47:00.000Z", null), true);
 });
 
-// Regression for the wipe engine in #1290: the migration branch of
-// pushPendingNotes PATCHed only { client_note_id } for cloud_id-bearing pending
-// notes — bumping the cloud row's updated_at without ever uploading the local
-// content, so the same sync pass pulled the still-empty-but-now-"newer" cloud
-// row back down over the local edit. The update payload must carry the full
-// note content.
+// Regression for #1290's wipe engine: pushPendingNotes' migration branch
+// PATCHed only { client_note_id }, bumping the cloud row's updated_at without
+// uploading the local edit — the same pass then pulled the empty row back down.
 
 const localNote = {
   id: 7,
@@ -84,10 +78,8 @@ test("the note update payload carries the full content, not just identifiers", a
   const { buildNoteUpdatePayload } = await load();
   const payload = buildNoteUpdatePayload(localNote, new Map([[3, "cloud-folder-3"]]));
 
-  // client_note_id stays OUT of the shared payload: pre-client_note_id-era
-  // cloud notes carry a different backfilled UUID per device, so PATCHing it
-  // from the debounced push would flip the cloud row's identity between
-  // devices on every edit. Only the one-shot migration branch may send it.
+  // Only the one-shot migration branch may send client_note_id
+  // (see buildNoteUpdatePayload):
   assert.equal("client_note_id" in payload, false);
   assert.equal(payload.title, "Vision, Values, and Product Priorities");
   assert.equal(payload.content, "REAL MEETING NOTES");

--- a/test/helpers/noteCloudUpsertGuard.test.js
+++ b/test/helpers/noteCloudUpsertGuard.test.js
@@ -1,0 +1,230 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+let userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-note-sync-db-"));
+const originalLoad = Module._load;
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: {
+        getPath: () => userDataDir,
+        getAppPath: () => process.cwd(),
+        isReady: () => false,
+      },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+process.env.NODE_ENV = "test";
+
+const DatabaseManager = require("../../src/helpers/database.js");
+const loadGuards = () => import("../../src/helpers/cloudSyncGuards.js");
+
+function isNativeBindingUnavailable(error) {
+  const message = String(error?.message || error);
+  return (
+    message.includes("NODE_MODULE_VERSION") ||
+    message.includes("Could not locate the bindings file")
+  );
+}
+
+function createDb(t) {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-note-sync-db-"));
+  try {
+    const BetterSqlite = require("better-sqlite3");
+    const probe = new BetterSqlite(path.join(userDataDir, "probe.db"));
+    probe.close();
+    fs.rmSync(path.join(userDataDir, "probe.db"), { force: true });
+  } catch (error) {
+    if (isNativeBindingUnavailable(error)) {
+      t.skip("better-sqlite3 native binding is not available for this Node runtime");
+      return null;
+    }
+    throw error;
+  }
+
+  try {
+    return new DatabaseManager();
+  } catch (error) {
+    if (isNativeBindingUnavailable(error)) {
+      t.skip("better-sqlite3 native binding is not available for this Node runtime");
+      return null;
+    }
+    throw error;
+  }
+}
+
+// Regression for #1290: a meeting note is created as an empty shell locally and
+// in the cloud, the user's transcript and notes are saved locally, and a sync
+// pull elects the still-empty cloud shell (its ISO timestamp lexically beats
+// the local SQLite-format timestamp) and overwrites the local edit wholesale.
+
+const TRANSCRIPT = JSON.stringify([{ text: "T".repeat(70000), source: "system", timestamp: 1 }]);
+
+// The shell exactly as meetingDetectionEngine creates it, then the user's edit
+// via the real save path. Returns the edited local row (sync_status pending,
+// SQLite-format updated_at).
+function seedEditedMeetingNote(db) {
+  const saved = db.saveNote("Gabriel / Joshua", "", "meeting");
+  const shell = saved.note || saved;
+  db.updateNote(shell.id, {
+    title: "Vision, Values, and Product Priorities",
+    content: "REAL MEETING NOTES",
+    enhanced_content: "ENHANCED NOTES",
+    enhancement_prompt: "summarize the meeting",
+    enhanced_at_content_hash: "hash-of-real-notes",
+    transcript: TRANSCRIPT,
+    cloud_id: "cloud-test-1",
+  });
+  return db.getNote(shell.id);
+}
+
+// The cloud's copy: the empty shell, stamped at the local edit's UTC midnight
+// — older in real time (same instant at worst, if the edit lands exactly at
+// 00:00:00) but with an ISO timestamp ('T' at index 10) that lexically beats
+// the local SQLite format (' ' at index 10).
+function emptyCloudShell(local) {
+  const today = local.updated_at.slice(0, 10);
+  return {
+    id: "cloud-test-1",
+    client_note_id: local.client_note_id,
+    title: "Gabriel / Joshua",
+    content: "",
+    enhanced_content: null,
+    transcript: null,
+    note_type: "meeting",
+    folder_id: null,
+    source_file: null,
+    audio_duration_seconds: null,
+    enhancement_prompt: null,
+    enhanced_at_content_hash: null,
+    participants: JSON.stringify([{ email: "test@example.com" }]),
+    calendar_event_id: "cal-ev-1",
+    diarization_enabled: null,
+    expected_speaker_count: null,
+    deleted_at: null,
+    created_at: `${today}T00:00:00.000Z`,
+    updated_at: `${today}T00:00:00.000Z`,
+  };
+}
+
+test("pull gate: an hours-older empty cloud shell is not elected over a fresh local edit", async (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  const local = seedEditedMeetingNote(db);
+  assert.match(
+    local.updated_at,
+    /^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d$/,
+    "premise: local edits carry SQLite-format updated_at"
+  );
+  assert.equal(local.sync_status, "pending");
+
+  const cloudNote = emptyCloudShell(local);
+  assert.equal(
+    cloudNote.updated_at > local.updated_at,
+    true,
+    "premise: the raw lexical compare would elect the hours-older cloud shell"
+  );
+
+  const { isCloudEntryNewer } = await loadGuards();
+  assert.equal(
+    isCloudEntryNewer(cloudNote.updated_at, local.updated_at),
+    false,
+    "the normalized pull gate must not elect the hours-older empty cloud shell"
+  );
+});
+
+test("upsertNoteFromCloud: empty cloud values never destroy non-empty local content", (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  const before = seedEditedMeetingNote(db);
+  db.upsertNoteFromCloud(emptyCloudShell(before), null);
+  const after = db.getNote(before.id);
+
+  assert.equal(after.content, "REAL MEETING NOTES", "content must survive an empty cloud copy");
+  assert.equal(after.transcript, TRANSCRIPT, "transcript must survive an empty cloud copy");
+  assert.equal(
+    after.enhanced_content,
+    "ENHANCED NOTES",
+    "enhanced_content must survive an empty cloud copy"
+  );
+  assert.equal(
+    after.enhancement_prompt,
+    "summarize the meeting",
+    "enhancement_prompt must travel with the preserved enhanced_content"
+  );
+  assert.equal(
+    after.enhanced_at_content_hash,
+    "hash-of-real-notes",
+    "enhanced_at_content_hash must travel with the preserved enhanced_content (staleness detection breaks without it)"
+  );
+  assert.ok(after.participants, "participants still preserved (COALESCE)");
+  assert.equal(after.calendar_event_id, "cal-ev-1", "calendar_event_id still preserved (COALESCE)");
+});
+
+test("upsertNoteFromCloud: non-empty cloud values still overwrite (last-writer-wins intact)", (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  const before = seedEditedMeetingNote(db);
+  const cloudNote = {
+    ...emptyCloudShell(before),
+    title: "Cloud Title",
+    content: "CLOUD EDIT",
+    enhanced_content: "CLOUD ENHANCED",
+    transcript: '[{"text":"cloud"}]',
+  };
+  db.upsertNoteFromCloud(cloudNote, null);
+  const after = db.getNote(before.id);
+
+  assert.equal(after.title, "Cloud Title");
+  assert.equal(after.content, "CLOUD EDIT");
+  assert.equal(after.enhanced_content, "CLOUD ENHANCED");
+  assert.equal(after.transcript, '[{"text":"cloud"}]');
+  assert.equal(
+    after.enhancement_prompt,
+    null,
+    "a non-empty cloud enhancement brings its own prompt/hash (null here)"
+  );
+  assert.equal(after.sync_status, "synced");
+});
+
+test("upsertNoteFromCloud: a brand-new empty cloud note still inserts as-is", (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  const cloudNote = {
+    id: "cloud-new-1",
+    client_note_id: "client-new-1",
+    title: "Fresh from cloud",
+    content: "",
+    enhanced_content: null,
+    transcript: null,
+    note_type: "personal",
+    folder_id: null,
+    source_file: null,
+    audio_duration_seconds: null,
+    enhancement_prompt: null,
+    enhanced_at_content_hash: null,
+    participants: null,
+    calendar_event_id: null,
+    diarization_enabled: null,
+    expected_speaker_count: null,
+    deleted_at: null,
+    created_at: "2026-07-22T00:00:00.000Z",
+    updated_at: "2026-07-22T00:00:00.000Z",
+  };
+  const row = db.upsertNoteFromCloud(cloudNote, null);
+
+  assert.equal(row.title, "Fresh from cloud");
+  assert.equal(row.content, "");
+  assert.equal(row.sync_status, "synced");
+});


### PR DESCRIPTION
Fixes OpenWhispr/openwhispr#1290

Cloud sync could permanently destroy a note's local `content`, `transcript`, and `enhanced_content` — observed three times in one morning on a real meeting note, root-caused and reproduced in OpenWhispr/openwhispr#1290. Three interacting defects, fixed here in necessity order (the issue's proposed fixes 1–3):

**1.** `pushPendingNotes` **migration branch now pushes the full note content** (`src/services/SyncService.ts`)<br>The branch PATCHed only `{ client_note_id }` for `cloud_id`-bearing pending notes, bumping the cloud row's `updated_at` without ever uploading the local edit — so the pull in the same `syncNotes()` pass elected the *genuinely-newer but still empty* cloud row and destroyed the local edit. It now sends the same full-content payload as the debounced editor push, via a shared `buildNoteUpdatePayload()` helper both call sites use, so the two shapes can't drift apart again. `client_note_id` deliberately stays out of the shared payload and is sent only by the migration branch: pre-`client_note_id`-era cloud notes carry a different backfilled UUID per device, and PATCHing it on every push would flip the cloud row's identity between devices and fork duplicate notes.

**2. Pull gates compare normalized timestamps** (`src/services/SyncService.ts`)<br>The notes/folders/conversations pulls compared SQLite-format local timestamps (`2026-07-22 08:47:00`) against ISO cloud timestamps (`2026-07-22T08:18:27.790Z`) with a raw lexical `>` — since `'T'` > `' '` at index 10, **any same-UTC-day cloud copy beat any local one regardless of actual time**. All three gates now use `isCloudEntryNewer()`, which wraps both sides in the pre-existing `normalizeTimestamp()` (moved unchanged to `src/helpers/cloudSyncGuards.js`; the dictionary/snippet pulls already used it).

**3.** `upsertNoteFromCloud` **never lets an empty cloud value destroy non-empty local content** (`src/helpers/database.js`)<br>The upsert set `content`/`enhanced_content`/`transcript` to `excluded.*` unconditionally. Those three columns now keep the local value when the incoming cloud value is empty/NULL and the local one isn't — the same invariant OpenWhispr/openwhispr#938 established for dictation ("never replace non-empty local data with an empty remote response"), applied to the notes pull. `enhancement_prompt`/`enhanced_at_content_hash` travel with `enhanced_content`, so a preserved enhancement keeps its staleness hash. Non-empty cloud values still overwrite (last-writer-wins is unchanged), and the insert path for brand-new cloud notes is untouched.

Any one of the three stops the observed kill chain; together they also cover the unproven secondary trigger (an empty editor save reaching the cloud).

### Regression tests

`test/helpers/cloudSyncGuards.test.js` + `test/helpers/noteCloudUpsertGuard.test.js` — direct conversions of the executed repro from OpenWhispr/openwhispr#1290 (unit 6/6 + integration on the real `database.js`), assertions flipped to the fixed behavior. The DB tests reuse the `snippetsDatabase.test.js` harness (real `better-sqlite3`, throwaway DB). All were watched failing on the unfixed code — the upsert test fails with exactly the production corpse (`content: '' vs 'REAL MEETING NOTES'`) — and pass with the fix.

**CI change (**`tests.yml`**):** `npm ci --ignore-scripts` skips `better-sqlite3`'s native build, so every DB-backed test in the suite (`snippetsDatabase`, these new ones, …) was silently skipping in CI — a revert of the `database.js` fix would have left CI green. Added `npm rebuild better-sqlite3` so they actually execute, and `npm run typecheck` (previously not run by any workflow) so the TS-side sync wiring is covered too. Verified with a matching-ABI binding locally: full suite 689 tests, **684 pass, 0 fail** (5 remaining skips are unrelated).

### Semantics notes for reviewers

* A 5-lens adversarial review ran over this diff; its two substantive findings (the `client_note_id` tug-of-war, the enhancement-triple split) are folded in above.
* When the fix-3 guard fires, the row still takes the cloud's metadata/stamp and stays `synced` — the preserved local content is not re-pushed until the user's next edit. That's deliberate: passively keeping the data avoids resurrection ping-pong against a device that intentionally cleared a note, and with fix 1 in place, rows still `pending` upload their content before the pull runs. The residual case (deliberate cross-device clears may diverge until the next edit) is the accepted cost of the invariant; the server-side stale-write guard (below) is the systemic answer.
* The guard keys on exactly-empty (`''`/NULL), matching OpenWhispr/openwhispr#938's invariant; the migration PATCH now also writes `folder_id` with the same mapping the debounced push has always used.
* The transcriptions pull needs no gate change — it's insert-only at HEAD and already skips empty `text`.
* Server-side hardening (COALESCE on omitted columns + stale-write guard in `openwhispr-api`, issue fix 4) is a separate PR in that repo. Shipping a release that contains OpenWhispr/openwhispr#938 (issue fix 5) also still stands.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)