### PR TITLE
fix(permissions): prompt once so macOS lists the app under Accessibility

### DIFF
--- a/src/helpers/accessibilityPromptPolicy.js
+++ b/src/helpers/accessibilityPromptPolicy.js
@@ -1,0 +1,21 @@
+// macOS Accessibility registration policy.
+//
+// macOS only lists an app under Privacy & Security > Accessibility once that
+// app has *asked* for the permission. Every check OpenWhispr makes passes
+// `false` to isTrustedAccessibilityClient, which queries without registering,
+// so an install that has never prompted does not appear in the list at all.
+// Sending that user to System Settings is a dead end: there is no row to
+// enable, and the pane gives no hint that the app must ask first.
+//
+// The prompt is deliberately one-shot. macOS shows a modal TCC dialog that
+// cannot be suppressed once triggered, so firing it on every attempt would be
+// worse than the dead end it fixes. One prompt is enough — it creates the row,
+// after which System Settings is actionable forever.
+
+// Whether to trigger the registering TCC prompt before opening System Settings.
+// Returns false off macOS, where there is no Accessibility permission to grant.
+export function shouldPromptForAccessibility({ platform, alreadyGranted, hasPromptedBefore }) {
+  if (platform !== "darwin") return false;
+  if (alreadyGranted) return false;
+  return !hasPromptedBefore;
+}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -3,6 +3,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import type { PasteToolsResult } from "../types/electron";
 import { useLocalStorage } from "./useLocalStorage";
