### PR TITLE
fix(security): move per-scope custom API keys into the OS secure store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ Settings stored in localStorage with these keys:
 - `hasCompletedOnboarding`: Onboarding completion flag
 - `customDictionary`: JSON array of words/phrases for improved transcription accuracy
 
-Secret env vars (12 total: 7 BYOK API keys + 5 enterprise cloud creds — see `SECRET_KEYS` in `environment.js`) are encrypted at rest via Electron `safeStorage` and stored as per-key files under `userData/secure-keys/`. They are loaded into `process.env` at startup by `EnvironmentManager.init()`. Renderer reads them via IPC (`get-*-key`) and writes via debounced IPC (`save-*-key`). On Linux without a keyring, secrets fall back to plaintext.
+Secret env vars (BYOK API keys, per-scope custom-endpoint keys, and enterprise cloud creds — see `SECRET_KEYS` in `environment.js`) are encrypted at rest via Electron `safeStorage` and stored as per-key files under `userData/secure-keys/`. They are loaded into `process.env` at startup by `EnvironmentManager.init()`. Renderer reads them via IPC (`get-*-key`) and writes via debounced IPC (`save-*-key`). On Linux without a keyring, secrets fall back to plaintext.
 
 Non-secret env vars persisted to `.env` (via `saveAllKeysToEnvFile()`):
 
@@ -805,7 +805,7 @@ const { t } = useTranslation();
 
 ## Security Considerations
 
-- API keys and enterprise cloud creds (12 secrets total) encrypted at rest via Electron `safeStorage` → OS keychain (Keychain / DPAPI / libsecret), stored as per-key files in `userData/secure-keys/`. Linux without a keyring falls back to plaintext (Electron default). Closed in #629.
+- API keys and enterprise cloud creds encrypted at rest via Electron `safeStorage` → OS keychain (Keychain / DPAPI / libsecret), stored as per-key files in `userData/secure-keys/`. Linux without a keyring falls back to plaintext (Electron default). Closed in #629.
 - Context isolation enabled
 - No remote code execution
 - Sanitized file paths

--- a/preload.js
+++ b/preload.js
@@ -15,8 +15,23 @@ const BYOK_KEY_BRIDGES = [
   { base: "tinfoil", get: "getTinfoilKey", save: "saveTinfoilKey" },
   { base: "corti", get: "getCortiKey", save: "saveCortiKey" },
 ];
+// Per-scope custom/self-hosted endpoint keys; mirrors SCOPE_CUSTOM_API_KEYS.
+const SCOPE_KEY_BRIDGES = [
+  {
+    base: "note-formatting-custom",
+    get: "getNoteFormattingCustomKey",
+    save: "saveNoteFormattingCustomKey",
+  },
+  {
+    base: "dictation-agent-custom",
+    get: "getDictationAgentCustomKey",
+    save: "saveDictationAgentCustomKey",
+  },
+  { base: "chat-agent-custom", get: "getChatAgentCustomKey", save: "saveChatAgentCustomKey" },
+  { base: "translation-custom", get: "getTranslationCustomKey", save: "saveTranslationCustomKey" },
+];
 const secretKeyApi = {};
-for (const k of BYOK_KEY_BRIDGES) {
+for (const k of [...BYOK_KEY_BRIDGES, ...SCOPE_KEY_BRIDGES]) {
   secretKeyApi[k.get] = () => ipcRenderer.invoke(`get-${k.base}-key`);
   secretKeyApi[k.save] = (key) => ipcRenderer.invoke(`save-${k.base}-key`, key);
 }
@@ -424,6 +439,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   saveCustomTranscriptionKey: (key) => ipcRenderer.invoke("save-custom-transcription-key", key),
   getCleanupCustomKey: () => ipcRenderer.invoke("get-cleanup-custom-key"),
   saveCleanupCustomKey: (key) => ipcRenderer.invoke("save-cleanup-custom-key", key),
+  onSecretChanged: registerListener(
+    "secret-changed",
+    (callback) => (_event, data) => callback(data)
+  ),
 
   // Enterprise provider key management
   getBedrockRegion: () => ipcRenderer.invoke("get-bedrock-region"),

--- a/src/config/secretKeys.js
+++ b/src/config/secretKeys.js
@@ -66,4 +66,38 @@ const BYOK_API_KEYS = [
   },
 ];
 
