### PR TITLE
fix(transcription): pass language to OpenAI realtime sessions

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -500,6 +500,7 @@ class IPCHandlers {
     this.deepgramStreaming = null;
     this.cortiStreaming = null;
     this._dictationStreaming = null;
+    this._dictationStreamingFingerprint = null;
     this._dictationConnectPromise = null;
     this._dictationIdleTimer = null;
     this._dictationPreviewEnabled = false;
@@ -5246,7 +5247,7 @@ class IPCHandlers {
 
       const data = await postServerToken("/api/openai-realtime-token", {
         model: options.model,
-        language: options.language,
+        language: OpenAIRealtimeStreaming.normalizeLanguage(options.language),
         streams: streams || 1,
       });
       if (streams === 2) {
@@ -6154,6 +6155,19 @@ class IPCHandlers {
 
     const DICTATION_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 
+    const getDictationStreamingFingerprint = (options = {}) => {
+      const provider = options.provider || "openai-realtime";
+      const isTinfoil = provider === "tinfoil-realtime";
+      const model = isTinfoil
+        ? options.model || TINFOIL_REALTIME_MODEL
+        : options.model || "gpt-4o-mini-transcribe";
+      const language = isTinfoil
+        ? undefined
+        : OpenAIRealtimeStreaming.normalizeLanguage(options.language);
+      const mode = options.mode === "byok" ? "byok" : "openwhispr";
+      return JSON.stringify([provider, mode, model, language || "auto"]);
+    };
+
     const clearDictationIdleTimer = () => {
       if (this._dictationIdleTimer) {
         clearTimeout(this._dictationIdleTimer);
@@ -6168,13 +6182,21 @@ class IPCHandlers {
           debugLogger.debug("Closing idle dictation warmup connection");
           this._dictationStreaming.disconnect().catch(() => {});
           this._dictationStreaming = null;
+          this._dictationStreamingFingerprint = null;
         }
       }, DICTATION_IDLE_TIMEOUT_MS);
     };
 
     const connectDictationStreaming = async (event, options) => {
+      const fingerprint = getDictationStreamingFingerprint(options);
       if (this._dictationConnectPromise) {
         await this._dictationConnectPromise.catch(() => {});
+      }
+      if (
+        this._dictationStreaming?.isConnected &&
+        this._dictationStreamingFingerprint === fingerprint
+      ) {
+        return;
       }
 
       clearDictationIdleTimer();
@@ -6183,6 +6205,7 @@ class IPCHandlers {
       if (this._dictationStreaming) {
         await this._dictationStreaming.disconnect().catch(() => {});
         this._dictationStreaming = null;
+        this._dictationStreamingFingerprint = null;
       }
 
       const connectInner = async () => {
@@ -6194,11 +6217,9 @@ class IPCHandlers {
         // of silently dropping the start of the recording.
         streaming.beginConnecting();
         this._dictationStreaming = streaming;
+        this._dictationStreamingFingerprint = fingerprint;
         try {
-          const apiKey = await fetchRealtimeToken(event, {
-            mode: options.mode,
-            provider: options.provider,
-          });
+          const apiKey = await fetchRealtimeToken(event, options);
           if (options.provider === "tinfoil-realtime") {
             const model = options.model || TINFOIL_REALTIME_MODEL;
             await streaming.connect({
@@ -6212,13 +6233,17 @@ class IPCHandlers {
             await streaming.connect({
               apiKey,
               model: options.model || "gpt-4o-mini-transcribe",
+              language: options.language,
               // OpenAI rejects rates below 24kHz; the 16kHz capture is upsampled instead.
               captureRate: 16000,
               preconfigured: isCloud,
             });
           }
         } catch (err) {
-          if (this._dictationStreaming === streaming) this._dictationStreaming = null;
+          if (this._dictationStreaming === streaming) {
+            this._dictationStreaming = null;
+            this._dictationStreamingFingerprint = null;
+          }
           throw err;
         }
       };
@@ -6683,7 +6708,7 @@ class IPCHandlers {
       try {
         clearDictationIdleTimer();
         this._dictationPreviewEnabled = !!options.preview;
-        if (!this._dictationStreaming?.isConnected) await connectDictationStreaming(event, options);
+        await connectDictationStreaming(event, options);
         return { success: true };
       } catch (err) {
         return streamingStartFailure(err);
@@ -6697,10 +6722,12 @@ class IPCHandlers {
     ipcMain.handle("dictation-realtime-stop", async () => {
       clearDictationIdleTimer();
       if (!this._dictationStreaming) {
+        this._dictationStreamingFingerprint = null;
         return { success: true, text: "" };
       }
       const result = await this._dictationStreaming.disconnect().catch(() => ({ text: "" }));
       this._dictationStreaming = null;
+      this._dictationStreamingFingerprint = null;
       if (this._dictationPreviewEnabled) {
         this.windowManager.hideTranscriptionPreview();
         this._dictationPreviewEnabled = false;

--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -28,6 +28,13 @@ async function createSocketWithTimeout(createSocket, timeoutMs) {
 }
 
 class OpenAIRealtimeStreaming {
+  static normalizeLanguage(language) {
+    if (typeof language !== "string") return undefined;
+    const normalized = language.trim().toLowerCase();
+    if (!normalized || normalized === "auto") return undefined;
+    return normalized.split(/[-_]/)[0] || undefined;
+  }
+
   constructor() {
     this.ws = null;
     this.isConnected = false;
@@ -47,6 +54,7 @@ class OpenAIRealtimeStreaming {
     this.isDisconnecting = false;
     this.audioBytesSent = 0;
     this.model = "gpt-4o-mini-transcribe";
+    this.language = undefined;
     this.inputRate = SAMPLE_RATE;
     this.captureRate = SAMPLE_RATE;
     this.coldStartBuffer = [];
@@ -70,7 +78,8 @@ class OpenAIRealtimeStreaming {
   }
 
   async connect(options = {}) {
-    const { apiKey, model, preconfigured, inputRate, captureRate, createSocket } = options;
+    const { apiKey, model, language, preconfigured, inputRate, captureRate, createSocket } =
+      options;
     if (!apiKey) throw new Error("OpenAI API key is required");
 
     if (this.isConnected || this.isConnecting) {
@@ -84,6 +93,7 @@ class OpenAIRealtimeStreaming {
 
     this.isConnecting = true;
     this.model = model || "gpt-4o-mini-transcribe";
+    this.language = OpenAIRealtimeStreaming.normalizeLanguage(language);
     this.preconfigured = !!preconfigured;
     this.inputRate = inputRate || SAMPLE_RATE;
     this.captureRate = captureRate || this.inputRate;
@@ -94,7 +104,10 @@ class OpenAIRealtimeStreaming {
     this._sessionExpired = false;
 
     const url = "wss://api.openai.com/v1/realtime?intent=transcription";
-    debugLogger.debug("OpenAI Realtime connecting", { model: this.model });
+    debugLogger.debug("OpenAI Realtime connecting", {
+      model: this.model,
+      language: this.language || "auto",
+    });
 
     // Attested providers (Tinfoil) supply their socket via an async factory.
     let ws;
@@ -172,11 +185,13 @@ class OpenAIRealtimeStreaming {
             // sending an update would strip language and noise-reduction.
             debugLogger.debug("OpenAI Realtime session created (preconfigured)", {
               model: this.model,
+              language: this.language || "auto",
             });
             this._markConnected();
           } else {
             debugLogger.debug("OpenAI Realtime session created, sending configuration", {
               model: this.model,
+              language: this.language || "auto",
             });
             if (!this.ws || this.ws.readyState !== WebSocket.OPEN) break;
             this.ws.send(
@@ -187,7 +202,10 @@ class OpenAIRealtimeStreaming {
                   audio: {
                     input: {
                       format: { type: "audio/pcm", rate: this.inputRate },
-                      transcription: { model: this.model },
+                      transcription: {
+                        model: this.model,
+                        ...(this.language ? { language: this.language } : {}),
+                      },
                       turn_detection: {
                         type: "server_vad",
                         threshold: 0.6,
@@ -207,6 +225,7 @@ class OpenAIRealtimeStreaming {
           if (this.pendingResolve) {
             debugLogger.debug("OpenAI Realtime session configured", {
               model: this.model,
+              language: this.language || "auto",
             });
             this._markConnected();
           }

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1946,10 +1946,16 @@ declare global {
       dictationRealtimeWarmup?: (options: {
         model?: string;
         mode?: "byok" | "openwhispr";
+        language?: string;
+        provider?: string;
+        preview?: boolean;
       }) => Promise<{ success: boolean; error?: string }>;
       dictationRealtimeStart?: (options: {
         model?: string;
         mode?: "byok" | "openwhispr";
+        language?: string;
+        provider?: string;
+        preview?: boolean;
       }) => Promise<{ success: boolean; error?: string }>;
       dictationRealtimeSend?: (buffer: ArrayBuffer) => void;
       dictationRealtimeStop?: () => Promise<{ success: boolean; text: string }>;

--- a/test/helpers/openaiRealtimeStreaming.test.js
+++ b/test/helpers/openaiRealtimeStreaming.test.js
@@ -21,17 +21,90 @@ function makeFakeSocket(readyState) {
   return socket;
 }
 
-async function connectPreconfigured(streaming, socket) {
+async function connectPreconfigured(streaming, socket, options = {}) {
   const connected = streaming.connect({
     apiKey: "key",
     preconfigured: true,
     createSocket: async () => socket,
+    ...options,
   });
   await new Promise((resolve) => setImmediate(resolve));
   socket.readyState = WS.OPEN;
   socket.emit("message", JSON.stringify({ type: "session.created" }));
   await connected;
 }
+
+async function connectConfigured(streaming, options = {}) {
+  const socket = makeFakeSocket(WS.CONNECTING);
+  const connected = streaming.connect({
+    apiKey: "key",
+    createSocket: async () => socket,
+    ...options,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  socket.readyState = WS.OPEN;
+  socket.emit("message", JSON.stringify({ type: "session.created" }));
+  const update = JSON.parse(socket.sent[0]);
+  socket.emit("message", JSON.stringify({ type: "session.updated" }));
+  await connected;
+  return { socket, update };
+}
+
+test("normalizeLanguage returns base ISO-639-1 codes and preserves auto-detection", async () => {
+  const OpenAIRealtimeStreaming = (await load()).default;
+
+  assert.equal(OpenAIRealtimeStreaming.normalizeLanguage(" en-US "), "en");
+  assert.equal(OpenAIRealtimeStreaming.normalizeLanguage("PT_BR"), "pt");
+  assert.equal(OpenAIRealtimeStreaming.normalizeLanguage("AUTO"), undefined);
+  assert.equal(OpenAIRealtimeStreaming.normalizeLanguage(undefined), undefined);
+});
+
+test("BYOK session sends the selected language as an ISO-639-1 hint", async () => {
+  const OpenAIRealtimeStreaming = (await load()).default;
+  const streaming = new OpenAIRealtimeStreaming();
+
+  const { update } = await connectConfigured(streaming, {
+    model: "gpt-4o-transcribe",
+    language: "en-US",
+  });
+
+  assert.equal(update.type, "session.update");
+  assert.deepEqual(update.session.audio.input.transcription, {
+    model: "gpt-4o-transcribe",
+    language: "en",
+  });
+  streaming.cleanup();
+});
+
+test("BYOK session omits the language hint when auto-detection is selected", async () => {
+  const OpenAIRealtimeStreaming = (await load()).default;
+  const streaming = new OpenAIRealtimeStreaming();
+
+  const { update } = await connectConfigured(streaming, {
+    model: "gpt-4o-transcribe",
+    language: "auto",
+  });
+
+  assert.deepEqual(update.session.audio.input.transcription, {
+    model: "gpt-4o-transcribe",
+  });
+  streaming.cleanup();
+});
+
+test("preconfigured session preserves server configuration without sending an update", async () => {
+  const OpenAIRealtimeStreaming = (await load()).default;
+  const streaming = new OpenAIRealtimeStreaming();
+  const socket = makeFakeSocket(WS.CONNECTING);
+
+  await connectPreconfigured(streaming, socket, {
+    model: "gpt-4o-transcribe",
+    language: "en-US",
+  });
+
+  assert.equal(streaming.language, "en");
+  assert.deepEqual(socket.sent, []);
+  streaming.cleanup();
+});
 
 test("sendAudio buffers frames arriving before the socket exists (token-fetch window)", async () => {
   const OpenAIRealtimeStreaming = (await load()).default;


### PR DESCRIPTION
## Summary

- forward the selected model and language when creating OpenWhispr Cloud realtime tokens
- normalize regional language selections such as `en-US` to the OpenAI hint `en`
- include the language hint in BYOK OpenAI realtime `session.update` payloads
- reconnect pre-warmed dictation sessions when provider, mode, model, or language changes
- cover explicit language, Auto, normalization, and preconfigured cloud behavior with regression tests

## Root cause

The renderer supplied `preferredLanguage` when starting realtime dictation, but `connectDictationStreaming()` reduced the token request to only `mode` and `provider` and did not pass language into `OpenAIRealtimeStreaming.connect()`. Non-preconfigured BYOK sessions consequently sent only the model in `audio.input.transcription`, leaving the backend to auto-detect every utterance.

OpenAI's realtime transcription API accepts an optional language hint such as `en`. Supplying it prevents an explicit UI language selection from silently falling back to auto-detection.

## User impact

Users can keep realtime models such as `gpt-4o-transcribe` while having English US/UK and other regional selections honored. Auto remains opt-in: `auto`, blank, and missing values omit the hint. Preconfigured OpenWhispr Cloud sessions continue to skip client-side session updates so server-provided language and noise-reduction settings are preserved.

Warm connections are fingerprinted using their effective configuration, preventing a socket prepared under Auto or a previous language/model from being reused after settings change.

## Validation

- rebased cleanly onto `main` at `6f9c7f8`
- Node.js 24.14.0 in a rootless container
- targeted OpenAI realtime suite: 26/26 passed
- full test suite: 871 tests; 869 passed, 2 skipped, 0 failed
- `npm run quality-check`: root and renderer ESLint, Prettier, and TypeScript passed
- `npm run i18n:check`: passed
- JavaScript syntax and `git diff --check`: passed
