### PR TITLE
feat: add spoken commands (hands-free mode) during dictation

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -45,6 +45,7 @@ const registerListener = (channel, handlerFactory) => {
 
 contextBridge.exposeInMainWorld("electronAPI", {
   pasteText: (text, options) => ipcRenderer.invoke("paste-text", text, options),
+  sendKeystroke: (key) => ipcRenderer.invoke("send-keystroke", key),
   hideWindow: () => ipcRenderer.invoke("hide-window"),
   showDictationPanel: () => ipcRenderer.invoke("show-dictation-panel"),
   onToggleDictation: registerListener("toggle-dictation", (callback) => () => callback()),

--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -626,6 +626,70 @@ static paste_mode_t resolve_paste_mode(int force_terminal, int force_shift_inser
     return is_term ? PASTE_MODE_CTRL_SHIFT_V : PASTE_MODE_CTRL_V;
 }
 
+/* -------------------------------------------------------------------------
+ * Spoken-command keystroke injection (--key <KEY_NAME>)
+ * Supported: Return, Escape, Tab, BackSpace, Shift+Return
+ * Uses XTest on X11.  For Wayland portal mode the caller should use xdotool
+ * or ydotool as a fallback (JS layer handles that gracefully).
+ * ------------------------------------------------------------------------- */
+
+typedef struct { const char *name; KeySym sym; int shift; } LinuxKeyEntry;
+
+static const LinuxKeyEntry LINUX_KEY_TABLE[] = {
+    { "Return",       XK_Return, 0 },
+    { "Escape",       XK_Escape, 0 },
+    { "Tab",          XK_Tab,    0 },
+    { "BackSpace",    XK_BackSpace, 0 },
+    { "Shift+Return", XK_Return, 1 },
+    { NULL,           0,         0 },
+};
+
+static int send_named_key_x11(const char *keyName) {
+    const LinuxKeyEntry *entry = NULL;
+    for (int i = 0; LINUX_KEY_TABLE[i].name != NULL; i++) {
+        if (strcasecmp(keyName, LINUX_KEY_TABLE[i].name) == 0) {
+            entry = &LINUX_KEY_TABLE[i];
+            break;
+        }
+    }
+    if (!entry) {
+        fprintf(stderr, "ERROR: Unknown key name '%s'\n", keyName);
+        return 1;
+    }
+
+    Display *dpy = XOpenDisplay(NULL);
+    if (!dpy) { fprintf(stderr, "ERROR: Cannot open X display\n"); return 1; }
+
+    int event_base, error_base, major, minor;
+    if (!XTestQueryExtension(dpy, &event_base, &error_base, &major, &minor)) {
+        XCloseDisplay(dpy);
+        fprintf(stderr, "ERROR: XTest extension unavailable\n");
+        return 2;
+    }
+
+    KeyCode kc = XKeysymToKeycode(dpy, entry->sym);
+    KeyCode shift_kc = XKeysymToKeycode(dpy, XK_Shift_L);
+
+    if (entry->shift) {
+        XTestFakeKeyEvent(dpy, shift_kc, True, CurrentTime);
+        usleep(8000);
+    }
+    XTestFakeKeyEvent(dpy, kc, True, CurrentTime);
+    usleep(8000);
+    XTestFakeKeyEvent(dpy, kc, False, CurrentTime);
+    if (entry->shift) {
+        usleep(8000);
+        XTestFakeKeyEvent(dpy, shift_kc, False, CurrentTime);
+    }
+
+    XFlush(dpy);
+    usleep(20000);
+    XCloseDisplay(dpy);
+    printf("KEY_OK %s\n", keyName);
+    fflush(stdout);
+    return 0;
+}
+
 int main(int argc, char *argv[]) {
     int force_terminal = 0;
     int force_shift_insert = 0;
@@ -633,6 +697,7 @@ int main(int argc, char *argv[]) {
     int use_portal = 0;
     int media_play_pause = 0;
     const char *restore_token = NULL;
+    const char *key_name = NULL;
     Window target_window = None;
 
     for (int i = 1; i < argc; i++) {
@@ -650,11 +715,18 @@ int main(int argc, char *argv[]) {
             restore_token = argv[++i];
         } else if (strcmp(argv[i], "--window") == 0 && i + 1 < argc) {
             target_window = (Window)strtoul(argv[++i], NULL, 0);
+        } else if (strcmp(argv[i], "--key") == 0 && i + 1 < argc) {
+            key_name = argv[++i];
         }
     }
 
     if (media_play_pause) {
         return send_media_play_pause();
+    }
+
+    /* Spoken-command mode: inject a named keystroke via XTest (X11 only). */
+    if (key_name != NULL) {
+        return send_named_key_x11(key_name);
     }
 
     if (use_portal) {

--- a/resources/macos-fast-paste.swift
+++ b/resources/macos-fast-paste.swift
@@ -1,8 +1,86 @@
 import Cocoa
 
+// -----------------------------------------------------------------------
+// Spoken-command mode: --key <KEY_NAME>
+// Accepted keys: Return, Escape, Tab, BackSpace, Shift+Return
+// When --key is supplied the binary injects that keystroke instead of Cmd+V.
+// -----------------------------------------------------------------------
+
+struct KeyEntry {
+    let name: String
+    let keyCode: CGKeyCode
+    let shift: Bool
+}
+
+let KEY_TABLE: [KeyEntry] = [
+    KeyEntry(name: "Return",       keyCode: 0x24, shift: false),
+    KeyEntry(name: "Escape",       keyCode: 0x35, shift: false),
+    KeyEntry(name: "Tab",          keyCode: 0x30, shift: false),
+    KeyEntry(name: "BackSpace",    keyCode: 0x33, shift: false),
+    KeyEntry(name: "Shift+Return", keyCode: 0x24, shift: true),
+]
+
+func sendNamedKey(_ keyName: String) -> Int32 {
+    guard let entry = KEY_TABLE.first(where: { $0.name.lowercased() == keyName.lowercased() }) else {
+        fputs("ERROR: Unknown key name '\(keyName)'\n", stderr)
+        return 1
+    }
+
+    let src: CGEventSource? = nil
+    guard let keyDown = CGEvent(keyboardEventSource: src, virtualKey: entry.keyCode, keyDown: true),
+          let keyUp   = CGEvent(keyboardEventSource: src, virtualKey: entry.keyCode, keyDown: false)
+    else {
+        return 1
+    }
+
+    if entry.shift {
+        keyDown.flags = .maskShift
+        keyUp.flags   = .maskShift
+    }
+
+    keyDown.post(tap: .cgSessionEventTap)
+    usleep(8000)
+    keyUp.post(tap: .cgSessionEventTap)
+    usleep(20000)
+
+    print("KEY_OK \(keyName)")
+    return 0
+}
+
+// -----------------------------------------------------------------------
+// Parse arguments
+// -----------------------------------------------------------------------
+
+var keyArg: String? = nil
+var argIdx = 1
+while argIdx < CommandLine.arguments.count {
+    let arg = CommandLine.arguments[argIdx]
+    if arg == "--key" && argIdx + 1 < CommandLine.arguments.count {
+        argIdx += 1
+        keyArg = CommandLine.arguments[argIdx]
+    }
+    argIdx += 1
+}
+
+// -----------------------------------------------------------------------
+// Accessibility check (required for both paste and key injection)
+// -----------------------------------------------------------------------
+
 if !AXIsProcessTrusted() {
     exit(2)
 }
+
+// -----------------------------------------------------------------------
+// Spoken-command mode
+// -----------------------------------------------------------------------
+
+if let keyName = keyArg {
+    exit(sendNamedKey(keyName))
+}
+
+// -----------------------------------------------------------------------
+// Original paste mode (Cmd+V)
+// -----------------------------------------------------------------------
 
 guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
       let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {

--- a/resources/windows-fast-paste.c
+++ b/resources/windows-fast-paste.c
@@ -10,6 +10,10 @@
  *   1. Window class name (fast, works for native terminals)
  *   2. Executable name (fallback, catches Electron-based terminals like Termius)
  *
+ * Spoken-command mode (--key <KEY_NAME>):
+ *   Skips clipboard entirely and injects a single keystroke.  Accepted keys:
+ *   Return, Escape, Tab, BackSpace, Shift+Return.
+ *
  * Compile with: cl /O2 windows-fast-paste.c /Fe:windows-fast-paste.exe user32.lib
  * Or with MinGW: gcc -O2 windows-fast-paste.c -o windows-fast-paste.exe -luser32
  */
@@ -159,13 +163,81 @@ static int SendPasteTerminal(void) {
     return (sent == 6) ? 0 : 1;
 }
 
+/* -------------------------------------------------------------------------
+ * Spoken-command keystroke injection (--key <KEY_NAME>)
+ * Supported keys: Return, Escape, Tab, BackSpace, Shift+Return
+ * ------------------------------------------------------------------------- */
+
+typedef struct { const char* name; WORD vk; BOOL shift; } KeyEntry;
+
+static const KeyEntry KEY_TABLE[] = {
+    { "Return",       VK_RETURN,    FALSE },
+    { "Escape",       VK_ESCAPE,    FALSE },
+    { "Tab",          VK_TAB,       FALSE },
+    { "BackSpace",    VK_BACK,      FALSE },
+    { "Shift+Return", VK_RETURN,    TRUE  },
+    { NULL,           0,            FALSE },
+};
+
+static int SendNamedKey(const char* keyName) {
+    const KeyEntry* entry = NULL;
+    for (int i = 0; KEY_TABLE[i].name != NULL; i++) {
+        if (_stricmp(keyName, KEY_TABLE[i].name) == 0) {
+            entry = &KEY_TABLE[i];
+            break;
+        }
+    }
+    if (!entry) {
+        fprintf(stderr, "ERROR: Unknown key name '%s'\n", keyName);
+        return 1;
+    }
+
+    /* Build: [Shift down,] key down, key up [, Shift up] */
+    INPUT inputs[4];
+    ZeroMemory(inputs, sizeof(inputs));
+    int n = 0;
+
+    if (entry->shift) {
+        SetKey(&inputs[n++], VK_LSHIFT, 0);
+    }
+    SetKey(&inputs[n++], entry->vk, 0);
+    SetKey(&inputs[n++], entry->vk, KEYEVENTF_KEYUP);
+    if (entry->shift) {
+        SetKey(&inputs[n++], VK_LSHIFT, KEYEVENTF_KEYUP);
+    }
+
+    UINT sent = SendInput((UINT)n, inputs, sizeof(INPUT));
+    if (sent != (UINT)n) {
+        fprintf(stderr, "ERROR: SendInput failed (error %lu)\n", GetLastError());
+        return 1;
+    }
+    printf("KEY_OK %s\n", keyName);
+    fflush(stdout);
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
     BOOL detectOnly = FALSE;
+    const char* keyName = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--detect-only") == 0) {
             detectOnly = TRUE;
+        } else if (strcmp(argv[i], "--key") == 0 && i + 1 < argc) {
+            keyName = argv[++i];
         }
+    }
+
+    /* Spoken-command mode: inject a named keystroke, no clipboard involved. */
+    if (keyName != NULL) {
+        Sleep(10);
+        INPUT releasedInputs[NUM_MODIFIERS];
+        WORD  releasedVKs[NUM_MODIFIERS];
+        ZeroMemory(releasedInputs, sizeof(releasedInputs));
+        int releasedCount = ReleaseModifiers(releasedInputs, releasedVKs);
+        int result = SendNamedKey(keyName);
+        RestoreModifiers(releasedVKs, releasedCount);
+        return result;
     }
 
     HWND hwnd = GetForegroundWindow();

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -765,6 +765,8 @@ export default function SettingsPage({
     setShowTranscriptionPreview,
     autoPasteEnabled,
     setAutoPasteEnabled,
+    spokenCommandsEnabled,
+    setSpokenCommandsEnabled,
     keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard,
     floatingIconAutoHide,
@@ -2545,6 +2547,14 @@ export default function SettingsPage({
                     description={t("settingsPage.general.clipboard.autoPasteDescription")}
                   >
                     <Toggle checked={autoPasteEnabled} onChange={setAutoPasteEnabled} />
+                  </SettingsRow>
+                </SettingsPanelRow>
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.general.clipboard.spokenCommands")}
+                    description={t("settingsPage.general.clipboard.spokenCommandsDescription")}
+                  >
+                    <Toggle checked={spokenCommandsEnabled} onChange={setSpokenCommandsEnabled} />
                   </SettingsRow>
                 </SettingsPanelRow>
                 <SettingsPanelRow>

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -3016,6 +3016,38 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
+  /**
+   * Injects a named keystroke via the platform fast-paste binary.
+   * Used by the spoken-command (hands-free) feature.
+   * Fails silently if the IPC call throws — the user still gets the
+   * transcription saved, they just don't get the keystroke.
+   *
+   * @param {string} key - Return | Shift+Return | Escape | Tab | BackSpace
+   * @returns {Promise<boolean>}
+   */
+  async safeKeystroke(key) {
+    try {
+      const result = await window.electronAPI.sendKeystroke(key);
+      if (result && !result.success) {
+        this.onError?.({
+          title: "Spoken Command Error",
+          description: `Could not send keystroke "${key}": ${result.error || "unknown error"}`,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      const message =
+        error?.message ??
+        (typeof error?.toString === "function" ? error.toString() : String(error));
+      this.onError?.({
+        title: "Spoken Command Error",
+        description: `Could not send keystroke "${key}": ${message}`,
+      });
+      return false;
+    }
+  }
+
   async saveTranscription(text, rawText = null, { clientTranscriptionId } = {}) {
     if (!getSettings().dataRetentionEnabled) {
       logger.debug("Skipping transcription save — data retention disabled", {}, "audio");

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -743,6 +743,133 @@ class ClipboardManager {
     }
   }
 
+  /**
+   * Inject a named keystroke into the focused application without touching
+   * the clipboard.  Used by the spoken-command (hands-free) feature.
+   *
+   * @param {string} key - Platform-neutral key name: Return | Shift+Return |
+   *                        Escape | Tab | BackSpace
+   * @returns {Promise<void>}
+   */
+  async sendKeystroke(key) {
+    const platform = process.platform;
+    this.safeLog(`⌨️ sendKeystroke: ${key} (platform=${platform})`);
+
+    if (platform === "darwin") {
+      const fastPaste = this.resolveFastPasteBinary();
+      if (!fastPaste) {
+        this.safeLog("⚠️ sendKeystroke: macos-fast-paste binary unavailable");
+        return;
+      }
+      await new Promise((resolve, reject) => {
+        const proc = spawn(fastPaste, ["--key", key]);
+        let stderr = "";
+        proc.stderr.on("data", (d) => {
+          stderr += d.toString();
+        });
+        proc.on("close", (code) => {
+          proc.removeAllListeners();
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`macos-fast-paste --key exited with code ${code}: ${stderr.trim()}`));
+          }
+        });
+        proc.on("error", (err) => {
+          proc.removeAllListeners();
+          reject(err);
+        });
+      });
+      return;
+    }
+
+    if (platform === "win32") {
+      const fastPaste = this.resolveWindowsFastPasteBinary();
+      if (!fastPaste) {
+        this.safeLog("⚠️ sendKeystroke: windows-fast-paste binary unavailable");
+        return;
+      }
+      await new Promise((resolve, reject) => {
+        const proc = spawn(fastPaste, ["--key", key]);
+        let stderr = "";
+        proc.stderr.on("data", (d) => {
+          stderr += d.toString();
+        });
+        proc.on("close", (code) => {
+          proc.removeAllListeners();
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(
+              new Error(`windows-fast-paste --key exited with code ${code}: ${stderr.trim()}`)
+            );
+          }
+        });
+        proc.on("error", (err) => {
+          proc.removeAllListeners();
+          reject(err);
+        });
+      });
+      return;
+    }
+
+    if (platform === "linux") {
+      const fastPaste = this.resolveLinuxFastPasteBinary();
+      if (fastPaste && !this._isWayland()) {
+        // X11: linux-fast-paste supports --key directly
+        await new Promise((resolve, reject) => {
+          const proc = spawn(fastPaste, ["--key", key]);
+          let stderr = "";
+          proc.stderr.on("data", (d) => {
+            stderr += d.toString();
+          });
+          proc.on("close", (code) => {
+            proc.removeAllListeners();
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(
+                new Error(`linux-fast-paste --key exited with code ${code}: ${stderr.trim()}`)
+              );
+            }
+          });
+          proc.on("error", (err) => {
+            proc.removeAllListeners();
+            reject(err);
+          });
+        });
+        return;
+      }
+
+      // Wayland fallback: try xdotool (available on XWayland sessions)
+      if (this.commandExists("xdotool")) {
+        // Map our canonical names to xdotool key names
+        const xdotoolKey = key === "Shift+Return" ? "shift+Return" : key;
+        const result = spawnSync("xdotool", ["key", xdotoolKey], { timeout: 2000 });
+        if (result.status === 0) return;
+        this.safeLog("⚠️ xdotool key failed", { key, stderr: result.stderr?.toString() });
+      }
+
+      // ydotool fallback (native Wayland)
+      if (this.commandExists("ydotool")) {
+        const ydotoolKey =
+          key === "Shift+Return"
+            ? "shift+enter"
+            : key === "Return"
+              ? "enter"
+              : key === "BackSpace"
+                ? "backspace"
+                : key.toLowerCase();
+        const result = spawnSync("ydotool", ["key", ydotoolKey], { timeout: 2000 });
+        if (result.status === 0) return;
+        this.safeLog("⚠️ ydotool key failed", { key, stderr: result.stderr?.toString() });
+      }
+
+      this.safeLog("⚠️ sendKeystroke: no suitable tool found on Linux");
+      return;
+    }
+  }
+
   async _pasteText(text, options = {}) {
     const startTime = Date.now();
     const platform = process.platform;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1918,6 +1918,34 @@ class IPCHandlers {
       return result;
     });
 
+    // ---------------------------------------------------------------------------
+    // Spoken-command keystroke injection
+    // Only keys in ALLOWED_KEYSTROKE_NAMES can be injected to prevent the
+    // renderer from being used as a general-purpose keyboard injector.
+    // ---------------------------------------------------------------------------
+    const ALLOWED_KEYSTROKE_NAMES = new Set([
+      "Return",
+      "Shift+Return",
+      "Escape",
+      "Tab",
+      "BackSpace",
+    ]);
+
+    ipcMain.handle("send-keystroke", async (_event, key) => {
+      if (typeof key !== "string" || !ALLOWED_KEYSTROKE_NAMES.has(key)) {
+        debugLogger.warn("[SpokenCommands] Rejected unknown key name", { key });
+        return { success: false, error: `Key '${key}' is not in the allowed keystroke list` };
+      }
+      try {
+        await this.clipboardManager.sendKeystroke(key);
+        debugLogger.debug("[SpokenCommands] Keystroke sent", { key });
+        return { success: true };
+      } catch (error) {
+        debugLogger.error("[SpokenCommands] sendKeystroke failed", { key, error: error.message });
+        return { success: false, error: error.message };
+      }
+    });
+
     ipcMain.handle("check-accessibility-permission", async (_event, silent = false) => {
       return this.clipboardManager.checkAccessibilityPermissions(silent);
     });

--- a/src/helpers/spokenCommands.js
+++ b/src/helpers/spokenCommands.js
@@ -1,0 +1,103 @@
+/**
+ * Spoken command detection for hands-free control (issue #1308).
+ *
+ * Recognises a fixed set of voice commands from the dictated transcript and
+ * maps them to platform-neutral key descriptors that ClipboardManager can
+ * inject via the fast-paste binaries.
+ *
+ * Detection strategy — exact whole-transcript match only:
+ *   The entire trimmed, lower-cased transcript must equal one of the command
+ *   phrases.  This prevents incidental phrase matches inside ordinary
+ *   sentences (e.g. "I pressed enter the competition" must NOT fire Enter).
+ *   Trailing punctuation (., !, ?) is stripped before comparison so that
+ *   "Submit." is treated the same as "Submit".
+ *
+ * Extend SPOKEN_COMMANDS to add more commands; no other changes are needed.
+ */
+
+/**
+ * @typedef {Object} SpokenCommand
+ * @property {string[]} phrases   - Recognised spoken phrases (lower-case).
+ * @property {string}   key       - Platform-neutral key name sent to the fast-paste binary.
+ * @property {string}   label     - Human-readable label for logging / UI.
+ */
+
+/** @type {SpokenCommand[]} */
+const SPOKEN_COMMANDS = [
+  {
+    // Submit / send the current field — fires a bare Return keystroke.
+    phrases: ["press enter", "press return", "submit", "send it", "send message"],
+    key: "Return",
+    label: "Enter",
+  },
+  {
+    // Soft newline — Shift+Return does NOT submit in most chat apps.
+    phrases: ["new line", "new paragraph", "line break"],
+    key: "Shift+Return",
+    label: "Shift+Enter",
+  },
+  {
+    // Dismiss dialogs / cancel.
+    phrases: ["press escape", "escape", "cancel"],
+    key: "Escape",
+    label: "Escape",
+  },
+  {
+    // Move focus to the next field.
+    phrases: ["press tab", "next field", "tab"],
+    key: "Tab",
+    label: "Tab",
+  },
+  {
+    // Delete the character before the cursor.
+    phrases: ["press backspace", "delete that", "backspace"],
+    key: "BackSpace",
+    label: "Backspace",
+  },
+];
+
+// Build a flat lookup map: lower-case phrase → SpokenCommand
+// (constructed once at module load; O(1) detection at runtime)
+/** @type {Map<string, SpokenCommand>} */
+const COMMAND_MAP = new Map();
+for (const cmd of SPOKEN_COMMANDS) {
+  for (const phrase of cmd.phrases) {
+    COMMAND_MAP.set(phrase, cmd);
+  }
+}
+
+/**
+ * Strips trailing sentence-ending punctuation from a string.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripTrailingPunctuation(text) {
+  return text.replace(/[.!?,;]+$/, "");
+}
+
+/**
+ * Detects whether `text` is a recognised spoken command.
+ *
+ * @param {string} text - The final (post-cleanup) transcript.
+ * @returns {SpokenCommand|null} The matched command, or null if not a command.
+ */
+function detectSpokenCommand(text) {
+  if (!text || typeof text !== "string") return null;
+
+  const normalized = stripTrailingPunctuation(text.trim()).toLowerCase();
+  if (!normalized) return null;
+
+  return COMMAND_MAP.get(normalized) ?? null;
+}
+
+/**
+ * Returns the full list of spoken commands (for display in settings / docs).
+ *
+ * @returns {SpokenCommand[]}
+ */
+function getSpokenCommands() {
+  return SPOKEN_COMMANDS;
+}
+
+module.exports = { detectSpokenCommand, getSpokenCommands, SPOKEN_COMMANDS };

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -7,6 +7,7 @@ import { getSettings } from "../stores/settingsStore";
 import { expandSnippets } from "../utils/snippets";
 import { getRecordingErrorTitle, getRecordingErrorDescription } from "../utils/recordingErrors";
 import { isAccessibilitySkipped } from "../utils/permissions";
+import { detectSpokenCommand } from "../helpers/spokenCommands";
 
 export const useAudioRecording = (toast, options = {}) => {
   const { t } = useTranslation();
@@ -166,6 +167,27 @@ export const useAudioRecording = (toast, options = {}) => {
               variant: "default",
             });
             return;
+          }
+
+          // ------------------------------------------------------------------
+          // Spoken-command interception (hands-free mode, issue #1308).
+          // If the entire transcript matches a recognised command phrase and
+          // the feature is enabled, fire the keystroke and bail out — the
+          // literal command words are NOT pasted and NOT saved to history.
+          // ------------------------------------------------------------------
+          const { spokenCommandsEnabled } = getSettings();
+          if (spokenCommandsEnabled) {
+            const command = detectSpokenCommand(transcribedText);
+            if (command) {
+              logger.info(
+                "[SpokenCommands] Command detected, sending keystroke",
+                { phrase: transcribedText, key: command.key },
+                "audio"
+              );
+              window.electronAPI?.hideDictationPreview?.();
+              await audioManagerRef.current.safeKeystroke(command.key);
+              return;
+            }
           }
 
           result.text = expandSnippets(result.text, getSettings().snippets);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -334,6 +334,8 @@ function useSettingsInternal() {
     setShowTranscriptionPreview: store.setShowTranscriptionPreview,
     autoPasteEnabled: store.autoPasteEnabled,
     setAutoPasteEnabled: store.setAutoPasteEnabled,
+    spokenCommandsEnabled: store.spokenCommandsEnabled,
+    setSpokenCommandsEnabled: store.setSpokenCommandsEnabled,
     keepTranscriptionInClipboard: store.keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard: store.setKeepTranscriptionInClipboard,
     noteFilesEnabled: store.noteFilesEnabled,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1658,6 +1658,8 @@
         "title": "Clipboard",
         "autoPaste": "Automatic pasting",
         "autoPasteDescription": "Automatically paste transcribed text into the active app when dictation finishes",
+        "spokenCommands": "Spoken commands",
+        "spokenCommandsDescription": "Say phrases like \"press Enter\" or \"submit\" to send keystrokes instead of typing the words (hands-free mode)",
         "keepInClipboard": "Keep transcription in clipboard",
         "keepInClipboardDescription": "Keep dictated text in your clipboard so you can paste it manually if needed"
       },

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -144,6 +144,7 @@ const BOOLEAN_SETTINGS = new Set([
   "notifyCalendarReminders",
   "notifyUpdates",
   "gcalPrimaryOnly",
+  "spokenCommandsEnabled",
 ]);
 
 const ARRAY_SETTINGS = new Set([
@@ -434,6 +435,7 @@ export interface SettingsState
   panelStartPosition: "bottom-right" | "center" | "bottom-left";
   showTranscriptionPreview: boolean;
   autoPasteEnabled: boolean;
+  spokenCommandsEnabled: boolean;
   keepTranscriptionInClipboard: boolean;
   noteFilesEnabled: boolean;
   noteFilesPath: string;
@@ -686,6 +688,7 @@ export interface SettingsState
   setPanelStartPosition: (position: "bottom-right" | "center" | "bottom-left") => void;
   setShowTranscriptionPreview: (value: boolean) => void;
   setAutoPasteEnabled: (value: boolean) => void;
+  setSpokenCommandsEnabled: (value: boolean) => void;
   setKeepTranscriptionInClipboard: (value: boolean) => void;
   setNoteFilesEnabled: (value: boolean) => void;
   setNoteFilesPath: (value: string) => void;
@@ -1059,6 +1062,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   showTranscriptionPreview: readBoolean("showTranscriptionPreview", false),
   autoPasteEnabled: readBoolean("autoPasteEnabled", true),
+  spokenCommandsEnabled: readBoolean("spokenCommandsEnabled", false),
   keepTranscriptionInClipboard: readBoolean("keepTranscriptionInClipboard", false),
   noteFilesEnabled: readBoolean("noteFilesEnabled", false),
   noteFilesPath: readString("noteFilesPath", ""),
@@ -1715,6 +1719,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setShowTranscriptionPreview: createBooleanSetter("showTranscriptionPreview"),
   setAutoPasteEnabled: createBooleanSetter("autoPasteEnabled"),
+  setSpokenCommandsEnabled: createBooleanSetter("spokenCommandsEnabled"),
   setKeepTranscriptionInClipboard: createBooleanSetter("keepTranscriptionInClipboard"),
   setNoteFilesEnabled: createBooleanSetter("noteFilesEnabled"),
   setNoteFilesPath: createStringSetter("noteFilesPath"),

--- a/test/helpers/spokenCommands.test.js
+++ b/test/helpers/spokenCommands.test.js
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for src/helpers/spokenCommands.js
+ *
+ * Uses the project's native test runner (node:test + node:assert).
+ * Run with: npm test
+ */
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { detectSpokenCommand, getSpokenCommands } = require("../../src/helpers/spokenCommands");
+
+// ---------------------------------------------------------------------------
+// Positive matches — all recognized commands
+// ---------------------------------------------------------------------------
+
+const POSITIVE_CASES = [
+  // Enter / submit group
+  ["press enter", "Return"],
+  ["press return", "Return"],
+  ["submit", "Return"],
+  ["send it", "Return"],
+  ["send message", "Return"],
+  // New line group
+  ["new line", "Shift+Return"],
+  ["new paragraph", "Shift+Return"],
+  ["line break", "Shift+Return"],
+  // Escape group
+  ["press escape", "Escape"],
+  ["escape", "Escape"],
+  ["cancel", "Escape"],
+  // Tab group
+  ["press tab", "Tab"],
+  ["next field", "Tab"],
+  ["tab", "Tab"],
+  // Backspace group
+  ["press backspace", "BackSpace"],
+  ["delete that", "BackSpace"],
+  ["backspace", "BackSpace"],
+];
+
+for (const [phrase, expectedKey] of POSITIVE_CASES) {
+  test(`detectSpokenCommand("${phrase}") → key "${expectedKey}"`, () => {
+    const result = detectSpokenCommand(phrase);
+    assert.notStrictEqual(result, null, `Expected a command match for "${phrase}"`);
+    assert.strictEqual(result.key, expectedKey);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Case-insensitivity
+// ---------------------------------------------------------------------------
+
+const CASE_VARIANTS = [
+  "Press Enter",
+  "PRESS ENTER",
+  "Submit",
+  "SUBMIT",
+  "Send It",
+  "New Line",
+  "NEW LINE",
+  "Escape",
+  "ESCAPE",
+];
+
+for (const phrase of CASE_VARIANTS) {
+  test(`detectSpokenCommand("${phrase}") matches case-insensitively`, () => {
+    const result = detectSpokenCommand(phrase);
+    assert.notStrictEqual(result, null, `Expected case-insensitive match for "${phrase}"`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Trailing punctuation stripped
+// ---------------------------------------------------------------------------
+
+const PUNCTUATION_VARIANTS = [
+  "press enter.",
+  "submit.",
+  "submit!",
+  "submit?",
+  "submit,",
+  "submit;",
+  "Submit.",
+  "Escape.",
+  "new line.",
+];
+
+for (const phrase of PUNCTUATION_VARIANTS) {
+  test(`detectSpokenCommand("${phrase}") matches after stripping trailing punctuation`, () => {
+    const result = detectSpokenCommand(phrase);
+    assert.notStrictEqual(result, null, `Expected match after punctuation strip for "${phrase}"`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Negative matches — partial sentences must NOT fire a command
+// ---------------------------------------------------------------------------
+
+const NEGATIVE_CASES = [
+  "I pressed enter into the competition",
+  "please submit the following text",
+  "make sure to submit this form later",
+  "I need to escape the loop",
+  "let me add a new line here",
+  "hello world press enter", // command phrase at end of longer text
+  "press enter now please", // extra words after the phrase
+  "don't escape", // prefix before the phrase
+];
+
+for (const phrase of NEGATIVE_CASES) {
+  test(`detectSpokenCommand("${phrase}") returns null (partial sentence)`, () => {
+    const result = detectSpokenCommand(phrase);
+    assert.strictEqual(result, null, `Expected null for partial-sentence phrase "${phrase}"`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Edge / boundary cases
+// ---------------------------------------------------------------------------
+
+test('detectSpokenCommand("") returns null', () => {
+  assert.strictEqual(detectSpokenCommand(""), null);
+});
+
+test("detectSpokenCommand(whitespace-only) returns null", () => {
+  assert.strictEqual(detectSpokenCommand("   "), null);
+});
+
+test("detectSpokenCommand(null) returns null", () => {
+  assert.strictEqual(detectSpokenCommand(null), null);
+});
+
+test("detectSpokenCommand(undefined) returns null", () => {
+  assert.strictEqual(detectSpokenCommand(undefined), null);
+});
+
+test("detectSpokenCommand(number) returns null", () => {
+  assert.strictEqual(detectSpokenCommand(42), null);
+});
+
+test("detectSpokenCommand trims leading/trailing whitespace before matching", () => {
+  const result = detectSpokenCommand("  press enter  ");
+  assert.notStrictEqual(result, null);
+  assert.strictEqual(result.key, "Return");
+});
+
+test("matched command has key (string) and label (string) properties", () => {
+  const result = detectSpokenCommand("submit");
+  assert.ok(result, "Expected a non-null result for 'submit'");
+  assert.strictEqual(typeof result.key, "string");
+  assert.strictEqual(typeof result.label, "string");
+  assert.ok(result.key.length > 0, "key should be non-empty");
+  assert.ok(result.label.length > 0, "label should be non-empty");
+});
+
+// ---------------------------------------------------------------------------
+// getSpokenCommands API contract
+// ---------------------------------------------------------------------------
+
+test("getSpokenCommands returns a non-empty array", () => {
+  const commands = getSpokenCommands();
+  assert.ok(Array.isArray(commands), "Expected an array");
+  assert.ok(commands.length > 0, "Expected at least one command");
+});
+
+test("each command has phrases (array), key (string), and label (string)", () => {
+  for (const cmd of getSpokenCommands()) {
+    assert.ok(Array.isArray(cmd.phrases), `phrases should be an array in command "${cmd.key}"`);
+    assert.ok(cmd.phrases.length > 0, `phrases should be non-empty in command "${cmd.key}"`);
+    assert.strictEqual(typeof cmd.key, "string", `key should be a string in "${cmd.key}"`);
+    assert.strictEqual(typeof cmd.label, "string", `label should be a string in "${cmd.key}"`);
+  }
+});
+
+test("all phrases in getSpokenCommands are lower-case strings", () => {
+  for (const cmd of getSpokenCommands()) {
+    for (const phrase of cmd.phrases) {
+      assert.strictEqual(typeof phrase, "string", "phrase must be a string");
+      assert.strictEqual(phrase, phrase.toLowerCase(), `phrase "${phrase}" should be lower-case`);
+    }
+  }
+});
+
+test("every phrase in getSpokenCommands round-trips through detectSpokenCommand", () => {
+  for (const cmd of getSpokenCommands()) {
+    for (const phrase of cmd.phrases) {
+      const result = detectSpokenCommand(phrase);
+      assert.notStrictEqual(result, null, `phrase "${phrase}" should be detectable`);
+      assert.strictEqual(result.key, cmd.key, `phrase "${phrase}" should map to key "${cmd.key}"`);
+    }
+  }
+});


### PR DESCRIPTION
Fixes #1308.

## Why
Currently, dictation is paste-only: the transcribed text is written into the focused field via the clipboard. Users building a fully hands-free workflow requested a way to issue simple control commands by voice (e.g., saying "press Enter" to submit the dictated text) without needing to touch the keyboard.

## What
This PR adds a **spoken-command / hands-free mode** that intercepts recognized voice commands from the transcript *before* pasting and converts them into real keystrokes.

- **Exact whole-transcript matching**: The command is only recognized if the entire trimmed transcript matches a command phrase (case-insensitive, stripping trailing punctuation). This prevents incidental phrase matches inside ordinary sentences (e.g., "I pressed enter the competition" will *not* fire Enter).
- **Opt-in**: The feature is guarded by a new `spokenCommandsEnabled` setting (default: `false`), available in Settings → Clipboard.
- **No history pollution**: Recognized commands are not pasted and are not saved to the transcription history (treated similar to empty recordings).
- **Cross-platform**: `--key <KEY_NAME>` support has been added to all three fast-paste binaries (`windows-fast-paste.c`, `macos-fast-paste.swift`, `linux-fast-paste.c`).

### Supported Commands
- "press enter", "submit", "send it", "send message" → `Return`
- "new line", "new paragraph", "line break" → `Shift+Return`
- "press escape", "escape", "cancel" → `Escape`
- "press tab", "next field", "tab" → `Tab`
- "press backspace", "delete that", "backspace" → `BackSpace`

## Note to Reviewers
- IPC calls are guarded by an allowlist (`ALLOWED_KEYSTROKE_NAMES`) to ensure the renderer cannot be used as a general-purpose keyboard injector.
- 54 new unit tests added in `spokenCommands.test.js` (native `node:test` runner).
- **Important**: The native binaries will need to be recompiled for Windows and macOS before merging. The Linux C changes will be picked up during standard project builds.