-module.exports = { BYOK_API_KEYS };
+// Per-scope keys for user-supplied custom / self-hosted endpoints, plumbed the
+// same way as BYOK_API_KEYS. dictationCleanup is absent on purpose: it predates
+// this list and keeps a hand-written accessor for its legacy env var name.
+const SCOPE_CUSTOM_API_KEYS = [
+  {
+    base: "note-formatting-custom",
+    env: "CUSTOM_NOTE_FORMATTING_API_KEY",
+    get: "getNoteFormattingCustomKey",
+    save: "saveNoteFormattingCustomKey",
+    storeKey: "noteFormattingCustomApiKey",
+  },
+  {
+    base: "dictation-agent-custom",
+    env: "CUSTOM_DICTATION_AGENT_API_KEY",
+    get: "getDictationAgentCustomKey",
+    save: "saveDictationAgentCustomKey",
+    storeKey: "dictationAgentCustomApiKey",
+  },
+  {
+    base: "chat-agent-custom",
+    env: "CUSTOM_CHAT_AGENT_API_KEY",
+    get: "getChatAgentCustomKey",
+    save: "saveChatAgentCustomKey",
+    storeKey: "chatAgentCustomApiKey",
+  },
+  {
+    base: "translation-custom",
+    env: "CUSTOM_TRANSLATION_API_KEY",
+    get: "getTranslationCustomKey",
+    save: "saveTranslationCustomKey",
+    storeKey: "translationCustomApiKey",
+  },
+];
+
+module.exports = { BYOK_API_KEYS, SCOPE_CUSTOM_API_KEYS };

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -5,10 +5,11 @@ const { app } = require("electron");
 const debugLogger = require("./debugLogger");
 const { normalizeUiLanguage } = require("./i18nMain");
 const secretCrypto = require("./secretCrypto");
-const { BYOK_API_KEYS } = require("../config/secretKeys");
+const { BYOK_API_KEYS, SCOPE_CUSTOM_API_KEYS } = require("../config/secretKeys");
 
 const SECRET_KEYS = [
   ...BYOK_API_KEYS.map((k) => k.env),
+  ...SCOPE_CUSTOM_API_KEYS.map((k) => k.env),
   "ASSEMBLYAI_API_KEY",
   "DEEPGRAM_API_KEY",
   "CORTI_CLIENT_ID",
@@ -506,9 +507,9 @@ class EnvironmentManager {
   }
 }
 
