### PR TITLE
fix(linux): align Wayland development server with packaged behavior and use XWayland

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-// Wayland: self-relaunch under XWayland. Chromium picks the display backend
-// before JS runs, so appendSwitch is too late.
+// Chromium picks the display backend before JS runs, so appendSwitch is too
+// late — the flag has to come from a relaunch.
 const { XWAYLAND_FLAG, shouldForceXWayland } = require("./src/helpers/xwayland");
 
 if (shouldForceXWayland(process.argv)) {

--- a/main.js
+++ b/main.js
@@ -1,19 +1,14 @@
-// KDE/GNOME Wayland: self-relaunch with --ozone-platform=x11 to force XWayland.
-// Chromium picks the display backend before JS runs, so appendSwitch is too late.
-if (
-  process.platform === "linux" &&
-  process.env.XDG_SESSION_TYPE === "wayland" &&
-  !process.argv.includes("--ozone-platform=x11")
-) {
-  const desktop = (process.env.XDG_CURRENT_DESKTOP || "").toLowerCase();
-  if (desktop.includes("kde") || /gnome|ubuntu|unity|cosmic/.test(desktop)) {
-    const { spawn } = require("child_process");
-    spawn(process.execPath, [...process.argv.slice(1), "--ozone-platform=x11"], {
-      stdio: "inherit",
-      detached: true,
-    }).unref();
-    process.exit(0);
-  }
+// Wayland: self-relaunch under XWayland. Chromium picks the display backend
+// before JS runs, so appendSwitch is too late.
+const { XWAYLAND_FLAG, shouldForceXWayland } = require("./src/helpers/xwayland");
+
+if (shouldForceXWayland(process.argv)) {
+  const { spawn } = require("child_process");
+  spawn(process.execPath, [...process.argv.slice(1), XWAYLAND_FLAG], {
+    stdio: "inherit",
+    detached: true,
+  }).unref();
+  process.exit(0);
 }
 
 const {

--- a/scripts/run-electron.js
+++ b/scripts/run-electron.js
@@ -51,18 +51,16 @@ console.log("[run-electron] Electron path:", electronPath);
 console.log("[run-electron] App dir:", appDir);
 console.log("[run-electron] Args:", args);
 
-// On KDE/GNOME Wayland, force XWayland so globalShortcut and window positioning work.
+// On Wayland, force XWayland so globalShortcut and window positioning work.
 // Adding it here avoids the self-relaunch in main.js which kills concurrently in dev mode.
+const hasExplicitOzonePlatform = args.some((arg) => arg.startsWith("--ozone-platform="));
 if (
   process.platform === "linux" &&
   process.env.XDG_SESSION_TYPE === "wayland" &&
-  !args.includes("--ozone-platform=x11")
+  !hasExplicitOzonePlatform
 ) {
-  const desktop = (process.env.XDG_CURRENT_DESKTOP || "").toLowerCase();
-  if (desktop.includes("kde") || /gnome|ubuntu|unity/.test(desktop)) {
-    args.push("--ozone-platform=x11");
-    console.log("[run-electron] KDE/GNOME Wayland detected, forcing XWayland");
-  }
+  args.push("--ozone-platform=x11");
+  console.log("[run-electron] Wayland detected, forcing XWayland");
 }
 
 // Chromium flags must come before the app path, app args after.

--- a/scripts/run-electron.js
+++ b/scripts/run-electron.js
@@ -7,6 +7,11 @@
 
 const { spawn } = require("child_process");
 const path = require("path");
+const {
+  OZONE_PLATFORM_PREFIX,
+  XWAYLAND_FLAG,
+  shouldForceXWayland,
+} = require("../src/helpers/xwayland");
 
 // Remove ELECTRON_RUN_AS_NODE from environment
 delete process.env.ELECTRON_RUN_AS_NODE;
@@ -51,21 +56,15 @@ console.log("[run-electron] Electron path:", electronPath);
 console.log("[run-electron] App dir:", appDir);
 console.log("[run-electron] Args:", args);
 
-// On Wayland, force XWayland so globalShortcut and window positioning work.
-// Adding it here avoids the self-relaunch in main.js which kills concurrently in dev mode.
-const hasExplicitOzonePlatform = args.some((arg) => arg.startsWith("--ozone-platform="));
-if (
-  process.platform === "linux" &&
-  process.env.XDG_SESSION_TYPE === "wayland" &&
-  !hasExplicitOzonePlatform
-) {
-  args.push("--ozone-platform=x11");
+// Adding the flag here avoids the self-relaunch in main.js, which kills concurrently in dev mode.
+if (shouldForceXWayland(args)) {
+  args.push(XWAYLAND_FLAG);
   console.log("[run-electron] Wayland detected, forcing XWayland");
 }
 
 // Chromium flags must come before the app path, app args after.
-const chromiumFlags = args.filter((a) => a.startsWith("--ozone-platform="));
-const appArgs = args.filter((a) => !a.startsWith("--ozone-platform="));
+const chromiumFlags = args.filter((a) => a.startsWith(OZONE_PLATFORM_PREFIX));
+const appArgs = args.filter((a) => !a.startsWith(OZONE_PLATFORM_PREFIX));
 const child = spawn(electronPath, [...chromiumFlags, appDir, ...appArgs], {
   stdio: "inherit",
   env: process.env,

--- a/src/helpers/xwayland.js
+++ b/src/helpers/xwayland.js
@@ -1,0 +1,19 @@
+// Overlay positioning and globalShortcut both need X11, so every Linux Wayland
+// session runs under XWayland. An explicit --ozone-platform flag always wins so
+// native Wayland stays testable.
+//
+// Packaged builds apply the same rule from the launcher script before Electron
+// starts (scripts/lib/linux-launcher.js); keep the two in sync.
+
+const OZONE_PLATFORM_PREFIX = "--ozone-platform=";
+const XWAYLAND_FLAG = `${OZONE_PLATFORM_PREFIX}x11`;
+
+function shouldForceXWayland(argv) {
+  return (
+    process.platform === "linux" &&
+    process.env.XDG_SESSION_TYPE === "wayland" &&
+    !argv.some((arg) => arg.startsWith(OZONE_PLATFORM_PREFIX))
+  );
+}
+
+module.exports = { OZONE_PLATFORM_PREFIX, XWAYLAND_FLAG, shouldForceXWayland };

--- a/src/helpers/xwayland.js
+++ b/src/helpers/xwayland.js
@@ -1,9 +1,6 @@
 // Overlay positioning and globalShortcut both need X11, so every Linux Wayland
-// session runs under XWayland. An explicit --ozone-platform flag always wins so
-// native Wayland stays testable.
-//
-// Packaged builds apply the same rule from the launcher script before Electron
-// starts (scripts/lib/linux-launcher.js); keep the two in sync.
+// session runs under XWayland. Packaged builds apply the same rule from the
+// launcher script (scripts/lib/linux-launcher.js); keep the two in sync.
 
 const OZONE_PLATFORM_PREFIX = "--ozone-platform=";
 const XWAYLAND_FLAG = `${OZONE_PLATFORM_PREFIX}x11`;

--- a/test/helpers/xwayland.test.js
+++ b/test/helpers/xwayland.test.js
@@ -1,0 +1,53 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { XWAYLAND_FLAG, shouldForceXWayland } = require("../../src/helpers/xwayland.js");
+
+function setEnv(key, value) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function withSession({ platform, sessionType, desktop }, run) {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalSessionType = process.env.XDG_SESSION_TYPE;
+  const originalDesktop = process.env.XDG_CURRENT_DESKTOP;
+
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  setEnv("XDG_SESSION_TYPE", sessionType);
+  setEnv("XDG_CURRENT_DESKTOP", desktop);
+
+  try {
+    run();
+  } finally {
+    Object.defineProperty(process, "platform", originalPlatform);
+    setEnv("XDG_SESSION_TYPE", originalSessionType);
+    setEnv("XDG_CURRENT_DESKTOP", originalDesktop);
+  }
+}
+
+const WAYLAND_DESKTOPS = ["Hyprland", "KDE", "GNOME", "sway", "niri", ""];
+
+test("forces XWayland on every Wayland compositor", () => {
+  for (const desktop of WAYLAND_DESKTOPS) {
+    withSession({ platform: "linux", sessionType: "wayland", desktop }, () => {
+      assert.equal(shouldForceXWayland(["--dev"]), true, `expected XWayland for ${desktop || "?"}`);
+    });
+  }
+});
+
+test("leaves X11 sessions and non-Linux platforms alone", () => {
+  withSession({ platform: "linux", sessionType: "x11", desktop: "GNOME" }, () => {
+    assert.equal(shouldForceXWayland(["--dev"]), false);
+  });
+  withSession({ platform: "darwin", sessionType: undefined, desktop: undefined }, () => {
+    assert.equal(shouldForceXWayland(["--dev"]), false);
+  });
+});
+
+test("an explicit --ozone-platform flag wins", () => {
+  withSession({ platform: "linux", sessionType: "wayland", desktop: "Hyprland" }, () => {
+    assert.equal(shouldForceXWayland(["--ozone-platform=wayland"]), false);
+    assert.equal(shouldForceXWayland([XWAYLAND_FLAG]), false);
+  });
+});


### PR DESCRIPTION
While testing OpenWhispr, whenever I launched the local dev server (i.e  `npm run dev`) on Hyprland, the dictation overlay would open at the center of the screen and the dictation panel wouldn't open until I click the tray icon, for sometime I thought it was an issue with my system because the build/packaged versions worked fine.

Today I decided to debug the issue and found that OpenWhispr depends on launching the app as **XWayland** and it was already handled in the build pipeline for Wayland systems, but the dev launcher only did that for a few Wayland desktops. Hyprland, and any other unlisted compositor, got native Wayland instead.

This updates development launches to force XWayland for every Linux Wayland session, matching packaged behavior instead of maintaining a compositor allowlist.

Explicit `--ozone-platform=...` flags still win, so native-Wayland testing remains available when wanted.