### PR TITLE
feat: add hold-to-submit Voice Agent hotkey

### DIFF
--- a/main.js
+++ b/main.js
@@ -289,6 +289,7 @@ const LinuxPortalAudioManager = require("./src/helpers/linuxPortalAudioManager")
 const WindowsLoopbackAudioManager = require("./src/helpers/windowsLoopbackAudioManager");
 const MeetingAecManager = require("./src/helpers/meetingAecManager");
 const MeetingDetectionEngine = require("./src/helpers/meetingDetectionEngine");
+const { isGlobeLikeHotkey, isMouseButtonHotkey } = require("./src/helpers/hotkeyManager");
 const { i18nMain, changeLanguage } = require("./src/helpers/i18nMain");
 const { ensureYdotool } = require("./src/helpers/ensureYdotool");
 const sidecarRegistry = require("./src/helpers/sidecarRegistry");
@@ -908,6 +909,9 @@ async function startApp() {
   ipcMain.on("activation-mode-changed", (_event, mode) => {
     windowManager.setActivationModeCache(mode);
     environmentManager.saveActivationMode(mode);
+    if (process.platform === "darwin") {
+      windowManager.forceStopMacCompoundPush("activation-mode-changed");
+    }
   });
 
   ipcMain.on("floating-icon-auto-hide-changed", (_event, enabled) => {
@@ -970,7 +974,30 @@ async function startApp() {
 
   // Set up voice agent hotkey (dictation routed straight to the dictation
   // agent, bypassing cleanup)
-  const voiceAgentHotkeyCallback = () => {
+  const voiceAgentHotkeyCallback = (triggeredHotkey) => {
+    if (hotkeyManager.isInListeningMode()) return;
+
+    const currentHotkey = triggeredHotkey || hotkeyManager.getSlotHotkey("voiceAgent");
+
+    if (
+      process.platform === "darwin" &&
+      currentHotkey &&
+      !isGlobeLikeHotkey(currentHotkey) &&
+      currentHotkey.includes("+")
+    ) {
+      windowManager.startMacCompoundPushToTalk(currentHotkey, "voiceAgent");
+      return;
+    }
+
+    // Windows/Linux low-level listeners deliver key-down and key-up. Desktop
+    // shortcut backends only deliver a toggle, so retain tap behavior there.
+    if (
+      (process.platform === "win32" || process.platform === "linux") &&
+      !hotkeyManager.isUsingNativeShortcut()
+    ) {
+      return;
+    }
+
     windowManager.sendToggleVoiceAgent();
   };
   windowManager._voiceAgentHotkeyCallback = voiceAgentHotkeyCallback;
@@ -1174,7 +1201,6 @@ async function startApp() {
   updateManager.checkForUpdatesOnStartup();
 
   if (process.platform === "darwin") {
-    const { isGlobeLikeHotkey, isMouseButtonHotkey } = require("./src/helpers/hotkeyManager");
     let globeKeyDownTime = 0;
     let globeKeyIsRecording = false;
     let globeLastStopTime = 0;
@@ -1229,9 +1255,10 @@ async function startApp() {
 
       // Check agent and voice agent slots for Globe/Fn key
       const agentUsesGlobe = hotkeyManager.getSlotHotkeys("agent").some(isGlobeLikeHotkey);
-      const voiceAgentUsesGlobe = hotkeyManager
+      const voiceAgentGlobeHotkey = hotkeyManager
         .getSlotHotkeys("voiceAgent")
-        .some(isGlobeLikeHotkey);
+        .find(isGlobeLikeHotkey);
+      const voiceAgentUsesGlobe = Boolean(voiceAgentGlobeHotkey);
       const translationUsesGlobe = hotkeyManager
         .getSlotHotkeys("translation")
         .some(isGlobeLikeHotkey);
@@ -1239,7 +1266,7 @@ async function startApp() {
         windowManager.toggleAgentOverlay();
       }
       if (voiceAgentUsesGlobe) {
-        windowManager.sendToggleVoiceAgent();
+        windowManager.startVoiceAgentPushToTalk(voiceAgentGlobeHotkey);
       }
       if (translationUsesGlobe) {
         windowManager.sendToggleTranslation();
@@ -1270,6 +1297,13 @@ async function startApp() {
         }
       }
 
+      const voiceAgentGlobeHotkey = hotkeyManager
+        .getSlotHotkeys("voiceAgent")
+        .find(isGlobeLikeHotkey);
+      if (voiceAgentGlobeHotkey) {
+        windowManager.handleVoiceAgentPushKeyUp(voiceAgentGlobeHotkey);
+      }
+
       // Fn release also stops compound push-to-talk for Fn+F-key hotkeys
       windowManager.handleMacPushModifierUp("fn");
     });
@@ -1277,21 +1311,32 @@ async function startApp() {
     // Another key was pressed while Fn was held — user is using Fn as a
     // navigation modifier (Fn+Arrow → Home, Fn+Backspace → Forward Delete, etc.).
     // Cancel any bare-Fn push-to-talk in progress instead of transcribing noise.
-    // Only the bare-Fn path uses globeKeyDownTime/globeKeyIsRecording, so compound
-    // Fn-hotkey push-to-talk and tap mode are untouched.
+    // Bare-Fn dictation uses the local state below; bare-Fn Voice Agent uses its
+    // own push state. Compound Fn hotkeys and tap mode are untouched.
     globeKeyManager.on("globe-interrupted", () => {
-      if (globeKeyDownTime === 0 && !globeKeyIsRecording) {
+      const voiceAgentGlobePushActive =
+        windowManager.voiceAgentPushState?.active &&
+        isGlobeLikeHotkey(windowManager.voiceAgentPushState.key);
+      const dictationGlobePushActive = globeKeyDownTime !== 0 || globeKeyIsRecording;
+      if (!dictationGlobePushActive && !voiceAgentGlobePushActive) {
         return;
       }
-      const wasRecording = globeKeyIsRecording;
-      debugLogger?.debug("[Globe] Fn+key interrupted push-to-talk", { wasRecording });
-      globeKeyDownTime = 0;
-      globeKeyIsRecording = false;
-      globeLastStopTime = Date.now();
-      if (wasRecording) {
-        windowManager.sendCancelDictation();
-      } else {
-        windowManager.hideDictationPanel();
+
+      if (dictationGlobePushActive) {
+        const wasRecording = globeKeyIsRecording;
+        debugLogger?.debug("[Globe] Fn+key interrupted push-to-talk", { wasRecording });
+        globeKeyDownTime = 0;
+        globeKeyIsRecording = false;
+        globeLastStopTime = Date.now();
+        if (wasRecording) {
+          windowManager.sendCancelDictation();
+        } else {
+          windowManager.hideDictationPanel();
+        }
+      }
+
+      if (voiceAgentGlobePushActive) {
+        windowManager.cancelVoiceAgentPushToTalk();
       }
     });
 
@@ -1313,7 +1358,7 @@ async function startApp() {
         windowManager.toggleAgentOverlay();
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", modifier)) {
-        windowManager.sendToggleVoiceAgent();
+        windowManager.startVoiceAgentPushToTalk(modifier);
       }
       if (hotkeyManager.slotHasHotkey("translation", modifier)) {
         windowManager.sendToggleTranslation();
@@ -1345,6 +1390,10 @@ async function startApp() {
     });
 
     globeKeyManager.on("right-modifier-up", async (modifier) => {
+      if (hotkeyManager.slotHasHotkey("voiceAgent", modifier)) {
+        windowManager.handleVoiceAgentPushKeyUp(modifier);
+      }
+
       if (hotkeyManager.slotHasHotkey("dictation", modifier)) {
         if (!isLiveWindow(windowManager.mainWindow)) return;
 
@@ -1398,7 +1447,7 @@ async function startApp() {
         windowManager.toggleAgentOverlay();
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", button)) {
-        windowManager.sendToggleVoiceAgent();
+        windowManager.startVoiceAgentPushToTalk(button);
       }
       if (hotkeyManager.slotHasHotkey("translation", button)) {
         windowManager.sendToggleTranslation();
@@ -1433,6 +1482,10 @@ async function startApp() {
     globeKeyManager.on("mouse-button-up", async (button) => {
       if (hotkeyManager.isInListeningMode && hotkeyManager.isInListeningMode()) return;
       if (!isMouseButtonHotkey(button)) return;
+
+      if (hotkeyManager.slotHasHotkey("voiceAgent", button)) {
+        windowManager.handleVoiceAgentPushKeyUp(button);
+      }
 
       if (!hotkeyManager.slotHasHotkey("dictation", button)) return;
       if (!isLiveWindow(windowManager.mainWindow)) return;
@@ -1501,6 +1554,7 @@ async function startApp() {
       mouseButtonDownTime = 0;
       mouseButtonIsRecording = false;
       mouseButtonLastStopTime = 0;
+      windowManager.resetVoiceAgentPushState();
       syncSuppressedMouseButtons();
     });
   }
@@ -1514,8 +1568,8 @@ async function startApp() {
     const nativeKeyManager = isWindows ? windowsKeyManager : linuxKeyManager;
     debugLogger.debug("[Push-to-Talk] Native key listener setup starting");
 
-    // Dictation supports push-to-talk and needs the overlay window; agent/meeting
-    // drive other windows (matching their globalShortcut callbacks and macOS).
+    // Dictation and Voice Agent support push-to-talk. The remaining slots drive
+    // tap actions that match their globalShortcut callbacks and macOS paths.
     const dispatchNativeKeyDown = (key) => {
       if (hotkeyManager.slotHasHotkey("dictation", key)) {
         if (!isLiveWindow(windowManager.mainWindow)) return;
@@ -1527,7 +1581,7 @@ async function startApp() {
         return;
       }
       if (hotkeyManager.slotHasHotkey("voiceAgent", key)) {
-        windowManager.sendToggleVoiceAgent();
+        windowManager.startVoiceAgentPushToTalk(key);
       } else if (hotkeyManager.slotHasHotkey("translation", key)) {
         windowManager.sendToggleTranslation();
       } else if (hotkeyManager.slotHasHotkey("agent", key)) {
@@ -1537,8 +1591,12 @@ async function startApp() {
       }
     };
 
-    // Only dictation drives push-to-talk, so only its key-up matters.
+    // Route release to the push-to-talk pipeline that owns this key.
     const dispatchNativeKeyUp = (key) => {
+      if (hotkeyManager.slotHasHotkey("voiceAgent", key)) {
+        windowManager.handleVoiceAgentPushKeyUp(key);
+        return;
+      }
       if (!hotkeyManager.slotHasHotkey("dictation", key)) return;
       if (windowManager.winPushState?.active) {
         windowManager.handleWindowsPushKeyUp(key);

--- a/preload.js
+++ b/preload.js
@@ -51,6 +51,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onToggleVoiceAgent: registerListener("toggle-voice-agent", (callback) => () => callback()),
   onToggleTranslation: registerListener("toggle-translation", (callback) => () => callback()),
   onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
+  onStartVoiceAgent: registerListener("start-voice-agent", (callback) => () => callback()),
   onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
 
   // Database functions

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -372,9 +372,9 @@ class HotkeyManager extends EventEmitter {
   /**
    * Hotkeys that must be watched by a native low-level listener (Windows/Linux)
    * instead of globalShortcut. Modifier-only and right-side-modifier combos never
-   * register through globalShortcut, and in push-to-talk mode dictation also needs
-   * raw key-down/key-up events. Only the dictation slot supports push-to-talk;
-   * every other slot is tap-to-toggle. Globe/mouse hotkeys are macOS-only.
+   * register through globalShortcut. Voice Agent is always hold-to-submit, while
+   * dictation needs raw key-down/key-up events only in push-to-talk mode. Other
+   * slots remain tap-to-toggle. Globe/mouse hotkeys are macOS-only.
    * Each slot may bind several hotkeys, so we evaluate every one.
    */
   getNativeListenerKeys(activationMode) {
@@ -382,7 +382,8 @@ class HotkeyManager extends EventEmitter {
     for (const [slotName, slot] of this.slots) {
       for (const hotkey of slot.hotkeys ?? []) {
         if (!hotkey || isGlobeLikeHotkey(hotkey) || isMouseButtonHotkey(hotkey)) continue;
-        const pushToTalk = slotName === "dictation" && activationMode === "push";
+        const pushToTalk =
+          slotName === "voiceAgent" || (slotName === "dictation" && activationMode === "push");
         if (pushToTalk || isModifierOnlyHotkey(hotkey) || isRightSideModifier(hotkey)) {
           keys.push(hotkey);
         }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -8475,6 +8475,7 @@ class IPCHandlers {
       if (!voiceAgentCallback) {
         return { success: false, message: "Voice agent hotkey callback not initialized" };
       }
+      this.windowManager.resetVoiceAgentPushState();
 
       if (!hotkey) {
         hotkeyManager.unregisterSlot("voiceAgent");

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -42,6 +42,7 @@ class WindowManager {
     this.loadErrorShown = false;
     this.macCompoundPushState = null;
     this.winPushState = null;
+    this.voiceAgentPushState = null;
     this._cachedActivationMode = "tap";
     this._floatingIconAutoHide = false;
     this._agentAnimationState = null;
@@ -262,7 +263,7 @@ class WindowManager {
     };
   }
 
-  startMacCompoundPushToTalk(hotkey) {
+  startMacCompoundPushToTalk(hotkey, target = "dictation") {
     if (this.macCompoundPushState?.active) {
       return;
     }
@@ -292,6 +293,7 @@ class WindowManager {
       isRecording: false,
       requiredModifiers,
       safetyTimeoutId,
+      target,
     };
 
     setTimeout(() => {
@@ -301,7 +303,11 @@ class WindowManager {
 
       if (!this.macCompoundPushState.isRecording) {
         this.macCompoundPushState.isRecording = true;
-        this.sendStartDictation();
+        if (target === "voiceAgent") {
+          this.sendStartVoiceAgent();
+        } else {
+          this.sendStartDictation();
+        }
       }
     }, MIN_HOLD_DURATION_MS);
   }
@@ -450,6 +456,97 @@ class WindowManager {
     this.handleWindowsPushKeyUp();
   }
 
+  startVoiceAgentPushToTalk(key) {
+    if (this.voiceAgentPushState?.active) {
+      return;
+    }
+
+    const MIN_HOLD_DURATION_MS = 150;
+    const MAX_PUSH_DURATION_MS = 300000;
+    const downTime = Date.now();
+
+    debugLogger.debug("Voice Agent PTT key down", { key }, "ptt");
+    if (this.textEditMonitor) this.textEditMonitor.captureTargetPid();
+    this.showDictationPanel();
+
+    const safetyTimeoutId = setTimeout(() => {
+      if (this.voiceAgentPushState?.active) {
+        debugLogger.warn("Voice Agent PTT safety timeout", { key }, "ptt");
+        this.handleVoiceAgentPushKeyUp();
+      }
+    }, MAX_PUSH_DURATION_MS);
+
+    this.voiceAgentPushState = {
+      active: true,
+      key,
+      downTime,
+      isRecording: false,
+      safetyTimeoutId,
+    };
+
+    setTimeout(() => {
+      if (!this.voiceAgentPushState || this.voiceAgentPushState.downTime !== downTime) {
+        return;
+      }
+
+      if (!this.voiceAgentPushState.isRecording) {
+        this.voiceAgentPushState.isRecording = true;
+        this.sendStartVoiceAgent();
+      }
+    }, MIN_HOLD_DURATION_MS);
+  }
+
+  // With several Voice Agent hotkeys bound, only the key that started the push
+  // may stop it. Called without a key to force-stop after settings changes.
+  handleVoiceAgentPushKeyUp(key) {
+    if (!this.voiceAgentPushState?.active) {
+      return;
+    }
+    if (key && this.voiceAgentPushState.key && key !== this.voiceAgentPushState.key) {
+      return;
+    }
+
+    if (this.voiceAgentPushState.safetyTimeoutId) {
+      clearTimeout(this.voiceAgentPushState.safetyTimeoutId);
+    }
+
+    const wasRecording = this.voiceAgentPushState.isRecording;
+    const heldForMs = Date.now() - this.voiceAgentPushState.downTime;
+    this.voiceAgentPushState = null;
+
+    debugLogger.debug("Voice Agent PTT key up", { key, heldForMs, wasRecording }, "ptt");
+    if (wasRecording) {
+      this.sendStopDictation();
+    } else {
+      this.hideDictationPanel();
+    }
+  }
+
+  cancelVoiceAgentPushToTalk() {
+    if (!this.voiceAgentPushState?.active) {
+      return;
+    }
+
+    if (this.voiceAgentPushState.safetyTimeoutId) {
+      clearTimeout(this.voiceAgentPushState.safetyTimeoutId);
+    }
+
+    const wasRecording = this.voiceAgentPushState.isRecording;
+    this.voiceAgentPushState = null;
+    if (wasRecording) {
+      this.sendCancelDictation();
+    } else {
+      this.hideDictationPanel();
+    }
+  }
+
+  resetVoiceAgentPushState() {
+    this.handleVoiceAgentPushKeyUp();
+    if (this.macCompoundPushState?.target === "voiceAgent") {
+      this.forceStopMacCompoundPush("voice-agent-hotkey-reset");
+    }
+  }
+
   _sendDictationToggle(channel) {
     if (this.hotkeyManager.isInListeningMode()) {
       return;
@@ -472,6 +569,17 @@ class WindowManager {
     // refocus the target (#668).
     if (this.textEditMonitor) this.textEditMonitor.captureTargetPid();
     this._sendDictationToggle("toggle-voice-agent");
+  }
+
+  sendStartVoiceAgent() {
+    if (this.hotkeyManager.isInListeningMode()) {
+      return;
+    }
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.showDictationPanel();
+      this.mainWindow.webContents.send("start-voice-agent");
+      this.meetingDetectionEngine?.setUserRecording(true);
+    }
   }
 
   sendToggleTranslation() {

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -19,6 +19,8 @@ export const useAudioRecording = (toast, options = {}) => {
   const audioManagerRef = useRef(null);
   const startLockRef = useRef(false);
   const stopLockRef = useRef(false);
+  const stopAfterStartRef = useRef(false);
+  const performStopRecordingRef = useRef(null);
   const wasRecordingRef = useRef(false);
   const wasMicUnavailableRef = useRef(false);
   const { onToggle } = options;
@@ -61,6 +63,10 @@ export const useAudioRecording = (toast, options = {}) => {
         return didStart;
       } finally {
         startLockRef.current = false;
+        if (stopAfterStartRef.current) {
+          stopAfterStartRef.current = false;
+          await performStopRecordingRef.current?.();
+        }
       }
     },
     []
@@ -93,6 +99,7 @@ export const useAudioRecording = (toast, options = {}) => {
       stopLockRef.current = false;
     }
   }, []);
+  performStopRecordingRef.current = performStopRecording;
 
   useEffect(() => {
     audioManagerRef.current = new AudioManager();
@@ -264,6 +271,10 @@ export const useAudioRecording = (toast, options = {}) => {
       translationRequested = false,
     } = {}) => {
       if (!audioManagerRef.current) return;
+      if (startLockRef.current) {
+        stopAfterStartRef.current = true;
+        return;
+      }
       // Lazily warm the mic driver on first dictation use, not at launch. See #871.
       audioManagerRef.current.warmupMicDriver?.();
       const currentState = audioManagerRef.current.getState();
@@ -275,12 +286,16 @@ export const useAudioRecording = (toast, options = {}) => {
       }
     };
 
-    const handleStart = async () => {
+    const handleStart = async ({ voiceAgentRequested = false } = {}) => {
       audioManagerRef.current?.warmupMicDriver?.();
-      await performStartRecording();
+      await performStartRecording({ voiceAgentRequested });
     };
 
     const handleStop = async () => {
+      if (startLockRef.current) {
+        stopAfterStartRef.current = true;
+        return;
+      }
       await performStopRecording();
     };
 
@@ -301,6 +316,11 @@ export const useAudioRecording = (toast, options = {}) => {
 
     const disposeStart = window.electronAPI.onStartDictation?.(() => {
       handleStart();
+      onToggle?.();
+    });
+
+    const disposeVoiceAgentStart = window.electronAPI.onStartVoiceAgent?.(() => {
+      handleStart({ voiceAgentRequested: true });
       onToggle?.();
     });
 
@@ -328,6 +348,7 @@ export const useAudioRecording = (toast, options = {}) => {
       disposeVoiceAgentToggle?.();
       disposeTranslationToggle?.();
       disposeStart?.();
+      disposeVoiceAgentStart?.();
       disposeStop?.();
       disposeNoAudio?.();
       if (audioManagerRef.current) {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -221,13 +221,13 @@
     },
     "voiceAgent": {
       "title": "Voice Agent Setup",
-      "description": "Talk to your AI agent with a single keypress",
+      "description": "Talk to your AI agent with a hold-to-submit hotkey",
       "hotkey": "Hotkey",
-      "howItWorks": "Press the key and say what you want — for example “write a short thank-you note”. {{agentName}} types the result wherever your cursor is. No need to say “Hey {{agentName}}” first.",
+      "howItWorks": "Hold the key and say what you want — for example “write a short thank-you note” — then release to submit. {{agentName}} types the result wherever your cursor is. No need to say “Hey {{agentName}}” first.",
       "test": "Try it",
-      "testInstruction": "Click below, press {{hotkey}} and say a command",
+      "testInstruction": "Click below, hold {{hotkey}}, say a command, then release",
       "testSetHotkey": "Set a hotkey above to try it",
-      "testPlaceholder": "Click here, press your hotkey and say one of the examples...",
+      "testPlaceholder": "Click here, hold your hotkey, say one of the examples, then release...",
       "examples": [
         "Translate to Italian: “I talk faster than I type”",
         "Write a short email to my boss telling him I want a promotion, his name is Mark",
@@ -1625,7 +1625,7 @@
       },
       "voiceAgentHotkey": {
         "title": "Voice Agent Hotkey",
-        "description": "Speak a request — your AI agent types the result, not your words"
+        "description": "Hold while speaking, then release to submit the request to your AI agent"
       },
       "translationHotkey": {
         "title": "Translation Hotkey",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -559,6 +559,7 @@ declare global {
       onToggleVoiceAgent?: (callback: () => void) => () => void;
       onToggleTranslation?: (callback: () => void) => () => void;
       onStartDictation?: (callback: () => void) => () => void;
+      onStartVoiceAgent?: (callback: () => void) => () => void;
       onStopDictation?: (callback: () => void) => () => void;
 
       // STT config

--- a/test/helpers/nativeListenerKeys.test.js
+++ b/test/helpers/nativeListenerKeys.test.js
@@ -29,17 +29,22 @@ test("tap mode watches modifier-only hotkeys for every slot", () => {
   ]);
 });
 
-test("regular key hotkeys are left to globalShortcut in tap mode", () => {
-  const mgr = makeManager({ dictation: "F8", voiceAgent: "Control+Shift+A" });
+test("regular non-Voice-Agent hotkeys are left to globalShortcut in tap mode", () => {
+  const mgr = makeManager({ dictation: "F8", agent: "Control+Shift+A" });
   assert.deepEqual(mgr.getNativeListenerKeys("tap"), []);
 });
 
-test("push mode watches the dictation key even when it is a regular key", () => {
+test("Voice Agent keys are watched for release even when dictation uses tap mode", () => {
   const mgr = makeManager({ dictation: "F8", voiceAgent: "Control+Shift+A" });
-  assert.deepEqual(mgr.getNativeListenerKeys("push"), ["F8"]);
+  assert.deepEqual(mgr.getNativeListenerKeys("tap"), ["Control+Shift+A"]);
 });
 
-test("push mode does not push-enable non-dictation slots", () => {
+test("push mode watches regular dictation and Voice Agent keys", () => {
+  const mgr = makeManager({ dictation: "F8", voiceAgent: "Control+Shift+A" });
+  assert.deepEqual(mgr.getNativeListenerKeys("push").sort(), ["Control+Shift+A", "F8"]);
+});
+
+test("push mode does not push-enable the Chat Agent slot", () => {
   const mgr = makeManager({ dictation: "Control+Super", agent: "F9" });
   assert.deepEqual(mgr.getNativeListenerKeys("push"), ["Control+Super"]);
 });
@@ -102,7 +107,7 @@ test("translation slot conflicts are detected and it is never push-enabled", () 
   const conflict = mgr._findSlotConflict("agent", "Control+Shift+T");
   assert.equal(conflict?.reason, "slot_conflict");
   assert.equal(conflict?.conflictSlot, "translation");
-  // Push mode only push-enables the dictation slot, never translation.
+  // Push mode never enables the translation slot.
   assert.deepEqual(mgr.getNativeListenerKeys("push"), ["F8"]);
   // Modifier-only translation hotkeys go through the native listener in tap mode.
   const mgr2 = makeManager({ translation: "Control+Alt" });

--- a/test/helpers/voiceAgentPushToTalk.test.js
+++ b/test/helpers/voiceAgentPushToTalk.test.js
@@ -1,0 +1,113 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const WindowManager = require("../../src/helpers/windowManager.js");
+
+const HOLD_DELAY_MS = 175;
+
+const makeManager = () => {
+  const calls = {
+    captureTarget: 0,
+    show: 0,
+    hide: 0,
+    startVoiceAgent: 0,
+    stop: 0,
+    cancel: 0,
+  };
+  const manager = Object.create(WindowManager.prototype);
+  manager.voiceAgentPushState = null;
+  manager.macCompoundPushState = null;
+  manager.textEditMonitor = {
+    captureTargetPid() {
+      calls.captureTarget += 1;
+    },
+  };
+  manager.showDictationPanel = () => {
+    calls.show += 1;
+  };
+  manager.hideDictationPanel = () => {
+    calls.hide += 1;
+  };
+  manager.sendStartVoiceAgent = () => {
+    calls.startVoiceAgent += 1;
+  };
+  manager.sendStopDictation = () => {
+    calls.stop += 1;
+  };
+  manager.sendCancelDictation = () => {
+    calls.cancel += 1;
+  };
+  return { manager, calls };
+};
+
+test("quick Voice Agent hotkey taps do not start or submit a recording", async () => {
+  const { manager, calls } = makeManager();
+
+  manager.startVoiceAgentPushToTalk("F8");
+  manager.handleVoiceAgentPushKeyUp("F8");
+  await new Promise((resolve) => setTimeout(resolve, HOLD_DELAY_MS));
+
+  assert.equal(calls.captureTarget, 1);
+  assert.equal(calls.show, 1);
+  assert.equal(calls.hide, 1);
+  assert.equal(calls.startVoiceAgent, 0);
+  assert.equal(calls.stop, 0);
+  assert.equal(manager.voiceAgentPushState, null);
+});
+
+test("holding and releasing the Voice Agent hotkey starts then submits", async () => {
+  const { manager, calls } = makeManager();
+
+  manager.startVoiceAgentPushToTalk("Control+Shift+A");
+  await new Promise((resolve) => setTimeout(resolve, HOLD_DELAY_MS));
+
+  assert.equal(calls.startVoiceAgent, 1);
+  assert.equal(manager.voiceAgentPushState?.isRecording, true);
+
+  manager.handleVoiceAgentPushKeyUp("Control+Shift+A");
+
+  assert.equal(calls.stop, 1);
+  assert.equal(calls.hide, 0);
+  assert.equal(manager.voiceAgentPushState, null);
+});
+
+test("macOS compound Voice Agent hotkeys start and submit without dictation mode state", async () => {
+  const { manager, calls } = makeManager();
+
+  manager.startMacCompoundPushToTalk("Command+Shift+K", "voiceAgent");
+  await new Promise((resolve) => setTimeout(resolve, HOLD_DELAY_MS));
+
+  assert.equal(calls.startVoiceAgent, 1);
+  assert.equal(manager.macCompoundPushState?.target, "voiceAgent");
+
+  manager.handleMacPushModifierUp("shift");
+
+  assert.equal(calls.stop, 1);
+  assert.equal(manager.macCompoundPushState, null);
+});
+
+test("a different Voice Agent key cannot stop the active hold", async () => {
+  const { manager, calls } = makeManager();
+
+  manager.startVoiceAgentPushToTalk("F8");
+  await new Promise((resolve) => setTimeout(resolve, HOLD_DELAY_MS));
+  manager.handleVoiceAgentPushKeyUp("F9");
+
+  assert.equal(calls.stop, 0);
+  assert.equal(manager.voiceAgentPushState?.active, true);
+
+  manager.handleVoiceAgentPushKeyUp("F8");
+  assert.equal(calls.stop, 1);
+});
+
+test("interrupting an active Voice Agent hold cancels instead of submitting", async () => {
+  const { manager, calls } = makeManager();
+
+  manager.startVoiceAgentPushToTalk("GLOBE");
+  await new Promise((resolve) => setTimeout(resolve, HOLD_DELAY_MS));
+  manager.cancelVoiceAgentPushToTalk();
+
+  assert.equal(calls.cancel, 1);
+  assert.equal(calls.stop, 0);
+  assert.equal(manager.voiceAgentPushState, null);
+});


### PR DESCRIPTION
## Summary

- make the Voice Agent hotkey hold-to-submit independently of Dictation activation mode
- preserve Voice Agent routing through a dedicated start IPC event and stop/submit on key release
- support macOS Globe, right-modifier, mouse, and compound hotkeys plus Windows/Linux low-level listeners
- keep a tap fallback for native desktop shortcut backends that cannot report key-up events
- handle quick taps and releases during asynchronous microphone startup
- update the Voice Agent UI copy and add regression coverage

Closes #1306

## Testing

- `npm test` (701 passed, 19 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run build:renderer`