### PR TITLE
fix(ipc): treat unconfigured cloud API and missing auth as expected states

### DIFF
--- a/src/helpers/cloudConfigRequest.js
+++ b/src/helpers/cloudConfigRequest.js
@@ -1,4 +1,5 @@
 const { readPolicyResponseError, toPolicyFailure } = require("./policyResponseError");
+const { checkCloudPreconditions } = require("./cloudPreconditions");
 
 function createCloudConfigRequestHandler({
   getApiUrl,
@@ -9,13 +10,19 @@ function createCloudConfigRequestHandler({
   configPath,
 }) {
   return async function handleCloudConfigRequest(event) {
+    // No API URL (local-only install) and no auth header (session not ready at
+    // first paint) are expected states, not failures. Returning them at debug
+    // level keeps a healthy launch quiet; a thrown error would land in the
+    // catch below and log at error level on every startup.
+    const apiUrl = getApiUrl();
+    const authHeader = apiUrl ? await getAuthHeader(event) : {};
+    const gate = checkCloudPreconditions(apiUrl, authHeader);
+    if (!gate.ok) {
+      logger?.debug?.(`${configPath} unavailable`, { code: gate.result.code });
+      return gate.result;
+    }
+
     try {
-      const apiUrl = getApiUrl();
-      if (!apiUrl) throw new Error("OpenWhispr API URL not configured");
-
-      const authHeader = await getAuthHeader(event);
-      if (!Object.keys(authHeader).length) throw new Error("Not authenticated");
-
       const response = await proxyFetch(`${apiUrl}/api/${configPath}`, {
         headers: withPolicyHeaders(authHeader),
       });

--- a/src/helpers/cloudPreconditions.js
+++ b/src/helpers/cloudPreconditions.js
@@ -1,0 +1,44 @@
+// Every cloud-backed config request needs the same two things before it can
+// call the OpenWhispr API: a configured API URL and an authenticated session.
+// Neither absence is a failure. A local-only user never configures a URL, and
+// the session is not ready during the first paint, so logging them at error
+// level (as a thrown-and-caught error would) produces ERROR-level noise on a
+// healthy launch and trains people to ignore the log. Classify them as
+// expected states the caller can return at debug level instead.
+
+const NOT_CONFIGURED = "NOT_CONFIGURED";
+const NOT_AUTHENTICATED = "NOT_AUTHENTICATED";
+
+// Returns { ok: true } when the caller may proceed, otherwise { ok: false,
+// result } where `result` is the payload to hand straight back to the renderer.
+function checkCloudPreconditions(apiUrl, authHeader) {
+  if (!apiUrl) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        code: NOT_CONFIGURED,
+        error: "OpenWhispr API URL not configured",
+      },
+    };
+  }
+
+  if (!authHeader || Object.keys(authHeader).length === 0) {
+    return {
+      ok: false,
+      result: {
+        success: false,
+        code: NOT_AUTHENTICATED,
+        error: "Not authenticated",
+      },
+    };
+  }
+
+  return { ok: true };
+}
+
+module.exports = {
+  checkCloudPreconditions,
+  NOT_CONFIGURED,
+  NOT_AUTHENTICATED,
+};

--- a/test/helpers/cloudPreconditions.test.js
+++ b/test/helpers/cloudPreconditions.test.js
@@ -1,0 +1,115 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  checkCloudPreconditions,
+  NOT_CONFIGURED,
+  NOT_AUTHENTICATED,
+} = require("../../src/helpers/cloudPreconditions");
+const { createCloudConfigRequestHandler } = require("../../src/helpers/cloudConfigRequest");
+
+test("missing API URL is an expected state, not an error", () => {
+  const gate = checkCloudPreconditions("", { Authorization: "Bearer t" });
+  assert.equal(gate.ok, false);
+  assert.equal(gate.result.success, false);
+  assert.equal(gate.result.code, NOT_CONFIGURED);
+  assert.equal(typeof gate.result.error, "string");
+});
+
+test("empty auth header is an expected state, not an error", () => {
+  const gate = checkCloudPreconditions("https://api.example.com", {});
+  assert.equal(gate.ok, false);
+  assert.equal(gate.result.code, NOT_AUTHENTICATED);
+});
+
+test("a missing auth header is treated as unauthenticated", () => {
+  for (const header of [undefined, null]) {
+    const gate = checkCloudPreconditions("https://api.example.com", header);
+    assert.equal(gate.ok, false);
+    assert.equal(gate.result.code, NOT_AUTHENTICATED);
+  }
+});
+
+test("an unconfigured URL is reported before authentication", () => {
+  const gate = checkCloudPreconditions("", {});
+  assert.equal(gate.result.code, NOT_CONFIGURED);
+});
+
+test("both preconditions met lets the caller proceed", () => {
+  const gate = checkCloudPreconditions("https://api.example.com", { Cookie: "session=abc" });
+  assert.equal(gate.ok, true);
+  assert.equal(gate.result, undefined);
+});
+
+// Regression: the whole point of the change is that an unconfigured or
+// unauthenticated install does NOT log at error level on startup. Prove the
+// factory-built handler stays off logger.error and never issues a fetch.
+function makeLogger() {
+  const calls = { debug: [], error: [] };
+  return {
+    logger: {
+      debug: (...args) => calls.debug.push(args),
+      error: (...args) => calls.error.push(args),
+    },
+    calls,
+  };
+}
+
+test("handler returns NOT_CONFIGURED at debug level without fetching or error-logging", async () => {
+  const { logger, calls } = makeLogger();
+  let fetched = false;
+  const handler = createCloudConfigRequestHandler({
+    getApiUrl: () => "",
+    getAuthHeader: async () => ({ Authorization: "Bearer t" }),
+    proxyFetch: async () => {
+      fetched = true;
+      throw new Error("should not fetch");
+    },
+    withPolicyHeaders: (h) => h,
+    logger,
+    configPath: "stt-config",
+  });
+
+  const result = await handler({});
+  assert.equal(result.success, false);
+  assert.equal(result.code, NOT_CONFIGURED);
+  assert.equal(fetched, false, "must not hit the network when unconfigured");
+  assert.equal(calls.error.length, 0, "must not log at error level for an expected state");
+  assert.equal(calls.debug.length, 1);
+});
+
+test("handler returns NOT_AUTHENTICATED at debug level when the session is not ready", async () => {
+  const { logger, calls } = makeLogger();
+  const handler = createCloudConfigRequestHandler({
+    getApiUrl: () => "https://api.example.com",
+    getAuthHeader: async () => ({}),
+    proxyFetch: async () => {
+      throw new Error("should not fetch");
+    },
+    withPolicyHeaders: (h) => h,
+    logger,
+    configPath: "note-recording-config",
+  });
+
+  const result = await handler({});
+  assert.equal(result.code, NOT_AUTHENTICATED);
+  assert.equal(calls.error.length, 0);
+});
+
+test("a genuine fetch failure still logs at error level", async () => {
+  const { logger, calls } = makeLogger();
+  const handler = createCloudConfigRequestHandler({
+    getApiUrl: () => "https://api.example.com",
+    getAuthHeader: async () => ({ Authorization: "Bearer t" }),
+    proxyFetch: async () => {
+      throw new Error("network down");
+    },
+    withPolicyHeaders: (h) => h,
+    logger,
+    configPath: "stt-config",
+  });
+
+  const result = await handler({});
+  assert.equal(result.success, false);
+  assert.equal(calls.error.length, 1, "real failures must still surface at error level");
+});


### PR DESCRIPTION
## Problem

The shared cloud-config request handler `createCloudConfigRequestHandler` (in `src/helpers/cloudConfigRequest.js`, backing both `get-stt-config` and `get-note-recording-config`) throws for two conditions that are normal rather than exceptional:

- **No API URL.** A local-only user never sets `OPENWHISPR_API_URL`, so `getApiUrl()` returns `""`.
- **Empty auth header.** The session is not ready during the first paint.

Both land in the `catch`, which calls `logger.error`. So a healthy launch logs ERROR-level noise before the window finishes loading — on a clean run with no cloud config:

```
[ERROR] stt-config fetch error: Error: OpenWhispr API URL not configured
```

That trains people to ignore ERROR lines, which is expensive when a real one appears.

## Change

Gate the two expected states before the `try`: return `{ success: false, code: NOT_CONFIGURED | NOT_AUTHENTICATED }` at **debug** level, reserving error level and the `catch` for genuine failures.

The returned shape already matches `toPolicyFailure`, and both call sites (`useAudioRecording.js`, `streamingProvidersStore.ts`) gate on optional-chained `success`, so the renderer is unaffected.

Extracted into `src/helpers/cloudPreconditions.js` as a pure function.

## Note on scope (rebased after the handler refactor)

This PR originally patched the two handlers inline and also fixed a bare `return null` from their catch blocks. Since then, upstream refactored both handlers into this shared factory and **already fixed the `null` return** (the catch now returns `toPolicyFailure(error)`). I rebased onto current `main` and re-scoped this PR to the one issue that survives: the two expected states are still thrown and still logged at error level on every startup. History is now a single clean commit.

## Testing

- `test/helpers/cloudPreconditions.test.js` — 8 cases, including a **negative control**: the factory-built handler stays off `logger.error` for both expected states and never issues a fetch, while a genuine fetch failure still surfaces at error level.
- Verified the control fails against clean `main`: the old factory logs 1 error for an unconfigured install (the exact startup noise this removes).
- Full suite on this branch: 1479 passing, and the 38 pre-existing failures are unchanged from `main` (path-alias tests that need the Vite resolver, not runnable under raw `node --test`) — my change adds 8 tests and 8 passes and introduces no new failures.
- `tsc --noEmit` clean; `eslint` clean on changed files.
