### PR TITLE
fix(cuda): pin the CUDA whisper binaries and verify their digests

### DIFF
--- a/src/helpers/whisperCudaManager.js
+++ b/src/helpers/whisperCudaManager.js
@@ -1,12 +1,24 @@
 const GpuBinaryManager = require("./gpuBinaryManager");
 
-const GITHUB_RELEASE_URL = "https://api.github.com/repos/OpenWhispr/whisper.cpp/releases/latest";
+// Pinned so untested future binaries never auto-ship; bump together with the digests below
+const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.8";
+
+// sha256 per release tag; tags without an entry fall back to the API-reported digest
+const EXPECTED_DIGESTS = {
+  "0.0.8": {
+    "whisper-server-win32-x64-cuda.zip":
+      "ef6df3492b6e512ccfb04ce69e01ac26b2e12f3c90a665cdb35e7f1f471ed203",
+    "whisper-server-linux-x64-cuda.zip":
+      "8c71e63658fafd3efec39bb0ff3c0d15790ede0be87849dfbf9ad8a81e04b3d0",
+  },
+};
 
 class WhisperCudaManager extends GpuBinaryManager {
   constructor() {
     super({
       name: "CUDA whisper",
-      releaseUrl: GITHUB_RELEASE_URL,
+      releaseUrl: `https://api.github.com/repos/OpenWhispr/whisper.cpp/releases/tags/${WHISPER_CPP_TAG}`,
+      expectedDigests: EXPECTED_DIGESTS[WHISPER_CPP_TAG],
       assets: {
         "win32-x64": {
           assetName: "whisper-server-win32-x64-cuda.zip",

--- a/test/helpers/gpuBinaryManager.test.js
+++ b/test/helpers/gpuBinaryManager.test.js
@@ -76,6 +76,14 @@ const WhisperCudaManager = require("../../src/helpers/whisperCudaManager.js");
 const LlamaVulkanManager = require("../../src/helpers/llamaVulkanManager.js");
 const WhisperVulkanManager = require("../../src/helpers/whisperVulkanManager.js");
 
+// CUDA pins real release digests, which a stubbed archive can never hash to. Tests that
+// exercise shared pipeline behavior rather than integrity drop the pin to reach it.
+function cudaManagerWithoutDigestPin() {
+  const manager = new WhisperCudaManager();
+  manager.config.expectedDigests = undefined;
+  return manager;
+}
+
 function makeRelease(assetName, overrides = {}) {
   return {
     tag_name: "test-tag",
@@ -114,7 +122,7 @@ test.afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
-test("CUDA: resolves its exact asset from releases/latest and installs binary + companion libs", async () => {
+test("CUDA: resolves its exact asset from the pinned tag and installs binary + companion libs", async () => {
   state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
   state.extractedFiles = {
     "whisper-server-linux-x64-cuda": "binary",
@@ -122,10 +130,10 @@ test("CUDA: resolves its exact asset from releases/latest and installs binary + 
     "README.md": "doc",
   };
 
-  const manager = new WhisperCudaManager();
+  const manager = cudaManagerWithoutDigestPin();
   await manager.download();
 
-  assert.match(state.fetchedUrls[0], /OpenWhispr\/whisper\.cpp\/releases\/latest$/);
+  assert.match(state.fetchedUrls[0], /OpenWhispr\/whisper\.cpp\/releases\/tags\/0\.0\.8$/);
   assert.equal(state.downloads[0].url, "https://dl/whisper-server-linux-x64-cuda.zip");
 
   const binDir = path.join(userDataDir, "bin");
@@ -149,6 +157,14 @@ test("llama Vulkan: resolves asset by regex from the pinned tag", async () => {
   assert.match(state.fetchedUrls[0], /ggml-org\/llama\.cpp\/releases\/tags\/b9763$/);
   assert.ok(fs.existsSync(path.join(userDataDir, "bin", "llama-server-vulkan")), "renamed output");
   assert.ok(fs.existsSync(path.join(userDataDir, "bin", "libvulkan.so.1")));
+});
+
+test("CUDA: pinned digest rejects an asset that doesn't match (fail closed)", async () => {
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "whisper-server-linux-x64-cuda": "binary" };
+
+  await assert.rejects(() => new WhisperCudaManager().download(), { message: /integrity check/ });
+  assert.equal(new WhisperCudaManager().isDownloaded(), false);
 });
 
 test("whisper Vulkan: pinned asset, no companion libs, rejects a digest mismatch (fail closed)", async () => {
@@ -262,7 +278,7 @@ test("guard: a second download while one is in flight throws", async () => {
   };
   state.extractedFiles = { "whisper-server-linux-x64-cuda": "binary" };
 
-  const manager = new WhisperCudaManager();
+  const manager = cudaManagerWithoutDigestPin();
   const first = manager.download();
   await assert.rejects(() => manager.download(), { message: "Download already in progress" });
   releaseDownload();
@@ -275,7 +291,7 @@ test("cleanup on failure: archive and extract dir removed, next download can sta
     throw new Error("Extraction failed: corrupt");
   };
 
-  const manager = new WhisperCudaManager();
+  const manager = cudaManagerWithoutDigestPin();
   await assert.rejects(() => manager.download(), { message: /Extraction failed/ });
 
   assert.equal(fs.readdirSync(tempDir).length, 0, "temp artifacts removed");


### PR DESCRIPTION
Follow-up to #1369. Independent of it — different files, no conflict.

## Why

While verifying #1369 I checked the other whisper binary paths. [`whisperCudaManager.js`](https://github.com/OpenWhispr/openwhispr/blob/main/src/helpers/whisperCudaManager.js) resolved `releases/latest` **at runtime, on the user's machine**, with no pinned digest.

That's the same exposure that caused #1348 — an upstream whisper.cpp release silently changing what we ship — except worse in two ways:

- It resolves on the user's machine, so the binary can change under an already-installed app with **no release on our side at all** and no build to review.
- With no pinned digest, `_verifyDigest` falls back to the API-reported digest. GitHub release assets are mutable, so that only proves the download matches what the API currently claims — not that it matches anything we tested.

Vulkan was already pinned with digests. CUDA was the last unpinned whisper binary path.

## What

Pin to `0.0.8` with sha256 digests, mirroring `whisperVulkanManager.js` exactly. `WHISPER_CPP_VERSION` still overrides, and tags with no digest entry fall back to the API digest (which also fails closed).

Both digests were verified by downloading the assets and hashing them independently, not copied from the API:

```
whisper-server-linux-x64-cuda.zip  8c71e63658fafd3efec39bb0ff3c0d15790ede0be87849dfbf9ad8a81e04b3d0
whisper-server-win32-x64-cuda.zip  ef6df3492b6e512ccfb04ce69e01ac26b2e12f3c90a665cdb35e7f1f471ed203
```

This matters because `_verifyDigest` **fails closed** — a wrong pinned digest would break CUDA downloads for every NVIDIA user rather than degrading quietly.

## Non-breaking

`releases/latest` already resolves to `0.0.8`, so this is not a rollback and not a version change — it just stops the version from moving on its own. Digests are only checked at download time, so users with an already-installed CUDA binary are unaffected.

## Tests

The CUDA manager now carries real digests that a stubbed archive can never hash to, which broke three existing tests that used it as a stand-in for shared `GpuBinaryManager` behavior (install, in-flight guard, cleanup-on-failure). Those drop the pin through a small helper so they still test what they're named for. Added coverage for the pinned-digest fail-closed path.

Full suite: 866 tests, 0 failures.
