### PR TITLE
fix(models): restore local llama-server pre-warming

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -7,6 +7,7 @@ const debugLogger = require("./debugLogger");
 const { BYOK_API_KEYS } = require("../config/secretKeys");
 const tokenStore = require("./tokenStore");
 const { classifyAndLog } = require("./networkErrors");
+const { resolveLocalServerNeeds } = require("./localServerPolicy");
 const GnomeShortcutManager = require("./gnomeShortcut");
 const HyprlandShortcutManager = require("./hyprlandShortcut");
 const AssemblyAiStreaming = require("./assemblyAiStreaming");
@@ -3558,41 +3559,28 @@ class IPCHandlers {
         });
       }
 
+      const localServer = resolveLocalServerNeeds(prefs);
+
+      if (localServer.cleanup) {
+        setVars.CLEANUP_PROVIDER = "local";
+        setVars.LOCAL_CLEANUP_MODEL = localServer.cleanup;
+      } else {
+        clearVars.push("CLEANUP_PROVIDER", "LOCAL_CLEANUP_MODEL");
+      }
       // TODO: drop legacy REASONING_PROVIDER / LOCAL_REASONING_MODEL clears once
       // the read fallback is removed (~2 releases after this lands).
-      if (prefs.cleanupProvider === "local" && prefs.cleanupModel) {
-        setVars.CLEANUP_PROVIDER = "local";
-        setVars.LOCAL_CLEANUP_MODEL = prefs.cleanupModel;
-        clearVars.push("REASONING_PROVIDER", "LOCAL_REASONING_MODEL");
-      } else if (prefs.cleanupProvider && prefs.cleanupProvider !== "local") {
-        clearVars.push(
-          "CLEANUP_PROVIDER",
-          "LOCAL_CLEANUP_MODEL",
-          "REASONING_PROVIDER",
-          "LOCAL_REASONING_MODEL"
-        );
-      }
+      clearVars.push("REASONING_PROVIDER", "LOCAL_REASONING_MODEL");
 
