### PR TITLE
test(sync): shared harness, SyncService orchestration tests, and #1290 kill-chain scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "postcss": "^8.5.10",
         "prettier": "^3.8.3",
         "tailwindcss": "^4.1.10",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.1",
         "vite": "^8.1.4"
@@ -1630,6 +1631,448 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -7343,6 +7786,48 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -12189,6 +12674,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "format": "npm run format:js",
     "format:check": "eslint . && cd src && eslint . && prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "lint": "eslint . && cd src && eslint .",
-    "test": "node --test \"test/**/*.test.js\"",
+    "test": "node --import tsx --test \"test/**/*.test.js\"",
     "typecheck": "cd src && tsc --noEmit",
     "quality-check": "npm run format:check && npm run typecheck",
     "i18n:check": "node scripts/check-i18n.js",
@@ -112,6 +112,7 @@
     "postcss": "^8.5.10",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.1.10",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.1",
     "vite": "^8.1.4"

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -204,7 +204,7 @@ export async function upsertCloudSpaces(cloudSpaces: MySpace[]): Promise<number[
   return backfillIds;
 }
 
-class SyncService {
+export class SyncService {
   private syncing = false;
   private syncAllPending = false;
   private autoSyncStarted = false;

--- a/test/helpers/harness/browserGlobals.js
+++ b/test/helpers/harness/browserGlobals.js
@@ -1,0 +1,189 @@
+// The renderer globals syncAll() actually reads: localStorage for the canSync
+// gate and the sync cursors, navigator.locks for the cross-window lock.
+
+const store = new Map();
+
+const localStorageStub = {
+  getItem(key) {
+    const value = store.get(String(key));
+    return value === undefined ? null : value;
+  },
+  setItem(key, value) {
+    store.set(String(key), String(value));
+  },
+  removeItem(key) {
+    store.delete(String(key));
+  },
+  clear() {
+    store.clear();
+  },
+  key(index) {
+    return [...store.keys()][index] ?? null;
+  },
+  get length() {
+    return store.size;
+  },
+};
+
+const held = new Set();
+const waiters = new Map();
+
+function queueFor(name) {
+  let queue = waiters.get(name);
+  if (!queue) {
+    queue = [];
+    waiters.set(name, queue);
+  }
+  return queue;
+}
+
+async function holdAndRun(name, callback) {
+  held.add(name);
+  try {
+    return await callback({ name, mode: "exclusive" });
+  } finally {
+    held.delete(name);
+    const next = waiters.get(name)?.shift();
+    if (next) next();
+  }
+}
+
+async function requestLock(name, optionsOrCallback, maybeCallback) {
+  const options = typeof optionsOrCallback === "function" ? {} : (optionsOrCallback ?? {});
+  const callback = typeof optionsOrCallback === "function" ? optionsOrCallback : maybeCallback;
+  if (typeof callback !== "function") {
+    throw new TypeError("navigator.locks.request requires a callback");
+  }
+
+  if (held.has(String(name))) {
+    // ifAvailable hands the caller a null lock instead of queueing, which is how
+    // an ambient sync pass bows out while another window holds the lock.
+    if (options.ifAvailable) return callback(null);
+    return new Promise((resolve, reject) => {
+      queueFor(String(name)).push(() => holdAndRun(String(name), callback).then(resolve, reject));
+    });
+  }
+  return holdAndRun(String(name), callback);
+}
+
+const navigatorStub = { locks: { request: requestLock } };
+
+const documentStub = {
+  visibilityState: "visible",
+  addEventListener() {},
+  removeEventListener() {},
+};
+
+const windowStub = {
+  addEventListener() {},
+  removeEventListener() {},
+  localStorage: localStorageStub,
+  navigator: navigatorStub,
+  document: documentStub,
+  // authRequestContext resolves get-session URLs against the window origin.
+  location: { origin: "https://harness.openwhispr.test" },
+};
+
+function define(name, value) {
+  Object.defineProperty(globalThis, name, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function installBrowserGlobals() {
+  define("localStorage", localStorageStub);
+  define("navigator", navigatorStub);
+  define("document", documentStub);
+  define("window", windowStub);
+  return windowStub;
+}
+
+// Marks the three keys canSync() requires; without all three every sync path
+// returns before doing any work.
+function enableSync() {
+  localStorageStub.setItem("isSignedIn", "true");
+  localStorageStub.setItem("cloudBackupEnabled", "true");
+  localStorageStub.setItem("isSubscribed", "true");
+}
+
+function resetBrowserGlobals() {
+  store.clear();
+  held.clear();
+  waiters.clear();
+  documentStub.visibilityState = "visible";
+  delete windowStub.electronAPI;
+  delete globalThis.electronAPI;
+}
+
+// Takes the lock out of band so a test can drive the "another window is
+// syncing" path. Returns the release function.
+async function acquireLock(name) {
+  let release;
+  const acquired = new Promise((resolve) => {
+    void requestLock(
+      name,
+      () =>
+        new Promise((done) => {
+          release = done;
+          resolve();
+        })
+    );
+  });
+  await acquired;
+  return () => release();
+}
+
+// syncAll() refuses to run without a validated auth context: a token
+// generation bound to a resolved get-session user. Drive the real
+// authRequestContext module through its exported surface so the harness holds
+// the same lease the renderer would after sign-in. Requires
+// window.electronAPI.authGetTokenState (the bridge provides it).
+async function establishValidatedAuth(userId = "user-harness") {
+  const auth = require("../../../src/lib/authRequestContext.ts");
+  auth.resetAuthRequestContextForTests();
+  const request = await auth.prepareAuthRequest({
+    url: `${windowStub.location.origin}/api/auth/get-session`,
+    headers: {},
+  });
+  await auth.handleAuthRequestSuccess({
+    data: { user: { id: userId } },
+    response: new Response(null),
+    request,
+  });
+  const { generation } = await auth.readAuthTokenState();
+  if (!auth.commitValidatedAuthContext(generation, userId)) {
+    throw new Error("harness auth bootstrap failed to validate the session");
+  }
+}
+
+// A failed team-spaces probe schedules a real-timer retry that would fire long
+// after the test closed its database; every SyncService a test creates must be
+// swept before the test ends.
+function stopSyncTimers(service) {
+  if (!service) return;
+  if (service.teamSpacesRetryTimer) {
+    clearTimeout(service.teamSpacesRetryTimer);
+    service.teamSpacesRetryTimer = null;
+  }
+  if (service.openNoteSyncTimer) {
+    clearInterval(service.openNoteSyncTimer);
+    service.openNoteSyncTimer = null;
+  }
+  for (const timer of service.pushTimers?.values?.() ?? []) clearTimeout(timer);
+  service.pushTimers?.clear?.();
+}
+
+module.exports = {
+  installBrowserGlobals,
+  resetBrowserGlobals,
+  enableSync,
+  establishValidatedAuth,
+  stopSyncTimers,
+  acquireLock,
+  localStorage: localStorageStub,
+  navigator: navigatorStub,
+  document: documentStub,
+  window: windowStub,
+};

--- a/test/helpers/harness/db.js
+++ b/test/helpers/harness/db.js
@@ -28,4 +28,51 @@ function skipOrFail(t, error) {
   t.skip("better-sqlite3 native binding is not available for this Node runtime");
 }
 
-module.exports = { isNativeBindingUnavailable, skipOrFail };
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { installElectronStub, setUserDataDir } = require("./electronStub.js");
+
+installElectronStub();
+const DatabaseManager = require("../../../src/helpers/database.js");
+
+// A real DatabaseManager over a private tmpdir. Returns null when the caller
+// must bail because skipOrFail marked the test skipped.
+function createDb(t) {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-sync-harness-"));
+  setUserDataDir(userDataDir);
+
+  // Probe first: a binding failure here is the loader's, not schema setup's.
+  try {
+    const BetterSqlite = require("better-sqlite3");
+    const probe = new BetterSqlite(path.join(userDataDir, "probe.db"));
+    probe.close();
+    fs.rmSync(path.join(userDataDir, "probe.db"), { force: true });
+  } catch (error) {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    skipOrFail(t, error);
+    return null;
+  }
+
+  let db;
+  try {
+    db = new DatabaseManager();
+  } catch (error) {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    skipOrFail(t, error);
+    return null;
+  }
+
+  t.after(() => {
+    try {
+      db.db?.close();
+    } catch {
+      // an already-closed handle must not mask the test's own failure
+    }
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  return db;
+}
+
+module.exports = { isNativeBindingUnavailable, skipOrFail, createDb };

--- a/test/helpers/harness/electronApiBridge.js
+++ b/test/helpers/harness/electronApiBridge.js
@@ -1,0 +1,155 @@
+// window.electronAPI as the renderer sees it: every method here mirrors the
+// name, argument order and return value of its ipcHandlers.js passthrough, so a
+// drift between SyncService and the real IPC surface shows up as a test failure.
+
+// Fixed credential state for the whole test process; establishValidatedAuth()
+// in browserGlobals.js turns it into a validated renderer auth context.
+const AUTH_TOKEN = "harness-token";
+const AUTH_GENERATION = 0;
+
+// syncAll() asserts the whole dictionary and snippet surface exists before doing
+// any work and aborts the pass if a name is missing, so both are present but
+// inert — this harness covers notes and folders.
+function inertDictionaryApi() {
+  return {
+    getPendingDictionary: async () => [],
+    getPendingDictionaryDeletes: async () => [],
+    getDictionaryByClientId: async () => null,
+    upsertDictionaryFromCloud: async () => undefined,
+    markDictionarySynced: async () => ({ success: true, changes: 1 }),
+    hardDeleteDictionary: async () => ({ success: true }),
+    clearDictionaryCloudId: async () => ({ success: true }),
+    broadcastDictionaryUpdated: async () => undefined,
+  };
+}
+
+function inertSnippetApi() {
+  return {
+    getPendingSnippets: async () => [],
+    getPendingSnippetDeletes: async () => [],
+    getSnippetForCloudMerge: async () => null,
+    upsertSnippetFromCloud: async () => undefined,
+    markSnippetSynced: async () => ({ success: true, changes: 1 }),
+    hardDeleteSnippet: async () => ({ success: true }),
+    clearSnippetCloudId: async () => ({ success: true }),
+    broadcastSnippetsUpdated: async () => undefined,
+  };
+}
+
+function createElectronApi(db, options = {}) {
+  if (!db) throw new TypeError("createElectronApi requires a DatabaseManager");
+  const cloud = options.cloud;
+  // UI signals SyncService rebroadcasts through the main process
+  // (space-revoked, note-relocated, …), recorded for assertions.
+  const syncEvents = [];
+
+  return {
+    syncEvents,
+
+    cloudApiRequest: async (opts) => {
+      if (!cloud) throw new Error("no fake cloud wired into this electronAPI");
+      return cloud.request(opts);
+    },
+
+    // Auth
+    authGetTokenState: async () => ({ token: AUTH_TOKEN, generation: AUTH_GENERATION }),
+
+    emitSyncEvent: async (name, payload) => {
+      syncEvents.push({ name, payload });
+      return { success: true };
+    },
+
+    // Notes
+    getNote: async (id) => db.getNote(id),
+    updateNote: async (id, updates) => db.updateNote(id, updates),
+    getPendingNotes: async (spaceKind) => db.getPendingNotes(spaceKind),
+    getPendingNoteDeletes: async () => db.getPendingNoteDeletes(),
+    getNoteByClientId: async (clientNoteId) => db.getNoteByClientId(clientNoteId),
+    upsertNoteFromCloud: async (cloudNote, localFolderId, localSpaceId) =>
+      db.upsertNoteFromCloud(cloudNote, localFolderId, localSpaceId),
+    acknowledgeNoteCreate: async (id, snapshot, cloudId, cloudUpdatedAt, ownerUserId, settleIfUnchanged) =>
+      db.acknowledgeNoteCreate(id, snapshot, cloudId, cloudUpdatedAt, ownerUserId, settleIfUnchanged),
+    markNoteSyncedIfUnchanged: async (id, snapshot, expectedCloudId, cloudUpdatedAt, ownerUserId) =>
+      db.markNoteSyncedIfUnchanged(id, snapshot, expectedCloudId, cloudUpdatedAt, ownerUserId),
+    markNoteSyncError: async (id) => db.markNoteSyncError(id),
+    setNoteOwnerFromCloud: async (id, ownerUserId) => db.setNoteOwnerFromCloud(id, ownerUserId),
+    countTeamNotesMissingOwner: async () => db.countTeamNotesMissingOwner(),
+    restoreNoteAfterDeniedDelete: async (id) => db.restoreNoteAfterDeniedDelete(id),
+    hardDeleteNote: async (id) => db.hardDeleteNote(id),
+
+    // Folders
+    getFolders: async (spaceId) => db.getFolders(spaceId),
+    getPendingFolders: async (spaceKind) => db.getPendingFolders(spaceKind),
+    getPendingFolderDeletes: async () => db.getPendingFolderDeletes(),
+    getFolderByClientId: async (clientFolderId) => db.getFolderByClientId(clientFolderId),
+    upsertFolderFromCloud: async (cloudFolder, localSpaceId) =>
+      db.upsertFolderFromCloud(cloudFolder, localSpaceId),
+    acknowledgeFolderCreate: async (
+      id,
+      snapshot,
+      expectedCloudId,
+      responseClientFolderId,
+      cloudId,
+      cloudUpdatedAt
+    ) =>
+      db.acknowledgeFolderCreate(
+        id,
+        snapshot,
+        expectedCloudId,
+        responseClientFolderId,
+        cloudId,
+        cloudUpdatedAt
+      ),
+    markFolderSyncedIfUnchanged: async (id, snapshot, expectedCloudId) =>
+      db.markFolderSyncedIfUnchanged(id, snapshot, expectedCloudId),
+    restoreFolderAfterDeniedDelete: async (id) => db.restoreFolderAfterDeniedDelete(id),
+    relocateRevokedFolder: async (id, privateSpaceId, preserveFolder) =>
+      db.relocateRevokedFolder(id, privateSpaceId, preserveFolder),
+    getFolderIdMap: async () => db.getFolderIdMap(),
+    hardDeleteFolder: async (id) => db.hardDeleteFolder(id),
+
+    // Spaces
+    getSpaces: async () => db.getSpaces(),
+    upsertSpaceFromCloud: async (cloudSpace) => db.upsertSpaceFromCloud(cloudSpace),
+    setSpaceSyncStatus: async (id, status) => db.setSpaceSyncStatus(id, status),
+    purgeSpace: async (id, purgeOptions) => {
+      // Mirrors the db-purge-space handler's stale-generation refusal.
+      if (
+        purgeOptions?.expectedAuthGeneration !== undefined &&
+        purgeOptions.expectedAuthGeneration !== AUTH_GENERATION
+      ) {
+        return {
+          success: false,
+          error: "Authentication context changed before account cleanup",
+          code: "AUTH_CONTEXT_CHANGED",
+        };
+      }
+      return db.purgeSpace(id, purgeOptions);
+    },
+
+    // Conversations
+    getAgentConversation: async (id) => db.getAgentConversation(id),
+    getPendingConversations: async () => db.getPendingConversations(),
+    getPendingConversationDeletes: async () => db.getPendingConversationDeletes(),
+    getConversationByClientId: async (clientId) => db.getConversationByClientId(clientId),
+    upsertConversationFromCloud: async (cloudConv, messages) =>
+      db.upsertConversationFromCloud(cloudConv, messages),
+    markConversationSynced: async (id, cloudId) => db.markConversationSynced(id, cloudId),
+    hardDeleteConversation: async (id) => db.hardDeleteConversation(id),
+
+    // Transcriptions
+    getTranscriptionById: async (id) => db.getTranscriptionById(id),
+    getPendingTranscriptions: async () => db.getPendingTranscriptions(),
+    getPendingTranscriptionDeletes: async () => db.getPendingTranscriptionDeletes(),
+    getTranscriptionByClientId: async (clientId) => db.getTranscriptionByClientId(clientId),
+    upsertTranscriptionFromCloud: async (cloudTranscription) =>
+      db.upsertTranscriptionFromCloud(cloudTranscription),
+    markTranscriptionSynced: async (id, cloudId) => db.markTranscriptionSynced(id, cloudId),
+    hardDeleteTranscription: async (id) => db.hardDeleteTranscription(id),
+
+    ...inertDictionaryApi(),
+    ...inertSnippetApi(),
+  };
+}
+
+module.exports = { createElectronApi, AUTH_TOKEN, AUTH_GENERATION };

--- a/test/helpers/harness/electronStub.js
+++ b/test/helpers/harness/electronStub.js
@@ -1,0 +1,41 @@
+const Module = require("node:module");
+
+// DatabaseManager requires electron at load time, which is unloadable under plain
+// node, so the module loader hands it a stub whose userData path tests repoint.
+let userDataDir = process.cwd();
+let patched = false;
+
+function installElectronStub() {
+  if (patched) return;
+  patched = true;
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        app: {
+          getPath: () => userDataDir,
+          getAppPath: () => process.cwd(),
+          isReady: () => false,
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+// Must be set before DatabaseManager loads: it picks the dev database filename
+// from NODE_ENV.
+process.env.NODE_ENV = "test";
+
+function setUserDataDir(dir) {
+  if (typeof dir !== "string" || dir.length === 0) {
+    throw new TypeError("setUserDataDir requires a non-empty path");
+  }
+  userDataDir = dir;
+}
+
+function getUserDataDir() {
+  return userDataDir;
+}
+
+module.exports = { installElectronStub, setUserDataDir, getUserDataDir };

--- a/test/helpers/harness/fakeCloud.js
+++ b/test/helpers/harness/fakeCloud.js
@@ -1,0 +1,410 @@
+// In-memory stand-in for the cloud API behind window.electronAPI.cloudApiRequest.
+// Notes and folders are modelled with the hardened server's real write rules;
+// the other entity types exist only so a full syncAll() pass can complete.
+//
+// Each hardening rule sits behind its own flag so a test can flip the server
+// back to the legacy behaviour and prove the client still does not lose data:
+//   materialPatchGate  a PATCH that changes nothing does not bump updated_at
+//   coalesceOnConflict an absent/null incoming field keeps the stored value
+//   staleWriteGuard    a write whose basis predates the stored row is rejected
+//   updatedAtClamp     a stored updated_at never moves backwards
+
+// The server compares timestamps itself; it must not borrow the client's guard,
+// or a client-side regression would be invisible here.
+function normalizeTimestamp(value) {
+  if (!value) return "";
+  const iso = String(value).replace(" ", "T").replace(/Z$/, "");
+  return (/\.\d+$/.test(iso) ? iso : `${iso}.000`) + "Z";
+}
+
+function sameValue(a, b) {
+  return (a ?? null) === (b ?? null);
+}
+
+function compare(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+class HttpError extends Error {
+  constructor(status, message, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const NOTE_FIELDS = [
+  "title",
+  "content",
+  "enhanced_content",
+  "note_type",
+  "enhancement_prompt",
+  "source_file",
+  "audio_duration_seconds",
+  "folder_id",
+  "transcript",
+  "enhanced_at_content_hash",
+  "participants",
+  "calendar_event_id",
+  "diarization_enabled",
+  "expected_speaker_count",
+];
+
+const FOLDER_FIELDS = ["name", "is_default", "sort_order"];
+
+const NOTE_DEFAULTS = {
+  title: null,
+  content: "",
+  enhanced_content: null,
+  note_type: "personal",
+  enhancement_prompt: null,
+  source_file: null,
+  audio_duration_seconds: null,
+  folder_id: null,
+  transcript: null,
+  enhanced_at_content_hash: null,
+  participants: null,
+  calendar_event_id: null,
+  diarization_enabled: null,
+  expected_speaker_count: null,
+};
+
+const FOLDER_DEFAULTS = { name: "", is_default: false, sort_order: 0 };
+
+function createFakeCloud(config = {}) {
+  const cfg = {
+    materialPatchGate: true,
+    coalesceOnConflict: true,
+    staleWriteGuard: true,
+    updatedAtClamp: true,
+    ...config,
+  };
+
+  const notes = new Map();
+  const folders = new Map();
+  const log = [];
+  const failures = [];
+  let seq = 0;
+  let clock = () => new Date().toISOString();
+
+  const nextId = (prefix) => `${prefix}-${String(++seq).padStart(4, "0")}`;
+
+  // The server stores timestamps and serves them back as ISO, whatever format
+  // the client sent. Local rows carry SQLite's "YYYY-MM-DD HH:MM:SS", so echoing
+  // the input back would hide the format skew every pull comparison has to
+  // survive.
+  const toIso = (value) => normalizeTimestamp(value);
+
+  // A stored updated_at only ever moves forward under the clamp.
+  function bump(row, proposed) {
+    const candidate = toIso(proposed ?? clock());
+    if (cfg.updatedAtClamp && candidate < toIso(row.updated_at)) {
+      return row.updated_at;
+    }
+    return candidate;
+  }
+
+  function applyWrite(collection, row, incoming) {
+    if (
+      cfg.staleWriteGuard &&
+      incoming.updated_at &&
+      normalizeTimestamp(incoming.updated_at) < normalizeTimestamp(row.updated_at)
+    ) {
+      throw new HttpError(409, "stale write rejected: basis is older than the stored row", "stale");
+    }
+
+    const next = {};
+    let material = false;
+    for (const key of collection.fields) {
+      if (!(key in incoming)) {
+        next[key] = row[key];
+        continue;
+      }
+      const value = incoming[key];
+      if (cfg.coalesceOnConflict && (value === null || value === undefined) && row[key] != null) {
+        next[key] = row[key];
+        continue;
+      }
+      next[key] = value ?? null;
+      if (!sameValue(next[key], row[key])) material = true;
+    }
+
+    // Without the gate a no-op PATCH still bumps updated_at, which is what hands
+    // the next pull a cloud copy that never received the local edit.
+    if (cfg.materialPatchGate && !material) return row;
+
+    Object.assign(row, next);
+    row.updated_at = bump(row, incoming.updated_at);
+    return row;
+  }
+
+  function insertRow(collection, input) {
+    const clientId = input[collection.clientKey] ?? nextId(`${collection.prefix}-client`);
+    const createdAt = toIso(input.created_at ?? clock());
+    const row = {
+      id: nextId(collection.prefix),
+      [collection.clientKey]: clientId,
+      ...collection.defaults,
+      deleted_at: null,
+      created_at: createdAt,
+      updated_at: toIso(input.updated_at ?? createdAt),
+    };
+    for (const key of collection.fields) {
+      if (input[key] !== undefined && input[key] !== null) row[key] = input[key];
+    }
+    collection.store.set(row.id, row);
+    return row;
+  }
+
+  function findByClientId(collection, clientId) {
+    if (!clientId) return null;
+    for (const row of collection.store.values()) {
+      if (row[collection.clientKey] === clientId) return row;
+    }
+    return null;
+  }
+
+  // batch-create is idempotent by client id: a retried batch must return the
+  // existing row instead of forking a duplicate.
+  function upsertRow(collection, input) {
+    const existing = findByClientId(collection, input[collection.clientKey]);
+    if (!existing) return insertRow(collection, input);
+    if (existing.deleted_at) return existing;
+    return applyWrite(collection, existing, input);
+  }
+
+  function requireLive(collection, id) {
+    const row = collection.store.get(id);
+    if (!row || row.deleted_at)
+      throw new HttpError(404, `${collection.prefix} not found`, "not_found");
+    return row;
+  }
+
+  function tombstone(collection, id) {
+    const row = collection.store.get(id);
+    if (!row) throw new HttpError(404, `${collection.prefix} not found`, "not_found");
+    const at = bump(row, clock());
+    row.deleted_at = at;
+    row.updated_at = at;
+    return row;
+  }
+
+  const noteCollection = {
+    store: notes,
+    fields: NOTE_FIELDS,
+    defaults: NOTE_DEFAULTS,
+    clientKey: "client_note_id",
+    prefix: "note",
+  };
+  const folderCollection = {
+    store: folders,
+    fields: FOLDER_FIELDS,
+    defaults: FOLDER_DEFAULTS,
+    clientKey: "client_folder_id",
+    prefix: "folder",
+  };
+
+  // Snapshot paging walks created_at backwards from `before` and hides
+  // tombstones; delta paging walks updated_at forwards from `since` and must
+  // carry tombstones, since that is how a delete reaches the other device.
+  function page(collection, query, orderKey) {
+    const limitRaw = Number(query.get("limit"));
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
+    const since = query.get("since");
+    const before = query.get("before");
+    let rows = [...collection.store.values()];
+
+    if (since) {
+      const bound = normalizeTimestamp(since);
+      rows = rows.filter((r) => normalizeTimestamp(r.updated_at) > bound);
+      rows.sort(
+        (a, b) =>
+          compare(normalizeTimestamp(a.updated_at), normalizeTimestamp(b.updated_at)) ||
+          compare(a.id, b.id)
+      );
+    } else {
+      rows = rows.filter((r) => !r.deleted_at);
+      if (before) {
+        const bound = normalizeTimestamp(before);
+        rows = rows.filter((r) => normalizeTimestamp(r[orderKey]) < bound);
+      }
+      rows.sort(
+        (a, b) =>
+          compare(normalizeTimestamp(b[orderKey]), normalizeTimestamp(a[orderKey])) ||
+          compare(b.id, a.id)
+      );
+    }
+
+    return rows.slice(0, limit).map((row) => structuredClone(row));
+  }
+
+  function handle(method, pathname, query, body) {
+    const route = `${method} ${pathname}`;
+    switch (route) {
+      case "POST /api/notes/create":
+        return upsertRow(noteCollection, body ?? {});
+      case "POST /api/notes/batch-create": {
+        const inputs = Array.isArray(body?.notes) ? body.notes : [];
+        return {
+          created: inputs.map((input) => {
+            const row = upsertRow(noteCollection, input);
+            return { client_note_id: row.client_note_id, id: row.id };
+          }),
+        };
+      }
+      case "PATCH /api/notes/update": {
+        const { id, ...updates } = body ?? {};
+        return applyWrite(noteCollection, requireLive(noteCollection, id), updates);
+      }
+      case "DELETE /api/notes/delete":
+        tombstone(noteCollection, body?.id);
+        return {};
+      case "DELETE /api/notes/delete-all": {
+        let deleted = 0;
+        for (const row of notes.values()) {
+          if (row.deleted_at) continue;
+          tombstone(noteCollection, row.id);
+          deleted += 1;
+        }
+        return { deleted };
+      }
+      case "GET /api/notes/list":
+        return { notes: page(noteCollection, query, "created_at") };
+      case "POST /api/notes/search":
+        return { notes: [] };
+
+      case "POST /api/folders/create":
+        return upsertRow(folderCollection, body ?? {});
+      case "POST /api/folders/batch-create": {
+        const inputs = Array.isArray(body?.folders) ? body.folders : [];
+        return { created: inputs.map((input) => upsertRow(folderCollection, input)) };
+      }
+      case "PATCH /api/folders/update": {
+        const { id, ...updates } = body ?? {};
+        return applyWrite(folderCollection, requireLive(folderCollection, id), updates);
+      }
+      case "DELETE /api/folders/delete":
+        tombstone(folderCollection, body?.id);
+        return {};
+      case "GET /api/folders/list": {
+        const since = query.get("since");
+        let rows = [...folders.values()];
+        if (since) {
+          const bound = normalizeTimestamp(since);
+          rows = rows.filter((r) => normalizeTimestamp(r.updated_at) > bound);
+        } else {
+          rows = rows.filter((r) => !r.deleted_at);
+        }
+        rows.sort((a, b) => a.sort_order - b.sort_order || compare(a.id, b.id));
+        return { folders: rows.map((row) => structuredClone(row)) };
+      }
+
+      // Not modelled: enough shape for a full pass, nothing more.
+      case "POST /api/conversations/create":
+        return { ...body, id: nextId("conv") };
+      case "PATCH /api/conversations/update":
+        return { ...body };
+      case "DELETE /api/conversations/delete":
+        return {};
+      case "GET /api/conversations/list":
+        return { conversations: [] };
+      case "POST /api/transcriptions/batch-create":
+        return {
+          created: (body?.transcriptions ?? []).map((t) => ({ ...t, id: nextId("trans") })),
+        };
+      case "POST /api/transcriptions/create":
+        return { ...body, id: nextId("trans") };
+      case "POST /api/transcriptions/batch-delete":
+        return { deleted: body?.ids ?? [] };
+      case "DELETE /api/transcriptions/delete":
+        return {};
+      case "GET /api/transcriptions/list":
+        return { transcriptions: [] };
+      case "GET /api/dictionary/list":
+        return { entries: [], hasMore: false };
+      case "POST /api/dictionary/batch-create":
+        return { created: [] };
+      case "GET /api/snippets/list":
+        return { entries: [], hasMore: false };
+      case "POST /api/snippets/batch-create":
+        return { created: [] };
+      default:
+        throw new HttpError(404, `fake cloud has no route for ${route}`, "no_route");
+    }
+  }
+
+  function toMatcher(matcher) {
+    if (typeof matcher === "function") return matcher;
+    const wanted = String(matcher);
+    return (call) =>
+      call.path.split("?")[0] === wanted || `${call.method} ${call.path.split("?")[0]}` === wanted;
+  }
+
+  function takeFailure(call) {
+    const index = failures.findIndex((entry) => entry.matcher(call));
+    if (index === -1) return null;
+    const entry = failures[index];
+    if (entry.once) failures.splice(index, 1);
+    return entry.failure;
+  }
+
+  async function request(opts) {
+    const method = String(opts?.method ?? "GET").toUpperCase();
+    const path = String(opts?.path ?? "");
+    const body = structuredClone(opts?.body ?? null);
+    const call = { method, path, body };
+    // The log keeps its own copy so a handler can never rewrite history.
+    log.push({ method, path, body: structuredClone(body) });
+
+    const failure = takeFailure(call);
+    if (failure) {
+      return {
+        success: false,
+        error: failure.error ?? "fake cloud failure",
+        status: failure.status ?? 500,
+        code: failure.code,
+      };
+    }
+
+    const [pathname, rawQuery] = path.split("?");
+    try {
+      const data = handle(method, pathname, new URLSearchParams(rawQuery ?? ""), body);
+      return { success: true, data: structuredClone(data) };
+    } catch (err) {
+      if (err instanceof HttpError) {
+        return { success: false, error: err.message, status: err.status, code: err.code };
+      }
+      throw err;
+    }
+  }
+
+  return {
+    request,
+    log,
+    logFor: (pathname) => log.filter((c) => c.path.split("?")[0] === pathname),
+    failNext: (matcher, failure = {}) =>
+      failures.push({ matcher: toMatcher(matcher), failure, once: true }),
+    failWith: (matcher, failure = {}) =>
+      failures.push({ matcher: toMatcher(matcher), failure, once: false }),
+    clearFailures: () => failures.splice(0, failures.length),
+    setClock: (fn) => {
+      clock = fn;
+    },
+    seedNote: (input) => structuredClone(insertRow(noteCollection, input)),
+    seedFolder: (input) => structuredClone(insertRow(folderCollection, input)),
+    notes: () => [...notes.values()].map((row) => structuredClone(row)),
+    folders: () => [...folders.values()].map((row) => structuredClone(row)),
+    note: (id) => {
+      const row = notes.get(id) ?? findByClientId(noteCollection, id);
+      return row ? structuredClone(row) : null;
+    },
+    folder: (id) => {
+      const row = folders.get(id) ?? findByClientId(folderCollection, id);
+      return row ? structuredClone(row) : null;
+    },
+    config: cfg,
+  };
+}
+
+module.exports = { createFakeCloud, normalizeTimestamp };

--- a/test/helpers/harness/fakeCloud.js
+++ b/test/helpers/harness/fakeCloud.js
@@ -227,12 +227,17 @@ function createFakeCloud(config = {}) {
     const limitRaw = Number(query.get("limit"));
     const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
     const since = query.get("since");
+    const sinceId = query.get("since_id");
     const before = query.get("before");
+    const beforeId = query.get("before_id");
     let rows = [...collection.store.values()];
 
     if (since) {
       const bound = normalizeTimestamp(since);
-      rows = rows.filter((r) => normalizeTimestamp(r.updated_at) > bound);
+      rows = rows.filter((r) => {
+        const timestampOrder = compare(normalizeTimestamp(r.updated_at), bound);
+        return timestampOrder > 0 || (timestampOrder === 0 && (!sinceId || r.id > sinceId));
+      });
       rows.sort(
         (a, b) =>
           compare(normalizeTimestamp(a.updated_at), normalizeTimestamp(b.updated_at)) ||
@@ -242,7 +247,10 @@ function createFakeCloud(config = {}) {
       rows = rows.filter((r) => !r.deleted_at);
       if (before) {
         const bound = normalizeTimestamp(before);
-        rows = rows.filter((r) => normalizeTimestamp(r[orderKey]) < bound);
+        rows = rows.filter((r) => {
+          const timestampOrder = compare(normalizeTimestamp(r[orderKey]), bound);
+          return timestampOrder < 0 || (timestampOrder === 0 && !!beforeId && r.id < beforeId);
+        });
       }
       rows.sort(
         (a, b) =>

--- a/test/helpers/harness/fakeCloud.js
+++ b/test/helpers/harness/fakeCloud.js
@@ -1,6 +1,7 @@
 // In-memory stand-in for the cloud API behind window.electronAPI.cloudApiRequest.
-// Notes and folders are modelled with the hardened server's real write rules;
-// the other entity types exist only so a full syncAll() pass can complete.
+// Notes and folders are modelled with the hardened server's real write rules,
+// conversations only on the read side; the other entity types exist only so a
+// full syncAll() pass can complete.
 //
 // Each hardening rule sits behind its own flag so a test can flip the server
 // back to the legacy behaviour and prove the client still does not lose data:
@@ -53,6 +54,10 @@ const NOTE_FIELDS = [
 
 const FOLDER_FIELDS = ["name", "is_default", "sort_order"];
 
+// Conversations are read-only here: only the pull is modelled, so `messages`
+// rides along as a plain stored field.
+const CONVERSATION_FIELDS = ["title", "archived_at", "messages"];
+
 const NOTE_DEFAULTS = {
   title: null,
   content: "",
@@ -72,6 +77,8 @@ const NOTE_DEFAULTS = {
 
 const FOLDER_DEFAULTS = { name: "", is_default: false, sort_order: 0 };
 
+const CONVERSATION_DEFAULTS = { title: "Untitled", archived_at: null, messages: [] };
+
 function createFakeCloud(config = {}) {
   const cfg = {
     materialPatchGate: true,
@@ -83,6 +90,7 @@ function createFakeCloud(config = {}) {
 
   const notes = new Map();
   const folders = new Map();
+  const conversations = new Map();
   const log = [];
   const failures = [];
   let seq = 0;
@@ -204,6 +212,13 @@ function createFakeCloud(config = {}) {
     clientKey: "client_folder_id",
     prefix: "folder",
   };
+  const conversationCollection = {
+    store: conversations,
+    fields: CONVERSATION_FIELDS,
+    defaults: CONVERSATION_DEFAULTS,
+    clientKey: "client_conversation_id",
+    prefix: "conv",
+  };
 
   // Snapshot paging walks created_at backwards from `before` and hides
   // tombstones; delta paging walks updated_at forwards from `since` and must
@@ -300,15 +315,27 @@ function createFakeCloud(config = {}) {
         return { folders: rows.map((row) => structuredClone(row)) };
       }
 
-      // Not modelled: enough shape for a full pass, nothing more.
+      // Conversation writes stay echo-stubs; only the read side is modelled,
+      // because the pull is what has to survive the ISO/SQLite format skew.
       case "POST /api/conversations/create":
         return { ...body, id: nextId("conv") };
       case "PATCH /api/conversations/update":
         return { ...body };
       case "DELETE /api/conversations/delete":
         return {};
-      case "GET /api/conversations/list":
-        return { conversations: [] };
+      case "GET /api/conversations/list": {
+        const rows = page(conversationCollection, query, "created_at");
+        // The client asks for include=messages; a page that stopped asking must
+        // not silently keep receiving them.
+        if (
+          !String(query.get("include") ?? "")
+            .split(",")
+            .includes("messages")
+        ) {
+          for (const row of rows) delete row.messages;
+        }
+        return { conversations: rows };
+      }
       case "POST /api/transcriptions/batch-create":
         return {
           created: (body?.transcriptions ?? []).map((t) => ({ ...t, id: nextId("trans") })),
@@ -393,14 +420,28 @@ function createFakeCloud(config = {}) {
     },
     seedNote: (input) => structuredClone(insertRow(noteCollection, input)),
     seedFolder: (input) => structuredClone(insertRow(folderCollection, input)),
+    // Conversation deletes are echo-stubs, so a tombstone has to be seeded here
+    // rather than produced by the DELETE route.
+    seedConversation: (input = {}) => {
+      const row = insertRow(conversationCollection, input);
+      // The defaults object is spread, not cloned, so every row needs its own array.
+      row.messages = structuredClone(input.messages ?? []);
+      if (input.deleted_at) row.deleted_at = toIso(input.deleted_at);
+      return structuredClone(row);
+    },
     notes: () => [...notes.values()].map((row) => structuredClone(row)),
     folders: () => [...folders.values()].map((row) => structuredClone(row)),
+    conversations: () => [...conversations.values()].map((row) => structuredClone(row)),
     note: (id) => {
       const row = notes.get(id) ?? findByClientId(noteCollection, id);
       return row ? structuredClone(row) : null;
     },
     folder: (id) => {
       const row = folders.get(id) ?? findByClientId(folderCollection, id);
+      return row ? structuredClone(row) : null;
+    },
+    conversation: (id) => {
+      const row = conversations.get(id) ?? findByClientId(conversationCollection, id);
       return row ? structuredClone(row) : null;
     },
     config: cfg,

--- a/test/helpers/harness/invariants.js
+++ b/test/helpers/harness/invariants.js
@@ -1,0 +1,64 @@
+const assert = require("node:assert/strict");
+
+// The single user-visible harm this suite exists to catch: a sync pass replacing
+// text the user actually has with nothing.
+const CONTENT_FIELDS = ["content", "transcript", "enhanced_content"];
+
+function normalizeTimestamp(value) {
+  if (!value) return "";
+  const iso = String(value).replace(" ", "T").replace(/Z$/, "");
+  return (/\.\d+$/.test(iso) ? iso : `${iso}.000`) + "Z";
+}
+
+function isEmpty(value) {
+  return value === null || value === undefined || value === "";
+}
+
+// Every note row, soft-deleted ones included: a delete that empties the row is
+// still a regression.
+function snapshotNotes(db) {
+  if (!db?.db) throw new TypeError("snapshotNotes requires a DatabaseManager");
+  return db.db.prepare("SELECT * FROM notes").all();
+}
+
+function indexByClientId(rows) {
+  const map = new Map();
+  for (const row of rows ?? []) {
+    if (row?.client_note_id) map.set(row.client_note_id, row);
+  }
+  return map;
+}
+
+// An erasure is excused only when the cloud legitimately won: its copy is
+// strictly newer than the local row we started from, it is not an empty shell,
+// and the value we ended up with is exactly what the cloud holds.
+function erasureExcused(cloudRow, before, after, field) {
+  if (!cloudRow) return false;
+  if (normalizeTimestamp(cloudRow.updated_at) <= normalizeTimestamp(before.updated_at))
+    return false;
+  if (!CONTENT_FIELDS.some((f) => !isEmpty(cloudRow[f]))) return false;
+  return (cloudRow[field] ?? null) === (after[field] ?? null);
+}
+
+function assertNoContentRegression(dbBefore, dbAfter, cloudTruth) {
+  const before = indexByClientId(dbBefore);
+  const cloud = indexByClientId(
+    cloudTruth instanceof Map ? [...cloudTruth.values()] : (cloudTruth ?? [])
+  );
+
+  for (const after of dbAfter ?? []) {
+    const prior = before.get(after.client_note_id);
+    if (!prior) continue;
+    for (const field of CONTENT_FIELDS) {
+      if (isEmpty(prior[field]) || !isEmpty(after[field])) continue;
+      if (erasureExcused(cloud.get(after.client_note_id), prior, after, field)) continue;
+      assert.fail(
+        `sync erased ${field} on note ${after.id} (client_note_id ${after.client_note_id}): ` +
+          `had ${JSON.stringify(String(prior[field]).slice(0, 60))}, now ${JSON.stringify(after[field])}` +
+          " — and no strictly-newer non-empty cloud copy explains it"
+      );
+    }
+  }
+}
+
+module.exports = { assertNoContentRegression, snapshotNotes, CONTENT_FIELDS };

--- a/test/helpers/harness/invariants.js
+++ b/test/helpers/harness/invariants.js
@@ -40,21 +40,35 @@ function erasureExcused(cloudRow, before, after, field) {
   return (cloudRow[field] ?? null) === (after[field] ?? null);
 }
 
+function deletionExcused(cloudRow, before) {
+  if (before.deleted_at) return true;
+  if (!cloudRow?.deleted_at) return false;
+  return normalizeTimestamp(cloudRow.deleted_at) >= normalizeTimestamp(before.updated_at);
+}
+
 function assertNoContentRegression(dbBefore, dbAfter, cloudTruth) {
   const before = indexByClientId(dbBefore);
+  const after = indexByClientId(dbAfter);
   const cloud = indexByClientId(
     cloudTruth instanceof Map ? [...cloudTruth.values()] : (cloudTruth ?? [])
   );
 
-  for (const after of dbAfter ?? []) {
-    const prior = before.get(after.client_note_id);
-    if (!prior) continue;
-    for (const field of CONTENT_FIELDS) {
-      if (isEmpty(prior[field]) || !isEmpty(after[field])) continue;
-      if (erasureExcused(cloud.get(after.client_note_id), prior, after, field)) continue;
+  for (const prior of before.values()) {
+    const current = after.get(prior.client_note_id);
+    if (!current) {
+      if (!CONTENT_FIELDS.some((field) => !isEmpty(prior[field]))) continue;
+      if (deletionExcused(cloud.get(prior.client_note_id), prior)) continue;
       assert.fail(
-        `sync erased ${field} on note ${after.id} (client_note_id ${after.client_note_id}): ` +
-          `had ${JSON.stringify(String(prior[field]).slice(0, 60))}, now ${JSON.stringify(after[field])}` +
+        `sync hard-deleted note ${prior.id} (client_note_id ${prior.client_note_id}) ` +
+          "without a matching cloud tombstone"
+      );
+    }
+    for (const field of CONTENT_FIELDS) {
+      if (isEmpty(prior[field]) || !isEmpty(current[field])) continue;
+      if (erasureExcused(cloud.get(current.client_note_id), prior, current, field)) continue;
+      assert.fail(
+        `sync erased ${field} on note ${current.id} (client_note_id ${current.client_note_id}): ` +
+          `had ${JSON.stringify(String(prior[field]).slice(0, 60))}, now ${JSON.stringify(current[field])}` +
           " — and no strictly-newer non-empty cloud copy explains it"
       );
     }

--- a/test/helpers/syncHarness.test.js
+++ b/test/helpers/syncHarness.test.js
@@ -1,0 +1,77 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createFakeCloud } = require("./harness/fakeCloud.js");
+const { assertNoContentRegression } = require("./harness/invariants.js");
+
+const T1 = "2026-07-20T10:00:00.000Z";
+const T2 = "2026-07-20T11:00:00.000Z";
+
+function note(overrides = {}) {
+  return {
+    id: "local-1",
+    client_note_id: "client-1",
+    content: "important text",
+    transcript: null,
+    enhanced_content: null,
+    deleted_at: null,
+    updated_at: T1,
+    ...overrides,
+  };
+}
+
+test("content invariant rejects a note that disappears without a cloud tombstone", () => {
+  assert.throws(
+    () => assertNoContentRegression([note()], [], []),
+    /sync hard-deleted note local-1/
+  );
+});
+
+test("content invariant allows a note removed by a current cloud tombstone", () => {
+  const tombstone = note({ id: "note-1", deleted_at: T2, updated_at: T2 });
+  assert.doesNotThrow(() => assertNoContentRegression([note()], [], [tombstone]));
+});
+
+test("fake cloud paginates tied timestamps with the composite cursor id", async () => {
+  const cloud = createFakeCloud();
+  for (let i = 1; i <= 51; i += 1) {
+    cloud.seedNote({
+      client_note_id: `client-${i}`,
+      content: `note ${i}`,
+      created_at: T1,
+      updated_at: T1,
+    });
+  }
+
+  const snapshotFirst = await cloud.request({
+    path: `/api/notes/list?limit=50&before=${encodeURIComponent(T2)}`,
+  });
+  assert.equal(snapshotFirst.success, true);
+  assert.equal(snapshotFirst.data.notes.length, 50);
+  const snapshotCursor = snapshotFirst.data.notes.at(-1);
+  const snapshotSecond = await cloud.request({
+    path:
+      `/api/notes/list?limit=50&before=${encodeURIComponent(snapshotCursor.created_at)}` +
+      `&before_id=${snapshotCursor.id}`,
+  });
+  assert.deepEqual(
+    snapshotSecond.data.notes.map((row) => row.id),
+    ["note-0001"]
+  );
+
+  const deltaFirst = await cloud.request({
+    path: `/api/notes/list?limit=50&since=${encodeURIComponent(T1)}` + "&since_id=note-0000",
+  });
+  assert.equal(deltaFirst.success, true);
+  assert.equal(deltaFirst.data.notes.length, 50);
+  const deltaCursor = deltaFirst.data.notes.at(-1);
+  const deltaSecond = await cloud.request({
+    path:
+      `/api/notes/list?limit=50&since=${encodeURIComponent(deltaCursor.updated_at)}` +
+      `&since_id=${deltaCursor.id}`,
+  });
+  assert.deepEqual(
+    deltaSecond.data.notes.map((row) => row.id),
+    ["note-0051"]
+  );
+});

--- a/test/helpers/syncScenarios.test.js
+++ b/test/helpers/syncScenarios.test.js
@@ -1,0 +1,785 @@
+// Whole-pass kill chains: the real SyncService drives the real service stack over
+// one real SQLite database per device, with the fake cloud as the only boundary.
+// Each scenario is a story a user could tell end to end, and every one of them
+// finishes on the content-regression invariant.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDb } = require("./harness/db.js");
+const {
+  installBrowserGlobals,
+  resetBrowserGlobals,
+  establishValidatedAuth,
+  stopSyncTimers,
+  localStorage: browserLocalStorage,
+  window: browserWindow,
+} = require("./harness/browserGlobals.js");
+const { createElectronApi } = require("./harness/electronApiBridge.js");
+const { createFakeCloud } = require("./harness/fakeCloud.js");
+const { assertNoContentRegression, snapshotNotes } = require("./harness/invariants.js");
+const { SyncService } = require("../../src/services/SyncService.ts");
+
+installBrowserGlobals();
+
+// Mirrors BATCH_SIZE in SyncService.ts.
+const BATCH_SIZE = 50;
+const CAN_SYNC = { isSignedIn: "true", cloudBackupEnabled: "true", isSubscribed: "true" };
+
+// SQLite's datetime() shape, which is what local rows actually carry. Every
+// timestamp in this file is pinned by SQL; nothing here waits or fakes a clock.
+const T_SHELL = "2026-07-20 10:00:00";
+const T_TRANSCRIPT = "2026-07-20 11:00:00";
+const T_PEER = "2026-07-20 13:00:00";
+const T_FUTURE = "2027-01-01 00:00:00";
+
+// S2 keeps its sync cursors across every relaunch, so its edits have to be newer
+// than the wall-clock stamp a completed pass leaves behind, as real edits are.
+const F_SHELL = "2027-03-01 10:00:00";
+const F_TITLE = "2027-03-01 10:30:00";
+const F_TRANSCRIPT = "2027-03-01 11:00:00";
+
+function iso(sqliteTimestamp) {
+  return `${sqliteTimestamp.replace(" ", "T")}.000Z`;
+}
+
+function shift(isoString, hours) {
+  return new Date(Date.parse(isoString) + hours * 3600_000).toISOString();
+}
+
+function queryParam(path, name) {
+  const [, query] = path.split("?");
+  return new URLSearchParams(query ?? "").get(name);
+}
+
+function silenceConsoleErrors(t) {
+  t.mock.method(console, "error", () => {});
+}
+
+// The incident's payload was a real meeting transcript, not a token string; a
+// small body would not exercise the same batch and clone paths.
+function largeBody(label) {
+  return `${label} speaker turn long enough to make the payload realistic. `.repeat(1000);
+}
+
+function readStorage() {
+  const values = {};
+  for (let i = 0; i < browserLocalStorage.length; i += 1) {
+    const key = browserLocalStorage.key(i);
+    values[key] = browserLocalStorage.getItem(key);
+  }
+  return values;
+}
+
+function writeStorage(values) {
+  browserLocalStorage.clear();
+  for (const [key, value] of Object.entries(values)) browserLocalStorage.setItem(key, value);
+}
+
+function freshCloud(config) {
+  resetBrowserGlobals();
+  return createFakeCloud(config);
+}
+
+// One machine: its own SQLite file and its own localStorage, sharing the cloud.
+// Devices never see each other's cursors, which is the whole point of S2.
+function createDevice(t, cloud) {
+  const db = createDb(t);
+  if (!db) return null;
+  return { db, api: createElectronApi(db, { cloud }), storage: { ...CAN_SYNC } };
+}
+
+// One app launch: the device's stored localStorage comes back, its IPC surface is
+// installed, and a brand new SyncService runs against them.
+async function launch(device, body) {
+  writeStorage(device.storage);
+  browserWindow.electronAPI = device.api;
+  // Every launch re-validates the session, exactly as the renderer does.
+  await establishValidatedAuth();
+  const service = new SyncService();
+  try {
+    return await body(service);
+  } finally {
+    stopSyncTimers(service);
+    device.storage = readStorage();
+  }
+}
+
+function syncOnce(device) {
+  return launch(device, (service) => service.syncAll(true));
+}
+
+// A relaunch onto a wiped profile: the database survives, every sync cursor is
+// gone, so the next pull starts from the full snapshot again.
+function wipeCursors(device) {
+  device.storage = { ...CAN_SYNC };
+}
+
+function setNoteRow(db, id, columns) {
+  const keys = Object.keys(columns);
+  db.db
+    .prepare(`UPDATE notes SET ${keys.map((k) => `${k} = ?`).join(", ")} WHERE id = ?`)
+    .run(...keys.map((k) => columns[k]), id);
+  return db.getNote(id);
+}
+
+function noteByClientId(db, clientNoteId) {
+  return db.db.prepare("SELECT * FROM notes WHERE client_note_id = ?").get(clientNoteId) ?? null;
+}
+
+function noteCount(db) {
+  return db.db.prepare("SELECT COUNT(*) AS c FROM notes").get().c;
+}
+
+function folderByName(db, name) {
+  return db.db.prepare("SELECT * FROM folders WHERE name = ?").get(name) ?? null;
+}
+
+// A local row already bound to a cloud note, exactly as an earlier pull left it.
+function linkLocalNote(db, cloudRow, title, content) {
+  const local = db.saveNote(title, content, "personal").note;
+  return setNoteRow(db, local.id, {
+    client_note_id: cloudRow.client_note_id,
+    cloud_id: cloudRow.id,
+    sync_status: "synced",
+    created_at: cloudRow.created_at,
+    updated_at: cloudRow.updated_at,
+  });
+}
+
+test("S1 a meeting shell that gains a large transcript survives a relaunch and reaches the cloud", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  // Byte-faithful to meetingDetectionEngine.js: saveNote(eventSummary, "", "meeting").
+  const eventSummary = "Weekly Product Sync";
+  const shell = db.saveNote(eventSummary, "", "meeting").note;
+  setNoteRow(db, shell.id, { created_at: T_SHELL, updated_at: T_SHELL });
+
+  await syncOnce(device);
+
+  const cloudId = db.getNote(shell.id).cloud_id;
+  assert.ok(cloudId, "the shell must reach the cloud on the first pass");
+  assert.equal(cloud.note(cloudId).content, "", "the shell goes up empty, because it is empty");
+
+  // Transcription lands after the shell was already synced, so the row is pending
+  // again while carrying a cloud_id. That combination is the migration shape.
+  const content = largeBody("cleaned");
+  const transcript = largeBody("raw");
+  assert.ok(content.length > 60000, "the payload must be the incident's size");
+  db.updateNote(shell.id, { content, transcript });
+  setNoteRow(db, shell.id, { updated_at: T_TRANSCRIPT });
+  assert.equal(db.getNote(shell.id).sync_status, "pending");
+
+  const before = snapshotNotes(db);
+  wipeCursors(device);
+  await launch(device, async (service) => {
+    await service.syncAll(true);
+    await service.syncAll(true);
+  });
+
+  const row = db.getNote(shell.id);
+  assert.equal(row.content, content, "the local body must survive the relaunch untouched");
+  assert.equal(row.transcript, transcript);
+  assert.equal(row.title, eventSummary);
+  assert.equal(row.sync_status, "synced");
+  assert.equal(row.cloud_id, cloudId, "the note keeps its cloud identity across the relaunch");
+
+  const remote = cloud.note(cloudId);
+  assert.equal(remote.content, content, "the cloud must end up holding the transcript");
+  assert.equal(remote.transcript, transcript);
+  assert.equal(cloud.notes().length, 1, "two passes must not fork a second cloud note");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S1 the same migration holds the line on a legacy cloud with a stale peer overwriting it", async (t) => {
+  const cloud = freshCloud({
+    materialPatchGate: false,
+    coalesceOnConflict: false,
+    staleWriteGuard: false,
+    updatedAtClamp: false,
+  });
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const shell = db.saveNote("Weekly Product Sync", "", "meeting").note;
+  setNoteRow(db, shell.id, { created_at: T_SHELL, updated_at: T_SHELL });
+  await syncOnce(device);
+  const cloudId = db.getNote(shell.id).cloud_id;
+  assert.ok(cloudId);
+
+  const content = largeBody("cleaned");
+  const transcript = largeBody("raw");
+  db.updateNote(shell.id, { content, transcript });
+  setNoteRow(db, shell.id, { updated_at: T_TRANSCRIPT });
+
+  wipeCursors(device);
+  await syncOnce(device);
+
+  assert.equal(
+    cloud.note(cloudId).content,
+    content,
+    "the client's full-content PATCH must not depend on the server's no-op gate"
+  );
+
+  // A second device still on the pre-fix build pushes its own copy of the shell:
+  // empty, and on a legacy server that write lands and wins the timestamp.
+  const peer = await cloud.request({
+    method: "PATCH",
+    path: "/api/notes/update",
+    body: { id: cloudId, content: "", transcript: null, updated_at: iso(T_PEER) },
+  });
+  assert.equal(peer.success, true);
+  assert.equal(cloud.note(cloudId).content, "", "the legacy server accepted the empty overwrite");
+
+  const before = snapshotNotes(db);
+  wipeCursors(device);
+  await syncOnce(device);
+
+  const row = db.getNote(shell.id);
+  assert.equal(
+    row.content,
+    content,
+    "a strictly newer but empty cloud copy must never replace local text"
+  );
+  assert.equal(
+    row.transcript,
+    transcript,
+    "an absent cloud transcript must not blank the local one"
+  );
+  assert.equal(row.updated_at, iso(T_PEER), "the row still accepts the newer copy's timestamp");
+  assert.equal(row.sync_status, "synced");
+  // The cloud copy stays lost here: recovering it is what the server-side
+  // hardening is for, and the desktop's job is to keep the user's text.
+  assert.equal(cloud.note(cloudId).content, "");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S2 two devices: an older empty shell never destroys the transcript and the clash surfaces as a conflict", async (t) => {
+  const cloud = freshCloud();
+  const deviceA = createDevice(t, cloud);
+  if (!deviceA) return;
+  const deviceB = createDevice(t, cloud);
+  if (!deviceB) return;
+
+  const shell = deviceA.db.saveNote("Weekly Product Sync", "", "meeting").note;
+  setNoteRow(deviceA.db, shell.id, { created_at: F_SHELL, updated_at: F_SHELL });
+  await syncOnce(deviceA);
+  const clientNoteId = deviceA.db.getNote(shell.id).client_note_id;
+  const cloudId = deviceA.db.getNote(shell.id).cloud_id;
+
+  await syncOnce(deviceB);
+  const pulled = noteByClientId(deviceB.db, clientNoteId);
+  assert.ok(pulled, "device B must receive the shell through the cloud");
+  assert.equal(pulled.content, "");
+  assert.equal(pulled.cloud_id, cloudId);
+
+  // B does the recording, so B is the device that actually holds the transcript.
+  const content = largeBody("device B cleaned");
+  deviceB.db.updateNote(pulled.id, { content });
+  setNoteRow(deviceB.db, pulled.id, { updated_at: F_TRANSCRIPT });
+  await syncOnce(deviceB);
+  assert.equal(cloud.note(cloudId).content, content, "B's transcript must reach the cloud");
+
+  // Meanwhile A, still holding the empty shell, renames it. That re-queues A's row
+  // as pending with no content and a basis older than B's upload.
+  deviceA.db.updateNote(shell.id, { title: "Weekly Product Sync (rescheduled)" });
+  setNoteRow(deviceA.db, shell.id, { updated_at: F_TITLE });
+
+  const beforeA = snapshotNotes(deviceA.db);
+  const mark = cloud.log.length;
+  await syncOnce(deviceA);
+
+  const patches = cloud.log
+    .slice(mark)
+    .filter((c) => c.method === "PATCH" && c.path === "/api/notes/update");
+  assert.equal(patches.length, 1, "A must attempt exactly one push for its stale shell");
+  assert.equal(patches[0].body.content, "", "A really did offer an empty body");
+  assert.equal(
+    patches[0].body.updated_at,
+    F_TITLE,
+    "the push must carry A's own older basis, or nothing can reject it as stale"
+  );
+
+  assert.equal(cloud.note(cloudId).content, content, "B's transcript must still be in the cloud");
+  // A's unpushed rename collided with B's newer cloud copy: the pass surfaces a
+  // conflict and leaves both sides intact until the user picks Keep or Refresh,
+  // instead of silently electing a winner.
+  const rowA = deviceA.db.getNote(shell.id);
+  assert.equal(rowA.content, "", "A's local row is not silently overwritten");
+  assert.equal(rowA.title, "Weekly Product Sync (rescheduled)", "A keeps its unpushed rename");
+  assert.notEqual(rowA.sync_status, "synced", "the row must not settle while the conflict is open");
+  const conflicts = JSON.parse(deviceA.storage["noteConflicts.clientIds"] ?? "{}");
+  assert.ok(conflicts[clientNoteId], "the conflict must be surfaced for this note");
+  assert.equal(
+    conflicts[clientNoteId].content,
+    content,
+    "the registry holds B's cloud copy for the Refresh choice"
+  );
+
+  // The conflicted row is gated from later pushes, so A can never clobber B.
+  const mark2 = cloud.log.length;
+  await syncOnce(deviceA);
+  assert.equal(
+    cloud.log
+      .slice(mark2)
+      .filter((c) => c.method === "PATCH" && c.path === "/api/notes/update").length,
+    0,
+    "a conflicted row must not be re-pushed before the user resolves it"
+  );
+  assert.equal(cloud.note(cloudId).content, content);
+
+  const beforeB = snapshotNotes(deviceB.db);
+  await syncOnce(deviceB);
+  assert.equal(noteByClientId(deviceB.db, clientNoteId).content, content, "B keeps its own text");
+
+  assertNoContentRegression(beforeA, snapshotNotes(deviceA.db), cloud.notes());
+  assertNoContentRegression(beforeB, snapshotNotes(deviceB.db), cloud.notes());
+});
+
+test("S3 a delete travels to the cloud and back down to the other device", async (t) => {
+  const cloud = freshCloud();
+  const deviceA = createDevice(t, cloud);
+  if (!deviceA) return;
+  const deviceB = createDevice(t, cloud);
+  if (!deviceB) return;
+
+  const note = deviceA.db.saveNote("Shared note", "shared body", "personal").note;
+  setNoteRow(deviceA.db, note.id, { created_at: T_SHELL, updated_at: T_SHELL });
+  await syncOnce(deviceA);
+  const clientNoteId = deviceA.db.getNote(note.id).client_note_id;
+  const cloudId = deviceA.db.getNote(note.id).cloud_id;
+
+  await syncOnce(deviceB);
+  assert.ok(noteByClientId(deviceB.db, clientNoteId), "B must have the note before it is deleted");
+  const bCursor = deviceB.storage["lastSyncedAt.notes"];
+  assert.ok(bCursor, "B's first pass must leave a delta cursor");
+
+  // The server stamps the tombstone; wall-clock would land in B's cursor
+  // millisecond and the delta page would then hide it.
+  cloud.setClock(() => shift(bCursor, 1));
+  deviceA.db.deleteNote(note.id);
+  const beforeA = snapshotNotes(deviceA.db);
+  await syncOnce(deviceA);
+
+  const deletes = cloud.logFor("/api/notes/delete");
+  assert.equal(deletes.length, 1, "the delete must reach the cloud exactly once");
+  assert.deepEqual(deletes[0].body, { id: cloudId });
+  assert.equal(deviceA.db.getNote(note.id), null, "A drops the row only after the cloud ack");
+  assert.ok(cloud.note(cloudId).deleted_at, "the cloud row must be tombstoned");
+
+  const beforeB = snapshotNotes(deviceB.db);
+  const mark = cloud.log.length;
+  await syncOnce(deviceB);
+
+  const lists = cloud.log.slice(mark).filter((c) => c.path.split("?")[0] === "/api/notes/list");
+  assert.equal(
+    queryParam(lists[0].path, "since"),
+    bCursor,
+    "only the delta page carries tombstones, so B must send its cursor"
+  );
+  assert.equal(noteByClientId(deviceB.db, clientNoteId), null, "the delete must reach B");
+  assert.equal(noteCount(deviceB.db), 0);
+
+  assertNoContentRegression(beforeA, snapshotNotes(deviceA.db), cloud.notes());
+  assertNoContentRegression(beforeB, snapshotNotes(deviceB.db), cloud.notes());
+});
+
+test("S3 a delete racing an unsynced edit is won by the cloud tombstone", async (t) => {
+  const cloud = freshCloud();
+  const deviceA = createDevice(t, cloud);
+  if (!deviceA) return;
+  const deviceB = createDevice(t, cloud);
+  if (!deviceB) return;
+
+  const note = deviceA.db.saveNote("Contested note", "original body", "personal").note;
+  setNoteRow(deviceA.db, note.id, { created_at: T_SHELL, updated_at: T_SHELL });
+  await syncOnce(deviceA);
+  const clientNoteId = deviceA.db.getNote(note.id).client_note_id;
+  const cloudId = deviceA.db.getNote(note.id).cloud_id;
+
+  await syncOnce(deviceB);
+  const onB = noteByClientId(deviceB.db, clientNoteId);
+  assert.ok(onB);
+  const bCursor = deviceB.storage["lastSyncedAt.notes"];
+
+  // B edits while offline; A deletes and gets to the cloud first.
+  deviceB.db.updateNote(onB.id, { content: "B's late edit that never shipped" });
+  setNoteRow(deviceB.db, onB.id, { updated_at: T_TRANSCRIPT });
+
+  cloud.setClock(() => shift(bCursor, 1));
+  deviceA.db.deleteNote(note.id);
+  await syncOnce(deviceA);
+  assert.ok(cloud.note(cloudId).deleted_at);
+
+  const beforeB = snapshotNotes(deviceB.db);
+  const mark = cloud.log.length;
+  await syncOnce(deviceB);
+
+  const patches = cloud.log
+    .slice(mark)
+    .filter((c) => c.method === "PATCH" && c.path === "/api/notes/update");
+  assert.equal(patches.length, 1, "B still tries to push its edit onto the tombstoned row");
+  assert.equal(patches[0].body.content, "B's late edit that never shipped");
+
+  // Documented current behaviour, not a preference: the tombstone wins and the
+  // edit that never reached the cloud is destroyed.
+  assert.equal(noteByClientId(deviceB.db, clientNoteId), null, "the tombstone removes B's row");
+  assert.equal(noteCount(deviceB.db), 0);
+  assert.ok(cloud.note(cloudId).deleted_at, "the cloud row stays deleted");
+
+  assertNoContentRegression(beforeB, snapshotNotes(deviceB.db), cloud.notes());
+});
+
+test("S4 a quit before the push loses nothing and the next launch uploads the note", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const note = db.saveNote(
+    "Recorded then quit",
+    "body written just before the quit",
+    "personal"
+  ).note;
+  setNoteRow(db, note.id, { created_at: T_SHELL, updated_at: T_SHELL });
+  assert.equal(cloud.log.length, 0, "the quit happened before any request went out");
+
+  const before = snapshotNotes(db);
+  wipeCursors(device);
+  await syncOnce(device);
+
+  const row = db.getNote(note.id);
+  assert.equal(row.sync_status, "synced", "the pending row must be picked up on the next launch");
+  assert.ok(row.cloud_id);
+  assert.equal(cloud.note(row.cloud_id).content, "body written just before the quit");
+
+  await syncOnce(device);
+  assert.equal(cloud.notes().length, 1, "a second launch must not upload the note again");
+  assert.equal(cloud.logFor("/api/notes/batch-create").length, 1, "and must not re-push it");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S4 a quit between the cloud ack and the local mark does not fork a duplicate", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const note = db.saveNote("Acked but unmarked", "body the cloud already has", "personal").note;
+  setNoteRow(db, note.id, { created_at: T_SHELL, updated_at: T_SHELL });
+
+  // The crash window: the cloud accepted the batch, then the process died before
+  // markNoteSynced ran, so the row is still pending with no cloud_id.
+  const pending = db.getPendingNotes();
+  assert.equal(pending.length, 1);
+  const acked = await cloud.request({
+    method: "POST",
+    path: "/api/notes/batch-create",
+    body: {
+      notes: [
+        {
+          client_note_id: pending[0].client_note_id,
+          title: pending[0].title,
+          content: pending[0].content,
+          created_at: pending[0].created_at,
+          updated_at: pending[0].updated_at,
+        },
+      ],
+    },
+  });
+  const orphanCloudId = acked.data.created[0].id;
+  assert.equal(db.getNote(note.id).cloud_id, null);
+
+  const before = snapshotNotes(db);
+  wipeCursors(device);
+  await syncOnce(device);
+
+  assert.equal(cloud.notes().length, 1, "the retry must re-use the stable client id, not fork");
+  const row = db.getNote(note.id);
+  assert.equal(
+    row.cloud_id,
+    orphanCloudId,
+    "the local row must adopt the already-created cloud row"
+  );
+  assert.equal(row.sync_status, "synced");
+  assert.equal(row.content, "body the cloud already has");
+  assert.equal(noteCount(db), 1, "the pull must not insert a second local copy either");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S4 a 500 mid-batch leaves error rows that the next pass retries on its own", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  for (let i = 0; i < BATCH_SIZE + 3; i += 1) {
+    const saved = db.saveNote(`Note ${i}`, `body ${i}`, "personal").note;
+    setNoteRow(db, saved.id, { created_at: T_SHELL, updated_at: T_SHELL });
+  }
+  const doomed = db.getPendingNotes().slice(BATCH_SIZE);
+  assert.equal(doomed.length, 3);
+
+  // Only the trailing chunk is short, so this fires on the second request alone.
+  cloud.failNext(
+    (call) => call.path === "/api/notes/batch-create" && call.body?.notes?.length === 3,
+    { status: 500, error: "chunk rejected" }
+  );
+
+  const before = snapshotNotes(db);
+  await syncOnce(device);
+
+  for (const note of doomed) {
+    assert.equal(db.getNote(note.id).sync_status, "error");
+  }
+  assert.equal(cloud.notes().length, BATCH_SIZE, "only the healthy chunk landed");
+
+  // Errored rows are pushable again on the very next pass: the retry needs no
+  // re-edit, and its chunk carries exactly the rows that failed.
+  await syncOnce(device);
+
+  const batches = cloud.logFor("/api/notes/batch-create");
+  assert.equal(batches.length, 3, "the next pass must retry the failed chunk");
+  assert.equal(batches[2].body.notes.length, 3, "only the errored rows go out again");
+  for (const note of doomed) {
+    const row = db.getNote(note.id);
+    assert.equal(row.sync_status, "synced", "a clean retry settles the row");
+    assert.ok(row.cloud_id, "the retried row gains its cloud identity");
+    assert.equal(row.content, note.content, "the local body survives the error round-trip");
+  }
+  assert.equal(cloud.notes().length, BATCH_SIZE + 3, "every note reaches the cloud in the end");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S5 a snapshot pull of exactly BATCH_SIZE notes still asks for the page after it", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const base = Date.parse("2026-07-20T08:00:00.000Z");
+  const seeded = [];
+  for (let i = 0; i < BATCH_SIZE; i += 1) {
+    const at = new Date(base + i * 60000).toISOString();
+    seeded.push(
+      cloud.seedNote({
+        client_note_id: `cn-${String(i).padStart(3, "0")}`,
+        title: `Cloud note ${i}`,
+        content: `cloud body ${i}`,
+        created_at: at,
+        updated_at: at,
+      })
+    );
+  }
+
+  const before = snapshotNotes(db);
+  await syncOnce(device);
+
+  const lists = cloud.logFor("/api/notes/list");
+  assert.equal(
+    lists.length,
+    2,
+    "a full last page is indistinguishable from a full middle one, so the pull must probe again"
+  );
+  assert.equal(queryParam(lists[0].path, "before"), null);
+  assert.equal(
+    queryParam(lists[1].path, "before"),
+    seeded[0].created_at,
+    "the probe must carry the oldest row of the full page as its cursor"
+  );
+
+  assert.equal(noteCount(db), BATCH_SIZE, "every seeded note must be applied exactly once");
+  assert.equal(noteByClientId(db, "cn-000").content, "cloud body 0");
+  assert.equal(noteByClientId(db, "cn-049").content, "cloud body 49");
+  assert.ok(device.storage["lastSyncedAt.notes"], "a clean pull stamps the cursor");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S5 a tombstone as the last row of a delta page still hands the next page a cursor", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const cursor = "2026-07-20T07:00:00.000Z";
+  const base = Date.parse("2026-07-20T08:00:00.000Z");
+  const seeded = [];
+  for (let i = 0; i < BATCH_SIZE + 10; i += 1) {
+    const at = new Date(base + i * 60000).toISOString();
+    seeded.push(
+      cloud.seedNote({
+        client_note_id: `cn-${String(i).padStart(3, "0")}`,
+        title: `Cloud note ${i}`,
+        content: `cloud body ${i}`,
+        created_at: at,
+        updated_at: at,
+      })
+    );
+  }
+
+  const boundary = seeded[BATCH_SIZE - 1];
+  const local = linkLocalNote(db, boundary, "Boundary note", "local boundary body");
+  // Pinning the server clock to the row's own stamp keeps the tombstone in the
+  // last slot of page one instead of sorting it to the end of the delta.
+  cloud.setClock(() => boundary.updated_at);
+  await cloud.request({ method: "DELETE", path: "/api/notes/delete", body: { id: boundary.id } });
+  cloud.setClock(() => new Date().toISOString());
+
+  device.storage["lastSyncedAt.notes"] = cursor;
+  const before = snapshotNotes(db);
+  await syncOnce(device);
+
+  const lists = cloud.logFor("/api/notes/list");
+  assert.equal(lists.length, 2, "60 delta rows at a page size of 50 must take two requests");
+  assert.equal(queryParam(lists[0].path, "since"), cursor);
+  assert.equal(
+    queryParam(lists[1].path, "since"),
+    boundary.updated_at,
+    "a tombstone in the last slot must still supply the next cursor"
+  );
+
+  assert.equal(db.getNote(local.id), null, "the boundary tombstone must delete the local row");
+  assert.equal(
+    noteByClientId(db, "cn-059").content,
+    "cloud body 59",
+    "the page after the tombstone must still be applied"
+  );
+  assert.equal(noteCount(db), BATCH_SIZE + 9, "every row but the tombstoned one must be local");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+// A full delta page whose rows all carry the cursor's own updated_at trips the
+// stall guard in pullNotes and silently skips everything past that page.
+test.todo("S5 a full delta page tied on updated_at must not abandon the rest of the pull");
+
+test("S6 a fresh device adopts the cloud's default folders and both note directions land in them", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+
+  const cloudPersonal = cloud.seedFolder({
+    client_folder_id: "cf-personal",
+    name: "Personal",
+    is_default: true,
+    sort_order: 0,
+  });
+  const cloudMeetings = cloud.seedFolder({
+    client_folder_id: "cf-meetings",
+    name: "Meetings",
+    is_default: true,
+    sort_order: 1,
+  });
+  cloud.seedNote({
+    client_note_id: "cn-remote",
+    title: "Meeting from the other device",
+    content: "remote meeting body",
+    folder_id: cloudMeetings.id,
+    created_at: iso(T_SHELL),
+    updated_at: iso(T_SHELL),
+  });
+
+  const localMeeting = db.saveNote(
+    "Meeting from this device",
+    "local meeting body",
+    "meeting"
+  ).note;
+  setNoteRow(db, localMeeting.id, { created_at: T_SHELL, updated_at: T_SHELL });
+
+  const before = snapshotNotes(db);
+  await syncOnce(device);
+
+  const meetings = folderByName(db, "Meetings");
+  assert.equal(
+    meetings.cloud_id,
+    cloudMeetings.id,
+    "the local default must adopt the cloud folder"
+  );
+  assert.equal(meetings.client_folder_id, "cf-meetings");
+  assert.equal(folderByName(db, "Personal").cloud_id, cloudPersonal.id);
+  assert.equal(
+    cloud.folders().filter((f) => f.name === "Meetings").length,
+    1,
+    "adoption exists so a second device never forks a duplicate folder"
+  );
+
+  const [batch] = cloud.logFor("/api/notes/batch-create");
+  assert.equal(
+    batch.body.notes[0].folder_id,
+    cloudMeetings.id,
+    "the pushed note must carry the adopted cloud folder id, never the local integer"
+  );
+  assert.notEqual(batch.body.notes[0].folder_id, meetings.id);
+  assert.equal(
+    noteByClientId(db, "cn-remote").folder_id,
+    meetings.id,
+    "the pulled note must map back onto the same local folder"
+  );
+  assert.equal(noteByClientId(db, localMeeting.client_note_id).folder_id, meetings.id);
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("S6 a note in a never-synced folder pushes without one and re-pushes once the folder is mapped", async (t) => {
+  const cloud = freshCloud();
+  const device = createDevice(t, cloud);
+  if (!device) return;
+  const { db } = device;
+  silenceConsoleErrors(t);
+
+  cloud.failWith("POST /api/folders/batch-create", { status: 500, error: "folder push down" });
+  const folder = db.createFolder("Field Notes").folder;
+  const note = db.saveNote("Interview", "interview body", "personal", null, null, folder.id).note;
+  setNoteRow(db, note.id, { created_at: T_SHELL, updated_at: T_SHELL });
+
+  const before = snapshotNotes(db);
+  await syncOnce(device);
+
+  const [batch] = cloud.logFor("/api/notes/batch-create");
+  assert.equal(
+    batch.body.notes[0].folder_id,
+    null,
+    "an unmapped folder must null the reference, never leak the local integer id"
+  );
+  const cloudId = db.getNote(note.id).cloud_id;
+  assert.ok(cloudId, "the note must reach the cloud even with its folder stuck");
+  assert.equal(cloud.note(cloudId).folder_id, null);
+  assert.equal(db.db.prepare("SELECT * FROM folders WHERE id = ?").get(folder.id).cloud_id, null);
+
+  // The folder push recovers, and the next edit is what carries the mapping up.
+  cloud.clearFailures();
+  db.updateNote(note.id, { content: "interview body, second draft" });
+  setNoteRow(db, note.id, { updated_at: T_FUTURE });
+  const mark = cloud.log.length;
+  await syncOnce(device);
+
+  const folderCloudId = db.db.prepare("SELECT * FROM folders WHERE id = ?").get(folder.id).cloud_id;
+  assert.ok(folderCloudId, "the retried folder push must land");
+
+  const patches = cloud.log
+    .slice(mark)
+    .filter((c) => c.method === "PATCH" && c.path === "/api/notes/update");
+  assert.equal(patches.length, 1);
+  assert.equal(
+    patches[0].body.folder_id,
+    folderCloudId,
+    "once the folder is mapped the note must be filed under it in the cloud"
+  );
+  assert.equal(patches[0].body.content, "interview body, second draft");
+  assert.equal(cloud.note(cloudId).folder_id, folderCloudId);
+  assert.equal(cloud.note(cloudId).content, "interview body, second draft");
+  assert.equal(db.getNote(note.id).sync_status, "synced");
+
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});

--- a/test/helpers/syncServiceConversations.test.js
+++ b/test/helpers/syncServiceConversations.test.js
@@ -1,0 +1,171 @@
+// Conversation half of SyncService: the real service drives the real
+// ConversationsService/cloudApi stack over a real DatabaseManager, with only the
+// HTTP boundary faked. The pull gate is the target — local rows carry SQLite's
+// "YYYY-MM-DD HH:MM:SS" while the cloud answers in ISO, and on the same UTC day
+// a raw string compare hands every cloud copy the win.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDb } = require("./harness/db.js");
+const {
+  installBrowserGlobals,
+  resetBrowserGlobals,
+  enableSync,
+  establishValidatedAuth,
+  stopSyncTimers,
+  localStorage: localStorageStub,
+  window: windowStub,
+} = require("./harness/browserGlobals.js");
+const { createElectronApi } = require("./harness/electronApiBridge.js");
+const { createFakeCloud } = require("./harness/fakeCloud.js");
+const { SyncService } = require("../../src/services/SyncService.ts");
+
+// SQLite's datetime() format, the one local rows actually carry.
+const LOCAL_EARLY = "2026-07-20 10:00:00";
+
+async function setup(t) {
+  const db = createDb(t);
+  if (!db) return null;
+  resetBrowserGlobals();
+  installBrowserGlobals();
+  enableSync();
+  const cloud = createFakeCloud();
+  const api = createElectronApi(db, { cloud });
+  windowStub.electronAPI = api;
+  await establishValidatedAuth();
+  const service = new SyncService();
+  t.after(() => stopSyncTimers(service));
+  return { db, cloud, api, service };
+}
+
+// Deterministic timestamps come from SQL, never from a fake clock.
+function updateConversation(db, id, fields) {
+  const keys = Object.keys(fields);
+  db.db
+    .prepare(
+      `UPDATE agent_conversations SET ${keys.map((k) => `${k} = ?`).join(", ")} WHERE id = ?`
+    )
+    .run(...keys.map((k) => fields[k]), id);
+  return db.getAgentConversation(id);
+}
+
+function messageCount(db) {
+  return db.db.prepare("SELECT COUNT(*) AS c FROM agent_messages").get().c;
+}
+
+function queryParam(path, name) {
+  const [, query] = path.split("?");
+  return new URLSearchParams(query ?? "").get(name);
+}
+
+test("pullConversations applies a strictly newer cloud copy and rejects older and tied ones", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  // All three cloud copies sit on the same UTC day as the local rows, where a
+  // raw string compare wrongly elects the cloud value ('T' > ' ' at index 10).
+  const cases = [
+    { key: "older", cloudUpdatedAt: "2026-07-20T09:00:00.000Z", applied: false },
+    { key: "newer", cloudUpdatedAt: "2026-07-20T11:00:00.000Z", applied: true },
+    { key: "tied", cloudUpdatedAt: "2026-07-20T10:00:00.000Z", applied: false },
+  ];
+
+  for (const c of cases) {
+    const cloudRow = cloud.seedConversation({
+      client_conversation_id: `client-${c.key}`,
+      title: `Cloud ${c.key}`,
+      created_at: "2026-07-20T08:00:00.000Z",
+      updated_at: c.cloudUpdatedAt,
+      messages: [
+        { role: "user", content: `cloud message ${c.key}`, created_at: "2026-07-20T08:30:00.000Z" },
+      ],
+    });
+    const local = db.createAgentConversation(`Local ${c.key}`);
+    db.addAgentMessage(local.id, "user", `local message ${c.key}`);
+    // Set updated_at last: addAgentMessage bumps it to CURRENT_TIMESTAMP.
+    updateConversation(db, local.id, {
+      client_conversation_id: cloudRow.client_conversation_id,
+      cloud_id: cloudRow.id,
+      sync_status: "synced",
+      created_at: LOCAL_EARLY,
+      updated_at: LOCAL_EARLY,
+    });
+    c.localId = local.id;
+  }
+
+  await service.syncAll(true);
+
+  const listCalls = cloud.logFor("/api/conversations/list");
+  assert.equal(listCalls.length, 1, "three cloud rows must take exactly one page");
+  assert.equal(queryParam(listCalls[0].path, "include"), "messages");
+  assert.equal(queryParam(listCalls[0].path, "since"), null, "a fresh pull carries no cursor");
+  assert.equal(
+    cloud.logFor("/api/conversations/create").length,
+    0,
+    "the local rows are already synced, so nothing may be pushed ahead of the pull"
+  );
+
+  for (const c of cases) {
+    const row = db.getAgentConversation(c.localId);
+    const contents = row.messages.map((m) => m.content);
+    if (c.applied) {
+      assert.equal(row.title, `Cloud ${c.key}`, "a strictly newer cloud copy must win");
+      assert.deepEqual(contents, [`cloud message ${c.key}`]);
+      assert.equal(row.sync_status, "synced");
+    } else {
+      assert.equal(
+        row.title,
+        `Local ${c.key}`,
+        `the ${c.key} cloud copy must not overwrite the local row`
+      );
+      assert.equal(row.updated_at, LOCAL_EARLY, "a rejected pull must not move updated_at");
+      assert.deepEqual(
+        contents,
+        [`local message ${c.key}`],
+        `the ${c.key} cloud copy must not replace the local messages`
+      );
+    }
+  }
+});
+
+test("a cloud conversation tombstone hard-deletes the local row and its messages", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  const cloudRow = cloud.seedConversation({
+    client_conversation_id: "client-tombstoned",
+    title: "Deleted elsewhere",
+    created_at: "2026-07-20T08:00:00.000Z",
+    updated_at: "2026-07-20T12:00:00.000Z",
+    deleted_at: "2026-07-20T12:00:00.000Z",
+  });
+  const local = db.createAgentConversation("Deleted elsewhere");
+  db.addAgentMessage(local.id, "user", "gone");
+  updateConversation(db, local.id, {
+    client_conversation_id: cloudRow.client_conversation_id,
+    cloud_id: cloudRow.id,
+    sync_status: "synced",
+    created_at: LOCAL_EARLY,
+    updated_at: LOCAL_EARLY,
+  });
+
+  // Tombstones only travel on the delta page, so the cursor must already exist.
+  localStorageStub.setItem("lastSyncedAt.conversations", "2026-07-01T00:00:00.000Z");
+  await service.syncAll(true);
+
+  const listCalls = cloud.logFor("/api/conversations/list");
+  assert.equal(
+    queryParam(listCalls[0].path, "since"),
+    "2026-07-01T00:00:00.000Z",
+    "the delta page must be requested with the stored cursor"
+  );
+  assert.equal(
+    db.getConversationByClientId("client-tombstoned"),
+    null,
+    "the local row must be removed"
+  );
+  assert.equal(messageCount(db), 0, "the messages go with the conversation");
+});

--- a/test/helpers/syncServiceFolders.test.js
+++ b/test/helpers/syncServiceFolders.test.js
@@ -1,0 +1,485 @@
+// Folder half of the SyncService orchestration: real SyncService over the real
+// cloudApi/FoldersService stack, a real DatabaseManager, and the fake cloud.
+// Assertions are on the wire (cloud.log) as well as on the resulting rows.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDb } = require("./harness/db.js");
+const {
+  installBrowserGlobals,
+  resetBrowserGlobals,
+  enableSync,
+  establishValidatedAuth,
+  stopSyncTimers,
+  window: browserWindow,
+  localStorage: browserLocalStorage,
+} = require("./harness/browserGlobals.js");
+const { createElectronApi } = require("./harness/electronApiBridge.js");
+const { createFakeCloud } = require("./harness/fakeCloud.js");
+
+installBrowserGlobals();
+
+const loadSync = () => import("../../src/services/SyncService.ts");
+
+async function setup(t, cloudConfig) {
+  resetBrowserGlobals();
+  const db = createDb(t);
+  if (!db) return null;
+  enableSync();
+  const cloud = createFakeCloud(cloudConfig);
+  browserWindow.electronAPI = createElectronApi(db, { cloud });
+  await establishValidatedAuth();
+  return { db, cloud };
+}
+
+async function newSyncService(t) {
+  const { SyncService } = await loadSync();
+  const service = new SyncService();
+  if (t) t.after(() => stopSyncTimers(service));
+  return service;
+}
+
+function folderByName(db, name) {
+  return db.db.prepare("SELECT * FROM folders WHERE name = ?").get(name) ?? null;
+}
+
+function folderByClientId(db, clientFolderId) {
+  return db.db.prepare("SELECT * FROM folders WHERE client_folder_id = ?").get(clientFolderId);
+}
+
+function allFolders(db) {
+  return db.db.prepare("SELECT * FROM folders ORDER BY id").all();
+}
+
+function noteByClientId(db, clientNoteId) {
+  return db.db.prepare("SELECT * FROM notes WHERE client_note_id = ?").get(clientNoteId);
+}
+
+// Deterministic timestamps come from SQL, never from a faked clock: SQLite's
+// CURRENT_TIMESTAMP is second-granularity and the gate under test is textual.
+function setFolderRow(db, id, columns) {
+  const keys = Object.keys(columns);
+  db.db
+    .prepare(`UPDATE folders SET ${keys.map((k) => `${k} = ?`).join(", ")} WHERE id = ?`)
+    .run(...keys.map((k) => columns[k]), id);
+}
+
+function shift(iso, hours) {
+  return new Date(Date.parse(iso) + hours * 3600_000).toISOString();
+}
+
+test("a note in a folder with no cloud mapping pushes folder_id undefined, not the local row id", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  // Folder creation fails, so nothing local ever gets a cloud_id.
+  cloud.failWith("POST /api/folders/batch-create", { status: 500, error: "folder push down" });
+  const work = db.createFolder("Work").folder;
+  const saved = db.saveNote("Spec", "body", "personal", null, null, work.id);
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const [batch] = cloud.logFor("/api/notes/batch-create");
+  assert.ok(batch, "the note must still be pushed even though the folder push failed");
+  const sent = batch.body.notes[0];
+  assert.equal(sent.client_note_id, saved.note.client_note_id);
+  assert.equal(
+    sent.folder_id,
+    null,
+    "an unmapped folder must null the reference, never leak the local integer id"
+  );
+  assert.notEqual(sent.folder_id, work.id);
+  assert.equal(cloud.notes()[0].folder_id, null);
+  assert.equal(db.getNote(saved.note.id).sync_status, "synced");
+});
+
+test("pulled notes map cloud folder ids back to local ids and park the row when the folder is unknown", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+  const warnings = t.mock.method(console, "warn", () => {});
+
+  const work = cloud.seedFolder({
+    client_folder_id: "cf-work",
+    name: "Work",
+    is_default: false,
+    sort_order: 7,
+  });
+  cloud.seedNote({ client_note_id: "cn-mapped", title: "In Work", folder_id: work.id });
+  cloud.seedNote({ client_note_id: "cn-orphan", title: "Nowhere", folder_id: "folder-9999" });
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const localWork = folderByName(db, "Work");
+  const personal = folderByName(db, "Personal");
+  assert.ok(localWork, "the cloud-only folder must materialize locally");
+  assert.notEqual(localWork.id, personal.id);
+
+  assert.equal(
+    noteByClientId(db, "cn-mapped").folder_id,
+    localWork.id,
+    "a known cloud folder must resolve through the cloud-to-local map"
+  );
+  // Filing the orphan anywhere would stick forever (the advanced cursor never
+  // re-pulls the row), so the pull parks it until its folder arrives.
+  assert.equal(
+    noteByClientId(db, "cn-orphan"),
+    undefined,
+    "an unknown cloud folder must park the row, not file it locally"
+  );
+  assert.equal(
+    browserLocalStorage.getItem("lastSyncedAt.notes"),
+    null,
+    "a parked pull must leave the note cursor unstamped so the row is re-seen"
+  );
+  assert.ok(
+    warnings.mock.calls.some((c) => String(c.arguments[0]).includes("Parking note")),
+    "the parked row must be named in the warnings"
+  );
+});
+
+test("a fresh device adopts the cloud's default folders by name instead of pushing duplicates", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  const cloudPersonal = cloud.seedFolder({
+    client_folder_id: "cf-personal",
+    name: "Personal",
+    is_default: true,
+    sort_order: 0,
+  });
+  const cloudMeetings = cloud.seedFolder({
+    client_folder_id: "cf-meetings",
+    name: "Meetings",
+    is_default: true,
+    sort_order: 1,
+  });
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const [batch] = cloud.logFor("/api/folders/batch-create");
+  assert.deepEqual(
+    batch.body.folders.map((f) => f.name),
+    ["Videos"],
+    "adopted defaults must be gone from the push, or the cloud forks a second Personal"
+  );
+
+  assert.equal(cloud.folders().length, 3);
+  assert.equal(cloud.folders().filter((f) => f.name === "Personal").length, 1);
+  assert.equal(allFolders(db).length, 3, "adoption must not add a local row either");
+
+  const personal = folderByName(db, "Personal");
+  assert.equal(personal.client_folder_id, "cf-personal");
+  assert.equal(personal.cloud_id, cloudPersonal.id);
+  assert.equal(personal.sync_status, "synced");
+  assert.equal(folderByName(db, "Meetings").cloud_id, cloudMeetings.id);
+});
+
+test("pushPendingFolders sends name/client_folder_id/is_default/sort_order in row order and links each folder on ack", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const calls = cloud.logFor("/api/folders/batch-create");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "POST");
+
+  const sent = calls[0].body.folders;
+  assert.deepEqual(
+    sent.map((f) => f.name),
+    ["Meetings", "Personal", "Videos"],
+    "input order is what pairs created[i] with fresh[i] during identity adoption"
+  );
+  for (const folder of sent) {
+    assert.deepEqual(Object.keys(folder).sort(), [
+      "client_folder_id",
+      "is_default",
+      "name",
+      "sort_order",
+    ]);
+    assert.equal(folder.is_default, true, "SQLite's 1 must be coerced to a boolean on the wire");
+    assert.equal(typeof folder.sort_order, "number");
+    assert.equal(typeof folder.client_folder_id, "string");
+  }
+  assert.deepEqual(
+    sent.map((f) => f.sort_order),
+    [1, 0, 2]
+  );
+
+  for (const local of allFolders(db)) {
+    assert.equal(local.sync_status, "synced");
+    const remote = cloud.folder(local.client_folder_id);
+    assert.ok(remote, `cloud row missing for ${local.name}`);
+    assert.equal(local.cloud_id, remote.id, "the ack's cloud id must be stored on the local row");
+  }
+});
+
+test("a renamed linked folder PATCHes /api/folders/update instead of creating a second cloud folder", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  const work = db.createFolder("Work").folder;
+  await (await newSyncService(t)).syncAll(true);
+  const cloudId = folderByName(db, "Work").cloud_id;
+  assert.ok(cloudId);
+  const folderCountAfterFirstPass = cloud.folders().length;
+
+  db.renameFolder(work.id, "Work Renamed");
+  // Future-dated so the pull in this same pass cannot stand in for the push ack.
+  setFolderRow(db, work.id, { updated_at: "2027-01-01 00:00:00" });
+  await (await newSyncService(t)).syncAll(true);
+
+  const patches = cloud.logFor("/api/folders/update");
+  assert.equal(patches.length, 1);
+  assert.equal(patches[0].method, "PATCH");
+  assert.deepEqual(patches[0].body, { id: cloudId, name: "Work Renamed", sort_order: 3 });
+
+  assert.equal(cloud.folder(cloudId).name, "Work Renamed");
+  assert.equal(
+    cloud.folders().length,
+    folderCountAfterFirstPass,
+    "a linked folder must never be re-created as a new cloud row"
+  );
+  assert.equal(folderByName(db, "Work Renamed").sync_status, "synced");
+  assert.equal(cloud.logFor("/api/folders/batch-create").length, 1, "no second batch-create");
+});
+
+test("a failed folder PATCH leaves that folder pending and does not abort the rest of the loop", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  const alpha = db.createFolder("Alpha").folder;
+  const beta = db.createFolder("Beta").folder;
+  await (await newSyncService(t)).syncAll(true);
+  const alphaCloudId = folderByName(db, "Alpha").cloud_id;
+  const betaCloudId = folderByName(db, "Beta").cloud_id;
+
+  db.renameFolder(alpha.id, "Alpha Renamed");
+  db.renameFolder(beta.id, "Beta Renamed");
+  // Future-dated so the pull in this same pass cannot mask the push outcome.
+  setFolderRow(db, alpha.id, { updated_at: "2027-01-01 00:00:00" });
+  setFolderRow(db, beta.id, { updated_at: "2027-01-01 00:00:00" });
+
+  cloud.failNext("PATCH /api/folders/update", { status: 500, error: "boom" });
+  await (await newSyncService(t)).syncAll(true);
+
+  const patches = cloud.logFor("/api/folders/update");
+  assert.equal(
+    patches.length,
+    2,
+    "the second folder must still be attempted after the first threw"
+  );
+  assert.deepEqual(patches[0].body, { id: alphaCloudId, name: "Alpha Renamed", sort_order: 3 });
+  assert.deepEqual(patches[1].body, { id: betaCloudId, name: "Beta Renamed", sort_order: 4 });
+
+  assert.equal(
+    folderByName(db, "Alpha Renamed").sync_status,
+    "pending",
+    "a folder whose push failed must stay pending so the next pass retries it"
+  );
+  assert.equal(folderByName(db, "Beta Renamed").sync_status, "synced");
+  assert.equal(cloud.folder(alphaCloudId).name, "Alpha");
+  assert.equal(cloud.folder(betaCloudId).name, "Beta Renamed");
+});
+
+test("pushFolderDeletes sends the cloud id, hard-deletes on ack, and keeps the tombstone on failure", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  const work = db.createFolder("Trash Me").folder;
+  await (await newSyncService(t)).syncAll(true);
+  const cloudId = folderByName(db, "Trash Me").cloud_id;
+
+  db.deleteFolder(work.id);
+  cloud.failNext("DELETE /api/folders/delete", { status: 503, error: "offline" });
+  await (await newSyncService(t)).syncAll(true);
+
+  const firstAttempt = cloud.logFor("/api/folders/delete");
+  assert.equal(firstAttempt.length, 1);
+  assert.equal(firstAttempt[0].method, "DELETE");
+  assert.deepEqual(firstAttempt[0].body, { id: cloudId });
+
+  const tombstone = db.db.prepare("SELECT * FROM folders WHERE id = ?").get(work.id);
+  assert.ok(tombstone, "a failed delete must keep the local tombstone for the next pass");
+  assert.ok(tombstone.deleted_at);
+  assert.equal(tombstone.sync_status, "pending");
+  assert.equal(cloud.folder(cloudId).deleted_at, null);
+
+  await (await newSyncService(t)).syncAll(true);
+
+  assert.equal(cloud.logFor("/api/folders/delete").length, 2, "the delete must be retried");
+  assert.equal(
+    db.db.prepare("SELECT * FROM folders WHERE id = ?").get(work.id),
+    undefined,
+    "an acked delete must drop the local row"
+  );
+  assert.ok(cloud.folder(cloudId).deleted_at, "the cloud row must be tombstoned");
+});
+
+test("pullFolders keeps a local folder whose same-day cloud copy is older and accepts a genuinely newer one", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  // "2026-07-27T11:00:00.000Z" > "2026-07-27 12:00:00" under a raw string
+  // compare ('T' > ' '), so an unnormalized gate hands this to the stale cloud.
+  const stale = cloud.seedFolder({
+    client_folder_id: "cf-stale",
+    name: "Stale Cloud Name",
+    is_default: false,
+    sort_order: 8,
+    created_at: "2026-07-27T09:00:00.000Z",
+    updated_at: "2026-07-27T11:00:00.000Z",
+  });
+  const fresher = cloud.seedFolder({
+    client_folder_id: "cf-fresher",
+    name: "Fresher Cloud Name",
+    is_default: false,
+    sort_order: 9,
+    created_at: "2026-07-27T09:00:00.000Z",
+    updated_at: "2026-07-27T13:00:00.000Z",
+  });
+
+  const keep = db.createFolder("Local Wins").folder;
+  setFolderRow(db, keep.id, {
+    client_folder_id: "cf-stale",
+    cloud_id: stale.id,
+    sync_status: "synced",
+    updated_at: "2026-07-27 12:00:00",
+  });
+  const lose = db.createFolder("Local Loses").folder;
+  setFolderRow(db, lose.id, {
+    client_folder_id: "cf-fresher",
+    cloud_id: fresher.id,
+    sync_status: "synced",
+    updated_at: "2026-07-27 12:00:00",
+  });
+
+  await (await newSyncService(t)).syncAll(true);
+
+  assert.equal(
+    folderByClientId(db, "cf-stale").name,
+    "Local Wins",
+    "an older cloud copy on the same UTC day must not overwrite the local folder"
+  );
+  assert.equal(
+    folderByClientId(db, "cf-fresher").name,
+    "Fresher Cloud Name",
+    "a strictly newer cloud copy must still win, or the gate is just a no-op"
+  );
+});
+
+test("a failed folder list leaves lastSyncedAt.folders unstamped so the next pass re-pulls from scratch", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { cloud } = ctx;
+
+  cloud.failWith("/api/folders/list", { status: 500, error: "list down" });
+  await (await newSyncService(t)).syncAll(true);
+
+  assert.equal(
+    browserLocalStorage.getItem("lastSyncedAt.folders"),
+    null,
+    "stamping a failed pull would silently skip every folder change in that window"
+  );
+
+  cloud.clearFailures();
+  await (await newSyncService(t)).syncAll(true);
+
+  const lists = cloud.logFor("/api/folders/list");
+  assert.equal(
+    lists[lists.length - 1].path,
+    "/api/folders/list",
+    "with no stamp the recovery pass must ask for the full snapshot"
+  );
+  assert.ok(browserLocalStorage.getItem("lastSyncedAt.folders"), "a clean pull must stamp");
+});
+
+test("the folders cursor advances and the next pass only receives folders changed since the stamp", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  await (await newSyncService(t)).syncAll(true);
+  const stamp = browserLocalStorage.getItem("lastSyncedAt.folders");
+  assert.match(stamp, /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/);
+
+  cloud.seedFolder({
+    client_folder_id: "cf-old",
+    name: "Before The Stamp",
+    is_default: false,
+    sort_order: 20,
+    created_at: shift(stamp, -2),
+    updated_at: shift(stamp, -1),
+  });
+  cloud.seedFolder({
+    client_folder_id: "cf-new",
+    name: "After The Stamp",
+    is_default: false,
+    sort_order: 21,
+    created_at: shift(stamp, -2),
+    updated_at: shift(stamp, 1),
+  });
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const lists = cloud.logFor("/api/folders/list");
+  assert.equal(
+    lists[lists.length - 1].path,
+    `/api/folders/list?since=${encodeURIComponent(stamp)}`,
+    "the stored stamp must be sent as the since cursor"
+  );
+  assert.ok(folderByName(db, "After The Stamp"), "a folder newer than the cursor must arrive");
+  assert.equal(
+    folderByName(db, "Before The Stamp"),
+    null,
+    "re-delivering pre-cursor folders means the cursor was never sent"
+  );
+  assert.ok(
+    Date.parse(browserLocalStorage.getItem("lastSyncedAt.folders")) >= Date.parse(stamp),
+    "the cursor must advance"
+  );
+});
+
+test("a folder tombstone arriving in the delta pull hard-deletes the local folder", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+
+  const shared = db.createFolder("Shared").folder;
+  await (await newSyncService(t)).syncAll(true);
+  const cloudId = folderByName(db, "Shared").cloud_id;
+  const stamp = browserLocalStorage.getItem("lastSyncedAt.folders");
+
+  // Another device deletes the folder. The server clock puts the tombstone past
+  // the cursor; wall-clock would land in the same millisecond as the stamp.
+  cloud.setClock(() => shift(stamp, 1));
+  const deleted = await cloud.request({
+    method: "DELETE",
+    path: "/api/folders/delete",
+    body: { id: cloudId },
+  });
+  assert.equal(deleted.success, true);
+
+  await (await newSyncService(t)).syncAll(true);
+
+  const lists = cloud.logFor("/api/folders/list");
+  assert.equal(
+    lists[lists.length - 1].path,
+    `/api/folders/list?since=${encodeURIComponent(stamp)}`,
+    "only the delta list carries tombstones; a snapshot pull would never see this delete"
+  );
+  assert.equal(
+    db.db.prepare("SELECT * FROM folders WHERE id = ?").get(shared.id),
+    undefined,
+    "a remote delete must remove the local folder"
+  );
+});

--- a/test/helpers/syncServiceNotes.test.js
+++ b/test/helpers/syncServiceNotes.test.js
@@ -1,0 +1,651 @@
+// Orchestration coverage for the note half of SyncService: the real service
+// drives the real cloudApi/NotesService layer over a real DatabaseManager, with
+// only the HTTP boundary faked. Assertions land on what was *sent* whenever the
+// behaviour under test is about the request, not just on the row that survived.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createDb } = require("./harness/db.js");
+const {
+  installBrowserGlobals,
+  resetBrowserGlobals,
+  enableSync,
+  establishValidatedAuth,
+  stopSyncTimers,
+  acquireLock,
+  localStorage: localStorageStub,
+  window: windowStub,
+} = require("./harness/browserGlobals.js");
+const { createElectronApi } = require("./harness/electronApiBridge.js");
+const { createFakeCloud } = require("./harness/fakeCloud.js");
+const { assertNoContentRegression, snapshotNotes } = require("./harness/invariants.js");
+const { SyncService } = require("../../src/services/SyncService.ts");
+const { NotesService } = require("../../src/services/NotesService.ts");
+const { CloudApiError } = require("../../src/services/cloudApi.ts");
+
+// Mirrors SYNC_ALL_LOCK in SyncService.ts.
+const SYNC_ALL_LOCK = "openwhispr-sync-all";
+const BATCH_SIZE = 50;
+
+// SQLite's datetime() format, the one local rows actually carry.
+const LOCAL_EARLY = "2026-07-20 10:00:00";
+const LOCAL_LATE = "2026-07-20 11:00:00";
+
+async function setup(t) {
+  const db = createDb(t);
+  if (!db) return null;
+  resetBrowserGlobals();
+  installBrowserGlobals();
+  enableSync();
+  const cloud = createFakeCloud();
+  const api = createElectronApi(db, { cloud });
+  windowStub.electronAPI = api;
+  await establishValidatedAuth();
+  const service = new SyncService();
+  t.after(() => stopSyncTimers(service));
+  return { db, cloud, api, service };
+}
+
+// Deterministic timestamps come from SQL, never from a fake clock.
+function updateNote(db, id, fields) {
+  const keys = Object.keys(fields);
+  db.db
+    .prepare(`UPDATE notes SET ${keys.map((k) => `${k} = ?`).join(", ")} WHERE id = ?`)
+    .run(...keys.map((k) => fields[k]), id);
+  return db.getNote(id);
+}
+
+function noteCount(db) {
+  return db.db.prepare("SELECT COUNT(*) AS c FROM notes").get().c;
+}
+
+function queryParam(path, name) {
+  const [, query] = path.split("?");
+  return new URLSearchParams(query ?? "").get(name);
+}
+
+function silenceConsoleErrors(t) {
+  return t.mock.method(console, "error", () => {});
+}
+
+function errorMessages(mock) {
+  return mock.mock.calls.map((call) =>
+    call.arguments.map((a) => String(a?.message ?? a)).join(" ")
+  );
+}
+
+test("migration push sends the full note body, not just the client id", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  // The meeting shell exactly as meetingDetectionEngine.js creates it.
+  const shell = db.saveNote("Weekly sync", "", "meeting").note;
+  updateNote(db, shell.id, { created_at: LOCAL_EARLY, updated_at: LOCAL_EARLY });
+
+  await service.syncAll(true);
+  const cloudId = db.getNote(shell.id).cloud_id;
+  assert.ok(cloudId, "first pass must give the shell a cloud id");
+  assert.equal(cloud.note(cloudId).content, "", "the shell reaches the cloud empty");
+
+  // Transcription lands afterwards and re-queues the row: this is the state the
+  // migration branch has to upload.
+  const filled = updateNote(db, shell.id, {
+    content: "the transcribed meeting body",
+    transcript: "raw diarized transcript",
+    updated_at: LOCAL_LATE,
+    sync_status: "pending",
+  });
+
+  const before = snapshotNotes(db);
+  const mark = cloud.log.length;
+  await service.syncAll(true);
+
+  const patches = cloud.log
+    .slice(mark)
+    .filter((c) => c.method === "PATCH" && c.path === "/api/notes/update");
+  assert.equal(patches.length, 1, "exactly one PATCH for the pending migration note");
+  const body = patches[0].body;
+  assert.equal(body.id, cloudId);
+  assert.equal(body.client_note_id, filled.client_note_id);
+  // A payload of { client_note_id } alone changes nothing server-side, so the
+  // DB would still look fine; only the sent body exposes the regression.
+  assert.equal(body.content, "the transcribed meeting body");
+  assert.equal(body.transcript, "raw diarized transcript");
+  assert.equal(body.title, "Weekly sync");
+  assert.equal(body.updated_at, LOCAL_LATE);
+
+  assert.equal(cloud.note(cloudId).content, "the transcribed meeting body");
+  assert.equal(cloud.note(cloudId).transcript, "raw diarized transcript");
+  assert.equal(db.getNote(shell.id).sync_status, "synced");
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("migration push marks the note errored when the PATCH fails", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  silenceConsoleErrors(t);
+
+  const shell = db.saveNote("Weekly sync", "", "meeting").note;
+  updateNote(db, shell.id, { created_at: LOCAL_EARLY, updated_at: LOCAL_EARLY });
+  await service.syncAll(true);
+  const cloudId = db.getNote(shell.id).cloud_id;
+
+  updateNote(db, shell.id, {
+    content: "the transcribed meeting body",
+    updated_at: LOCAL_LATE,
+    sync_status: "pending",
+  });
+
+  cloud.failNext("PATCH /api/notes/update", { status: 500, error: "boom" });
+  const before = snapshotNotes(db);
+  await service.syncAll(true);
+
+  const row = db.getNote(shell.id);
+  assert.equal(row.sync_status, "error", "a failed push must leave the row retryable, not synced");
+  assert.equal(row.cloud_id, cloudId, "the cloud id is not dropped by a failed push");
+  assert.equal(row.content, "the transcribed meeting body", "the local body survives the failure");
+  assert.equal(cloud.note(cloudId).content, "", "nothing reached the cloud");
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("fresh notes are pushed in BATCH_SIZE chunks with acks matched by client id", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  for (let i = 0; i < BATCH_SIZE + 1; i += 1) {
+    db.saveNote(`Note ${i}`, `body ${i}`, "personal");
+  }
+
+  // The cloud is free to answer in any order; matching acks positionally would
+  // hand every note its neighbour's cloud id.
+  const inner = windowStub.electronAPI.cloudApiRequest;
+  windowStub.electronAPI.cloudApiRequest = async (opts) => {
+    const result = await inner(opts);
+    if (opts.path === "/api/notes/batch-create" && result.success) {
+      return { ...result, data: { created: [...result.data.created].reverse() } };
+    }
+    return result;
+  };
+
+  await service.syncAll(true);
+
+  const batches = cloud.logFor("/api/notes/batch-create");
+  assert.equal(batches.length, 2, "51 fresh notes must go out as two chunks");
+  assert.equal(batches[0].body.notes.length, BATCH_SIZE);
+  assert.equal(batches[1].body.notes.length, 1);
+
+  const rows = db.db.prepare("SELECT * FROM notes ORDER BY id").all();
+  assert.equal(rows.length, BATCH_SIZE + 1);
+  for (const row of rows) {
+    assert.equal(row.sync_status, "synced");
+    assert.equal(
+      row.cloud_id,
+      cloud.note(row.client_note_id).id,
+      `note ${row.id} was acked with another note's cloud id`
+    );
+  }
+});
+
+test("a failing chunk marks only its own members as errored", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  silenceConsoleErrors(t);
+
+  for (let i = 0; i < BATCH_SIZE + 1; i += 1) {
+    db.saveNote(`Note ${i}`, `body ${i}`, "personal");
+  }
+  const pending = db.getPendingNotes();
+  const firstChunk = pending.slice(0, BATCH_SIZE);
+  const secondChunk = pending.slice(BATCH_SIZE);
+
+  // Only the second chunk carries a single note, so this fires on it alone.
+  cloud.failNext(
+    (call) => call.path === "/api/notes/batch-create" && call.body?.notes?.length === 1,
+    { status: 500, error: "chunk rejected" }
+  );
+
+  await service.syncAll(true);
+
+  for (const note of firstChunk) {
+    const row = db.getNote(note.id);
+    assert.equal(row.sync_status, "synced", `note ${note.id} of the healthy chunk must be synced`);
+    assert.ok(row.cloud_id);
+  }
+  for (const note of secondChunk) {
+    const row = db.getNote(note.id);
+    assert.equal(row.sync_status, "error", `note ${note.id} of the failed chunk must be errored`);
+    assert.equal(row.cloud_id, null);
+  }
+  assert.equal(cloud.notes().length, BATCH_SIZE, "only the healthy chunk reached the cloud");
+});
+
+test("pullNotes applies a strictly newer cloud copy and rejects older and tied ones", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  // All three cloud copies sit on the same UTC day as the local rows, where a
+  // raw string compare wrongly elects the cloud value ('T' > ' ' at index 10).
+  const cases = [
+    { key: "older", cloudUpdatedAt: "2026-07-20T09:00:00.000Z", applied: false },
+    { key: "newer", cloudUpdatedAt: "2026-07-20T11:00:00.000Z", applied: true },
+    { key: "tied", cloudUpdatedAt: "2026-07-20T10:00:00.000Z", applied: false },
+  ];
+
+  for (const c of cases) {
+    const cloudRow = cloud.seedNote({
+      client_note_id: `client-${c.key}`,
+      title: `Cloud ${c.key}`,
+      content: `cloud body ${c.key}`,
+      created_at: "2026-07-20T08:00:00.000Z",
+      updated_at: c.cloudUpdatedAt,
+    });
+    const local = db.saveNote(`Local ${c.key}`, `local body ${c.key}`, "personal").note;
+    updateNote(db, local.id, {
+      client_note_id: cloudRow.client_note_id,
+      cloud_id: cloudRow.id,
+      sync_status: "synced",
+      created_at: LOCAL_EARLY,
+      updated_at: LOCAL_EARLY,
+    });
+    c.localId = local.id;
+  }
+
+  const before = snapshotNotes(db);
+  await service.syncAll(true);
+
+  for (const c of cases) {
+    const row = db.getNote(c.localId);
+    if (c.applied) {
+      assert.equal(row.content, `cloud body ${c.key}`, "a strictly newer cloud copy must win");
+      assert.equal(row.title, `Cloud ${c.key}`);
+    } else {
+      assert.equal(
+        row.content,
+        `local body ${c.key}`,
+        `the ${c.key} cloud copy must not overwrite the local row`
+      );
+      assert.equal(row.title, `Local ${c.key}`);
+      assert.equal(row.updated_at, LOCAL_EARLY, "a rejected pull must not move updated_at");
+    }
+  }
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});
+
+test("a cloud tombstone hard-deletes the local note", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  const cloudRow = cloud.seedNote({
+    client_note_id: "client-tombstoned",
+    title: "Deleted elsewhere",
+    content: "gone",
+    created_at: "2026-07-20T08:00:00.000Z",
+    updated_at: "2026-07-20T08:00:00.000Z",
+  });
+  const local = db.saveNote("Deleted elsewhere", "gone", "personal").note;
+  updateNote(db, local.id, {
+    client_note_id: cloudRow.client_note_id,
+    cloud_id: cloudRow.id,
+    sync_status: "synced",
+    created_at: LOCAL_EARLY,
+    updated_at: LOCAL_EARLY,
+  });
+
+  // Tombstones only travel on the delta page, so the cursor must already exist.
+  localStorageStub.setItem("lastSyncedAt.notes", "2026-07-01T00:00:00.000Z");
+  await cloud.request({ method: "DELETE", path: "/api/notes/delete", body: { id: cloudRow.id } });
+  const mark = cloud.log.length;
+
+  await service.syncAll(true);
+
+  const listCalls = cloud.log.slice(mark).filter((c) => c.path.split("?")[0] === "/api/notes/list");
+  assert.ok(listCalls.length > 0);
+  assert.equal(
+    queryParam(listCalls[0].path, "since"),
+    "2026-07-01T00:00:00.000Z",
+    "the delta page must be requested with the stored cursor"
+  );
+  assert.equal(db.getNoteByClientId("client-tombstoned"), null, "the local row must be removed");
+  assert.equal(noteCount(db), 0);
+});
+
+test("a pending local delete issues the DELETE and then hard-deletes locally", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  const cloudRow = cloud.seedNote({
+    client_note_id: "client-locally-deleted",
+    title: "Removed here",
+    content: "body",
+    created_at: "2026-07-19T09:00:00.000Z",
+    updated_at: "2026-07-19T09:00:00.000Z",
+  });
+  const local = db.saveNote("Removed here", "body", "personal").note;
+  updateNote(db, local.id, {
+    client_note_id: cloudRow.client_note_id,
+    cloud_id: cloudRow.id,
+    sync_status: "pending",
+    deleted_at: LOCAL_LATE,
+    created_at: LOCAL_EARLY,
+    updated_at: LOCAL_EARLY,
+  });
+
+  await service.syncAll(true);
+
+  const deletes = cloud.logFor("/api/notes/delete");
+  assert.equal(deletes.length, 1, "the tombstone must reach the cloud exactly once");
+  assert.equal(deletes[0].method, "DELETE");
+  assert.deepEqual(deletes[0].body, { id: cloudRow.id });
+  assert.equal(db.getNote(local.id), null, "the local row is only removed after the cloud ack");
+  assert.ok(cloud.note(cloudRow.id).deleted_at, "the cloud row is tombstoned");
+});
+
+test("a 500 on the delete leaves the tombstone pending and the local row intact", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  silenceConsoleErrors(t);
+
+  const cloudRow = cloud.seedNote({
+    client_note_id: "client-delete-failed",
+    title: "Removed here",
+    content: "body",
+    created_at: "2026-07-19T09:00:00.000Z",
+    updated_at: "2026-07-19T09:00:00.000Z",
+  });
+  const local = db.saveNote("Removed here", "body", "personal").note;
+  updateNote(db, local.id, {
+    client_note_id: cloudRow.client_note_id,
+    cloud_id: cloudRow.id,
+    sync_status: "pending",
+    deleted_at: LOCAL_LATE,
+    created_at: LOCAL_EARLY,
+    updated_at: LOCAL_EARLY,
+  });
+
+  cloud.failNext("DELETE /api/notes/delete", { status: 500, error: "delete failed" });
+  await service.syncAll(true);
+
+  const row = db.getNote(local.id);
+  assert.ok(row, "a failed delete must not remove the row locally");
+  assert.equal(row.deleted_at, LOCAL_LATE);
+  assert.equal(row.sync_status, "pending", "the tombstone stays queued for the next pass");
+  assert.equal(db.getPendingNoteDeletes().length, 1);
+  assert.equal(cloud.note(cloudRow.id).deleted_at, null, "the cloud row is untouched");
+});
+
+test("the pull pages 120 cloud notes with a correct cursor and stamps the cursor once", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+
+  const base = Date.parse("2026-07-20T08:00:00.000Z");
+  const seeded = [];
+  for (let i = 0; i < 120; i += 1) {
+    const at = new Date(base + i * 60000).toISOString();
+    seeded.push(
+      cloud.seedNote({
+        client_note_id: `client-${String(i).padStart(3, "0")}`,
+        title: `Cloud note ${i}`,
+        content: `cloud body ${i}`,
+        created_at: at,
+        updated_at: at,
+      })
+    );
+  }
+
+  await service.syncAll(true);
+
+  const listCalls = cloud.logFor("/api/notes/list");
+  assert.equal(listCalls.length, 3, "120 notes at a page size of 50 must take three requests");
+  assert.equal(queryParam(listCalls[0].path, "limit"), String(BATCH_SIZE));
+  assert.equal(queryParam(listCalls[0].path, "before"), null, "the first page carries no cursor");
+  // Pages walk created_at backwards, so each cursor is the oldest row of the
+  // page before it.
+  assert.equal(queryParam(listCalls[1].path, "before"), seeded[70].created_at);
+  assert.equal(queryParam(listCalls[2].path, "before"), seeded[20].created_at);
+
+  assert.equal(noteCount(db), 120, "every page must be applied exactly once");
+  assert.equal(db.getNoteByClientId("client-000").content, "cloud body 0");
+  assert.equal(db.getNoteByClientId("client-119").content, "cloud body 119");
+  assert.ok(
+    Date.parse(localStorageStub.getItem("lastSyncedAt.notes")) > 0,
+    "a clean pull stamps the cursor"
+  );
+});
+
+test("a mid-pagination failure leaves the pull cursor unstamped", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  silenceConsoleErrors(t);
+
+  const base = Date.parse("2026-07-20T08:00:00.000Z");
+  for (let i = 0; i < 120; i += 1) {
+    const at = new Date(base + i * 60000).toISOString();
+    cloud.seedNote({
+      client_note_id: `client-${String(i).padStart(3, "0")}`,
+      title: `Cloud note ${i}`,
+      content: `cloud body ${i}`,
+      created_at: at,
+      updated_at: at,
+    });
+  }
+
+  // Only pages after the first carry a cursor.
+  cloud.failNext(
+    (call) => call.path.startsWith("/api/notes/list") && call.path.includes("before="),
+    { status: 500, error: "page 2 exploded" }
+  );
+
+  await service.syncAll(true);
+
+  assert.equal(cloud.logFor("/api/notes/list").length, 2, "paging stops at the failure");
+  assert.equal(noteCount(db), 50, "the first page is still applied");
+  assert.equal(
+    localStorageStub.getItem("lastSyncedAt.notes"),
+    null,
+    "a partial pull must not advance the cursor, or the missing pages are lost forever"
+  );
+});
+
+test("canSync gating: sign-in and subscription block every call, backup off blocks personal pushes", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud } = ctx;
+  const note = db.saveNote("Pending note", "body", "personal").note;
+
+  for (const key of ["isSignedIn", "isSubscribed"]) {
+    enableSync();
+    localStorageStub.removeItem(key);
+    const service = new SyncService();
+    await service.syncAll(true);
+    stopSyncTimers(service);
+    assert.equal(cloud.log.length, 0, `sync ran with ${key} unset`);
+    assert.equal(localStorageStub.getItem("lastSyncedAt"), null);
+  }
+
+  // Backup off is not sign-out: team-space membership still syncs, but nothing
+  // personal may leave the machine.
+  enableSync();
+  localStorageStub.removeItem("cloudBackupEnabled");
+  const teamOnlyService = new SyncService();
+  await teamOnlyService.syncAll(true);
+  stopSyncTimers(teamOnlyService);
+  assert.equal(
+    cloud.logFor("/api/notes/batch-create").length,
+    0,
+    "a personal note must not push while backup is off"
+  );
+  assert.equal(db.getNote(note.id).sync_status, "pending");
+
+  enableSync();
+  const mark = cloud.log.length;
+  const fullService = new SyncService();
+  await fullService.syncAll(true);
+  stopSyncTimers(fullService);
+  assert.ok(cloud.log.length > mark, "with all three keys set the same pass must do real work");
+  assert.equal(
+    db.getNote(note.id).sync_status,
+    "synced",
+    "the personal note pushes once backup is back on"
+  );
+});
+
+test("an ambient pass bows out when another window holds the lock, a manual pass waits", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  db.saveNote("Pending note", "body", "personal");
+
+  const release = await acquireLock(SYNC_ALL_LOCK);
+
+  // Racing a timer, because an ambient pass that queues instead of bowing out
+  // never returns at all while the holder keeps the lock.
+  const ambient = service.syncAll(false);
+  const outcome = await Promise.race([
+    ambient.then(() => "returned"),
+    new Promise((resolve) => setTimeout(() => resolve("queued"), 50)),
+  ]);
+  assert.equal(outcome, "returned", "an ambient pass must bow out, not queue behind the holder");
+  assert.equal(cloud.log.length, 0, "an ambient pass must skip while the lock is held");
+  assert.equal(localStorageStub.getItem("lastSyncedAt"), null);
+
+  // A manual pass queues instead of skipping.
+  const manual = service.syncAll(true);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(cloud.log.length, 0, "the manual pass must wait, not run alongside the holder");
+
+  release();
+  await manual;
+  assert.ok(cloud.log.length > 0, "the manual pass runs once the lock frees");
+  assert.ok(localStorageStub.getItem("lastSyncedAt"));
+});
+
+test("a request arriving mid-pass re-runs syncAll exactly once", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { cloud, service } = ctx;
+
+  const first = service.syncAll(true);
+  // syncing is already true here, so this request must be deferred, not dropped.
+  await service.syncAll();
+  await first;
+
+  assert.equal(
+    cloud.logFor("/api/notes/list").length,
+    2,
+    "the deferred request must trigger exactly one extra pass"
+  );
+});
+
+test("a note pull failure is contained: the pass finishes and later stages still run", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  const errors = silenceConsoleErrors(t);
+  const note = db.saveNote("Pending note", "body", "personal").note;
+
+  cloud.failWith("/api/notes/list", { status: 500, error: "list exploded" });
+  await service.syncAll(true);
+
+  assert.equal(db.getNote(note.id).sync_status, "synced", "the push before the pull still lands");
+  assert.equal(cloud.logFor("/api/transcriptions/list").length, 1, "later stages still run");
+  assert.equal(cloud.logFor("/api/snippets/list").length, 1);
+  assert.equal(
+    localStorageStub.getItem("lastSyncedAt.notes"),
+    null,
+    "a failed pull must not advance the note cursor"
+  );
+  assert.ok(localStorageStub.getItem("lastSyncedAt"), "the pass as a whole still completes");
+  assert.ok(errorMessages(errors).some((m) => m.includes("Note pull failed")));
+});
+
+test("a missing dictionary IPC binding aborts the pass without stamping lastSyncedAt", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  const errors = silenceConsoleErrors(t);
+  const note = db.saveNote("Pending note", "body", "personal").note;
+
+  delete windowStub.electronAPI.markDictionarySynced;
+  await service.syncAll(true);
+
+  assert.equal(db.getNote(note.id).sync_status, "synced", "stages before the abort still ran");
+  assert.equal(cloud.logFor("/api/snippets/list").length, 0, "the pass stops at the bad binding");
+  assert.equal(
+    localStorageStub.getItem("lastSyncedAt"),
+    null,
+    "an aborted pass must not claim to have completed"
+  );
+  assert.ok(
+    errorMessages(errors).some((m) => m.includes("markDictionarySynced")),
+    "the missing binding must be named in the failure"
+  );
+});
+
+test("an AUTH_EXPIRED envelope surfaces as a 401 CloudApiError and nothing is marked synced", async (t) => {
+  const ctx = await setup(t);
+  if (!ctx) return;
+  const { db, cloud, service } = ctx;
+  silenceConsoleErrors(t);
+
+  const cloudRow = cloud.seedNote({
+    client_note_id: "client-queued-delete",
+    title: "Removed here",
+    content: "body",
+    created_at: "2026-07-19T09:00:00.000Z",
+    updated_at: "2026-07-19T09:00:00.000Z",
+  });
+  const fresh = db.saveNote("Fresh note", "fresh body", "personal").note;
+  updateNote(db, fresh.id, { created_at: LOCAL_EARLY, updated_at: LOCAL_EARLY });
+  const queuedDelete = db.saveNote("Removed here", "body", "personal").note;
+  updateNote(db, queuedDelete.id, {
+    client_note_id: cloudRow.client_note_id,
+    cloud_id: cloudRow.id,
+    sync_status: "pending",
+    deleted_at: LOCAL_LATE,
+    created_at: LOCAL_EARLY,
+    updated_at: LOCAL_EARLY,
+  });
+
+  cloud.failWith(() => true, {
+    status: 401,
+    code: "AUTH_EXPIRED",
+    error: "Session expired",
+  });
+
+  await assert.rejects(
+    () => NotesService.list(BATCH_SIZE),
+    (err) => {
+      assert.ok(err instanceof CloudApiError);
+      assert.equal(err.status, 401);
+      assert.equal(err.code, "AUTH_EXPIRED");
+      assert.equal(err.message, "Session expired");
+      return true;
+    }
+  );
+
+  const before = snapshotNotes(db);
+  await service.syncAll(true);
+
+  const freshRow = db.getNote(fresh.id);
+  assert.equal(freshRow.cloud_id, null, "an expired session must not hand out a cloud id");
+  assert.notEqual(freshRow.sync_status, "synced");
+  assert.equal(freshRow.content, "fresh body");
+
+  const deleteRow = db.getNote(queuedDelete.id);
+  assert.ok(deleteRow, "the queued delete must survive an expired session");
+  assert.equal(deleteRow.sync_status, "pending");
+  assert.equal(cloud.notes().length, 1, "nothing new reached the cloud");
+  assert.equal(cloud.note(cloudRow.id).deleted_at, null);
+  assertNoContentRegression(before, snapshotNotes(db), cloud.notes());
+});


