### PR TITLE
fix(reasoning): local voice agent silently echoes transcript instead of running the command

### DIFF
--- a/src/helpers/reasoningProviderId.js
+++ b/src/helpers/reasoningProviderId.js
@@ -1,0 +1,14 @@
+// The local-model picker groups GGUF models by vendor — "llama", "qwen",
+// "mistral", "gemma", "openai-oss", "liquidai" — and settings persist that
+// vendor id as the scope's provider. But those are UI groupings, not inference
+// providers: every local model is served by the single `local` entry in
+// PROVIDER_REGISTRY.
+//
+// So a vendor id must be normalized before any provider lookup. Without this,
+// selecting a local model for the dictation agent makes ReasoningService throw
+// "Unsupported reasoning provider: llama", which callers swallow — the user
+// just gets their raw transcript back with no error shown.
+export function normalizeReasoningProviderId(providerId, localProviderIds = []) {
+  if (!providerId) return providerId;
+  return localProviderIds.includes(providerId) ? "local" : providerId;
+}

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -1,4 +1,5 @@
 import modelDataRaw from "./modelRegistryData.json";
+import { normalizeReasoningProviderId as normalizeProviderId } from "../helpers/reasoningProviderId";
 import { isCloudCleanupMode, getSettings } from "../stores/settingsStore";
 import { readCachedTinfoilModels } from "./tinfoilModelCache";
 