-// Generate the uniform BYOK key accessors (getOpenAIKey/saveOpenAIKey/…) from
-// the shared manifest so each provider is defined in exactly one place.
-for (const k of BYOK_API_KEYS) {
+// Generate the manifest-driven key accessors (getOpenAIKey/saveOpenAIKey/…) so
+// each secret is defined in exactly one place.
+for (const k of [...BYOK_API_KEYS, ...SCOPE_CUSTOM_API_KEYS]) {
   EnvironmentManager.prototype[k.get] = function () {
     return this._getKey(k.env);
   };

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const os = require("os");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
-const { BYOK_API_KEYS } = require("../config/secretKeys");
+const { BYOK_API_KEYS, SCOPE_CUSTOM_API_KEYS } = require("../config/secretKeys");
 const tokenStore = require("./tokenStore");
 const { classifyAndLog } = require("./networkErrors");
 const { resolveLocalServerNeeds } = require("./localServerPolicy");
@@ -996,6 +996,17 @@ class IPCHandlers {
     for (const k of BYOK_API_KEYS) {
       ipcMain.handle(`get-${k.base}-key`, () => this.environmentManager[k.get]());
       ipcMain.handle(`save-${k.base}-key`, (event, key) => this.environmentManager[k.save](key));
+    }
+
+    for (const k of SCOPE_CUSTOM_API_KEYS) {
+      ipcMain.handle(`get-${k.base}-key`, () => this.environmentManager[k.get]());
+      ipcMain.handle(`save-${k.base}-key`, (event, key) => {
+        const result = this.environmentManager[k.save](key);
+        // These used to live in localStorage, which kept every window in sync.
+        // The secure store is main-process state, so push the change out instead.
+        this.broadcastToWindows("secret-changed", { storeKey: k.storeKey, value: key });
+        return result;
+      });
     }
 
     ipcMain.handle("db-save-transcription", async (event, text, rawText, options) => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -812,6 +812,10 @@ const SECRET_IPC_SAVERS = {
   tinfoil: "saveTinfoilKey",
   customTranscription: "saveCustomTranscriptionKey",
   cleanupCustom: "saveCleanupCustomKey",
+  noteFormattingCustom: "saveNoteFormattingCustomKey",
+  dictationAgentCustom: "saveDictationAgentCustomKey",
+  chatAgentCustom: "saveChatAgentCustomKey",
+  translationCustom: "saveTranslationCustomKey",
   bedrockAccessKeyId: "saveBedrockAccessKeyId",
   bedrockSecretAccessKey: "saveBedrockSecretAccessKey",
   bedrockSessionToken: "saveBedrockSessionToken",
@@ -820,6 +824,17 @@ const SECRET_IPC_SAVERS = {
 } as const;
 
 type SecretProvider = keyof typeof SECRET_IPC_SAVERS;
+
+// Every inference scope's custom-endpoint key, by store key. These are secrets in
+// the OS secure store rather than localStorage, so writes have to be routed away
+// from the generic string path.
+const SCOPE_SECRET_SAVERS: Record<string, SecretProvider> = {
+  cleanupCustomApiKey: "cleanupCustom",
+  noteFormattingCustomApiKey: "noteFormattingCustom",
+  dictationAgentCustomApiKey: "dictationAgentCustom",
+  chatAgentCustomApiKey: "chatAgentCustom",
+  translationCustomApiKey: "translationCustom",
+};
 
 const secretSaveTimers: Partial<Record<SecretProvider, ReturnType<typeof setTimeout>>> = {};
 function debouncedSaveSecret(provider: SecretProvider, key: string) {
@@ -1159,7 +1174,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   noteFormattingCloudMode: readString("noteFormattingCloudMode", ""),
   noteFormattingCloudBaseUrl: readString("noteFormattingCloudBaseUrl", ""),
   noteFormattingRemoteUrl: readString("noteFormattingRemoteUrl", ""),
-  noteFormattingCustomApiKey: readString("noteFormattingCustomApiKey", ""),
+  noteFormattingCustomApiKey: "",
 
   translationMode: (() => {
     const v = readString("translationMode", "openwhispr");
@@ -1178,7 +1193,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   translationCloudMode: readString("translationCloudMode", "openwhispr"),
   translationCloudBaseUrl: readString("translationCloudBaseUrl", ""),
   translationRemoteUrl: readString("translationRemoteUrl", ""),
-  translationCustomApiKey: readString("translationCustomApiKey", ""),
+  translationCustomApiKey: "",
   translationDisableThinking: readBoolean("translationDisableThinking", true),
   useDictationTranslation: readBoolean("useDictationTranslation", false),
   translationSourceLanguage: readString("translationSourceLanguage", "auto"),
@@ -1240,7 +1255,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setNoteFormattingCloudMode: createStringSetter("noteFormattingCloudMode"),
   setNoteFormattingCloudBaseUrl: createStringSetter("noteFormattingCloudBaseUrl"),
   setNoteFormattingRemoteUrl: createStringSetter("noteFormattingRemoteUrl"),
-  setNoteFormattingCustomApiKey: createStringSetter("noteFormattingCustomApiKey"),
+  setNoteFormattingCustomApiKey: createSecretSetter(
+    "noteFormattingCustomApiKey",
+    "noteFormattingCustom",
+    "custom"
+  ),
 
   setTranslationMode: createStringSetter("translationMode") as (mode: InferenceMode) => void,
   setTranslationProvider: createStringSetter("translationProvider"),
@@ -1248,7 +1267,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setTranslationCloudMode: createStringSetter("translationCloudMode"),
   setTranslationCloudBaseUrl: createStringSetter("translationCloudBaseUrl"),
   setTranslationRemoteUrl: createStringSetter("translationRemoteUrl"),
-  setTranslationCustomApiKey: createStringSetter("translationCustomApiKey"),
+  setTranslationCustomApiKey: createSecretSetter(
+    "translationCustomApiKey",
+    "translationCustom",
+    "custom"
+  ),
   setTranslationDisableThinking: createBooleanSetter("translationDisableThinking"),
   setUseDictationTranslation: createBooleanSetter("useDictationTranslation"),
   setTranslationSourceLanguage: createStringSetter("translationSourceLanguage"),
@@ -1279,7 +1302,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   chatAgentRemoteUrl: readString("chatAgentRemoteUrl", ""),
   chatAgentCloudBaseUrl: readString("chatAgentCloudBaseUrl", ""),
-  chatAgentCustomApiKey: readString("chatAgentCustomApiKey", ""),
+  chatAgentCustomApiKey: "",
 
   dictationAgentMode: (() => {
     const v = readString("dictationAgentMode", "openwhispr");
@@ -1298,7 +1321,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   dictationAgentCloudMode: readString("dictationAgentCloudMode", "openwhispr"),
   dictationAgentCloudBaseUrl: readString("dictationAgentCloudBaseUrl", ""),
   dictationAgentRemoteUrl: readString("dictationAgentRemoteUrl", ""),
-  dictationAgentCustomApiKey: readString("dictationAgentCustomApiKey", ""),
+  dictationAgentCustomApiKey: "",
 
   cleanupDisableThinking: readBoolean("cleanupDisableThinking", true),
   dictationAgentDisableThinking: readBoolean("dictationAgentDisableThinking", true),
@@ -1322,7 +1345,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setDictationAgentCloudMode: createStringSetter("dictationAgentCloudMode"),
   setDictationAgentCloudBaseUrl: createStringSetter("dictationAgentCloudBaseUrl"),
   setDictationAgentRemoteUrl: createStringSetter("dictationAgentRemoteUrl"),
-  setDictationAgentCustomApiKey: createStringSetter("dictationAgentCustomApiKey"),
+  setDictationAgentCustomApiKey: createSecretSetter(
+    "dictationAgentCustomApiKey",
+    "dictationAgentCustom",
+    "custom"
+  ),
 
   setCleanupDisableThinking: createBooleanSetter("cleanupDisableThinking"),
   setDictationAgentDisableThinking: createBooleanSetter("dictationAgentDisableThinking"),
@@ -1784,7 +1811,11 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setChatAgentMode: createStringSetter("chatAgentMode") as (mode: InferenceMode) => void,
   setChatAgentCloudBaseUrl: createStringSetter("chatAgentCloudBaseUrl"),
   setChatAgentRemoteUrl: createStringSetter("chatAgentRemoteUrl"),
-  setChatAgentCustomApiKey: createStringSetter("chatAgentCustomApiKey"),
+  setChatAgentCustomApiKey: createSecretSetter(
+    "chatAgentCustomApiKey",
+    "chatAgentCustom",
+    "custom"
+  ),
 
   updateTranscriptionSettings: (settings: Partial<TranscriptionSettings>) => {
     const s = useSettingsStore.getState();
@@ -2124,11 +2155,9 @@ export function setResolvedLLMConfig(
     if (value === undefined) continue;
     const storeKey = def.storeKeys[field as keyof InferenceScopeStoreKeys];
     if (!storeKey) continue;
-    // cleanupCustomApiKey is a secret kept in the OS secure store, not
-    // localStorage (which is stripped on startup). Route it through the
-    // dedicated setter so it survives restarts.
-    if (storeKey === "cleanupCustomApiKey") {
-      useSettingsStore.getState().setCleanupCustomApiKey(value as string);
+    const secretSaver = SCOPE_SECRET_SAVERS[storeKey as string];
+    if (secretSaver) {
+      createSecretSetter(storeKey as string, secretSaver, "custom")(value as string);
       continue;
     }
     if (isBrowser) {
@@ -2202,6 +2231,29 @@ export function isCloudTranslationMode() {
 
 let hasInitialized = false;
 
+/**
+ * Moves scope custom-endpoint keys left in localStorage by earlier releases into
+ * the secure store. The plaintext copy is dropped only once the encrypted write
+ * resolves, so a failure leaves the key recoverable and retries next launch —
+ * which is also why these keys are not in STALE_SECRET_LOCALSTORAGE_KEYS, whose
+ * sweep runs first and would delete them before they were saved.
+ */
+async function liftScopeSecretsFromLocalStorage(): Promise<void> {
+  const state = useSettingsStore.getState() as unknown as Record<string, string>;
+  for (const [storeKey, provider] of Object.entries(SCOPE_SECRET_SAVERS)) {
+    const legacy = localStorage.getItem(storeKey);
+    if (!legacy) continue;
+    if (!state[storeKey]) {
+      const save = window.electronAPI?.[SECRET_IPC_SAVERS[provider]] as
+        ((k: string) => Promise<unknown>) | undefined;
+      if (!save) continue;
+      await save(legacy);
+      useSettingsStore.setState({ [storeKey]: legacy });
+    }
+    localStorage.removeItem(storeKey);
+  }
+}
+
 export async function initializeSettings(): Promise<void> {
   if (hasInitialized) return;
   hasInitialized = true;
@@ -2231,6 +2283,10 @@ export async function initializeSettings(): Promise<void> {
         bedrockSessionToken,
         azureApiKey,
         vertexApiKey,
+        noteFormattingCustom,
+        dictationAgentCustom,
+        chatAgentCustom,
+        translationCustom,
       ] = await Promise.all([
         window.electronAPI.getOpenAIKey?.(),
         window.electronAPI.getAnthropicKey?.(),
@@ -2250,6 +2306,10 @@ export async function initializeSettings(): Promise<void> {
         window.electronAPI.getBedrockSessionToken?.(),
         window.electronAPI.getAzureApiKey?.(),
         window.electronAPI.getVertexApiKey?.(),
+        window.electronAPI.getNoteFormattingCustomKey?.(),
+        window.electronAPI.getDictationAgentCustomKey?.(),
+        window.electronAPI.getChatAgentCustomKey?.(),
+        window.electronAPI.getTranslationCustomKey?.(),
       ]);
 
       useSettingsStore.setState({
@@ -2271,11 +2331,17 @@ export async function initializeSettings(): Promise<void> {
         bedrockSessionToken: bedrockSessionToken || "",
         azureApiKey: azureApiKey || "",
         vertexApiKey: vertexApiKey || "",
+        noteFormattingCustomApiKey: noteFormattingCustom || "",
+        dictationAgentCustomApiKey: dictationAgentCustom || "",
+        chatAgentCustomApiKey: chatAgentCustom || "",
+        translationCustomApiKey: translationCustom || "",
       });
 
       for (const key of STALE_SECRET_LOCALSTORAGE_KEYS) {
         localStorage.removeItem(key);
       }
+
+      await liftScopeSecretsFromLocalStorage();
 
       // Users who configured OpenRouter through the Custom tab keep their key
       // in the shared custom slot — seed the dedicated slot from it once.
@@ -2613,6 +2679,14 @@ export async function initializeSettings(): Promise<void> {
   // Active hotkey updates from backend — display state, never persisted.
   window.electronAPI?.onDictationKeyActive?.((key: string) => {
     useSettingsStore.setState({ activeDictationKey: key });
+  });
+
+  // Secrets live in the main process, so they get no localStorage `storage` event
+  // to sync the other windows.
+  window.electronAPI?.onSecretChanged?.(({ storeKey, value }) => {
+    if (!(storeKey in SCOPE_SECRET_SAVERS)) return;
+    useSettingsStore.setState({ [storeKey]: value });
+    invalidateApiKeyCaches("custom");
   });
 
   // Sync settings pushed from main process (e.g., hotkey changed in control panel)

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1185,6 +1185,17 @@ declare global {
       saveCustomTranscriptionKey?: (key: string) => Promise<void>;
       getCleanupCustomKey?: () => Promise<string | null>;
       saveCleanupCustomKey?: (key: string) => Promise<void>;
+      getNoteFormattingCustomKey?: () => Promise<string | null>;
+      saveNoteFormattingCustomKey?: (key: string) => Promise<void>;
+      getDictationAgentCustomKey?: () => Promise<string | null>;
+      saveDictationAgentCustomKey?: (key: string) => Promise<void>;
+      getChatAgentCustomKey?: () => Promise<string | null>;
+      saveChatAgentCustomKey?: (key: string) => Promise<void>;
+      getTranslationCustomKey?: () => Promise<string | null>;
+      saveTranslationCustomKey?: (key: string) => Promise<void>;
+      onSecretChanged?: (
+        callback: (data: { storeKey: string; value: string }) => void
+      ) => () => void;
 
       // Enterprise provider key persistence
       getBedrockRegion?: () => Promise<string | null>;

--- a/test/helpers/secretKeys.test.js
+++ b/test/helpers/secretKeys.test.js
@@ -21,12 +21,13 @@ Module._load = function (request, ...rest) {
   return origLoad.call(this, request, ...rest);
 };
 
-const { BYOK_API_KEYS } = require("../../src/config/secretKeys");
+const { BYOK_API_KEYS, SCOPE_CUSTOM_API_KEYS } = require("../../src/config/secretKeys");
+const ALL_KEYS = [...BYOK_API_KEYS, ...SCOPE_CUSTOM_API_KEYS];
 const EnvironmentManager = require("../../src/helpers/environment");
 
 test("manifest entries are unique and complete", () => {
   const seen = { base: new Set(), env: new Set(), storeKey: new Set() };
-  for (const k of BYOK_API_KEYS) {
+  for (const k of ALL_KEYS) {
     for (const field of ["base", "env", "get", "save", "storeKey"]) {
       assert.ok(k[field], `${field} present on ${k.base}`);
     }
@@ -37,9 +38,9 @@ test("manifest entries are unique and complete", () => {
   }
 });
 
-test("every BYOK key round-trips through the generated accessors", () => {
+test("every manifest key round-trips through the generated accessors", () => {
   const env = new EnvironmentManager();
-  for (const k of BYOK_API_KEYS) {
+  for (const k of ALL_KEYS) {
     assert.equal(typeof env[k.get], "function", `${k.get} generated`);
     assert.equal(typeof env[k.save], "function", `${k.save} generated`);
 
@@ -63,18 +64,23 @@ test("openrouter is a first-class secret", () => {
   assert.equal(env.getOpenrouterKey(), "sk-or-abc");
 });
 
-test("preload BYOK_KEY_BRIDGES mirror the manifest exactly", () => {
-  // preload.js can't require the manifest under sandbox, so it inlines the
-  // {base, get, save} tuples. Assert they stay in lockstep with the manifest.
-  const preloadSrc = fs.readFileSync(path.join(__dirname, "../../preload.js"), "utf8");
-  const block = preloadSrc.match(/BYOK_KEY_BRIDGES = \[([\s\S]*?)\];/);
-  assert.ok(block, "BYOK_KEY_BRIDGES declared in preload.js");
-  for (const k of BYOK_API_KEYS) {
-    const entry = new RegExp(
-      `\\{\\s*base:\\s*"${k.base}",\\s*get:\\s*"${k.get}",\\s*save:\\s*"${k.save}"\\s*\\}`
-    );
-    assert.match(block[1], entry, `preload mirrors ${k.base}`);
-  }
-  const bridgeCount = (block[1].match(/base:/g) || []).length;
-  assert.equal(bridgeCount, BYOK_API_KEYS.length, "no extra/missing preload bridges");
-});
+// preload.js can't require the manifest under sandbox, so it inlines the
+// {base, get, save} tuples. Assert they stay in lockstep with the manifest.
+for (const [name, manifest] of [
+  ["BYOK_KEY_BRIDGES", BYOK_API_KEYS],
+  ["SCOPE_KEY_BRIDGES", SCOPE_CUSTOM_API_KEYS],
+]) {
+  test(`preload ${name} mirrors its manifest exactly`, () => {
+    const preloadSrc = fs.readFileSync(path.join(__dirname, "../../preload.js"), "utf8");
+    const block = preloadSrc.match(new RegExp(`${name} = \\[([\\s\\S]*?)\\];`));
+    assert.ok(block, `${name} declared in preload.js`);
+    for (const k of manifest) {
+      const entry = new RegExp(
+        `\\{\\s*base:\\s*"${k.base}",\\s*get:\\s*"${k.get}",\\s*save:\\s*"${k.save}",?\\s*\\}`
+      );
+      assert.match(block[1], entry, `preload mirrors ${k.base}`);
+    }
+    const bridgeCount = (block[1].match(/base:/g) || []).length;
+    assert.equal(bridgeCount, manifest.length, "no extra/missing preload bridges");
+  });
+}


### PR DESCRIPTION
Found while working on #1364. **Do not merge without a review** — this touches secret storage and has a migration.

## Problem

Dictation cleanup's custom-endpoint API key has been encrypted at rest since #629: it lives in `userData/secure-keys/`, is scrubbed from localStorage on startup, and is fetched over IPC.

Its four siblings never got that treatment. `noteFormattingCustomApiKey`, `dictationAgentCustomApiKey`, `chatAgentCustomApiKey`, and `translationCustomApiKey` were plain `createStringSetter` keys, so a key typed into any of those tabs was written to localStorage in cleartext and left there — readable by any process running as the user, and included in any profile backup.

Same kind of credential, same settings UI, same threat model. Only the cleanup scope was protected.

## Fix

All four now follow the established path. `src/config/secretKeys.js` gains a `SCOPE_CUSTOM_API_KEYS` manifest alongside `BYOK_API_KEYS`, and one entry drives everything: the env var in `SECRET_KEYS`, the generated `EnvironmentManager` accessors, the `get-*`/`save-*` IPC handlers, the preload bridge, and the store's `SECRET_IPC_SAVERS` slug. Adding a fifth scope later is one entry.

Consequently:

- Store defaults stop reading localStorage and hydrate over IPC like every other secret.
- The four setters become `createSecretSetter`, so writes go to the secure store, invalidate the `custom` provider cache, and never touch localStorage.
- `setResolvedLLMConfig` — the single write path behind the settings UI for all five scopes — had a hardcoded `storeKey === "cleanupCustomApiKey"` special case. It's now a lookup over all five, so no scope can fall through to the plaintext branch.

`dictationCleanup` is deliberately not in the manifest: it predates it and keeps a hand-written accessor for its legacy `CUSTOM_REASONING_API_KEY` env fallback. Folding it in would put that fallback at risk for no benefit.

## Migration

Existing users have keys sitting in localStorage right now, and the main-process migration can't help — `_migrateToSecureStorage` is sentinel-gated and already ran for them (and these keys were never in `.env` anyway). So the lift happens renderer-side in `initializeSettings`:

```ts
const legacy = localStorage.getItem(storeKey);
if (!legacy) continue;
if (!state[storeKey]) {
  await save(legacy);                                  // encrypted write first
  useSettingsStore.setState({ [storeKey]: legacy });
}
localStorage.removeItem(storeKey);                     // only then drop plaintext
```

The ordering is the whole point: the plaintext copy is removed only after the encrypted write resolves. If the save rejects, the `await` throws into the existing hydration `catch`, localStorage still holds the key, and the migration retries next launch. Losing a user's key is the one outcome worth designing against.

For the same reason these four keys are **not** added to `STALE_SECRET_LOCALSTORAGE_KEYS` — that sweep runs earlier in `initializeSettings` and would delete them before they were ever saved. There's a comment on the function saying so, because it looks like an omission otherwise.

No sentinel flag is needed: the loop is self-limiting once the localStorage entry is gone.

## Cross-window propagation

These keys used to sync between the control panel and the dictation window for free, via the localStorage `storage` event. Secrets live in the main process and get no such event, so moving them would have introduced a real regression: edit the translation key in the control panel, and the dictation window keeps the stale value until restart — [`audioManager.js`](src/helpers/audioManager.js) reads `translationCustomApiKey` and `dictationAgentCustomApiKey` at dictation time.

Saving one of these keys now broadcasts `secret-changed` to every window through the existing `broadcastToWindows` helper, and the store applies it and clears the `custom` provider cache. This also covers the migration itself: if two windows race the lift, the loser picks up the value from the winner's broadcast.

Worth noting the same staleness still exists for the BYOK keys and the cleanup key — pre-existing, untouched here, and worth its own PR.

## Blast radius

- No main-process reads of these four keys exist; every consumer is in the renderer and reads through the store, so read sites are unchanged.
- No code writes these keys to localStorage directly (checked).
- No settings export/import feature that could round-trip an empty value over a real key.
- 24 secrets now, no env-name collisions (asserted across both manifests by the parity test).
- Linux without a keyring still degrades to plaintext via `_saveKey`, exactly as it does for every other secret.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` — 831 tests, 0 failures
- `test/helpers/secretKeys.test.js` generalized to both manifests: uniqueness of `base`/`env`/`storeKey` across all of them, accessor round-trip through `EnvironmentManager`, and the preload-bridge parity check (which regex-matches `preload.js`, since sandboxed preloads can't require the manifest)

**Not runtime-tested in the app.** The migration especially deserves a manual pass: set a custom endpoint key in one of the four tabs on `main`, switch to this branch, launch, and confirm the key still works and `localStorage` no longer holds it. There are no tests for the lift itself — `settingsStore.ts` isn't loadable under `node --test` (extensionless imports), and none of the other migrations in that file are tested either.

## Also here

`CLAUDE.md` claimed "12 secrets total" in two places. That was already stale before this change and would only get staler, so both now point at `SECRET_KEYS` instead of citing a number.