### PR DESCRIPTION
## Summary

Three layers, each protecting something the current suite does not. The harness in `test/helpers/harness/` wires a real `DatabaseManager` behind a fake `electronAPI` and runs the real `cloudApi.ts`/`NotesService` against an in-memory cloud, so a test drives the actual sync code end to end instead of a mock of it. The orchestration tests assert on what `SyncService` *sends*, not only on what the DB ends up holding, because the primary defect in #1290 was request shape: a migration PATCH carrying `client_note_id` alone leaves the local row looking perfectly synced. The scenarios run whole `syncAll()` passes over real SQLite across relaunches and two devices, and every one of them ends in `assertNoContentRegression`.

The gold acceptance test is the evidence that any of this is worth having. Checking out `SyncService.ts` and `database.js` at `fa47857a^` into an otherwise-current tree makes S1 fail with the production corpse: `AssertionError`, `actual: ''`, where a 70 KB transcript should be, both in the local SQLite row and in the cloud copy. Restoring those two files makes it pass, in the same worktree with the same modules, so there is no environmental delta to hide behind. Reverting only the push-wiring hunk fails `migration push sends the full note body, not just the client id` plus five scenarios; reverting only the timestamp-gate hunk fails `pullNotes applies a strictly newer cloud copy and rejects older and tied ones` and its folders equivalent.

