### PR TITLE
Standardize LLM settings copy

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1490,7 +1490,7 @@
       "enableTextCleanupDescription": "Use AI to remove filler words, fix grammar, and polish punctuation",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
-        "providers": "Cloud Providers",
+        "providers": "Configure key",
         "local": "Local",
         "selfHosted": "Self-Hosted",
         "enterprise": "Enterprise",
@@ -2732,15 +2732,15 @@
     "enabledDescription": "Dictate instructions to your agent. Activate by saying \"{{agentName}}\". Configurable below.",
     "modes": {
       "openwhispr": "OpenWhispr Cloud",
-      "openwhisprDesc": "Use the OpenWhispr-managed agent — no API key needed.",
-      "providers": "Bring your own key",
-      "providersDesc": "Connect to OpenAI, Anthropic, Gemini, or Groq with your own API key.",
+      "openwhisprDesc": "Reliable accuracy. No setup needed.",
+      "providers": "Configure key",
+      "providersDesc": "Bring your own API key.",
       "local": "Local",
-      "localDesc": "Run a local LLM on your device — fully private.",
-      "selfHosted": "Self-hosted",
-      "selfHostedDesc": "Point at a self-hosted OpenAI-compatible endpoint.",
+      "localDesc": "On-device models. Fully private.",
+      "selfHosted": "Self-Hosted",
+      "selfHostedDesc": "Your own server on your network.",
       "enterprise": "Enterprise",
-      "enterpriseDesc": "Use AWS Bedrock, Azure OpenAI, or Google Vertex."
+      "enterpriseDesc": "Use your organization's cloud account (AWS, Azure, GCP)."
     },
     "prompt": {
       "title": "Agent prompt",
@@ -2758,7 +2758,7 @@
       "systemPromptPlaceholder": "Enter custom system prompt...",
       "modes": {
         "openwhispr": "OpenWhispr Cloud",
-        "providers": "Cloud Providers",
+        "providers": "Configure key",
         "local": "Local",
         "selfHosted": "Self-Hosted",
         "enterprise": "Enterprise",


### PR DESCRIPTION
## Summary

- standardize the provider option as Configure key across all English LLM settings tabs
- align Voice Agent mode descriptions with Dictation Cleanup, Note Formatting, Translation, and Chat
- normalize the Self-Hosted label capitalization

## Testing

- parsed src/locales/en/translation.json successfully with Node.js
- git diff --check
- verified all English LLM mode labels and descriptions match

## Issue

Closes #1324