### PR TITLE
fix: gpt-oss-20b local model download returning 404

### DIFF
--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -950,7 +950,7 @@
           "size": "12.1GB",
           "sizeBytes": 12999763968,
           "description": "OpenAI's open-weight model for consumer hardware",
-          "fileName": "gpt-oss-20b-mxfp4.gguf",
+          "fileName": "gpt-oss-20b-MXFP4.gguf",
           "quantization": "mxfp4",
           "contextLength": 128000,
           "hfRepo": "ggml-org/gpt-oss-20b-GGUF",


### PR DESCRIPTION
updated the filename to `gpt-oss-20b-MXFP4.gguf` so that it correctly resolves to the working huggingface download url (https://huggingface.co/ggml-org/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-MXFP4.gguf).

fixes #1281 