That same revert sweep initially surfaced one gap: reverting the **conversations** pull gate left the entire suite green. Closed now — `syncServiceConversations.test.js` mirrors the notes gate test end to end through `pullConversations` (same-UTC-day older ISO copy rejected, strictly newer applied, ties rejected, plus a tombstone pass), and reverting that gate alone fails exactly that test while everything else stays green. S5's tie-skip case remains a `test.todo`, visible instead of quietly omitted.

The test script now runs `node --import tsx`, because `SyncService.ts` imports `./NotesService.js`-style specifiers that resolve to `.ts` files and Node's type stripping will not remap them. This is Phases 1-3 of the sync test coverage plan, with the API-side suite as Phase 4. `test/helpers/harness/db.js` is also created by #1351; lines 1-30 are byte-identical here, so the two reconcile on a single export line in either merge order.

## Changes

- `test/helpers/harness/electronStub.js`: the `Module._load` electron fake and `NODE_ENV=test`, extracted from the pattern already used by the DB tests
- `test/helpers/harness/db.js`: `createDb(t)` returning a real `DatabaseManager` over a private tmpdir, on top of the binding-detection helpers shared with #1351
- `test/helpers/harness/browserGlobals.js`: Map-backed `localStorage`, and `navigator.locks.request` with real `ifAvailable` semantics including FIFO queueing when the lock is held
- `test/helpers/harness/electronApiBridge.js`: `window.electronAPI` built from a real `DatabaseManager`, 40 methods mirroring the IPC surface, including the dictionary and snippet methods `syncAll()` asserts up front
- `test/helpers/harness/fakeCloud.js`: in-memory cloud with the hardened server semantics each behind its own flag (material-PATCH gate, COALESCE on conflict, stale-write guard, `updated_at` clamp), a request log, one-shot fault injection, and a read-side conversations surface serving seeded rows with tombstones
- `test/helpers/harness/invariants.js`: `assertNoContentRegression`, which encodes the user-visible harm as a single assertion
- `test/helpers/syncServiceNotes.test.js`: migration and fresh push paths, pull gate wired end to end, tombstones, cursor progression, gating and lock behavior, error containment, 401 handling
- `test/helpers/syncServiceFolders.test.js`: folder mapping both directions, default adoption by name, folder push and delete request shapes, folder pull gate and cursor
- `test/helpers/syncServiceConversations.test.js`: conversations pull gate end to end through `pullConversations`, plus a tombstone hard-delete pass
- `test/helpers/syncScenarios.test.js`: S1 the meeting-shell acceptance test in hardened and legacy cloud modes, S2 cross-device convergence, S3 deletes and the delete-vs-edit race, S4 crash and offline, S5 pagination edges, S6 folder lifecycle
- `package.json`: `tsx` devDependency and the loader in the test script
- `src/services/SyncService.ts`: export the class so tests can construct isolated instances; the singleton export is unchanged
