### PR TITLE
ci: restore better-sqlite3 rebuild and typecheck steps dropped by #1285

### DIFF
--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -25,6 +25,10 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Build better-sqlite3 for the runner's node
+        # --ignore-scripts skips the native build; DB-backed tests silently
+        # skip without it. This job is the only test gate on push to main.
+        run: npm rebuild better-sqlite3
       - name: Run tests
         run: npm test
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,12 @@ jobs:
           node-version-file: .nvmrc
       - name: Install dependencies
         run: npm ci --ignore-scripts
+      - name: Build better-sqlite3 for the runner's node
+        # --ignore-scripts skips the native build, so every DB-backed test
+        # (snippetsDatabase, noteCloudUpsertGuard, …) silently skips without this.
+        run: npm rebuild better-sqlite3
+      - name: Typecheck
+        run: npm run typecheck
       - name: Run tests
         run: npm test
         env:


### PR DESCRIPTION
#1285 merged from a branch that predated #1291's workflow changes and silently reverted them: both test gates lost the `npm rebuild better-sqlite3` step (so every DB-backed test — `snippetsDatabase`, `noteCloudUpsertGuard`, the #1290 regression suite — silently skips again) and `tests.yml` lost the typecheck step.

Byte-identical restore of the #1291 workflow hunks, nothing else. The `tests` check on this PR itself demonstrates the fix: it executes the DB-backed tests instead of skipping them.