@@ -239,6 +240,22 @@ export type EnterpriseProvider = "bedrock" | "azure" | "vertex";
 export const ENTERPRISE_PROVIDERS: readonly EnterpriseProvider[] = ["bedrock", "azure", "vertex"];
 export function isEnterpriseProvider(value: unknown): value is EnterpriseProvider {
   return typeof value === "string" && (ENTERPRISE_PROVIDERS as readonly string[]).includes(value);
+}
+
+// Vendor ids from the local-model picker ("llama", "qwen", …). These group
+// models in the UI; they are not entries in PROVIDER_REGISTRY, which serves
+// every local model through the single `local` provider.
+const LOCAL_PROVIDER_IDS: readonly string[] = modelData.localProviders.map((p) => p.id);
+
+export function isLocalProviderId(value: unknown): boolean {
+  return typeof value === "string" && LOCAL_PROVIDER_IDS.includes(value);
+}
+
+// Map a stored provider id to the one PROVIDER_REGISTRY actually keys on.
+// Settings persist the vendor id for local scopes, so this must run before any
+// provider lookup or local inference throws "Unsupported reasoning provider".
+export function normalizeReasoningProviderId(providerId: string): string {
+  return normalizeProviderId(providerId, LOCAL_PROVIDER_IDS as string[]);
 }
 
 export function toReasoningModel(m: CloudModelDefinition): ReasoningModel {

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -4,6 +4,7 @@ import {
   getOpenAiApiConfig,
   getProviderDisplayName,
   isEnterpriseProvider,
+  normalizeReasoningProviderId,
   type EnterpriseProvider,
 } from "../models/ModelRegistry";
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
@@ -334,7 +335,11 @@ class ReasoningService extends BaseReasoningService {
   ): Promise<string> {
     const trimmedModel = model?.trim?.() || "";
     const isLanCleanup = !!config.lanUrl || this.isLanCleanupMode();
-    const providerId = isLanCleanup ? "lan" : config.provider || getModelProvider(trimmedModel);
+    // Local scopes persist the picker's vendor id ("llama", "qwen", …), which is
+    // not a PROVIDER_REGISTRY key — normalize before the lookup below.
+    const providerId = isLanCleanup
+      ? "lan"
+      : normalizeReasoningProviderId(config.provider || getModelProvider(trimmedModel));
 
     if (!trimmedModel && providerId !== "openwhispr" && providerId !== "lan") {
       throw new Error("No reasoning model selected");

--- a/test/helpers/reasoningProviderId.test.js
+++ b/test/helpers/reasoningProviderId.test.js
@@ -1,0 +1,62 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/reasoningProviderId.js");
+
+// Mirrors the ids in modelRegistryData.json -> localProviders.
+const LOCAL_PROVIDER_IDS = ["qwen", "mistral", "llama", "openai-oss", "gemma", "liquidai"];
+
+test("every local vendor id normalizes to the local provider", async () => {
+  const { normalizeReasoningProviderId } = await load();
+
+  for (const vendor of LOCAL_PROVIDER_IDS) {
+    assert.equal(
+      normalizeReasoningProviderId(vendor, LOCAL_PROVIDER_IDS),
+      "local",
+      `${vendor} should map to "local"`
+    );
+  }
+});
+
+test("real provider ids pass through untouched", async () => {
+  const { normalizeReasoningProviderId } = await load();
+
+  for (const provider of [
+    "openai",
+    "anthropic",
+    "gemini",
+    "groq",
+    "openwhispr",
+    "lan",
+    "local",
+    "custom",
+    "openrouter",
+    "bedrock",
+  ]) {
+    assert.equal(normalizeReasoningProviderId(provider, LOCAL_PROVIDER_IDS), provider);
+  }
+});
+
+test("an empty provider is left alone so callers can fall back", async () => {
+  const { normalizeReasoningProviderId } = await load();
+
+  assert.equal(normalizeReasoningProviderId("", LOCAL_PROVIDER_IDS), "");
+  assert.equal(normalizeReasoningProviderId(undefined, LOCAL_PROVIDER_IDS), undefined);
+});
+
+test("an unknown provider is not silently rewritten", async () => {
+  const { normalizeReasoningProviderId } = await load();
+
+  // Better to surface "Unsupported reasoning provider: totally-made-up" than to
+  // guess wrong and route the request somewhere it does not belong.
+  assert.equal(
+    normalizeReasoningProviderId("totally-made-up", LOCAL_PROVIDER_IDS),
+    "totally-made-up"
+  );
+});
+
+test("defaults to no local ids when the list is omitted", async () => {
+  const { normalizeReasoningProviderId } = await load();
+
+  assert.equal(normalizeReasoningProviderId("llama"), "llama");
+});


### PR DESCRIPTION
## What I was seeing

I set up OpenWhispr to run fully locally — local Whisper for transcription, and a local GGUF model for the voice agent. Transcription worked perfectly. The voice agent did not.

Every time I addressed my agent, I just got my own words back:

> **Me:** "Hey Jarvis, write me an email thanking Chris for meeting with me today"
> **Pasted:** `Hey Jarvis, write me an email thanking Chris for meeting with me today`

No error, no toast, nothing in the UI. It looked exactly as if the agent had never been invoked — like the app had simply decided my command was dictation.

The confusing part was that **OpenWhispr Cloud worked perfectly** with the identical prompt and identical agent name. Only local was broken.

I spent a long time assuming I'd misconfigured something. I tried:

- Llama 3.1 8B, then Qwen3.5 9B — same result on both
- Re-downloading models
- Renaming the agent (I initially had a name Whisper couldn't transcribe consistently, which was a genuine and separate mistake on my part)
- Saying "Hey Jarvis" vs just "Jarvis"
- Switching between Local and Self-hosted
- Fully quitting and relaunching

None of it mattered, because none of it was the problem.

## Root cause

`PROVIDER_REGISTRY` in `src/services/ai/inferenceProviders/index.ts` keys on inference providers:

```
openai, custom, openrouter, anthropic, gemini, groq, tinfoil,
corti, local, bedrock, azure, vertex, openwhispr, lan
```

Every local GGUF model is served through the single `local` entry.

But `modelRegistryData.json → localProviders` uses a completely different vocabulary — these are the **vendor tabs in the model picker UI**:

```
qwen, mistral, llama, openai-oss, gemma, liquidai
```

When you pick a local model for the dictation agent, settings persist the *vendor* id into `dictationAgentProvider`. So mine was literally `"llama"`.

`resolveReasoningRoute()` in `src/helpers/audioManager.js` then passes that straight through as the provider:

```js
const provider = isCloudAgent ? "openwhispr" : settings.dictationAgentProvider?.trim() || undefined;
```

and `ReasoningService.processText()` looks it up directly:

```ts
const providerId = isLanCleanup ? "lan" : config.provider || getModelProvider(trimmedModel);
const handler = PROVIDER_REGISTRY[providerId];
if (!handler) throw new Error(`Unsupported reasoning provider: ${providerId}`);
```

`PROVIDER_REGISTRY["llama"]` is `undefined`, so **every local dictation-agent call throws**. The caller catches it and returns the untouched transcript:

```js
try { const e = await r(l); if (e) l = e; } catch (e) { s && s(e) }
return { text: l, ... }   // l is still the original text
```

Hence the silent echo. The feature wasn't misbehaving — it was throwing on every single invocation and swallowing the error.

### Why cloud and cleanup were unaffected

This is what made it so hard to pin down:

- **Cloud** — provider is hardcoded to `"openwhispr"`, a real registry key. Works.
- **Dictation cleanup** — `cleanupProvider` is normally empty, so it falls through to `getModelProvider(model)`, which correctly resolves local models to `"local"`. Works.
- **Local dictation agent** — the only path that passes a stored vendor id. Broken 100% of the time.

So the two paths that happened to bypass the stored provider both worked, which strongly suggested my *local setup* was at fault rather than the routing.

## The fix

Normalize vendor ids to `local` before the registry lookup. The list is derived from `modelRegistryData.json`, so it stays correct if providers are added or renamed.

- `src/helpers/reasoningProviderId.js` — pure helper, no store or registry dependencies
- `src/models/ModelRegistry.ts` — `isLocalProviderId()` / `normalizeReasoningProviderId()` bound to the real provider list
- `src/services/ReasoningService.ts` — normalize in `processText()` before the lookup

Normalizing centrally rather than at the call site fixes every scope at once — dictation agent, chat agent, note formatting — instead of just the one I hit.

Unknown providers are deliberately **not** rewritten. A genuine misconfiguration should still surface as `Unsupported reasoning provider: <id>` rather than being silently rerouted somewhere it doesn't belong.

## Testing

`test/helpers/reasoningProviderId.test.js` — 5 tests covering: every vendor id maps to `local`, all real provider ids pass through untouched, empty/undefined is preserved so callers can still fall back to `getModelProvider()`, and unknown ids are left alone.

```
npm test        731 tests, 712 pass, 0 fail
npm run lint    pass
tsc --noEmit    pass
prettier        clean
```

Verified manually on macOS 15 (M4, 24 GB) against Llama 3.1 8B Q4_K_M via bundled llama-server with Metal: the voice agent now executes commands instead of echoing them.

## Reproducing

1. Settings → AI Models → Language Models → Voice Agent
2. Enable it, choose **Local**, pick any vendor tab, download and select a model
3. Dictate "Hey \<agent\>, write a short thank-you note"

Before: your transcript, verbatim, no error. After: the note.