+import { shouldPromptForAccessibility } from "../helpers/accessibilityPromptPolicy";
 import logger from "../utils/logger";
 
 export interface UsePermissionsReturn {
@@ -117,6 +118,15 @@ export const usePermissions = (
   const [micPermissionError, setMicPermissionError] = useState<string | null>(null);
   const [accessibilityPermissionGranted, setAccessibilityPermissionGranted] = useLocalStorage(
     "accessibilityPermissionGranted",
+    false,
+    {
+      serialize: String,
+      deserialize: (value) => value === "true",
+    }
+  );
+  // One-shot: records that the registering TCC prompt has already been shown.
+  const [hasPromptedAccessibility, setHasPromptedAccessibility] = useLocalStorage(
+    "hasPromptedAccessibility",
     false,
     {
       serialize: String,
@@ -250,8 +260,25 @@ export const usePermissions = (
         return;
       }
 
-      // Open System Settings directly — avoids the undismissable macOS TCC dialog
-      // that isTrustedAccessibilityClient(true) would show.
+      // macOS only lists an app under Accessibility once it has asked for the
+      // permission, so an install that has never prompted has no row to enable
+      // and System Settings is a dead end. Prompt once to create the row. The
+      // TCC dialog cannot be dismissed programmatically, so this stays one-shot.
+      if (
+        shouldPromptForAccessibility({
+          platform,
+          alreadyGranted: false,
+          hasPromptedBefore: hasPromptedAccessibility,
+        })
+      ) {
+        setHasPromptedAccessibility(true);
+        const granted = await window.electronAPI?.promptAccessibilityPermission?.();
+        if (granted) {
+          setAccessibilityPermissionGranted(true);
+          return;
+        }
+      }
+
       await openSystemSettings("accessibility", window.electronAPI?.openAccessibilitySettings);
       return;
     }
@@ -267,7 +294,13 @@ export const usePermissions = (
       await checkPasteToolsAvailability();
       setAccessibilityPermissionGranted(true);
     }
-  }, [openSystemSettings, checkPasteToolsAvailability, setAccessibilityPermissionGranted]);
+  }, [
+    openSystemSettings,
+    checkPasteToolsAvailability,
+    setAccessibilityPermissionGranted,
+    hasPromptedAccessibility,
+    setHasPromptedAccessibility,
+  ]);
 
   // Check paste tools on mount
   useEffect(() => {

--- a/test/helpers/accessibilityPromptPolicy.test.js
+++ b/test/helpers/accessibilityPromptPolicy.test.js
@@ -1,0 +1,56 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/accessibilityPromptPolicy.js");
+
+test("a macOS install that has never asked is prompted, so the row gets created", async () => {
+  const { shouldPromptForAccessibility } = await load();
+  assert.equal(
+    shouldPromptForAccessibility({
+      platform: "darwin",
+      alreadyGranted: false,
+      hasPromptedBefore: false,
+    }),
+    true
+  );
+});
+
+test("the prompt is one-shot — a second attempt goes straight to System Settings", async () => {
+  const { shouldPromptForAccessibility } = await load();
+  // The macOS TCC dialog cannot be dismissed programmatically, so re-prompting
+  // on every attempt would be worse than the dead end it fixes.
+  assert.equal(
+    shouldPromptForAccessibility({
+      platform: "darwin",
+      alreadyGranted: false,
+      hasPromptedBefore: true,
+    }),
+    false
+  );
+});
+
+test("an already-granted install is never prompted", async () => {
+  const { shouldPromptForAccessibility } = await load();
+  assert.equal(
+    shouldPromptForAccessibility({
+      platform: "darwin",
+      alreadyGranted: true,
+      hasPromptedBefore: false,
+    }),
+    false
+  );
+});
+
+test("no prompt off macOS, where there is no Accessibility permission", async () => {
+  const { shouldPromptForAccessibility } = await load();
+  for (const platform of ["win32", "linux"]) {
+    assert.equal(
+      shouldPromptForAccessibility({
+        platform,
+        alreadyGranted: false,
+        hasPromptedBefore: false,
+      }),
+      false
+    );
+  }
+});


### PR DESCRIPTION
## Problem

macOS only lists an app under **Privacy & Security → Accessibility** once that app has *asked* for the permission. Every check OpenWhispr makes passes `false` to `isTrustedAccessibilityClient`, which queries without registering:

- `main.js:1472`, `main.js:1486`
- `src/helpers/clipboard.js:1957`

So a fresh install never appears in the list at all. `requestAccessibilityPermission` then sends the user straight to System Settings (`src/hooks/usePermissions.ts:255`), which in that state is a dead end — there is no row to enable, and the pane gives no hint that the app has to ask first. The user is told to grant a permission they cannot find.

The IPC that *would* register it already exists and is fully plumbed:

- handler: `src/helpers/ipcHandlers.js:1926` — the one call site that passes `true`
- bridge: `preload.js:237` — `promptAccessibilityPermission`
- type: `src/types/electron.ts:835`

It is never called from the renderer. Dead code.

## Change

Call it once before falling back to System Settings.

The existing comment at `usePermissions.ts:253` is right that the macOS TCC dialog cannot be dismissed programmatically, so this is **not** a revert of that decision — the prompt is one-shot, persisted as `hasPromptedAccessibility` in localStorage. One prompt creates the row; every attempt after that goes straight to System Settings exactly as today. If the user happens to grant it at the prompt, the flow short-circuits and never opens Settings at all.

Decision logic lives in `src/helpers/accessibilityPromptPolicy.js` as a pure function so it is unit-testable, matching the `dockPolicy.js` pattern described in `CLAUDE.md`.

## Note for contributors

In development this registers as **"Electron"**, not "OpenWhispr" — the dev binary is `node_modules/electron/dist/Electron.app`, ad-hoc signed with `Identifier=Electron` and no Team ID. That surprised me while debugging, and is worth knowing when testing this change. Packaged builds register under the product name.

## Testing

- `test/helpers/accessibilityPromptPolicy.test.js` — 4 cases: never-asked prompts, one-shot suppression, already-granted, and non-darwin platforms.
- Full suite: **699 passing, 0 failing, 19 skipped** (`node --test "test/**/*.test.js"`).
- `tsc --noEmit` clean; `eslint` clean.
- Ran the app on macOS 27 (arm64, Node 24.18.0). Clean start with the change applied: no hook-order or ErrorBoundary errors, app reaches `qdrant started successfully` and the usual accessibility notice.
- Confirmed the underlying mechanism separately: invoking `isTrustedAccessibilityClient(true)` against the same ad-hoc `Electron.app` bundle does trigger the macOS dialog and create the Accessibility row, where `(false)` alone never does.

**What I could not automate:** clicking through the TCC dialog itself and confirming the row appears via the real Settings button is a manual step. The policy function, the wiring, and the underlying API behaviour are each verified; the human click-through is not.
