### PR TITLE
Fix meeting mic detection when a listener fails to launch

### DIFF
--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -47,10 +47,10 @@ class AudioActivityDetector extends EventEmitter {
   async start() {
     if (this._running) return;
     this._running = true;
-    const startGeneration = ++this._startGeneration;
+    const generation = ++this._startGeneration;
 
-    const started = await this._tryEventDriven(startGeneration);
-    if (!this._running || startGeneration !== this._startGeneration) return;
+    const started = await this._tryEventDriven(generation);
+    if (this._isStale(generation)) return;
 
     if (started) {
       this._eventDriven = true;
@@ -73,7 +73,6 @@ class AudioActivityDetector extends EventEmitter {
   stop() {
     if (!this._running) return;
     this._running = false;
-    this._startGeneration++;
     this._killListenerProcess();
     this._clearSustainedTimer();
     this._clearResetTimer();
@@ -148,18 +147,23 @@ class AudioActivityDetector extends EventEmitter {
     }
   }
 
+  // True once stop() or a newer start() has superseded the run that owns `generation`.
+  _isStale(generation) {
+    return !this._running || generation !== this._startGeneration;
+  }
+
   // ---------------------------------------------------------------------------
   // Event-driven approach
   // ---------------------------------------------------------------------------
 
-  async _tryEventDriven(startGeneration) {
+  async _tryEventDriven(generation) {
     switch (process.platform) {
       case "darwin":
-        return this._tryEventDrivenDarwin();
+        return this._tryEventDrivenDarwin(generation);
       case "win32":
-        return this._tryEventDrivenWin32();
+        return this._tryEventDrivenWin32(generation);
       case "linux":
-        return this._tryEventDrivenLinux(startGeneration);
+        return this._tryEventDrivenLinux(generation);
       default:
         return false;
     }
@@ -194,6 +198,61 @@ class AudioActivityDetector extends EventEmitter {
     return null;
   }
 
+  // Spawns a listener and resolves only once the OS has confirmed it started, so a
+  // failure to launch (missing binary, not executable) is reported as false instead
+  // of being raced by the asynchronous "error" event.
+  _spawnListener({ command, args = [], options, label, generation, onLine }) {
+    return new Promise((resolve) => {
+      let child;
+      try {
+        child = spawn(command, args, options);
+      } catch (err) {
+        debugLogger.warn(`Failed to spawn ${label}`, { error: err.message }, "meeting");
+        resolve(false);
+        return;
+      }
+
+      const onSpawn = () => {
+        child.removeListener("error", onError);
+        if (this._isStale(generation)) {
+          child.kill();
+          resolve(false);
+          return;
+        }
+
+        this._listenerProcess = child;
+        this._readLines(child.stdout, onLine);
+        child.stderr.on("data", (data) => {
+          debugLogger.debug(`${label} stderr`, { output: data.toString().trim() }, "meeting");
+        });
+        this._attachFallbackHandlers(child, label);
+        resolve(true);
+      };
+
+      const onError = (err) => {
+        child.removeListener("spawn", onSpawn);
+        debugLogger.warn(`Failed to spawn ${label}`, { error: err.message }, "meeting");
+        resolve(false);
+      };
+
+      child.once("spawn", onSpawn);
+      child.once("error", onError);
+    });
+  }
+
+  _readLines(stream, onLine) {
+    let buffer = "";
+    stream.on("data", (data) => {
+      buffer += data.toString();
+      let newlineIdx;
+      while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        onLine(line);
+      }
+    });
+  }
+
   _attachFallbackHandlers(child, label) {
     const fallbackToPolling = () => {
       if (this._listenerProcess !== child) return;
@@ -215,88 +274,44 @@ class AudioActivityDetector extends EventEmitter {
     });
   }
 
-  _tryEventDrivenDarwin() {
+  _tryEventDrivenDarwin(generation) {
     const binaryPath = this._resolveBinary("macos-mic-listener");
     if (!binaryPath) {
       debugLogger.warn("macos-mic-listener binary not found, will use polling", {}, "meeting");
       return false;
     }
 
-    try {
-      const child = spawn(binaryPath, [], { stdio: ["ignore", "pipe", "pipe"] });
-      this._listenerProcess = child;
-
-      let buffer = "";
-      child.stdout.on("data", (data) => {
-        buffer += data.toString();
-        let newlineIdx;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          if (line === "MIC_ACTIVE") {
-            this._onMicStateChanged(true);
-          } else if (line === "MIC_INACTIVE") {
-            this._onMicStateChanged(false);
-          }
+    return this._spawnListener({
+      command: binaryPath,
+      options: { stdio: ["ignore", "pipe", "pipe"] },
+      label: "macos-mic-listener",
+      generation,
+      onLine: (line) => {
+        if (line === "MIC_ACTIVE") {
+          this._onMicStateChanged(true);
+        } else if (line === "MIC_INACTIVE") {
+          this._onMicStateChanged(false);
         }
-      });
-
-      child.stderr.on("data", (data) => {
-        debugLogger.debug(
-          "macos-mic-listener stderr",
-          { output: data.toString().trim() },
-          "meeting"
-        );
-      });
-
-      this._attachFallbackHandlers(child, "macos-mic-listener");
-      return true;
-    } catch (err) {
-      debugLogger.warn("Failed to spawn macos-mic-listener", { error: err.message }, "meeting");
-      return false;
-    }
+      },
+    });
   }
 
-  _tryEventDrivenWin32() {
+  _tryEventDrivenWin32(generation) {
     const binaryPath = this._resolveBinary("windows-mic-listener.exe");
     if (!binaryPath) {
       debugLogger.warn("windows-mic-listener.exe not found, will use polling", {}, "meeting");
       return false;
     }
 
-    try {
+    return this._spawnListener({
+      command: binaryPath,
+      args: ["--exclude-pid", String(process.pid)],
       // stdin must be "pipe" — the Windows binary monitors stdin for parent death
-      const child = spawn(binaryPath, ["--exclude-pid", String(process.pid)], {
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      });
-      this._listenerProcess = child;
-
-      let buffer = "";
-      child.stdout.on("data", (data) => {
-        buffer += data.toString();
-        let newlineIdx;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          this._parseWin32ListenerLine(line);
-        }
-      });
-
-      child.stderr.on("data", (data) => {
-        debugLogger.debug(
-          "windows-mic-listener stderr",
-          { output: data.toString().trim() },
-          "meeting"
-        );
-      });
-
-      this._attachFallbackHandlers(child, "windows-mic-listener");
-      return true;
-    } catch (err) {
-      debugLogger.warn("Failed to spawn windows-mic-listener", { error: err.message }, "meeting");
-      return false;
-    }
+      options: { stdio: ["pipe", "pipe", "pipe"], windowsHide: true },
+      label: "windows-mic-listener",
+      generation,
+      onLine: (line) => this._parseWin32ListenerLine(line),
+    });
   }
 
   _parseWin32ListenerLine(line) {
@@ -319,52 +334,14 @@ class AudioActivityDetector extends EventEmitter {
     }
   }
 
-  _tryEventDrivenLinux(startGeneration) {
-    return new Promise((resolve) => {
-      try {
-        const child = spawn("pactl", ["subscribe"], { stdio: ["ignore", "pipe", "pipe"] });
-        this._listenerProcess = child;
-
-        let buffer = "";
-        child.stdout.on("data", (data) => {
-          buffer += data.toString();
-          let newlineIdx;
-          while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-            const line = buffer.slice(0, newlineIdx).trim();
-            buffer = buffer.slice(newlineIdx + 1);
-            this._parsePactlSubscribeLine(line);
-          }
-        });
-
-        const handleStartupError = (err) => {
-          child.removeListener("spawn", handleSpawn);
-          if (this._listenerProcess === child) {
-            this._listenerProcess = null;
-          }
-          debugLogger.warn("pactl subscribe error", { error: err.message }, "meeting");
-          resolve(false);
-        };
-
-        const handleSpawn = () => {
-          child.removeListener("error", handleStartupError);
-          if (!this._running || startGeneration !== this._startGeneration) {
-            if (this._listenerProcess === child) {
-              this._listenerProcess = null;
-            }
-            child.kill();
-            resolve(false);
-            return;
-          }
-          this._attachFallbackHandlers(child, "pactl subscribe");
-          resolve(true);
-        };
-
-        child.once("error", handleStartupError);
-        child.once("spawn", handleSpawn);
-      } catch (err) {
-        debugLogger.warn("pactl subscribe error", { error: err.message }, "meeting");
-        resolve(false);
-      }
+  _tryEventDrivenLinux(generation) {
+    return this._spawnListener({
+      command: "pactl",
+      args: ["subscribe"],
+      options: { stdio: ["ignore", "pipe", "pipe"] },
+      label: "pactl subscribe",
+      generation,
+      onLine: (line) => this._parsePactlSubscribeLine(line),
     });
   }
 
@@ -387,6 +364,7 @@ class AudioActivityDetector extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   _onMicStateChanged(active) {
+    if (!this._running) return;
     if (this._userRecording) {
       debugLogger.debug("Mic state changed but user recording, ignoring", { active }, "meeting");
       return;

--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -31,6 +31,7 @@ class AudioActivityDetector extends EventEmitter {
     this._running = false;
     this._eventDriven = false;
     this._resetTimer = null;
+    this._startGeneration = 0;
   }
 
   setUserRecording(active) {
@@ -46,8 +47,11 @@ class AudioActivityDetector extends EventEmitter {
   async start() {
     if (this._running) return;
     this._running = true;
+    const startGeneration = ++this._startGeneration;
 
-    const started = await this._tryEventDriven();
+    const started = await this._tryEventDriven(startGeneration);
+    if (!this._running || startGeneration !== this._startGeneration) return;
+
     if (started) {
       this._eventDriven = true;
       debugLogger.info(
@@ -69,6 +73,7 @@ class AudioActivityDetector extends EventEmitter {
   stop() {
     if (!this._running) return;
     this._running = false;
+    this._startGeneration++;
     this._killListenerProcess();
     this._clearSustainedTimer();
     this._clearResetTimer();
@@ -147,14 +152,14 @@ class AudioActivityDetector extends EventEmitter {
   // Event-driven approach
   // ---------------------------------------------------------------------------
 
-  async _tryEventDriven() {
+  async _tryEventDriven(startGeneration) {
     switch (process.platform) {
       case "darwin":
         return this._tryEventDrivenDarwin();
       case "win32":
         return this._tryEventDrivenWin32();
       case "linux":
-        return this._tryEventDrivenLinux();
+        return this._tryEventDrivenLinux(startGeneration);
       default:
         return false;
     }
@@ -191,6 +196,7 @@ class AudioActivityDetector extends EventEmitter {
 
   _attachFallbackHandlers(child, label) {
     const fallbackToPolling = () => {
+      if (this._listenerProcess !== child) return;
       this._listenerProcess = null;
       if (this._running && this._eventDriven) {
         this._eventDriven = false;
@@ -313,27 +319,53 @@ class AudioActivityDetector extends EventEmitter {
     }
   }
 
-  _tryEventDrivenLinux() {
-    try {
-      const child = spawn("pactl", ["subscribe"], { stdio: ["ignore", "pipe", "pipe"] });
-      this._listenerProcess = child;
+  _tryEventDrivenLinux(startGeneration) {
+    return new Promise((resolve) => {
+      try {
+        const child = spawn("pactl", ["subscribe"], { stdio: ["ignore", "pipe", "pipe"] });
+        this._listenerProcess = child;
 
-      let buffer = "";
-      child.stdout.on("data", (data) => {
-        buffer += data.toString();
-        let newlineIdx;
-        while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          this._parsePactlSubscribeLine(line);
-        }
-      });
+        let buffer = "";
+        child.stdout.on("data", (data) => {
+          buffer += data.toString();
+          let newlineIdx;
+          while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
+            const line = buffer.slice(0, newlineIdx).trim();
+            buffer = buffer.slice(newlineIdx + 1);
+            this._parsePactlSubscribeLine(line);
+          }
+        });
 
-      this._attachFallbackHandlers(child, "pactl subscribe");
-      return true;
-    } catch {
-      return false;
-    }
+        const handleStartupError = (err) => {
+          child.removeListener("spawn", handleSpawn);
+          if (this._listenerProcess === child) {
+            this._listenerProcess = null;
+          }
+          debugLogger.warn("pactl subscribe error", { error: err.message }, "meeting");
+          resolve(false);
+        };
+
+        const handleSpawn = () => {
+          child.removeListener("error", handleStartupError);
+          if (!this._running || startGeneration !== this._startGeneration) {
+            if (this._listenerProcess === child) {
+              this._listenerProcess = null;
+            }
+            child.kill();
+            resolve(false);
+            return;
+          }
+          this._attachFallbackHandlers(child, "pactl subscribe");
+          resolve(true);
+        };
+
+        child.once("error", handleStartupError);
+        child.once("spawn", handleSpawn);
+      } catch (err) {
+        debugLogger.warn("pactl subscribe error", { error: err.message }, "meeting");
+        resolve(false);
+      }
+    });
   }
 
   _parsePactlSubscribeLine(line) {

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -1,0 +1,226 @@
+const test = require("node:test");
+const { afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+const childProcess = require("node:child_process");
+
+const detectorModulePath = require.resolve("../../src/helpers/audioActivityDetector");
+const originalLoad = Module._load;
+const originalPlatform = process.platform;
+
+// The detector reads process.platform both at load time (poll interval) and at
+// start() time (listener selection), so it stays pinned for the whole test.
+function setPlatform(platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+afterEach(() => setPlatform(originalPlatform));
+
+function loadDetector(platform, spawn) {
+  delete require.cache[detectorModulePath];
+  setPlatform(platform);
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "./debugLogger") {
+      return { info() {}, warn() {}, debug() {}, error() {} };
+    }
+    if (request === "child_process") {
+      return { ...childProcess, spawn };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(detectorModulePath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+// Mirrors child_process: "spawn" and "error" are both delivered on the nextTick
+// queue, which drains before the promise microtasks awaiting start().
+function createFakeChild(spawnError) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = () => {
+    child.killed = true;
+    process.nextTick(() => child.emit("exit", null));
+    return true;
+  };
+  process.nextTick(() => {
+    if (spawnError) child.emit("error", new Error(spawnError));
+    else child.emit("spawn");
+  });
+  return child;
+}
+
+function createDetector(platform, { spawnError } = {}) {
+  const children = [];
+  const calls = [];
+  const AudioActivityDetector = loadDetector(platform, (command, args, options) => {
+    calls.push({ command, args, options });
+    const child = createFakeChild(spawnError);
+    children.push(child);
+    return child;
+  });
+
+  const detector = new AudioActivityDetector();
+  detector._resolveBinary = (name) => `/fake/bin/${name}`;
+  detector._isMicActive = async () => false;
+  return { detector, children, calls };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+const PLATFORMS = ["darwin", "win32", "linux"];
+
+for (const platform of PLATFORMS) {
+  test(`${platform}: a listener that fails to launch falls back to polling`, async () => {
+    const { detector } = createDetector(platform, { spawnError: "spawn ENOENT" });
+
+    await detector.start();
+
+    assert.equal(detector._eventDriven, false);
+    assert.notEqual(detector.checkInterval, null, "polling must take over");
+    detector.stop();
+  });
+
+  test(`${platform}: a listener that launches stays event-driven`, async () => {
+    const { detector, children } = createDetector(platform);
+
+    await detector.start();
+
+    assert.equal(detector._eventDriven, true);
+    assert.equal(detector.checkInterval, null, "polling must not run alongside a listener");
+    detector.stop();
+    assert.equal(children[0].killed, true, "stop() must kill the listener");
+  });
+
+  test(`${platform}: stop() during launch kills the listener and starts nothing`, async () => {
+    const { detector, children } = createDetector(platform);
+
+    const starting = detector.start();
+    detector.stop();
+    await starting;
+    await flush();
+
+    assert.equal(detector._eventDriven, false);
+    assert.equal(detector.checkInterval, null);
+    assert.equal(children[0].killed, true, "the orphaned listener must be killed");
+  });
+
+  test(`${platform}: restarting does not orphan the previous listener`, async () => {
+    const { detector, children } = createDetector(platform);
+
+    await detector.start();
+    detector.stop();
+    await detector.start();
+    await flush();
+
+    assert.equal(children.length, 2);
+    assert.equal(children[0].killed, true, "the first listener must be killed");
+    assert.equal(detector._listenerProcess, children[1], "the live listener must be tracked");
+    assert.equal(detector.checkInterval, null, "a dead listener must not trigger polling");
+
+    detector.stop();
+    assert.equal(children[1].killed, true, "the second listener must be killed");
+  });
+
+  test(`${platform}: listener output after stop() cannot emit a detection`, async () => {
+    const { detector, children } = createDetector(platform);
+    let emitted = false;
+    detector.on("sustained-audio-detected", () => (emitted = true));
+
+    await detector.start();
+    detector.stop();
+    children[0].stdout.emit("data", "MIC_ACTIVE\nEvent 'new' on source-output #1\nMIC_START 42\n");
+    await flush();
+
+    assert.equal(emitted, false);
+    assert.equal(detector._sustainedTimer, null);
+  });
+}
+
+test("darwin: MIC_ACTIVE then MIC_INACTIVE drives the sustained timer", async () => {
+  const { detector, children } = createDetector("darwin");
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  assert.notEqual(detector._sustainedTimer, null);
+
+  children[0].stdout.emit("data", "MIC_INACTIVE\n");
+  assert.equal(detector._sustainedTimer, null);
+  detector.stop();
+});
+
+test("win32: mic-listener spawns hidden, keeps stdin piped, and excludes its own pid", async () => {
+  const { detector, calls } = createDetector("win32");
+
+  await detector.start();
+
+  assert.deepEqual(calls[0].args, ["--exclude-pid", String(process.pid)]);
+  assert.equal(calls[0].options.windowsHide, true, "no console window may flash");
+  assert.deepEqual(
+    calls[0].options.stdio,
+    ["pipe", "pipe", "pipe"],
+    "stdin must stay piped so the binary can detect parent death"
+  );
+  detector.stop();
+});
+
+test("win32: MIC_START/MIC_STOP pids are tracked across partial chunks", async () => {
+  const { detector, children } = createDetector("win32");
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_START 11\nMIC_STA");
+  children[0].stdout.emit("data", "RT 22\n");
+  assert.deepEqual([...detector._activeMicPids], [11, 22]);
+
+  children[0].stdout.emit("data", "MIC_STOP 11\n");
+  assert.notEqual(detector._sustainedTimer, null, "one mic is still active");
+
+  children[0].stdout.emit("data", "MIC_STOP 22\n");
+  assert.equal(detector._sustainedTimer, null);
+  detector.stop();
+});
+
+test("linux: pactl source-output events drive the sustained timer", async () => {
+  const { detector, children, calls } = createDetector("linux");
+
+  await detector.start();
+  assert.equal(calls[0].command, "pactl");
+  assert.deepEqual(calls[0].args, ["subscribe"]);
+
+  children[0].stdout.emit("data", "Event 'new' on source-output #7\n");
+  assert.notEqual(detector._sustainedTimer, null);
+
+  children[0].stdout.emit("data", "Event 'remove' on source-output #7\n");
+  assert.equal(detector._sustainedTimer, null);
+  detector.stop();
+});
+
+test("a listener that dies while running falls back to polling", async () => {
+  const { detector, children } = createDetector("linux");
+
+  await detector.start();
+  assert.equal(detector.checkInterval, null);
+
+  children[0].emit("exit", 1);
+  await flush();
+
+  assert.equal(detector._eventDriven, false);
+  assert.notEqual(detector.checkInterval, null);
+  detector.stop();
+});
+
+test("unsupported platforms poll without spawning a listener", async () => {
+  const { detector, calls } = createDetector("freebsd");
+
+  await detector.start();
+
+  assert.equal(calls.length, 0);
+  assert.notEqual(detector.checkInterval, null);
+  detector.stop();
+});

--- a/test/helpers/windowsHelperSpawnHide.test.js
+++ b/test/helpers/windowsHelperSpawnHide.test.js
@@ -22,6 +22,6 @@ test("text edit monitor spawns set windowsHide", () => {
 test("Windows mic-listener spawn sets windowsHide", () => {
   assert.match(
     read("src/helpers/audioActivityDetector.js"),
-    /spawn\(binaryPath, \["--exclude-pid"[^{}]*\{[^{}]*windowsHide: true/
+    /args: \["--exclude-pid"[^{}]*\{[^{}]*windowsHide: true/
   );
 });


### PR DESCRIPTION
Fixes #1349

## What

- Wait for the OS to confirm a mic listener has started before treating event-driven detection as active, on all three platforms.
- Fall back to the existing polling path whenever a listener cannot start.
- Ignore listener events that arrive after detection is stopped or restarted.

## Why

`spawn()` reports a failed launch through the asynchronous `error` event, which Node drains from the nextTick queue *before* the promise microtask awaiting `start()`. The listener therefore reported success, `_eventDriven` was still `false` when the error handler ran, and the polling fallback never started — leaving mic detection silently dead.

This was first found on PipeWire-only Linux systems, where `pactl` is often not installed at all. It is not Linux-specific: the macOS and Windows listeners race the same way whenever their binary resolves but fails to exec (quarantine, wrong architecture, `EACCES`, or deletion between the `existsSync` check and the spawn). Because the defect lives in the shared `start()` contract rather than in one platform branch, the spawn handshake now happens in a single helper that all three platforms use.

Two related problems surfaced while fixing this:

- On a stop → start sequence, the dying listener's `exit` handler nulled the reference to the *new* listener, orphaning a live child process for the lifetime of the app and starting polling alongside it.
- Listener output buffered past `stop()` could still arm the sustained timer and emit `sustained-audio-detected` while the detector was stopped.

## Impact

Any system whose mic listener cannot launch now falls back to polling instead of silently detecting nothing — PipeWire-only Linux via the existing `pw-cli` path, and macOS/Windows via the existing process-name checks. Systems where the listener launches normally are unaffected: the same binaries, arguments, and spawn options are used, including the piped stdin and `windowsHide` the Windows listener depends on.

Refactoring the three platform paths onto the shared helper also removed the line-buffering loop each of them duplicated verbatim, net -121 lines.

## Validation

`npm run lint`, Prettier, and `npm test` under Node.js 24 — 714 → 735 tests, 0 failures, skips unchanged at 19.

New `test/helpers/audioActivityDetector.test.js` covers launch failure, clean launch, stop-during-launch, restart races, and post-stop events, parameterized across darwin/win32/linux. It stubs `child_process` with the repo's existing `Module._load` convention; the fake child emits `spawn`/`error` on `process.nextTick`, reproducing the exact ordering that caused the bug.

Run against each revision to confirm the tests are not vacuous:

| | pre-PR `main` | first commit | this branch |
|---|---|---|---|
| passing | 9 / 21 | 16 / 21 | **21 / 21** |

The five still failing at the first commit are precisely the macOS/Windows launch-failure cases and the post-stop event guard.

Also verified against real spawned processes: no orphaned children across stop/start races, listener killed on stop, real stdout lines parsed, and polling taking over when a running listener dies. Plus a manual check on a PipeWire-only Linux system with a locally built binary.

`test/helpers/windowsHelperSpawnHide.test.js` guards against a console window flashing on Windows via a source-pattern match, which was tied to the old call shape. It is updated for the new shape, and a behavioral assertion now checks that `windowsHide: true` and piped stdin actually reach `spawn`. Both guards were confirmed to fail when `windowsHide` is removed.
