### PR TITLE
fix(translation): route local models through llama.cpp

### DIFF
--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -387,6 +387,17 @@ export function getModelProvider(modelId: string): string {
   return model?.provider || "openai";
 }
 
+// Local catalog IDs group models for selection and downloads, but all execute
+// through the single local llama.cpp inference provider.
+export function resolveInferenceProvider(
+  configuredProvider: string | undefined,
+  modelId: string
+): string {
+  const provider = configuredProvider?.trim();
+  if (provider && modelRegistry.getProvider(provider)) return "local";
+  return provider || getModelProvider(modelId);
+}
+
 export function getTranscriptionProviders(): TranscriptionProviderData[] {
   return modelRegistry.getTranscriptionProviders();
 }

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -1,5 +1,5 @@
 import {
-  getModelProvider,
+  resolveInferenceProvider,
   getCloudModel,
   getOpenAiApiConfig,
   getProviderDisplayName,
@@ -334,7 +334,9 @@ class ReasoningService extends BaseReasoningService {
   ): Promise<string> {
     const trimmedModel = model?.trim?.() || "";
     const isLanCleanup = !!config.lanUrl || this.isLanCleanupMode();
-    const providerId = isLanCleanup ? "lan" : config.provider || getModelProvider(trimmedModel);
+    const providerId = isLanCleanup
+      ? "lan"
+      : resolveInferenceProvider(config.provider, trimmedModel);
 
     if (!trimmedModel && providerId !== "openwhispr" && providerId !== "lan") {
       throw new Error("No reasoning model selected");

--- a/test/helpers/inferenceProviderIds.test.js
+++ b/test/helpers/inferenceProviderIds.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const modelData = require("../../src/models/modelRegistryData.json");
+
+// PROVIDER_REGISTRY is TypeScript, so node --test can't require it. Parse its
+// keys from source the way secretKeys.test.js mirrors preload's inlined list.
+function inferenceProviderIds() {
+  const src = fs.readFileSync(
+    path.join(__dirname, "../../src/services/ai/inferenceProviders/index.ts"),
+    "utf8"
+  );
+  const block = src.match(/PROVIDER_REGISTRY[^=]*=\s*Object\.freeze\(\{([\s\S]*?)\}\)/);
+  assert.ok(block, "PROVIDER_REGISTRY declared in inferenceProviders/index.ts");
+  const ids = [...block[1].matchAll(/^\s*([A-Za-z][\w-]*):/gm)].map((m) => m[1]);
+  assert.ok(ids.length > 0, "parsed at least one provider id");
+  return ids;
+}
+
+const localIds = modelData.localProviders.map((p) => p.id);
+const cloudIds = modelData.cloudProviders.map((p) => p.id);
+const enterpriseIds = modelData.enterpriseProviders.map((p) => p.id);
+
+test("every selectable cloud and enterprise provider has an inference handler", () => {
+  const handlers = inferenceProviderIds();
+  assert.ok(cloudIds.length > 0 && enterpriseIds.length > 0, "catalogs are non-empty");
+
+  for (const id of [...cloudIds, ...enterpriseIds]) {
+    assert.ok(handlers.includes(id), `provider "${id}" is selectable but has no inference handler`);
+  }
+});
+
+test("local catalog ids never shadow an inference provider id", () => {
+  // resolveInferenceProvider maps a local catalog id (qwen, gemma, …) to the
+  // llama.cpp "local" provider by looking it up in the model registry, so a
+  // cloud provider sharing one of those ids would silently route to llama.cpp.
+  const handlers = inferenceProviderIds();
+  assert.ok(localIds.length > 0, "local catalog is non-empty");
+
+  for (const id of localIds) {
+    assert.ok(!handlers.includes(id), `local catalog id "${id}" shadows an inference provider`);
+    assert.ok(!cloudIds.includes(id), `"${id}" is both a local catalog and a cloud provider`);
+    assert.ok(
+      !enterpriseIds.includes(id),
+      `"${id}" is both a local catalog and an enterprise provider`
+    );
+  }
+});


### PR DESCRIPTION
Fix local translation requests failing with `Unsupported reasoning provider: {provider name}` by routing locally selected translation models through the local **llama.cpp** provider instead of treating model-family IDs as inference providers.