### PR TITLE
feat: add Vercel AI Gateway reasoning provider

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -14,6 +14,7 @@ const BYOK_KEY_BRIDGES = [
   { base: "openrouter", get: "getOpenrouterKey", save: "saveOpenrouterKey" },
   { base: "tinfoil", get: "getTinfoilKey", save: "saveTinfoilKey" },
   { base: "corti", get: "getCortiKey", save: "saveCortiKey" },
+  { base: "vercel", get: "getVercelKey", save: "saveVercelKey" },
 ];
 const secretKeyApi = {};
 for (const k of BYOK_KEY_BRIDGES) {

--- a/src/assets/icons/providers/vercel.svg
+++ b/src/assets/icons/providers/vercel.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Vercel</title><path d="M12 1.608l12 20.784H0L12 1.608z"></path></svg>

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -39,7 +39,7 @@ const OPENROUTER_TAB = "openrouter";
 const OPENROUTER_KEYS_URL = "https://openrouter.ai/keys";
 
 const VERCEL_TAB = "vercel";
-const VERCEL_KEYS_URL = "https://vercel.com/docs/ai-gateway";
+const VERCEL_KEYS_URL = "https://vercel.com/docs/ai-gateway/authentication-and-byok/api-keys";
 
 const CLOUD_PROVIDER_IDS = [
   "openai",

--- a/src/components/ReasoningModelSelector.tsx
+++ b/src/components/ReasoningModelSelector.tsx
@@ -38,12 +38,16 @@ type CloudModelOption = {
 const OPENROUTER_TAB = "openrouter";
 const OPENROUTER_KEYS_URL = "https://openrouter.ai/keys";
 
+const VERCEL_TAB = "vercel";
+const VERCEL_KEYS_URL = "https://vercel.com/docs/ai-gateway";
+
 const CLOUD_PROVIDER_IDS = [
   "openai",
   "anthropic",
   "gemini",
   "groq",
   OPENROUTER_TAB,
+  VERCEL_TAB,
   "tinfoil",
   "corti",
   "custom",
@@ -336,6 +340,8 @@ export default function ReasoningModelSelector({
   const setGroqApiKey = useSettingsStore((s) => s.setGroqApiKey);
   const openrouterApiKey = useSettingsStore((s) => s.openrouterApiKey);
   const setOpenrouterApiKey = useSettingsStore((s) => s.setOpenrouterApiKey);
+  const vercelApiKey = useSettingsStore((s) => s.vercelApiKey);
+  const setVercelApiKey = useSettingsStore((s) => s.setVercelApiKey);
   const tinfoilApiKey = useSettingsStore((s) => s.tinfoilApiKey);
   const setTinfoilApiKey = useSettingsStore((s) => s.setTinfoilApiKey);
   const cortiApiKey = useSettingsStore((s) => s.cortiApiKey);
@@ -358,7 +364,9 @@ export default function ReasoningModelSelector({
         ? t("reasoning.custom.providerName")
         : id === OPENROUTER_TAB
           ? "OpenRouter"
-          : REASONING_PROVIDERS[id as keyof typeof REASONING_PROVIDERS]?.name || id,
+          : id === VERCEL_TAB
+            ? "Vercel AI Gateway"
+            : REASONING_PROVIDERS[id as keyof typeof REASONING_PROVIDERS]?.name || id,
   }));
 
   const localProviders = useMemo<LocalProvider[]>(() => {
@@ -392,7 +400,12 @@ export default function ReasoningModelSelector({
 
   const selectedCloudModels = useMemo<CloudModelOption[]>(() => {
     if (selectedCloudProvider === "openai") return openaiModelOptions;
-    if (selectedCloudProvider === "custom" || selectedCloudProvider === OPENROUTER_TAB) return [];
+    if (
+      selectedCloudProvider === "custom" ||
+      selectedCloudProvider === OPENROUTER_TAB ||
+      selectedCloudProvider === VERCEL_TAB
+    )
+      return [];
 
     const { icon: iconUrl, invertInDark } = getRemoteProviderIcon(selectedCloudProvider);
 
@@ -442,9 +455,9 @@ export default function ReasoningModelSelector({
   }, []);
 
   const selectDefaultModelForProvider = (provider: string) => {
-    // Custom/OpenRouter fetch their model list dynamically — clear instead of
-    // presetting so another provider's model id can't persist under this one.
-    if (provider === "custom" || provider === OPENROUTER_TAB) {
+    // Custom/OpenRouter/Vercel fetch their model list dynamically — clear instead
+    // of presetting so another provider's model id can't persist under this one.
+    if (provider === "custom" || provider === OPENROUTER_TAB || provider === VERCEL_TAB) {
       setReasoningModel("");
       return;
     }
@@ -559,6 +572,19 @@ export default function ReasoningModelSelector({
                 lockedBaseUrl
                 apiKeyRequired
                 getKeyUrl={OPENROUTER_KEYS_URL}
+              />
+            ) : selectedCloudProvider === VERCEL_TAB ? (
+              <OpenAICompatiblePanel
+                key={VERCEL_TAB}
+                baseUrl={API_ENDPOINTS.VERCEL_AI_GATEWAY_BASE}
+                setBaseUrl={() => {}}
+                apiKey={vercelApiKey}
+                setApiKey={setVercelApiKey}
+                model={reasoningModel}
+                setModel={setReasoningModel}
+                lockedBaseUrl
+                apiKeyRequired
+                getKeyUrl={VERCEL_KEYS_URL}
               />
             ) : selectedCloudProvider === "custom" ? (
               <OpenAICompatiblePanel

--- a/src/components/chat/useChatStreaming.ts
+++ b/src/components/chat/useChatStreaming.ts
@@ -111,6 +111,7 @@ export function useChatStreaming({
           "tinfoil",
           "openrouter",
           "corti",
+          "vercel",
         ].includes(settings.chatAgentProvider);
       const localModelCanUseTool =
         isLocalProvider && estimateModelSizeB(settings.chatAgentModel) >= LOCAL_TOOL_MIN_PARAMS_B;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -92,6 +92,7 @@ export const API_ENDPOINTS = {
   XAI_BASE: "https://api.x.ai/v1",
   MISTRAL_BASE: "https://api.mistral.ai/v1",
   OPENROUTER_BASE: "https://openrouter.ai/api/v1",
+  VERCEL_AI_GATEWAY_BASE: "https://ai-gateway.vercel.sh/v1",
   TRANSCRIPTION_BASE: DEFAULT_TRANSCRIPTION_BASE,
   TRANSCRIPTION: buildApiUrl(DEFAULT_TRANSCRIPTION_BASE, "/audio/transcriptions"),
 } as const;

--- a/src/config/secretKeys.js
+++ b/src/config/secretKeys.js
@@ -64,6 +64,13 @@ const BYOK_API_KEYS = [
     save: "saveCortiKey",
     storeKey: "cortiApiKey",
   },
+  {
+    base: "vercel",
+    env: "VERCEL_AI_GATEWAY_API_KEY",
+    get: "getVercelKey",
+    save: "saveVercelKey",
+    storeKey: "vercelApiKey",
+  },
 ];
 
 module.exports = { BYOK_API_KEYS };

--- a/src/helpers/chatRouting.js
+++ b/src/helpers/chatRouting.js
@@ -7,6 +7,7 @@ const CLOUD_CHAT_PROVIDERS = new Set([
   "custom",
   "openrouter",
   "corti",
+  "vercel",
 ]);
 
 // Resolve Chat from Chat-owned settings only. In particular, this must never

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -75,6 +75,7 @@ export interface ApiKeySettings {
   cortiClientSecret: string;
   cortiApiKey: string;
   tinfoilApiKey: string;
+  vercelApiKey: string;
   customTranscriptionApiKey: string;
   cleanupCustomApiKey: string;
 }
@@ -254,6 +255,7 @@ function useSettingsInternal() {
     mistralApiKey: store.mistralApiKey,
     openrouterApiKey: store.openrouterApiKey,
     tinfoilApiKey: store.tinfoilApiKey,
+    vercelApiKey: store.vercelApiKey,
     dictationKey: store.dictationKey,
     meetingKey: store.meetingKey,
     voiceAgentKey: store.voiceAgentKey,

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -324,6 +324,7 @@ export function getReasoningModelLabel(modelId: string): string {
 
 const NON_REGISTRY_PROVIDER_NAMES: Record<string, string> = {
   openrouter: "OpenRouter",
+  vercel: "Vercel AI Gateway",
   custom: "Custom",
 };
 
@@ -348,6 +349,10 @@ export function getModelProvider(modelId: string): string {
 
   if (storedProvider === "openrouter") {
     return "openrouter";
+  }
+
+  if (storedProvider === "vercel") {
+    return "vercel";
   }
 
   if (isEnterpriseProvider(storedProvider)) {
@@ -458,10 +463,11 @@ export function getOpenAiApiConfig(modelId: string, provider?: string): OpenAiAp
     };
   }
 
-  // OpenRouter's vendor-prefixed ids (openai/gpt-4o, anthropic/claude-…) speak
-  // standard Chat Completions. Scoped to the provider so vendor-prefixed ids on
-  // custom endpoints keep the request shape they had before OpenRouter landed.
-  if (provider === "openrouter" && modelId.includes("/")) {
+  // OpenRouter's and Vercel AI Gateway's vendor-prefixed ids (openai/gpt-4o,
+  // anthropic/claude-…) speak standard Chat Completions. Scoped to the provider
+  // so vendor-prefixed ids on custom endpoints keep the request shape they had
+  // before OpenRouter landed.
+  if ((provider === "openrouter" || provider === "vercel") && modelId.includes("/")) {
     return { tokenParam: "max_tokens", supportsTemperature: true };
   }
 

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -88,7 +88,15 @@ class ReasoningService extends BaseReasoningService {
 
   private async getApiKey(
     provider:
-      "openai" | "anthropic" | "gemini" | "groq" | "tinfoil" | "custom" | "openrouter" | "corti"
+      | "openai"
+      | "anthropic"
+      | "gemini"
+      | "groq"
+      | "tinfoil"
+      | "custom"
+      | "openrouter"
+      | "corti"
+      | "vercel"
   ): Promise<string> {
     if (provider === "custom") {
       let customKey = "";
@@ -129,6 +137,7 @@ class ReasoningService extends BaseReasoningService {
           openrouter: () => window.electronAPI.getOpenrouterKey(),
           tinfoil: () => window.electronAPI.getTinfoilKey?.(),
           corti: () => window.electronAPI.getCortiKey?.(),
+          vercel: () => window.electronAPI.getVercelKey?.(),
         };
         apiKey = (await keyGetters[provider]()) ?? undefined;
 
@@ -410,7 +419,15 @@ class ReasoningService extends BaseReasoningService {
       endpoint = `http://127.0.0.1:${serverResult.port}/v1/chat/completions`;
     } else {
       const providerKey = provider as
-        "openai" | "groq" | "gemini" | "anthropic" | "tinfoil" | "custom" | "openrouter" | "corti";
+        | "openai"
+        | "groq"
+        | "gemini"
+        | "anthropic"
+        | "tinfoil"
+        | "custom"
+        | "openrouter"
+        | "corti"
+        | "vercel";
       const overrideKey = providerKey === "custom" ? config.customApiKey?.trim() : "";
       apiKey = overrideKey || (await this.getApiKey(providerKey));
 
@@ -426,6 +443,9 @@ class ReasoningService extends BaseReasoningService {
           break;
         case "openrouter":
           endpoint = buildApiUrl(API_ENDPOINTS.OPENROUTER_BASE, "/chat/completions");
+          break;
+        case "vercel":
+          endpoint = buildApiUrl(API_ENDPOINTS.VERCEL_AI_GATEWAY_BASE, "/chat/completions");
           break;
         case "tinfoil":
           throw new Error("Tinfoil streaming must use the verified SDK transport");
@@ -631,15 +651,25 @@ class ReasoningService extends BaseReasoningService {
       baseURL = `http://127.0.0.1:${serverResult.port}/v1`;
     } else {
       const providerKey = provider as
-        "openai" | "groq" | "gemini" | "anthropic" | "tinfoil" | "custom" | "openrouter" | "corti";
+        | "openai"
+        | "groq"
+        | "gemini"
+        | "anthropic"
+        | "tinfoil"
+        | "custom"
+        | "openrouter"
+        | "corti"
+        | "vercel";
       const overrideKey = providerKey === "custom" ? config.customApiKey?.trim() : "";
       apiKey = overrideKey || (await this.getApiKey(providerKey));
       baseURL =
         provider === "openrouter"
           ? API_ENDPOINTS.OPENROUTER_BASE
-          : provider === "custom"
-            ? config.baseUrl?.trim() || getConfiguredOpenAIBase()
-            : undefined;
+          : provider === "vercel"
+            ? API_ENDPOINTS.VERCEL_AI_GATEWAY_BASE
+            : provider === "custom"
+              ? config.baseUrl?.trim() || getConfiguredOpenAIBase()
+              : undefined;
     }
     const aiProvider = isLocalProvider || isLanChat ? "local" : provider;
     // OpenRouter ids are never in the local registry, so the supportsThinking
@@ -954,6 +984,7 @@ class ReasoningService extends BaseReasoningService {
       const openrouterKey = await window.electronAPI?.getOpenrouterKey?.();
       const tinfoilKey = await window.electronAPI?.getTinfoilKey?.();
       const cortiKey = await window.electronAPI?.getCortiKey?.();
+      const vercelKey = await window.electronAPI?.getVercelKey?.();
       const localAvailable = await window.electronAPI?.checkLocalReasoningAvailable?.();
 
       logger.logReasoning("API_KEY_CHECK", {
@@ -964,6 +995,7 @@ class ReasoningService extends BaseReasoningService {
         hasOpenrouter: !!openrouterKey,
         hasTinfoil: !!tinfoilKey,
         hasCorti: !!cortiKey,
+        hasVercel: !!vercelKey,
         hasLocal: !!localAvailable,
       });
 
@@ -975,6 +1007,7 @@ class ReasoningService extends BaseReasoningService {
         openrouterKey ||
         tinfoilKey ||
         cortiKey ||
+        vercelKey ||
         localAvailable
       );
     } catch (error) {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -998,6 +998,7 @@ class ReasoningService extends BaseReasoningService {
       | "custom"
       | "openrouter"
       | "corti"
+      | "vercel"
   ): void {
     if (provider) {
       if (provider !== "custom") {

--- a/src/services/ai/inferenceProviders/index.ts
+++ b/src/services/ai/inferenceProviders/index.ts
@@ -9,6 +9,7 @@ import { lanProvider } from "./lan";
 import { openaiProvider } from "./openai";
 import { tinfoilProvider } from "./tinfoil";
 import { cortiProvider } from "./corti";
+import { vercelProvider } from "./vercel";
 
 export const PROVIDER_REGISTRY: Readonly<Record<string, InferenceProvider>> = Object.freeze({
   openai: openaiProvider,
@@ -25,6 +26,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, InferenceProvider>> = Ob
   vertex: enterpriseProvider,
   openwhispr: openwhisprProvider,
   lan: lanProvider,
+  vercel: vercelProvider,
 });
 
 export type { InferenceProvider, ProviderContext, ProviderCallParams } from "./types";

--- a/src/services/ai/inferenceProviders/vercel.ts
+++ b/src/services/ai/inferenceProviders/vercel.ts
@@ -1,0 +1,21 @@
+import logger from "@/utils/logger";
+import { InferenceProvider } from "./types";
+import { API_ENDPOINTS, buildApiUrl } from "../../../config/constants";
+
+export const vercelProvider: InferenceProvider = {
+  id: "vercel",
+  async call({ text, model, agentName, config, ctx }) {
+    logger.logReasoning("VERCEL_START", { model, agentName });
+    const apiKey = await ctx.getApiKey("vercel");
+    const endpoint = buildApiUrl(API_ENDPOINTS.VERCEL_AI_GATEWAY_BASE, "/chat/completions");
+    return ctx.callChatCompletionsApi(
+      endpoint,
+      apiKey,
+      model,
+      text,
+      agentName,
+      config,
+      "Vercel AI Gateway"
+    );
+  },
+};

--- a/src/services/ai/providers.ts
+++ b/src/services/ai/providers.ts
@@ -56,6 +56,8 @@ export async function getAIModel(
         baseURL,
         ...(opts?.disableThinking ? { fetch: withDisabledReasoning } : {}),
       }).chat(model);
+    case "vercel":
+      return createOpenAI({ apiKey, baseURL: API_ENDPOINTS.VERCEL_AI_GATEWAY_BASE }).chat(model);
     case "local":
       return createOpenAI({ apiKey: apiKey || "no-key", baseURL }).chat(model);
     default:

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -604,6 +604,7 @@ export interface SettingsState
   setCortiClientSecret: (key: string) => void;
   setCortiApiKey: (key: string) => void;
   setTinfoilApiKey: (key: string) => void;
+  setVercelApiKey: (key: string) => void;
   setCustomTranscriptionApiKey: (key: string) => void;
   setCleanupCustomApiKey: (key: string) => void;
 
@@ -803,6 +804,7 @@ const SECRET_IPC_SAVERS = {
   cortiClientSecret: "saveCortiClientSecret",
   cortiApiKey: "saveCortiKey",
   tinfoil: "saveTinfoilKey",
+  vercel: "saveVercelKey",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
   bedrockAccessKeyId: "saveBedrockAccessKeyId",
@@ -845,6 +847,7 @@ const STALE_SECRET_LOCALSTORAGE_KEYS = [
   "cortiClientSecret",
   "cortiApiKey",
   "tinfoilApiKey",
+  "vercelApiKey",
   "customTranscriptionApiKey",
   "customReasoningApiKey",
   "cleanupCustomApiKey",
@@ -866,6 +869,7 @@ function invalidateApiKeyCaches(
     | "custom"
     | "openrouter"
     | "corti"
+    | "vercel"
 ) {
   if (provider) {
     if (_ReasoningService) {
@@ -954,6 +958,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   cortiClientSecret: "",
   cortiApiKey: "",
   tinfoilApiKey: "",
+  vercelApiKey: "",
   customTranscriptionApiKey: "",
   cleanupCustomApiKey: "",
 
@@ -1426,6 +1431,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setCortiEnvironment: createStringSetter("cortiEnvironment"),
   setCortiTenant: createStringSetter("cortiTenant"),
   setTinfoilApiKey: createSecretSetter("tinfoilApiKey", "tinfoil", "tinfoil"),
+  setVercelApiKey: createSecretSetter("vercelApiKey", "vercel", "vercel"),
   setCustomTranscriptionApiKey: (key: string) => {
     set({ customTranscriptionApiKey: key });
     debouncedSaveSecret("customTranscription", key);
@@ -1874,6 +1880,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (keys.cortiClientSecret !== undefined) s.setCortiClientSecret(keys.cortiClientSecret);
     if (keys.cortiApiKey !== undefined) s.setCortiApiKey(keys.cortiApiKey);
     if (keys.tinfoilApiKey !== undefined) s.setTinfoilApiKey(keys.tinfoilApiKey);
+    if (keys.vercelApiKey !== undefined) s.setVercelApiKey(keys.vercelApiKey);
     if (keys.customTranscriptionApiKey !== undefined)
       s.setCustomTranscriptionApiKey(keys.customTranscriptionApiKey);
     if (keys.cleanupCustomApiKey !== undefined) s.setCleanupCustomApiKey(keys.cleanupCustomApiKey);
@@ -2134,6 +2141,7 @@ export async function initializeSettings(): Promise<void> {
         cortiClientSecret,
         cortiApiKey,
         tinfoil,
+        vercelApiKey,
         customTx,
         customRx,
         bedrockAccessKeyId,
@@ -2153,6 +2161,7 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getCortiClientSecret?.(),
         window.electronAPI.getCortiKey?.(),
         window.electronAPI.getTinfoilKey?.(),
+        window.electronAPI.getVercelKey?.(),
         window.electronAPI.getCustomTranscriptionKey?.(),
         window.electronAPI.getCleanupCustomKey?.(),
         window.electronAPI.getBedrockAccessKeyId?.(),
@@ -2174,6 +2183,7 @@ export async function initializeSettings(): Promise<void> {
         cortiClientSecret: cortiClientSecret || "",
         cortiApiKey: cortiApiKey || "",
         tinfoilApiKey: tinfoil || "",
+        vercelApiKey: vercelApiKey || "",
         customTranscriptionApiKey: customTx || "",
         cleanupCustomApiKey: customRx || "",
         bedrockAccessKeyId: bedrockAccessKeyId || "",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1173,6 +1173,10 @@ declare global {
         { text: string; model: string } | { error: string; code?: string; messageKey?: string }
       >;
 
+      // Vercel API key management
+      getVercelKey?: () => Promise<string | null>;
+      saveVercelKey?: (key: string) => Promise<void>;
+
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;
       saveCustomTranscriptionKey?: (key: string) => Promise<void>;

--- a/src/utils/providerIcons.ts
+++ b/src/utils/providerIcons.ts
@@ -16,6 +16,7 @@ import xaiIcon from "@/assets/icons/providers/xai.svg";
 import cortiIcon from "@/assets/icons/providers/corti.svg";
 import openrouterIcon from "@/assets/icons/providers/openrouter.svg";
 import tinfoilIcon from "@/assets/icons/providers/tinfoil.svg";
+import vercelIcon from "@/assets/icons/providers/vercel.svg";
 
 export const PROVIDER_ICONS: Record<string, string> = {
   openai: openaiIcon,
@@ -37,6 +38,7 @@ export const PROVIDER_ICONS: Record<string, string> = {
   corti: cortiIcon,
   openrouter: openrouterIcon,
   tinfoil: tinfoilIcon,
+  vercel: vercelIcon,
 };
 
 export function getProviderIcon(provider: string): string | undefined {
@@ -53,6 +55,7 @@ export const MONOCHROME_PROVIDERS = [
   "corti",
   "openrouter",
   "tinfoil",
+  "vercel",
 ] as const;
 
 export function isMonochromeProvider(provider: string): boolean {

--- a/test/helpers/chatRouting.test.js
+++ b/test/helpers/chatRouting.test.js
@@ -20,6 +20,13 @@ test("built-in provider Chat stays on its provider route", async () => {
   assert.equal(route.kind, "provider");
 });
 
+test("Vercel AI Gateway Chat stays on its provider route", async () => {
+  const { resolveChatRoute } = await load();
+  const route = resolveChatRoute({ provider: "vercel" });
+
+  assert.equal(route.kind, "provider");
+});
+
 test("local Chat stays on its local route", async () => {
   const { resolveChatRoute } = await load();
   const route = resolveChatRoute({ provider: "ollama" });


### PR DESCRIPTION
Part of #1356 (reasoning/chat support; the speech-to-text follow-up is tracked there).

## Why

Vercel AI Gateway routes to hundreds of models with a single API key. It already works through the Custom tab for chat, but as a first-class provider it gets a named tab, its own encrypted key entry, and one-click model selection. It's the same treatment OpenRouter has. Full code in #1356.

## What

- New `vercel` inference provider mirroring the `groq.ts` pattern: fixed base URL (`https://ai-gateway.vercel.sh/v1`) + Chat Completions via the shared helper.
- BYOK key storage: one entry in the `secretKeys.js` manifest (mirrored in `preload.js`), reusing the generic IPC/encryption plumbing.
- Wiring: `ReasoningService` (cleanup + streaming paths), `getAIModel()` (`createOpenAI({ baseURL }).chat(model)` — Chat Completions, not Responses API), chat routing, and `ModelRegistry` (vendor-prefixed model ids like `openai/gpt-4o` resolve `max_tokens` correctly).
- UI: "Vercel AI Gateway" tab in the model selector using `OpenAICompatiblePanel` with a locked base URL and dynamic model listing via `/models` (OpenRouter-style — no static catalog, so no i18n additions), plus provider icon.

## Test plan

- `npm run typecheck`, `npm test` (696 passing, includes a new `chatRouting` case for the provider route), `npm run lint`, `npm run format`
- Manual, against the live gateway: key persistence across app restarts (encrypted storage), dynamic model list loading, dictation cleanup path, and agent chat streaming path
- The gateway sends permissive CORS headers, so direct renderer fetch works like Groq/OpenRouter. No IPC proxy needed