### PR TITLE
feat(dictionary): expose list and bulk update over the CLI bridge

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -262,6 +262,16 @@ class CliBridge {
       return id;
     };
 
+    const requireWordList = (value, field) => {
+      if (value === undefined || value === null) return [];
+      if (!Array.isArray(value) || value.some((w) => typeof w !== "string")) {
+        const err = new Error(`'${field}' must be an array of strings`);
+        err.code = "VALIDATION";
+        throw err;
+      }
+      return value;
+    };
+
     const requireSuccess = (result, message) => {
       if (!result?.success) {
         const err = new Error(result?.error || message);
@@ -349,6 +359,25 @@ class CliBridge {
         },
         201
       ),
+      exact("GET", "/v1/dictionary/list", () => {
+        return { data: db.getDictionary(), has_more: false, next_cursor: null };
+      }),
+      // Bulk edits without writing to SQLite by hand, which lost rows on the
+      // next launch and never reached the cloud (#1295). Takes a delta, so an
+      // import cannot delete words it didn't name.
+      exact("POST", "/v1/dictionary/update", ({ body }) => {
+        const add = requireWordList(body?.add, "add");
+        const remove = requireWordList(body?.remove, "remove");
+        if (add.length === 0 && remove.length === 0) {
+          const err = new Error("Provide at least one word in 'add' or 'remove'");
+          err.code = "VALIDATION";
+          throw err;
+        }
+        const result = db.applyDictionaryChanges({ add, remove });
+        const words = db.getDictionary();
+        setImmediate(() => ipc.broadcastToWindows("dictionary-updated", words));
+        return { data: { words, added: result.added, removed: result.removed } };
+      }),
       exact("GET", "/v1/transcriptions/list", ({ query }) => {
         const limit = query.get("limit") ? Number(query.get("limit")) : 50;
         return {

--- a/test/helpers/cliBridgeDictionary.test.js
+++ b/test/helpers/cliBridgeDictionary.test.js
@@ -1,0 +1,153 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+let userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-cli-dict-"));
+const originalLoad = Module._load;
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: {
+        getPath: () => userDataDir,
+        getAppPath: () => process.cwd(),
+        isReady: () => false,
+      },
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+process.env.NODE_ENV = "test";
+
+const DatabaseManager = require("../../src/helpers/database.js");
+const CliBridge = require("../../src/helpers/cliBridge.js");
+
+function isNativeBindingUnavailable(error) {
+  const message = String(error?.message || error);
+  return (
+    message.includes("NODE_MODULE_VERSION") || message.includes("Could not locate the bindings file")
+  );
+}
+
+// Builds the route table against a real database with broadcasts stubbed. The
+// constructor does not start a server, so routes can be invoked directly.
+function createBridge(t) {
+  userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-cli-dict-"));
+  let db;
+  try {
+    const BetterSqlite = require("better-sqlite3");
+    const probe = new BetterSqlite(path.join(userDataDir, "probe.db"));
+    probe.close();
+    fs.rmSync(path.join(userDataDir, "probe.db"), { force: true });
+    db = new DatabaseManager();
+  } catch (error) {
+    if (isNativeBindingUnavailable(error)) {
+      t.skip("better-sqlite3 native binding is not available for this Node runtime");
+      return null;
+    }
+    throw error;
+  }
+
+  const broadcasts = [];
+  const bridge = new CliBridge({
+    databaseManager: db,
+    broadcastToWindows: (channel, payload) => broadcasts.push({ channel, payload }),
+  });
+  return { bridge, db, broadcasts };
+}
+
+function call(bridge, method, pathname, body) {
+  for (const route of bridge.routes) {
+    if (route.method !== method) continue;
+    const params = route.match(pathname);
+    if (!params) continue;
+    return route.handler({ params, query: new URLSearchParams(), body });
+  }
+  throw new Error(`No route for ${method} ${pathname}`);
+}
+
+test("GET /v1/dictionary/list returns the stored words", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.db.setDictionary(["OpenWhispr", "Alice"]);
+  const result = call(ctx.bridge, "GET", "/v1/dictionary/list");
+  assert.deepEqual(result.data, ["OpenWhispr", "Alice"]);
+});
+
+test("POST /v1/dictionary/update bulk-adds words that survive a reload", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.db.setDictionary(["OpenWhispr"]);
+  const contacts = ["Ada Lovelace", "Grace Hopper", "Katherine Johnson"];
+  const result = call(ctx.bridge, "POST", "/v1/dictionary/update", { add: contacts });
+
+  assert.equal(result.data.added, 3);
+  assert.deepEqual(ctx.db.getDictionary(), ["OpenWhispr", ...contacts]);
+
+  // The point of the endpoint: rows arrive with the sync columns set, so they
+  // are uploadable rather than invisible to the cloud push (#1295).
+  const pending = ctx.db.getPendingDictionary().map((r) => r.word);
+  for (const name of contacts) assert.ok(pending.includes(name), `${name} should be pending`);
+  for (const row of ctx.db.getPendingDictionary()) assert.ok(row.client_dict_id);
+});
+
+test("POST /v1/dictionary/update removes only the named words", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.db.setDictionary(["OpenWhispr", "Alice", "Bob"]);
+  const result = call(ctx.bridge, "POST", "/v1/dictionary/update", { remove: ["Alice"] });
+
+  assert.equal(result.data.removed, 1);
+  assert.deepEqual(ctx.db.getDictionary(), ["OpenWhispr", "Bob"]);
+});
+
+test("POST /v1/dictionary/update broadcasts the new list to renderers", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.db.setDictionary(["OpenWhispr"]);
+  call(ctx.bridge, "POST", "/v1/dictionary/update", { add: ["Alice"] });
+
+  return new Promise((resolve) => {
+    setImmediate(() => {
+      assert.equal(ctx.broadcasts.length, 1);
+      assert.equal(ctx.broadcasts[0].channel, "dictionary-updated");
+      assert.deepEqual(ctx.broadcasts[0].payload, ["OpenWhispr", "Alice"]);
+      resolve();
+    });
+  });
+});
+
+test("POST /v1/dictionary/update rejects a non-array field", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  assert.throws(() => call(ctx.bridge, "POST", "/v1/dictionary/update", { add: "Alice" }), {
+    code: "VALIDATION",
+  });
+});
+
+test("POST /v1/dictionary/update rejects non-string entries", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  assert.throws(() => call(ctx.bridge, "POST", "/v1/dictionary/update", { add: ["Alice", 7] }), {
+    code: "VALIDATION",
+  });
+});
+
+test("POST /v1/dictionary/update rejects an empty request", (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  assert.throws(() => call(ctx.bridge, "POST", "/v1/dictionary/update", {}), {
+    code: "VALIDATION",
+  });
+});


