### PR TITLE
fix(linux): accept libpipewire-0.3-0t64 as deb dependency

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -208,7 +208,7 @@
   "deb": {
     "afterInstall": "resources/linux/after-install.sh",
     "afterRemove": "resources/linux/after-remove.sh",
-    "depends": ["ydotool", "libpipewire-0.3-0"],
+    "depends": ["ydotool", "libpipewire-0.3-0 | libpipewire-0.3-0t64"],
     "fpm": [
       "--deb-recommends",
       "ydotoold",


### PR DESCRIPTION
## Problem

The .deb package declares a hard dependency on `libpipewire-0.3-0`, but Ubuntu 24.04+ (and derivatives) renamed that package to `libpipewire-0.3-0t64` as part of the 64-bit `time_t` transition. On those systems `apt install ./OpenWhispr-*.deb` fails with an unsatisfiable dependency even though the library is installed under its new name.

## Fix

Use a Debian alternative dependency so either package name satisfies it:

```
"depends": ["ydotool", "libpipewire-0.3-0 | libpipewire-0.3-0t64"]
```

The rpm target needs no change — it already requires the library soname (`libpipewire-0.3.so.0()(64bit)`) rather than a package name.

## Testing

Rebuilt the .deb (`npm run build:linux:deb`) and installed it on Ubuntu with only `libpipewire-0.3-0t64` available (1.6.2): `dpkg-deb -f` shows the alternative in Depends, and `apt install` resolves it and installs cleanly.