### PR TITLE
fix(linux): prefer portal over uinput on GNOME Wayland paste

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1566,8 +1566,10 @@ class ClipboardManager {
 
         // KDE with XWayland: portal first because clipboard and input are both
         // on X11. uinput causes clipboard desync (X11 clipboard vs Wayland input).
-        // GNOME: uinput first because the portal often times out or shows a
-        // confusing permission dialog, causing a 10s+ delay (issue #494).
+        // GNOME Wayland: portal first (one-time dialog, reliable after approval).
+        // When two uinput devices coexist (linux-fast-paste ephemeral + ydotoold
+        // persistent), Mutter drops the modifier key from the short-lived device,
+        // causing paste to silently fail with exit 0 (issue #956).
         if (isKde && linuxFastPaste && !this.portalDenied) {
           const portalPaste = await tryPortalPaste();
           if (portalPaste) return { method: "portal", ...portalPaste };
@@ -1578,19 +1580,19 @@ class ClipboardManager {
             debugLogger.warn("uinput paste failed", { error: uinputError?.message }, "clipboard");
           }
         } else if (isGnome && linuxFastPaste) {
+          if (!this.portalDenied) {
+            const portalPaste = await tryPortalPaste();
+            if (portalPaste) return { method: "portal", ...portalPaste };
+          }
           try {
             const uinputPaste = await tryUinputPaste();
             return { method: "uinput", ...uinputPaste };
           } catch (uinputError) {
             debugLogger.warn(
-              "uinput paste failed on GNOME, trying portal",
+              "uinput paste failed on GNOME",
               { error: uinputError?.message },
               "clipboard"
             );
-          }
-          if (!this.portalDenied) {
-            const portalPaste = await tryPortalPaste();
-            if (portalPaste) return { method: "portal", ...portalPaste };
           }
         } else {
           // Other compositors (wlroots, etc.): try uinput only


### PR DESCRIPTION
## Problem

On GNOME Wayland, linux-fast-paste --uinput creates a throwaway uinput device for each paste operation. When ydotoold already has its own persistent uinput device running, the two devices race. Mutter/libinput drops the modifier key from the short-lived device, so instead of Ctrl+V the target window receives just V. Paste reports exit 0 but silently fails (false positive — the app never reaches its fallback tools).

This also manifests as portal GDBus errors in the journal:

```
xdg-desktop-portal-gnome: Failed to associate portal window with parent window
Failed to close session implementation: Object does not exist
```

## Fix

Swap the GNOME Wayland paste priority from `uinput → portal` to `portal → uinput`, matching the KDE Wayland approach. uinput remains as a fallback if the portal is denied or unavailable.

**Before (GNOME):** uinput → portal (uinput first, but silently fails)
**After (GNOME):** portal → uinput (one-time dialog, reliable after approval)

## Related

- Closes #956
- Continues the Linux Wayland paste reliability work from #292, #494
- The portal approach was already commented as "reliable once approved" in the existing code (it was the primary path for KDE)
- A simpler workaround (renaming the bundled binary) was confirmed working in the issue comments — this PR makes the fix proper

## Testing

Tested on Ubuntu 24.04 LTS, GNOME Wayland, OpenWhispr 1.7.6:
- One portal dialog on first paste (approve once, never asked again)
- All subsequent pastes work reliably without silent failures
- No regression for KDE or non-GNOME environments (their priority paths are unchanged)

## Changelog

- `src/helpers/clipboard.js`: GNOME Wayland paste priority changed from uinput-first to portal-first
- Updated code comment to document the rationale (uinput device race, #956)