### PR TITLE
fix(linux): enable push-to-talk under native D-Bus shortcuts on Wayland

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1,7 +1,7 @@
 const { app, screen, BrowserWindow, shell, dialog } = require("electron");
 const debugLogger = require("./debugLogger");
 const HotkeyManager = require("./hotkeyManager");
-const { isGlobeLikeHotkey } = HotkeyManager;
+const { isGlobeLikeHotkey, isMouseButtonHotkey } = HotkeyManager;
 const DragManager = require("./dragManager");
 const MenuManager = require("./menuManager");
 const DevServerManager = require("./devServerManager");
@@ -530,11 +530,23 @@ class WindowManager {
   reconcileNativeKeyListeners() {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     if (this.hotkeyManager.isInListeningMode()) return;
-    // GNOME/KDE/Hyprland deliver hotkeys via D-Bus native shortcuts; the low-level
-    // listener would be redundant there and could double-fire, so watch nothing.
-    const keys = this.hotkeyManager.isUsingNativeShortcut()
-      ? []
-      : this.hotkeyManager.getNativeListenerKeys(this.getActivationMode());
+    // GNOME/KDE/Hyprland deliver hotkeys via D-Bus native shortcuts, which emit
+    // press events only — enough for tap, but push-to-talk needs real
+    // key-down/key-up. In tap mode the low-level listener would double-fire with
+    // the D-Bus event, so watch nothing. In push mode the D-Bus dictation
+    // callback no-ops (createHotkeyCallback defers to the native listener), so
+    // watch the dictation keys here; other slots stay tap-only on D-Bus.
+    let keys;
+    if (this.hotkeyManager.isUsingNativeShortcut()) {
+      keys =
+        this.getActivationMode() === "push"
+          ? this.hotkeyManager
+              .getSlotHotkeys("dictation")
+              .filter((key) => key && !isGlobeLikeHotkey(key) && !isMouseButtonHotkey(key))
+          : [];
+    } else {
+      keys = this.hotkeyManager.getNativeListenerKeys(this.getActivationMode());
+    }
     if (process.platform === "win32" && this.windowsKeyManager) {
       this.windowsKeyManager.setKeys(keys);
     } else if (process.platform === "linux" && this.linuxKeyManager) {


### PR DESCRIPTION
## Problem

On KDE, GNOME, and Hyprland Wayland, the hold (push-to-talk) activation mode for dictation does nothing — pressing and holding the hotkey never starts a recording. Tap mode works fine.

## Root cause

Two code paths each assume the other one is handling push-to-talk:

- On these desktops, hotkeys are delivered via native D-Bus shortcuts (KGlobalAccel / gsettings / hyprctl), which only emit discrete **press** events — there is no key-release event, so they can't drive push-to-talk. Accordingly, the D-Bus dictation callback intentionally no-ops in push mode ("defer to native listener", `createHotkeyCallback` in `src/helpers/windowManager.js`).
- But `reconcileNativeKeyListeners()` told the low-level evdev `linux-key-listener` to watch **nothing** whenever native D-Bus shortcuts were active (to avoid double-firing in tap mode).

Result: in hold mode the press event is discarded by the D-Bus callback and the evdev listener isn't watching, so nothing ever happens.

The Settings UI still offers hold mode in this configuration because `supportsPushToTalk` on Linux only checks that the listener binary exists (`get-hotkey-mode-info` in `src/helpers/ipcHandlers.js`), so users can select a mode that can never fire.

## Fix

When the activation mode is `push`, let the evdev listener watch the dictation slot's hotkeys even when native D-Bus shortcuts are in use. This cannot double-fire:

- the D-Bus dictation callback already returns early in push mode, and
- only the dictation slot is watched — every other slot (agent, meeting, translation, voice agent) stays tap-only on D-Bus, and in tap mode the behavior is unchanged (evdev watches nothing).

## Testing

- KDE Plasma 6 (Wayland), `Control+Super` hotkey, hold mode: `linux-key-listener-x64` now spawns, recording starts after the 150 ms hold threshold and stops on release.
- Tap mode: unchanged, still driven by KGlobalAccel with no double-fire.
- `npm run lint` passes; `node --test` suite unchanged (708 tests, the 8 pre-existing failures are the better-sqlite3 Electron-ABI ones unrelated to this change).