### PR TITLE
fix(dictionary): assign client_dict_id in the schema; cover the agent-name guard

### DIFF
--- a/src/helpers/agentNameDictionary.js
+++ b/src/helpers/agentNameDictionary.js
@@ -1,0 +1,32 @@
+/**
+ * Drop a renamed-away agent name, move the current one to the front.
+ *
+ * `changed` is false when the snapshot already reflects the name; callers must
+ * skip the write then, since setCustomDictionary replaces the whole SQLite
+ * table and a stale snapshot would delete everything it omitted (#1295).
+ *
+ * @param {string[]} dictionary
+ * @param {string} newName
+ * @param {string} [oldName]
+ * @returns {{ changed: boolean, dictionary: string[] }}
+ */
+export function applyAgentNameToDictionary(dictionary, newName, oldName) {
+  let words = Array.isArray(dictionary) ? [...dictionary] : [];
+  let changed = false;
+
+  if (oldName && oldName !== newName) {
+    const kept = words.filter((w) => w !== oldName);
+    if (kept.length !== words.length) {
+      words = kept;
+      changed = true;
+    }
+  }
+
+  const trimmed = newName.trim();
+  if (trimmed && !words.includes(trimmed)) {
+    words = [trimmed, ...words];
+    changed = true;
+  }
+
+  return { changed, dictionary: words };
+}

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -640,6 +640,24 @@ class DatabaseManager {
       this.db.exec(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_dictionary_client_id ON custom_dictionary(client_dict_id)"
       );
+      // Cloud batch-create keys its response map on client_dict_id, so a row
+      // without one can never be marked synced and re-uploads on every pass.
+      // Rows written straight to SQLite (bulk imports, #1295) don't set it, so
+      // the schema assigns it rather than trusting every writer to. Explicit
+      // ids still win — the trigger only fires when one is missing.
+      this.db.exec(`
+        CREATE TRIGGER IF NOT EXISTS custom_dictionary_client_id_default
+        AFTER INSERT ON custom_dictionary
+        WHEN new.client_dict_id IS NULL
+        BEGIN
+          UPDATE custom_dictionary SET client_dict_id =
+            lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' ||
+            substr(lower(hex(randomblob(2))), 2) || '-' ||
+            substr('89ab', abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))), 2) ||
+            '-' || lower(hex(randomblob(6)))
+          WHERE id = new.id;
+        END
+      `);
       this.db.exec(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_snippets_client_id ON snippets(client_snippet_id) WHERE client_snippet_id IS NOT NULL"
       );
@@ -924,24 +942,6 @@ class DatabaseManager {
   getPendingDictionary() {
     try {
       if (!this.db) throw new Error("Database not initialized");
-      // Cloud batch-create needs a stable client_dict_id. Assign any that are
-      // still missing so pending rows remain uploadable after a successful sync.
-      const missingClientIds = this.db
-        .prepare(
-          `SELECT id FROM custom_dictionary
-           WHERE sync_status = 'pending' AND deleted_at IS NULL AND client_dict_id IS NULL`
-        )
-        .all();
-      if (missingClientIds.length > 0) {
-        const assignId = this.db.prepare(
-          "UPDATE custom_dictionary SET client_dict_id = ? WHERE id = ? AND client_dict_id IS NULL"
-        );
-        this.db.transaction(() => {
-          for (const row of missingClientIds) {
-            assignId.run(randomUUID(), row.id);
-          }
-        })();
-      }
       return this.db
         .prepare(
           "SELECT * FROM custom_dictionary WHERE sync_status = 'pending' AND deleted_at IS NULL"

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -640,11 +640,9 @@ class DatabaseManager {
       this.db.exec(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_dictionary_client_id ON custom_dictionary(client_dict_id)"
       );
-      // Cloud batch-create keys its response map on client_dict_id, so a row
-      // without one can never be marked synced and re-uploads on every pass.
-      // Rows written straight to SQLite (bulk imports, #1295) don't set it, so
-      // the schema assigns it rather than trusting every writer to. Explicit
-      // ids still win — the trigger only fires when one is missing.
+      // Cloud batch-create matches responses by client_dict_id, so a row
+      // without one can never be marked synced and re-uploads every pass. Rows
+      // written straight to SQLite don't set it (#1295), so the schema does.
       this.db.exec(`
         CREATE TRIGGER IF NOT EXISTS custom_dictionary_client_id_default
         AFTER INSERT ON custom_dictionary

--- a/src/utils/agentName.ts
+++ b/src/utils/agentName.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { getSettings, useSettingsStore } from "../stores/settingsStore";
+import { applyAgentNameToDictionary } from "../helpers/agentNameDictionary";
 
 const AGENT_NAME_KEY = "agentName";
 const DEFAULT_AGENT_NAME = "OpenWhispr";
@@ -9,28 +10,11 @@ export const getAgentName = (): string => {
 };
 
 function syncAgentNameToDictionary(newName: string, oldName?: string): void {
-  let dictionary = [...getSettings().customDictionary];
-  let changed = false;
-
-  // Remove old agent name if it changed
-  if (oldName && oldName !== newName) {
-    const next = dictionary.filter((w) => w !== oldName);
-    if (next.length !== dictionary.length) {
-      dictionary = next;
-      changed = true;
-    }
-  }
-
-  // Add new name at the front if not already present
-  const trimmed = newName.trim();
-  if (trimmed && !dictionary.includes(trimmed)) {
-    dictionary = [trimmed, ...dictionary];
-    changed = true;
-  }
-
-  // setCustomDictionary → setDictionary replaces the whole SQLite dictionary.
-  // Skip when the agent name is already present so startup cannot push a stale
-  // renderer cache over newer DB state (#1295).
+  const { changed, dictionary } = applyAgentNameToDictionary(
+    getSettings().customDictionary,
+    newName,
+    oldName
+  );
   if (!changed) return;
 
   useSettingsStore.getState().setCustomDictionary(dictionary);

--- a/test/helpers/agentNameDictionary.test.js
+++ b/test/helpers/agentNameDictionary.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/agentNameDictionary.js");
+
+// The `changed` flag is what stops a startup write from replacing the whole
+// SQLite dictionary with a stale renderer cache (#1295). Guard it directly.
+test("reports no change when the agent name is already present", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const existing = ["OpenWhispr", "Alice", "Bob"];
+  const result = applyAgentNameToDictionary(existing, "OpenWhispr");
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.dictionary, existing);
+});
+
+test("reports no change for a stale one-word cache that already has the name", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  assert.equal(applyAgentNameToDictionary(["OpenWhispr"], "OpenWhispr").changed, false);
+});
+
+test("adds the agent name at the front when missing", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const result = applyAgentNameToDictionary(["Alice"], "OpenWhispr");
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.dictionary, ["OpenWhispr", "Alice"]);
+});
+
+test("drops the previous agent name on rename", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const result = applyAgentNameToDictionary(["OpenWhispr", "Alice"], "Jarvis", "OpenWhispr");
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.dictionary, ["Jarvis", "Alice"]);
+});
+
+test("reports no change when the old name was never in the dictionary", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const result = applyAgentNameToDictionary(["Jarvis", "Alice"], "Jarvis", "OpenWhispr");
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.dictionary, ["Jarvis", "Alice"]);
+});
+
+test("ignores a blank agent name", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const result = applyAgentNameToDictionary(["Alice"], "   ");
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.dictionary, ["Alice"]);
+});
+
+test("does not mutate the caller's array", async () => {
+  const { applyAgentNameToDictionary } = await load();
+  const original = ["Alice"];
+  applyAgentNameToDictionary(original, "OpenWhispr");
+  assert.deepEqual(original, ["Alice"]);
+});

--- a/test/helpers/dictionaryDatabase.test.js
+++ b/test/helpers/dictionaryDatabase.test.js
@@ -87,24 +87,53 @@ test("startup reconcile preserves DB words that a stale renderer cache omitted (
   assert.deepEqual(db.getDictionary(), ["OpenWhispr", "Alice", "Bob", "Imported Term"]);
 });
 
-test("getPendingDictionary backfills missing client_dict_id before sync", (t) => {
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// The reporter's scenario: a bulk import writing straight to the table, with no
+// knowledge of the sync columns. Those rows still have to be uploadable (#1295).
+test("rows inserted outside the app get a client_dict_id from the schema", (t) => {
   const db = createDb(t);
   if (!db) return;
 
-  db.setDictionary(["OpenWhispr", "Alice"]);
-  db.db.prepare("UPDATE custom_dictionary SET client_dict_id = NULL WHERE word = 'Alice'").run();
+  db.setDictionary(["OpenWhispr"]);
+  db.db.prepare("INSERT INTO custom_dictionary (word) VALUES (?)").run("Contact Name");
 
-  const before = db.db
-    .prepare("SELECT client_dict_id FROM custom_dictionary WHERE word = 'Alice'")
+  const row = db.db
+    .prepare("SELECT * FROM custom_dictionary WHERE word = 'Contact Name'")
     .get();
-  assert.equal(before.client_dict_id, null);
+  assert.match(row.client_dict_id, UUID_V4);
 
-  const pending = db.getPendingDictionary();
-  const alice = pending.find((row) => row.word === "Alice");
-  assert.ok(alice);
-  assert.ok(alice.client_dict_id);
-  assert.equal(alice.cloud_id, null);
-  assert.equal(alice.sync_status, "pending");
+  const pending = db.getPendingDictionary().find((r) => r.word === "Contact Name");
+  assert.ok(pending, "externally inserted row should be uploadable");
+  assert.equal(pending.cloud_id, null);
+  assert.equal(pending.sync_status, "pending");
+});
+
+test("externally inserted rows get distinct client_dict_ids", (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  const insert = db.db.prepare("INSERT INTO custom_dictionary (word) VALUES (?)");
+  for (const word of ["Alpha", "Beta", "Gamma"]) insert.run(word);
+
+  const ids = db.db
+    .prepare("SELECT client_dict_id FROM custom_dictionary WHERE word IN ('Alpha','Beta','Gamma')")
+    .all()
+    .map((r) => r.client_dict_id);
+  assert.equal(ids.length, 3);
+  assert.equal(new Set(ids).size, 3);
+});
+
+test("an explicitly supplied client_dict_id is preserved", (t) => {
+  const db = createDb(t);
+  if (!db) return;
+
+  db.db
+    .prepare("INSERT INTO custom_dictionary (word, client_dict_id) VALUES (?, ?)")
+    .run("Delta", "supplied-id");
+
+  const row = db.db.prepare("SELECT * FROM custom_dictionary WHERE word = 'Delta'").get();
+  assert.equal(row.client_dict_id, "supplied-id");
 });
 
 test("cloud pull upserts remotes without deleting local-only pending rows", (t) => {


### PR DESCRIPTION
Follow-ups to #1304 / #1295. Two independent changes, one commit each.

## 1. Let the schema assign `client_dict_id`

Cloud batch-create keys its response map on `client_dict_id`. A row without one can never be marked synced, so it re-uploads on every pass and duplicates server-side. Rows written straight to SQLite — the bulk-import path the reporter used — don't set it.

#1304 fixed this by backfilling from `getPendingDictionary()`. That works, but it makes a read path mutate, and it only covers rows that happen to be read before a sync.

This moves the invariant into the schema with an `AFTER INSERT` trigger, so every writer gets a valid id regardless of how the row arrived, and drops the backfill. `getPendingDictionary()` is a pure read again.

Explicit ids still win — the trigger has a `WHEN new.client_dict_id IS NULL` guard, so the app's own inserts are unaffected and skip the extra UPDATE. Triggers are already used in this schema for the notes FTS index.

## 2. Test the agent-name guard

The `changed` guard in `agentName.ts` is the thing that actually stops startup from replacing the whole dictionary with a stale cache — and nothing tested it. There was no test for `agentName.ts` at all, and `node --test` can't load `.ts`.

Extracted the decision to `src/helpers/agentNameDictionary.js` so it's reachable from the existing test layout, mirroring how `dictionaryStartup.js` is structured. No behavior change.

## Validation

Ran with a node-ABI `better-sqlite3` so the DB-backed tests actually execute locally rather than skipping:

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run i18n:check` — clean
- Full suite — 742 tests, 737 passed, 0 failed, 5 skipped (pre-existing)
- Dictionary + agent-name tests — 25 passed, 0 skipped

New coverage: externally-inserted rows receive a v4 `client_dict_id`, ids are distinct, explicitly-supplied ids are preserved, and the agent-name guard reports no change for a stale one-word cache.

## Not included

The larger item is that `setDictionary(words[])` is a replace-everything API, so any caller holding a partial view can delete the rest. That's the root pattern behind #1295; both known triggers are now guarded, so it's a separate piece of work.