### PR TITLE
fix(privacy): wait for retention sync before cleanup

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -514,6 +514,7 @@ class IPCHandlers {
     this.audioStorageManager = new AudioStorageManager();
     this._retentionCleanupInterval = null;
     this._retentionSettings = { ...DEFAULT_RETENTION_SETTINGS }; // Synced from renderer
+    this._retentionSettingsSynced = false;
     this._noteFilesEnabled = false;
     this.speakerDiarizationEnabled = true;
     this.activeMeetingSpeakerConfig = null;
@@ -785,8 +786,17 @@ class IPCHandlers {
 
   _setupRetentionCleanup() {
     const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
-    this._runRetentionCleanup();
-    this._retentionCleanupInterval = setInterval(() => this._runRetentionCleanup(), SIX_HOURS_MS);
+    this._retentionCleanupInterval = setInterval(() => {
+      if (this._retentionSettingsSynced) this._runRetentionCleanup();
+    }, SIX_HOURS_MS);
+  }
+
+  _syncRetentionSettings(incoming) {
+    const firstSync = !this._retentionSettingsSynced;
+    const { changed, settings } = applyRetentionSettings(this._retentionSettings, incoming);
+    this._retentionSettings = settings;
+    this._retentionSettingsSynced = true;
+    if (firstSync || changed) this._runRetentionCleanup();
   }
 
   _runRetentionCleanup() {
@@ -1109,10 +1119,7 @@ class IPCHandlers {
     });
 
     ipcMain.on("retention-settings-changed", (_event, incoming) => {
-      const { changed, settings } = applyRetentionSettings(this._retentionSettings, incoming);
-      if (!changed) return;
-      this._retentionSettings = settings;
-      this._runRetentionCleanup();
+      this._syncRetentionSettings(incoming);
     });
 
     ipcMain.handle("delete-all-audio", async () => {

--- a/test/helpers/retentionSettings.test.js
+++ b/test/helpers/retentionSettings.test.js
@@ -6,6 +6,67 @@ const {
   applyRetentionSettings,
 } = require("../../src/helpers/retentionSettings");
 
+test("waits for persisted settings before running startup cleanup", () => {
+  const IPCHandlers = require("../../src/helpers/ipcHandlers");
+  const cleanupRuns = [];
+  const context = {
+    _retentionCleanupInterval: null,
+    _retentionSettings: { ...DEFAULT_RETENTION_SETTINGS },
+    _runRetentionCleanup() {
+      cleanupRuns.push({ ...this._retentionSettings });
+    },
+  };
+
+  IPCHandlers.prototype._setupRetentionCleanup.call(context);
+  clearInterval(context._retentionCleanupInterval);
+
+  assert.deepEqual(cleanupRuns, []);
+});
+
+test("applies disabled audio retention before the first cleanup", () => {
+  const IPCHandlers = require("../../src/helpers/ipcHandlers");
+  const cleanupRuns = [];
+  const context = {
+    _retentionSettings: { ...DEFAULT_RETENTION_SETTINGS },
+    _retentionSettingsSynced: false,
+    _runRetentionCleanup() {
+      cleanupRuns.push({ ...this._retentionSettings });
+    },
+  };
+
+  IPCHandlers.prototype._syncRetentionSettings.call(context, {
+    audioRetentionDays: 0,
+    transcriptRetentionDays: 0,
+  });
+
+  assert.deepEqual(cleanupRuns, [{ audioRetentionDays: 0, transcriptRetentionDays: 0 }]);
+});
+
+test("runs the default first sync once and de-duplicates an unchanged second-window sync", () => {
+  const IPCHandlers = require("../../src/helpers/ipcHandlers");
+  let cleanupRuns = 0;
+  const context = {
+    _retentionSettings: { ...DEFAULT_RETENTION_SETTINGS },
+    _retentionSettingsSynced: false,
+    _runRetentionCleanup() {
+      cleanupRuns++;
+    },
+  };
+
+  IPCHandlers.prototype._syncRetentionSettings.call(context, DEFAULT_RETENTION_SETTINGS);
+  IPCHandlers.prototype._syncRetentionSettings.call(context, DEFAULT_RETENTION_SETTINGS);
+
+  assert.equal(cleanupRuns, 1);
+
+  IPCHandlers.prototype._syncRetentionSettings.call(context, {
+    ...DEFAULT_RETENTION_SETTINGS,
+    audioRetentionDays: 7,
+  });
+
+  assert.equal(cleanupRuns, 2);
+  assert.equal(context._retentionSettings.audioRetentionDays, 7);
+});
+
 test("reports a change when a retention period is shortened", () => {
   assert.deepEqual(
     applyRetentionSettings(DEFAULT_RETENTION_SETTINGS, {


### PR DESCRIPTION
## Summary

- wait for persisted retention settings before the main process runs its first cleanup sweep
- preserve one first-sync cleanup while de-duplicating unchanged syncs from the second renderer window
- add deterministic regression coverage for Disabled, default, duplicate, and changed settings

## Problem

`IPCHandlers` ran retention cleanup during construction with the main-process default of 30 audio-retention days. Persisted settings live in renderer `localStorage` and arrive later over `retention-settings-changed`, so a user who selected Audio Retention **Disabled** (`0`) could still lose audio older than 30 days at launch.

## Root cause

`_setupRetentionCleanup()` invoked `_runRetentionCleanup()` before either renderer window could sync its persisted values. The existing change detection also treated an unchanged default first sync as a duplicate, so simply removing the eager call would have skipped the intended initial sweep for default settings.

## Solution

- mark retention settings as unsynchronized during main-process initialization
- defer startup and periodic cleanup until the first settings payload arrives
- apply the incoming settings before the first cleanup
- run the first sync once even when it matches the defaults, while retaining existing de-duplication for later unchanged syncs

The retention values, purge implementation, database behavior, and IPC payload shape remain unchanged.

## Tests

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/retentionSettings.test.js test/helpers/transcriptRetention.test.js test/helpers/discardedRecording.test.js` — 13 passed, 0 failed
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` — 862 passed, 0 failed, 6 environment-dependent skips

## Validation

- `npm ci --ignore-scripts` — passed
- `npm rebuild better-sqlite3` — passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed
- `node --check src/helpers/ipcHandlers.js` — passed
- `node --check test/helpers/retentionSettings.test.js` — passed
- `git diff --check` — passed

The first sandboxed full-suite attempt could not open loopback listeners (`listen EPERM 127.0.0.1`). Re-running the same suite with loopback access passed with the counts above.

## Compatibility and risk

This is cross-platform lifecycle ordering only. It does not change public APIs, stored settings, retention periods, deletion semantics, or error shapes. If renderer settings never sync, cleanup now safely remains inactive instead of applying a destructive guessed default.

## Documentation

No documentation changes are needed because the user-facing retention contract is unchanged.

## Related issues and prior work

Fixes #1370.

PR #1368 introduced the renderer-to-main retention sync and states that Audio Retention Disabled must not purge existing files. This PR fixes the startup ordering gap without changing that feature's scope.
