### PR TITLE
feat: add configurable voice stop command for hands-free dictation

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -765,6 +765,8 @@ export default function SettingsPage({
     setShowTranscriptionPreview,
     autoPasteEnabled,
     setAutoPasteEnabled,
+    voiceStopCommand,
+    setVoiceStopCommand,
     keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard,
     floatingIconAutoHide,
@@ -2545,6 +2547,19 @@ export default function SettingsPage({
                     description={t("settingsPage.general.clipboard.autoPasteDescription")}
                   >
                     <Toggle checked={autoPasteEnabled} onChange={setAutoPasteEnabled} />
+                  </SettingsRow>
+                </SettingsPanelRow>
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.general.clipboard.voiceStopCommand")}
+                    description={t("settingsPage.general.clipboard.voiceStopCommandDescription")}
+                  >
+                    <Input
+                      value={voiceStopCommand}
+                      onChange={(e) => setVoiceStopCommand(e.target.value)}
+                      placeholder={t("settingsPage.general.clipboard.voiceStopCommandPlaceholder")}
+                      className="w-[180px]"
+                    />
                   </SettingsRow>
                 </SettingsPanelRow>
                 <SettingsPanelRow>

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -55,6 +55,7 @@ import { evaluateFinishedRecording } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
 import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
+import { stripVoiceStopCommand } from "./voiceStopCommand";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
 const RECORDING_TIMESLICE_MS = 250; // flush chunks periodically so short recordings still carry audio frames. See #871.
@@ -1290,6 +1291,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         provider: result?.source || (useLocalWhisper ? localProvider : "cloud"),
         model: activeModel || null,
       };
+
+      const { voiceStopCommand } = getSettings();
+      if (voiceStopCommand && result?.text) {
+        result.text = stripVoiceStopCommand(result.text, voiceStopCommand);
+        if (result.rawText) {
+          result.rawText = stripVoiceStopCommand(result.rawText, voiceStopCommand);
+        }
+      }
 
       this.onTranscriptionComplete?.(result);
 

--- a/src/helpers/voiceStopCommand.js
+++ b/src/helpers/voiceStopCommand.js
@@ -1,0 +1,39 @@
+/**
+ * Utility for stripping a configured voice stop command (wake word) from the end of a transcript.
+ * This allows users to say a command like "Jarvis done" to stop dictating without having it appear
+ * in their final text.
+ */
+
+/**
+ * Strips the stopPhrase from the end of the text, ignoring case and trailing punctuation.
+ *
+ * @param {string} text The full transcribed text
+ * @param {string} stopPhrase The configured phrase to remove (e.g. "Jarvis done")
+ * @returns {string} The cleaned text
+ */
+function stripVoiceStopCommand(text, stopPhrase) {
+  if (!text || typeof text !== "string") return text || "";
+  if (!stopPhrase || typeof stopPhrase !== "string") return text;
+
+  const phrase = stopPhrase.trim();
+  if (!phrase) return text;
+
+  // Escape regex specials
+  const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  // Matches the phrase exactly as whole words at the end of the string,
+  // optionally followed by punctuation (.,!?) and whitespace.
+  // We use \b to ensure word boundaries.
+  const regex = new RegExp(`\\b${escapedPhrase}[.!?,\\s]*$`, "i");
+
+  if (regex.test(text)) {
+    const replaced = text.replace(regex, "");
+    return replaced.trimEnd();
+  }
+
+  return text;
+}
+
+module.exports = {
+  stripVoiceStopCommand,
+};

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -334,6 +334,8 @@ function useSettingsInternal() {
     setShowTranscriptionPreview: store.setShowTranscriptionPreview,
     autoPasteEnabled: store.autoPasteEnabled,
     setAutoPasteEnabled: store.setAutoPasteEnabled,
+    voiceStopCommand: store.voiceStopCommand,
+    setVoiceStopCommand: store.setVoiceStopCommand,
     keepTranscriptionInClipboard: store.keepTranscriptionInClipboard,
     setKeepTranscriptionInClipboard: store.setKeepTranscriptionInClipboard,
     noteFilesEnabled: store.noteFilesEnabled,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1658,6 +1658,9 @@
         "title": "Clipboard",
         "autoPaste": "Automatic pasting",
         "autoPasteDescription": "Automatically paste transcribed text into the active app when dictation finishes",
+        "voiceStopCommand": "Voice stop command",
+        "voiceStopCommandDescription": "A wake-word phrase (e.g. \"Jarvis done\") that will be automatically removed from the end of transcripts",
+        "voiceStopCommandPlaceholder": "e.g. Jarvis done",
         "keepInClipboard": "Keep transcription in clipboard",
         "keepInClipboardDescription": "Keep dictated text in your clipboard so you can paste it manually if needed"
       },

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -434,6 +434,7 @@ export interface SettingsState
   panelStartPosition: "bottom-right" | "center" | "bottom-left";
   showTranscriptionPreview: boolean;
   autoPasteEnabled: boolean;
+  voiceStopCommand: string;
   keepTranscriptionInClipboard: boolean;
   noteFilesEnabled: boolean;
   noteFilesPath: string;
@@ -686,6 +687,7 @@ export interface SettingsState
   setPanelStartPosition: (position: "bottom-right" | "center" | "bottom-left") => void;
   setShowTranscriptionPreview: (value: boolean) => void;
   setAutoPasteEnabled: (value: boolean) => void;
+  setVoiceStopCommand: (value: string) => void;
   setKeepTranscriptionInClipboard: (value: boolean) => void;
   setNoteFilesEnabled: (value: boolean) => void;
   setNoteFilesPath: (value: string) => void;
@@ -1059,6 +1061,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   showTranscriptionPreview: readBoolean("showTranscriptionPreview", false),
   autoPasteEnabled: readBoolean("autoPasteEnabled", true),
+  voiceStopCommand: readString("voiceStopCommand", ""),
   keepTranscriptionInClipboard: readBoolean("keepTranscriptionInClipboard", false),
   noteFilesEnabled: readBoolean("noteFilesEnabled", false),
   noteFilesPath: readString("noteFilesPath", ""),
@@ -1715,6 +1718,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setShowTranscriptionPreview: createBooleanSetter("showTranscriptionPreview"),
   setAutoPasteEnabled: createBooleanSetter("autoPasteEnabled"),
+  setVoiceStopCommand: createStringSetter("voiceStopCommand"),
   setKeepTranscriptionInClipboard: createBooleanSetter("keepTranscriptionInClipboard"),
   setNoteFilesEnabled: createBooleanSetter("noteFilesEnabled"),
   setNoteFilesPath: createStringSetter("noteFilesPath"),

--- a/test/helpers/voiceStopCommand.test.js
+++ b/test/helpers/voiceStopCommand.test.js
@@ -1,0 +1,59 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { stripVoiceStopCommand } = require("../../src/helpers/voiceStopCommand");
+
+test("stripVoiceStopCommand removes exact match at end", () => {
+  const result = stripVoiceStopCommand("Testing one two three stop dictation", "stop dictation");
+  assert.strictEqual(result, "Testing one two three");
+});
+
+test("stripVoiceStopCommand ignores case", () => {
+  const result = stripVoiceStopCommand("Testing one two three Stop Dictation", "stop dictation");
+  assert.strictEqual(result, "Testing one two three");
+
+  const result2 = stripVoiceStopCommand("hello JARVIS DONE", "jarvis done");
+  assert.strictEqual(result2, "hello");
+});
+
+test("stripVoiceStopCommand removes trailing punctuation", () => {
+  const cases = [
+    "Testing one two three stop dictation.",
+    "Testing one two three stop dictation!",
+    "Testing one two three stop dictation?",
+    "Testing one two three stop dictation,",
+    "Testing one two three stop dictation...",
+  ];
+
+  for (const text of cases) {
+    const result = stripVoiceStopCommand(text, "stop dictation");
+    assert.strictEqual(result, "Testing one two three", `Failed on: ${text}`);
+  }
+});
+
+test("stripVoiceStopCommand only removes if at the very end", () => {
+  // Should not strip
+  const result = stripVoiceStopCommand("I told you to stop dictation yesterday", "stop dictation");
+  assert.strictEqual(result, "I told you to stop dictation yesterday");
+});
+
+test("stripVoiceStopCommand handles phrase matching the entire string", () => {
+  const result = stripVoiceStopCommand("stop dictation", "stop dictation");
+  assert.strictEqual(result, "");
+
+  const result2 = stripVoiceStopCommand("stop dictation.", "stop dictation");
+  assert.strictEqual(result2, "");
+});
+
+test("stripVoiceStopCommand requires word boundaries", () => {
+  // Should not strip because it's part of a larger word
+  const result = stripVoiceStopCommand("Testing nonestop dictation", "stop dictation");
+  assert.strictEqual(result, "Testing nonestop dictation");
+});
+
+test("stripVoiceStopCommand handles empty or invalid inputs gracefully", () => {
+  assert.strictEqual(stripVoiceStopCommand(null, "stop"), "");
+  assert.strictEqual(stripVoiceStopCommand(undefined, "stop"), "");
+  assert.strictEqual(stripVoiceStopCommand("hello", ""), "hello");
+  assert.strictEqual(stripVoiceStopCommand("hello", null), "hello");
+  assert.strictEqual(stripVoiceStopCommand("hello", "  "), "hello");
+});


### PR DESCRIPTION
Fixes #1305.

## Why
Users who rely on hands-free accessibility software (like Talon Voice) can use voice commands to start dictation, but stopping the dictation hands-free was problematic. If they used a phrase like "Jarvis done", that phrase would get transcribed and polluted into the final output.

## What
This PR adds an optional **Voice stop command** setting (located in Settings → Clipboard/Dictation). 

- **End-of-transcript stripping**: If the user says the wake-word phrase at the end of their dictation, OpenWhispr automatically detects it and safely strips it from the final text.
- **Punctuation tolerant**: It gracefully handles any trailing punctuation added by Whisper (e.g. if the transcript is `"Here is the text, jarvis done."`, it strips it to `"Here is the text,"`).
- **Word boundaries**: It strictly requires whole words to avoid accidentally stripping substrings.
- **Global integration**: Because this stripping happens inside the `audioManager` right before `onTranscriptionComplete`, it automatically protects the Dictation, Voice Agent, and Chat input flows.

## Note to Reviewers
- A new setting `voiceStopCommand` has been added to the store (default: `""`).
- `stripVoiceStopCommand()` is fully unit-tested (7 new tests in `voiceStopCommand.test.js`) with the native `node:test` runner.
- The UI element is positioned near the auto-paste and spoken commands toggles for easy discovery.
