### PR TITLE
fix(whisper): stop local transcription splitting words mid-word

### DIFF
--- a/scripts/download-whisper-cpp.js
+++ b/scripts/download-whisper-cpp.js
@@ -13,8 +13,9 @@ const {
 
 const WHISPER_CPP_REPO = "OpenWhispr/whisper.cpp";
 
-// Version can be pinned via environment variable for reproducible builds
-const VERSION_OVERRIDE = process.env.WHISPER_CPP_VERSION || null;
+// Pinned to a tested build. Tracking the latest release let an upstream whisper.cpp bump
+// change transcription output between app releases with no diff to review. See #1348.
+const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.8";
 
 const BINARIES = {
   "darwin-arm64": {
@@ -47,11 +48,7 @@ let cachedRelease = null;
 async function getRelease() {
   if (cachedRelease) return cachedRelease;
 
-  if (VERSION_OVERRIDE) {
-    cachedRelease = await fetchLatestRelease(WHISPER_CPP_REPO, { tagPrefix: VERSION_OVERRIDE });
-  } else {
-    cachedRelease = await fetchLatestRelease(WHISPER_CPP_REPO);
-  }
+  cachedRelease = await fetchLatestRelease(WHISPER_CPP_REPO, { tag: WHISPER_CPP_TAG });
   return cachedRelease;
 }
 
@@ -112,11 +109,7 @@ async function downloadBinary(platformArch, config, release, isForce = false) {
 }
 
 async function main() {
-  if (VERSION_OVERRIDE) {
-    console.log(`\n[whisper-server] Using pinned version: ${VERSION_OVERRIDE}`);
-  } else {
-    console.log("\n[whisper-server] Fetching latest release...");
-  }
+  console.log(`\n[whisper-server] Using pinned version: ${WHISPER_CPP_TAG}`);
   const release = await getRelease();
 
   if (!release) {

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -143,6 +143,13 @@ function buildWhisperServerArgs({
   // explicitly pass "auto" to enable language auto-detection
   args.push("--language", language || "auto");
 
+  // whisper.cpp v1.9.x turned token timestamps on for every request, which enables the
+  // server's 60-character segment wrap. split_on_word is off, so the wrap lands on a token
+  // boundary and breaks words mid-word ("abschalten" -> "abs" + "chalten"); we join segments
+  // into one string, so the break surfaces as a stray space. We only read `text`, never
+  // per-token timings, so turn timestamps off and the wrap goes with them. See #1348.
+  args.push("--no-timestamps");
+
   if (isVadActive({ vadEnabled, vadModelPath })) {
     const cfg = sanitizeWhisperVadConfig(vadConfig || DEFAULT_WHISPER_VAD_CONFIG);
     args.push(

--- a/test/helpers/whisperServerVadArgs.test.js
+++ b/test/helpers/whisperServerVadArgs.test.js
@@ -29,6 +29,7 @@ test("buildWhisperServerArgs includes VAD flags when enabled and model path prov
     "8180",
     "--language",
     "auto",
+    "--no-timestamps",
     "--vad",
     "--vad-model",
     "/tmp/ggml-silero-v5.1.2.bin",
@@ -58,6 +59,16 @@ test("buildWhisperServerArgs omits VAD flags when vadModelPath is missing", () =
 
   assert.equal(args.includes("--vad"), false);
   assert.equal(args.includes("--vad-model"), false);
+});
+
+test("buildWhisperServerArgs disables timestamps so segments aren't wrapped mid-word", () => {
+  const args = WhisperServerManager.buildWhisperServerArgs({
+    modelPath: "/tmp/model.bin",
+    port: 8180,
+    language: "auto",
+  });
+
+  assert.equal(args.includes("--no-timestamps"), true);
 });
 
 test("buildWhisperServerArgs includes thread count when provided", () => {


### PR DESCRIPTION
Fixes #1348. Fixes #1158.

## The symptom

Since 1.7.4, local Whisper inserts a stray space inside words:

| Reported | Should be |
|---|---|
| `auf Vollbild zu sch alten` | `schalten` |
| `отк лючил`, `сообщ ение`, `рандом ных` | `отключил`, `сообщение`, `рандомных` |

The breaks land on BPE token boundaries — not phonetic ones — roughly every 60 characters, in any language, and independent of the Silero VAD toggle.

## Root cause

No source change caused this. `scripts/download-whisper-cpp.js` tracked the *latest* release of the binaries repo, so the whisper binary changed between app releases with no diff to review:

| App release | Built | Binaries |
|---|---|---|
| v1.7.3 | Jun 23 | 0.0.6 = whisper.cpp **v1.8.3** |
| v1.7.4 | Jul 7 | 0.0.7 = whisper.cpp **v1.9.1** ← regression |
| v1.7.5 / v1.7.6 | Jul 10 / Jul 18 | 0.0.7 / 0.0.8 (still v1.9.1) |

v1.8.3's server enabled token timestamps only for `verbose_json`:

```cpp
wparams.token_timestamps = !params.no_timestamps && params.response_format == vjson_format;
```

v1.9.1 enables them for **every** request (`params.token_timestamps` defaults true). Both versions force `wparams.max_len = params.max_len == 0 ? 60 : params.max_len;`, and `max_len` wrapping only runs on the token-timestamp path. So v1.9.1 wraps every segment at 60 characters with `split_on_word` off — the wrap lands mid-token. We join segments into one string, and `normalizeWhitespace` turns the `\n` into a space.

## The fix

Pass `--no-timestamps`, which turns the wrap off along with them. We only read `text` from this server, never per-token timings — verified across all five `transcribeLocalWhisper` call sites (dictation, notes, meetings).

Verified against the shipping 0.0.8 binary, same model and WAV:

```
without: "...ob die Anwendung sich abs chalten und dann wieder einschalten lässt."
with:    "...ob die Anwendung sich abschalten und dann wieder einschalten lässt."   ← matches v1.8.3 exactly
```

It has to be a startup flag: per-request form fields (`token_timestamps`, `max_len`, `split_on_word`) are ignored by the server. I tested all three.

## Also: pin the binaries

Pinned to `0.0.8` instead of tracking latest, matching how `download-llama-server.js` pins llama.cpp. Pinning in the script rather than in the workflows keeps one source of truth, gives local `prebuild` the same binary as CI, and lets the cache key (`hashFiles('scripts/download-*.js')`) invalidate on a bump. `WHISPER_CPP_VERSION` still overrides for testing.

0.0.8 is what 1.7.6 already ships, so this is not a rollback — it keeps the RTX 50 CUDA support and the macOS 13.3 floor fix.

## Tests

Updated the `deepEqual` args assertion and added a regression test for the flag. Full suite: 866 tests, 0 failures.