-      const dictationAgentLocal =
-        prefs.dictationAgentProvider === "local" && prefs.dictationAgentModel;
-      if (dictationAgentLocal) {
+      if (localServer.dictationAgent) {
         setVars.DICTATION_AGENT_PROVIDER = "local";
-        setVars.LOCAL_DICTATION_AGENT_MODEL = prefs.dictationAgentModel;
-      } else if (prefs.dictationAgentProvider && prefs.dictationAgentProvider !== "local") {
+        setVars.LOCAL_DICTATION_AGENT_MODEL = localServer.dictationAgent;
+      } else {
         clearVars.push("DICTATION_AGENT_PROVIDER", "LOCAL_DICTATION_AGENT_MODEL");
       }
 
-      // Stop the local llama-server only when neither cleanup nor dictation-agent
-      // still need a local model. Otherwise the still-active scope would lose
-      // its server on the next provider switch of the other scope.
-      const cleanupNeedsLocal = setVars.CLEANUP_PROVIDER === "local";
-      const dictationAgentNeedsLocal = setVars.DICTATION_AGENT_PROVIDER === "local";
-      if (
-        prefs.cleanupProvider &&
-        prefs.cleanupProvider !== "local" &&
-        !cleanupNeedsLocal &&
-        !dictationAgentNeedsLocal
-      ) {
+      // Stop the shared llama-server only when neither scope still needs it, so
+      // the active scope keeps its server when the other one switches away.
+      if (localServer.stopServer) {
         const modelManager = require("./modelManagerBridge").default;
         modelManager.stopServer().catch((err) => {
           debugLogger.error("Failed to stop llama-server on provider switch", {

--- a/src/helpers/localServerPolicy.js
+++ b/src/helpers/localServerPolicy.js
@@ -1,0 +1,20 @@
+// Which model each LLM scope needs pre-warmed in the shared llama-server, and
+// whether that server can be stopped.
+//
+// A scope stores its local selection as a catalog family id (qwen, gemma, …),
+// never the literal "local", so only the scope's mode says whether it runs
+// locally. A scope that is switched off never runs, so it needs no server.
+export function resolveLocalServerNeeds({
+  useCleanupModel,
+  cleanupMode,
+  cleanupModel,
+  useDictationAgent,
+  dictationAgentMode,
+  dictationAgentModel,
+}) {
+  const cleanup = useCleanupModel && cleanupMode === "local" ? cleanupModel?.trim() || "" : "";
+  const dictationAgent =
+    useDictationAgent && dictationAgentMode === "local" ? dictationAgentModel?.trim() || "" : "";
+
+  return { cleanup, dictationAgent, stopServer: !cleanup && !dictationAgent };
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -175,9 +175,11 @@ function useSettingsInternal() {
     localTranscriptionProvider,
     whisperModel,
     parakeetModel,
-    cleanupProvider,
+    useCleanupModel,
+    cleanupMode,
     cleanupModel,
-    dictationAgentProvider,
+    useDictationAgent,
+    dictationAgentMode,
     dictationAgentModel,
   } = store;
 
@@ -190,10 +192,12 @@ function useSettingsInternal() {
         useLocalWhisper,
         localTranscriptionProvider,
         model: model || undefined,
-        cleanupProvider,
-        cleanupModel: cleanupProvider === "local" ? cleanupModel : undefined,
-        dictationAgentProvider,
-        dictationAgentModel: dictationAgentProvider === "local" ? dictationAgentModel : undefined,
+        useCleanupModel,
+        cleanupMode,
+        cleanupModel,
+        useDictationAgent,
+        dictationAgentMode,
+        dictationAgentModel,
       })
       .catch((err) =>
         logger.warn(
@@ -207,9 +211,11 @@ function useSettingsInternal() {
     localTranscriptionProvider,
     whisperModel,
     parakeetModel,
-    cleanupProvider,
+    useCleanupModel,
+    cleanupMode,
     cleanupModel,
-    dictationAgentProvider,
+    useDictationAgent,
+    dictationAgentMode,
     dictationAgentModel,
   ]);
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -824,9 +824,11 @@ declare global {
         useLocalWhisper: boolean;
         localTranscriptionProvider: LocalTranscriptionProvider;
         model?: string;
-        cleanupProvider: string;
+        useCleanupModel: boolean;
+        cleanupMode: InferenceMode;
         cleanupModel?: string;
-        dictationAgentProvider: string;
+        useDictationAgent: boolean;
+        dictationAgentMode: InferenceMode;
         dictationAgentModel?: string;
       }) => Promise<void>;
 

--- a/test/helpers/localServerPolicy.test.js
+++ b/test/helpers/localServerPolicy.test.js
@@ -1,0 +1,90 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/localServerPolicy.js");
+
+const LOCAL_CLEANUP = {
+  useCleanupModel: true,
+  cleanupMode: "local",
+  cleanupModel: "qwen3-8b-q4_k_m",
+  useDictationAgent: false,
+  dictationAgentMode: "openwhispr",
+  dictationAgentModel: "",
+};
+
+test("a local scope pre-warms the model it selected", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  assert.deepEqual(resolveLocalServerNeeds(LOCAL_CLEANUP), {
+    cleanup: "qwen3-8b-q4_k_m",
+    dictationAgent: "",
+    stopServer: false,
+  });
+});
+
+test("a local selection is recognized by its mode, not its provider id", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  // Regression guard: scopes store the catalog family id (qwen, gemma, …) as
+  // their provider, never the literal "local". Keying off the provider left
+  // pre-warming permanently off and stopped the server for active local users.
+  const needs = resolveLocalServerNeeds({ ...LOCAL_CLEANUP, cleanupProvider: "qwen" });
+
+  assert.equal(needs.cleanup, "qwen3-8b-q4_k_m");
+  assert.equal(needs.stopServer, false);
+});
+
+test("a switched-off scope needs no server even with a local model selected", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  assert.deepEqual(resolveLocalServerNeeds({ ...LOCAL_CLEANUP, useCleanupModel: false }), {
+    cleanup: "",
+    dictationAgent: "",
+    stopServer: true,
+  });
+});
+
+test("local mode without a downloaded model pre-warms nothing", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  const needs = resolveLocalServerNeeds({ ...LOCAL_CLEANUP, cleanupModel: "  " });
+
+  assert.equal(needs.cleanup, "");
+  assert.equal(needs.stopServer, true);
+});
+
+test("the shared server survives one scope leaving while the other stays local", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  const needs = resolveLocalServerNeeds({
+    useCleanupModel: true,
+    cleanupMode: "providers",
+    cleanupModel: "gpt-5-mini",
+    useDictationAgent: true,
+    dictationAgentMode: "local",
+    dictationAgentModel: "gemma-4-e4b-it-q4_k_m",
+  });
+
+  assert.deepEqual(needs, {
+    cleanup: "",
+    dictationAgent: "gemma-4-e4b-it-q4_k_m",
+    stopServer: false,
+  });
+});
+
+test("the server stops once no scope runs locally", async () => {
+  const { resolveLocalServerNeeds } = await load();
+
+  for (const mode of ["openwhispr", "providers", "self-hosted", "enterprise"]) {
+    const needs = resolveLocalServerNeeds({
+      useCleanupModel: true,
+      cleanupMode: mode,
+      cleanupModel: "gpt-5-mini",
+      useDictationAgent: true,
+      dictationAgentMode: mode,
+      dictationAgentModel: "gpt-5-mini",
+    });
+
+    assert.deepEqual(needs, { cleanup: "", dictationAgent: "", stopServer: true }, mode);
+  }
+});


### PR DESCRIPTION
## The bug

Since #76 (v1.7.3) a scope stores its local selection as a **catalog family id** (`qwen`, `gemma`, …) — never the literal `"local"`. The startup-preferences sync never caught up, so for every local user:

- `CLEANUP_PROVIDER` / `LOCAL_CLEANUP_MODEL` were never set, leaving the [`main.js`](../blob/main/main.js#L1100) pre-warm permanently dead. The first dictation of every session paid a full model load.
- The `provider !== "local"` branch ran instead and called `stopServer()`. `useSettings` is mounted by `ControlPanel`, so **opening the control panel tore down a warm llama-server.**

Local inference itself always worked — `runInference` starts the server on demand — so this is a warm-path regression, not an outage.

## The fix

Key the decision off the scope's **mode**, which is what actually says whether a scope runs locally, and off its **enable flag**, so a scope that's switched off no longer loads a model into RAM.

The decision moves into a pure `localServerPolicy` module, mirroring `dockPolicy`, so it's unit-tested rather than buried in an `ipcMain` closure. The handler drops from ~40 lines to ~23.

## Notes for review

- **Behavior change:** local mode with no downloaded model now *clears* the stale env vars instead of leaving them pointing at a removed model. The old code hit neither branch in that case. This matches how the transcription block directly above already behaves.
- **Non-breaking:** renderer and main ship together, `preload.js` passes the payload through untyped, and no env var names or persisted formats changed.
- The pre-warm reads env persisted from the previous session, so the benefit lands on the next launch after settings sync once — that's the existing design of these startup vars, unchanged here.

## Testing

`test/helpers/localServerPolicy.test.js` — 6 cases covering mode-vs-provider, disabled scopes, missing models, and the shared-server handoff when one scope leaves local while the other stays.

Verified by mutation: reverting the predicate to the original `provider === "local"` check fails 3 of the 6 tests. Full suite 760 tests / 0 failures; `typecheck` and `format:check` clean.