### PR DESCRIPTION
**Stacked on #1361** (which is stacked on #1360). Merge in order; each retargets automatically.

Closes the loop on #1295 by removing the reason anyone writes to the dictionary table by hand.

## Why

The reporter wrote 357 contact names straight into SQLite because there was no supported programmatic path — no CLI command, no local endpoint, no documented import format. Those rows were wiped on launch, and because they had no `client_dict_id` they could never have reached the cloud either. The wipe is fixed; the missing feature that caused it isn't.

## What

Two routes on the existing local bridge:

- `GET /v1/dictionary/list` — current words
- `POST /v1/dictionary/update` — `{ add: [...], remove: [...] }`

The endpoint takes a **delta, not a word list**, so a bulk import cannot delete anything it didn't name — the same property the rest of this stack is built on. Writes go through `applyDictionaryChanges`, so rows carry the sync columns the cloud push needs, and renderers get a `dictionary-updated` broadcast.

```bash
curl -s -X POST localhost:$PORT/v1/dictionary/update \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"add": ["Ada Lovelace", "Grace Hopper"]}'
```

## Note on sync timing

Words added this way are marked pending and upload on the next sync cycle rather than immediately. The renderer broadcast deliberately doesn't trigger a sync — that would loop, since cloud pulls emit the same broadcast. No data is at risk; it's just eventual rather than instant.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- Full suite — 759 tests, 754 passed, 0 failed, 5 skipped (pre-existing)
- 7 new tests, including the one that matters: words added via the endpoint are present in `getPendingDictionary()` **with a `client_dict_id`**, i.e. actually uploadable — the exact thing the reporter's manual inserts failed at

This adds the **first test coverage for the bridge route table**. The constructor builds routes without starting a server, so handlers are exercised directly against a real database with broadcasts stubbed. That harness is reusable for the other routes, none of which are currently covered.

## Follow-up, not included

The `@openwhispr/cli` package needs a `dictionary` command to consume this — separate repo, separate PR. The endpoint is the enabling half and is useful on its own via curl.