### PR TITLE
fix(settings): carry the API key with an inherited endpoint

### DIFF
--- a/src/helpers/noteFormattingOverrides.js
+++ b/src/helpers/noteFormattingOverrides.js
@@ -1,7 +1,7 @@
 // Provider overrides for note-formatting ReasoningService.processText calls.
 // Self-hosted must forward remoteUrl as lanUrl — without it, processText
 // guesses the provider from the model and can silently hit a cloud API.
-export function buildNoteFormattingOverrides(noteFormatting, isCloudMode, customApiKey) {
+export function buildNoteFormattingOverrides(noteFormatting, isCloudMode) {
   if (isCloudMode) {
     return {
       provider: "openwhispr",
@@ -17,7 +17,7 @@ export function buildNoteFormattingOverrides(noteFormatting, isCloudMode, custom
     return {
       provider: undefined,
       baseUrl: undefined,
-      customApiKey: customApiKey || undefined,
+      customApiKey: noteFormatting?.customApiKey || undefined,
       lanUrl: noteFormatting?.remoteUrl || undefined,
     };
   }
@@ -35,7 +35,7 @@ export function buildNoteFormattingOverrides(noteFormatting, isCloudMode, custom
   return {
     provider,
     baseUrl: isCustom ? noteFormatting?.cloudBaseUrl || undefined : undefined,
-    customApiKey: isCustom ? customApiKey || undefined : undefined,
+    customApiKey: isCustom ? noteFormatting?.customApiKey || undefined : undefined,
     lanUrl: undefined,
   };
 }

--- a/src/helpers/reasoningRouting.js
+++ b/src/helpers/reasoningRouting.js
@@ -7,6 +7,14 @@ export function deriveReasoningMode(cloudMode, provider) {
   return "openwhispr";
 }
 
+// Whether a scope may borrow the fallback scope's API key along with its endpoint.
+// A scope pointing somewhere of its own, or in another mode, would send that key to
+// a host it was never entered for.
+export function inheritsFallbackEndpoint(own, fallbackMode) {
+  if (own.cloudBaseUrl || own.remoteUrl) return false;
+  return !!fallbackMode && own.mode === fallbackMode;
+}
+
 // Fan a cleanup config out to all five LLM scopes; the four non-cleanup scopes
 // mirror only cloud routing plus the derived mode (each tab selects on its mode).
 export function buildReasoningScopePatches(settings, mode) {

--- a/src/stores/actionProcessingStore.ts
+++ b/src/stores/actionProcessingStore.ts
@@ -134,11 +134,7 @@ export function runBackgroundAction(
   (async () => {
     try {
       const basePrompt = options.isMeetingNote ? MEETING_SYSTEM_PROMPT : BASE_SYSTEM_PROMPT;
-      const providerOverrides = buildNoteFormattingOverrides(
-        noteFormatting,
-        options.isCloudMode,
-        settings.noteFormattingCustomApiKey
-      );
+      const providerOverrides = buildNoteFormattingOverrides(noteFormatting, options.isCloudMode);
       const systemPrompt = appendDictionarySuffix(
         basePrompt + action.prompt,
         options.isMeetingNote ? settings.customDictionary : undefined,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -9,7 +9,11 @@ import whisperVadConstants from "../constants/whisperVad.json";
 import type { LocalTranscriptionProvider, InferenceMode, SelfHostedType } from "../types/electron";
 import type { GoogleCalendarAccount } from "../types/calendar";
 import { PROMPT_KIND_LIST, type PromptKind } from "../config/prompts/registry";
-import { deriveReasoningMode, buildReasoningScopePatches } from "../helpers/reasoningRouting";
+import {
+  deriveReasoningMode,
+  buildReasoningScopePatches,
+  inheritsFallbackEndpoint,
+} from "../helpers/reasoningRouting";
 import { findStaleLocalModelKeys } from "../helpers/localModelSelections";
 import {
   INFERENCE_SCOPES,
@@ -1995,10 +1999,22 @@ export interface ResolvedNoteFormatting {
   cloudMode: string;
   cloudBaseUrl: string;
   remoteUrl: string;
+  customApiKey: string;
 }
 
 export const selectResolvedNoteFormatting = (state: SettingsState): ResolvedNoteFormatting => {
   const cfg = selectResolvedLLMConfig(state, "noteFormatting");
+  const cleanup = selectResolvedLLMConfig(state, "dictationCleanup");
+  // The endpoint falls back to dictation cleanup, so the key that opens it must too,
+  // or an inherited endpoint gets called with no credential.
+  const borrowsEndpoint = inheritsFallbackEndpoint(
+    {
+      mode: cfg.mode,
+      cloudBaseUrl: state.noteFormattingCloudBaseUrl,
+      remoteUrl: state.noteFormattingRemoteUrl,
+    },
+    cleanup.mode
+  );
   return {
     provider: cfg.provider,
     model: cfg.model,
@@ -2006,6 +2022,7 @@ export const selectResolvedNoteFormatting = (state: SettingsState): ResolvedNote
     cloudMode: cfg.cloudMode || "",
     cloudBaseUrl: cfg.cloudBaseUrl || "",
     remoteUrl: cfg.remoteUrl || "",
+    customApiKey: cfg.customApiKey || (borrowsEndpoint ? cleanup.customApiKey || "" : ""),
   };
 };
 
@@ -2047,6 +2064,9 @@ export const selectResolvedLLMConfig = (
     cloudMode: read("cloudMode") || fallback?.cloudMode,
     cloudBaseUrl: read("cloudBaseUrl") || fallback?.cloudBaseUrl,
     remoteUrl: read("remoteUrl") || fallback?.remoteUrl,
+    // Not inherited here: the settings editor renders this field, and a borrowed key
+    // in it would be committed to this scope's storage by an idle edit. Inheritance
+    // belongs on the request path — see selectResolvedNoteFormatting.
     customApiKey: read("customApiKey"),
     disableThinking,
   };

--- a/test/helpers/noteFormattingOverrides.test.js
+++ b/test/helpers/noteFormattingOverrides.test.js
@@ -6,9 +6,8 @@ const load = () => import("../../src/helpers/noteFormattingOverrides.js");
 test("cloud mode routes to openwhispr and ignores self-hosted fields", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "self-hosted", remoteUrl: "http://192.168.1.126:11434/v1" },
-    true,
-    "secret"
+    { mode: "self-hosted", remoteUrl: "http://192.168.1.126:11434/v1", customApiKey: "secret" },
+    true
   );
   assert.deepEqual(overrides, {
     provider: "openwhispr",
@@ -21,9 +20,13 @@ test("cloud mode routes to openwhispr and ignores self-hosted fields", async () 
 test("self-hosted forwards remoteUrl as lanUrl and the api key (regression: was hitting OpenAI)", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "self-hosted", remoteUrl: "http://192.168.1.126:11434/v1", model: "llama3" },
-    false,
-    "sk-local"
+    {
+      mode: "self-hosted",
+      remoteUrl: "http://192.168.1.126:11434/v1",
+      model: "llama3",
+      customApiKey: "sk-local",
+    },
+    false
   );
   assert.equal(overrides.lanUrl, "http://192.168.1.126:11434/v1");
   assert.equal(overrides.customApiKey, "sk-local");
@@ -34,9 +37,8 @@ test("self-hosted forwards remoteUrl as lanUrl and the api key (regression: was 
 test("self-hosted with no key still routes via lanUrl", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "self-hosted", remoteUrl: "http://host:8080/v1" },
-    false,
-    ""
+    { mode: "self-hosted", remoteUrl: "http://host:8080/v1", customApiKey: "" },
+    false
   );
   assert.equal(overrides.lanUrl, "http://host:8080/v1");
   assert.equal(overrides.customApiKey, undefined);
@@ -45,9 +47,13 @@ test("self-hosted with no key still routes via lanUrl", async () => {
 test("providers/custom forwards cloudBaseUrl as baseUrl and the key", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "providers", provider: "custom", cloudBaseUrl: "https://api.example.com/v1" },
-    false,
-    "sk-custom"
+    {
+      mode: "providers",
+      provider: "custom",
+      cloudBaseUrl: "https://api.example.com/v1",
+      customApiKey: "sk-custom",
+    },
+    false
   );
   assert.deepEqual(overrides, {
     provider: "custom",
@@ -60,9 +66,8 @@ test("providers/custom forwards cloudBaseUrl as baseUrl and the key", async () =
 test("providers with a first-party cloud provider passes provider only, no key/baseUrl", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "providers", provider: "anthropic" },
-    false,
-    "should-not-leak"
+    { mode: "providers", provider: "anthropic", customApiKey: "should-not-leak" },
+    false
   );
   assert.deepEqual(overrides, {
     provider: "anthropic",
@@ -75,9 +80,8 @@ test("providers with a first-party cloud provider passes provider only, no key/b
 test("local mode pins the local provider and leaks no key", async () => {
   const { buildNoteFormattingOverrides } = await load();
   const overrides = buildNoteFormattingOverrides(
-    { mode: "local", model: "qwen2.5-3b" },
-    false,
-    "irrelevant"
+    { mode: "local", model: "qwen2.5-3b", customApiKey: "irrelevant" },
+    false
   );
   assert.deepEqual(overrides, {
     provider: "local",
@@ -89,7 +93,10 @@ test("local mode pins the local provider and leaks no key", async () => {
 
 test("local mode with no model stays local (regression: inherited cloud id hit the cloud)", async () => {
   const { buildNoteFormattingOverrides } = await load();
-  const overrides = buildNoteFormattingOverrides({ mode: "local", model: "" }, false, "sk-cloud");
+  const overrides = buildNoteFormattingOverrides(
+    { mode: "local", model: "", customApiKey: "sk-cloud" },
+    false
+  );
   assert.equal(overrides.provider, "local");
   assert.equal(overrides.customApiKey, undefined);
 });

--- a/test/helpers/reasoningRouting.test.js
+++ b/test/helpers/reasoningRouting.test.js
@@ -164,3 +164,40 @@ test("corti reasoning provider with empty models routes reasoning to openwhispr 
   );
   assert.deepEqual(reasoning, OPENWHISPR_REASONING);
 });
+
+test("a scope inherits the fallback key when it inherits the endpoint", async () => {
+  const { inheritsFallbackEndpoint } = await load();
+  assert.equal(inheritsFallbackEndpoint({ mode: "self-hosted" }, "self-hosted"), true);
+});
+
+test("a scope on its own remote url keeps its own key", async () => {
+  const { inheritsFallbackEndpoint } = await load();
+  assert.equal(
+    inheritsFallbackEndpoint(
+      { mode: "self-hosted", remoteUrl: "http://host:8080/v1" },
+      "self-hosted"
+    ),
+    false
+  );
+});
+
+test("a scope on its own cloud base url keeps its own key", async () => {
+  const { inheritsFallbackEndpoint } = await load();
+  assert.equal(
+    inheritsFallbackEndpoint(
+      { mode: "providers", cloudBaseUrl: "https://api.example.com/v1" },
+      "providers"
+    ),
+    false
+  );
+});
+
+test("a differing mode never borrows the key (regression: key sent to the wrong host)", async () => {
+  const { inheritsFallbackEndpoint } = await load();
+  assert.equal(inheritsFallbackEndpoint({ mode: "providers" }, "self-hosted"), false);
+});
+
+test("no fallback scope means nothing to inherit", async () => {
+  const { inheritsFallbackEndpoint } = await load();
+  assert.equal(inheritsFallbackEndpoint({ mode: "providers" }, undefined), false);
+});


### PR DESCRIPTION
## Problem

Note formatting inherits its connection settings from dictation cleanup when it has none of its own — that's the `fallbackScope` in [`inferenceScopes.ts`](src/config/inferenceScopes.ts). Provider, model, cloud base URL, and remote URL all fall back. The API key did not.

So this happens:

1. Point dictation cleanup at a custom or self-hosted OpenAI-compatible endpoint and enter its key.
2. Set note formatting to the same mode, without re-entering anything.
3. Note formatting inherits the endpoint but not the key, and sends unauthenticated requests to it.

Dictation cleanup keeps working against that same endpoint, so it reads as "note formatting is broken" rather than "note formatting has no credential".

The split was visible at the call site — [`actionProcessingStore.ts`](src/stores/actionProcessingStore.ts) passed the *resolved* config and the *raw* `noteFormattingCustomApiKey` as two separate arguments, and they disagreed exactly when the endpoint was inherited.

## Fix

The key falls back with the endpoint it opens — but only when the scope borrows that endpoint wholesale.

```js
export function inheritsFallbackEndpoint(own, fallbackMode) {
  if (own.cloudBaseUrl || own.remoteUrl) return false;
  return !!fallbackMode && own.mode === fallbackMode;
}
```

Both guards matter, and neither is theoretical:

- **Own endpoint → own key.** A scope with its own base URL that borrowed cleanup's key would send that credential to a different host.
- **Different mode → no inheritance.** Cleanup on self-hosted while note formatting is on `providers` would pair a self-hosted key with the inherited *cloud* base URL, which defaults to OpenAI's.

A plain `|| fallback?.customApiKey` opens both, which is why the rule is a named, tested predicate rather than an inline `||`.

## Why it lives in `selectResolvedNoteFormatting`

The obvious home is `selectResolvedLLMConfig`, and that is where I put it first. It is the wrong place.

That resolver is also what [`InferenceConfigEditor`](src/components/settings/InferenceConfigEditor.tsx#L150) renders. Inheriting there would pre-fill the note-formatting API key field with cleanup's key — and `ApiKeyInput` seeds its draft from the prop on `enterEdit()` and commits on click-outside. A user clicking into that field and clicking away, changing nothing, would write cleanup's **keychain** secret into note-formatting's **plaintext localStorage**.

Resolving it one level down keeps `selectResolvedLLMConfig` byte-identical to `main` (apart from a comment saying why), so the settings UI is provably unchanged, and only the request path sees the inherited key.

`buildNoteFormattingOverrides` also drops its third parameter and reads the key off the resolved config. One source of truth is what stops these drifting apart again.

## Blast radius

- `noteFormatting` is the only scope with a `fallbackScope`; the other four resolve `fallback` as `undefined` and are untouched.
- `selectResolvedLLMConfig` behaviour is unchanged, so the settings editor, the OpenRouter seeding check, and every scope tab behave exactly as before.
- `buildNoteFormattingOverrides` has one caller, updated here.
- The other resolved-key consumers (`PromptStudio`, `useChatStreaming`) read raw scope settings and never touch the resolver.
- No new data destination: the inherited base URL was already in effect, only the auth header was missing.

## Scope

This is the narrow, safe half of the follow-up noted in #1312. The other half — that `mode` doesn't participate in the fallback at all — is **not** addressed here, deliberately: gating model inheritance on matching modes regresses a common setup (move cleanup to your own OpenAI key, never touch note formatting, and note formatting stops inheriting the model and fails with "no model selected"). Fixing that properly needs an explicit "inherit" state for mode, which is feature work.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` — 759 tests, 0 failures
- 5 new tests for the inheritance rule in `test/helpers/reasoningRouting.test.js`, covering both leak cases
- `test/helpers/noteFormattingOverrides.test.js` updated for the signature change

Not runtime-tested in the app; the reasoning above is from tracing the call graph.

## Noticed, not fixed

`cleanupCustomApiKey` is scrubbed from localStorage at startup and kept in the OS secure store. `noteFormattingCustomApiKey` is in neither path — a key typed into the note-formatting tab persists in plaintext localStorage. Pre-existing and out of scope, but worth its own issue.