### PR TITLE
fix(sidecars): tolerate unreadable PID entries

### DIFF
--- a/src/helpers/sidecarPidFile.js
+++ b/src/helpers/sidecarPidFile.js
@@ -32,15 +32,25 @@ function clear(name) {
 
 function readAll() {
   const dir = pidDir();
-  if (!fs.existsSync(dir)) return [];
+  let files;
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+
   const entries = [];
-  for (const file of fs.readdirSync(dir)) {
+  for (const file of files) {
     if (!file.endsWith(".pid")) continue;
-    const name = path.basename(file, ".pid");
-    const raw = fs.readFileSync(path.join(dir, file), "utf-8").trim();
-    const pid = Number(raw);
-    if (!Number.isInteger(pid) || pid <= 0) continue;
-    entries.push({ name, pid });
+    try {
+      const name = path.basename(file, ".pid");
+      const raw = fs.readFileSync(path.join(dir, file), "utf-8").trim();
+      const pid = Number(raw);
+      if (!Number.isInteger(pid) || pid <= 0) continue;
+      entries.push({ name, pid });
+    } catch {
+      // Best-effort recovery metadata; skip entries that vanished or cannot be read.
+    }
   }
   return entries;
 }

--- a/test/helpers/sidecarPidFile.test.js
+++ b/test/helpers/sidecarPidFile.test.js
@@ -1,0 +1,63 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+let userDataDir;
+const electronPath = require.resolve("electron");
+require.cache[electronPath] = {
+  exports: {
+    app: {
+      getPath: () => userDataDir,
+    },
+  },
+};
+
+const { write, clear, readAll } = require("../../src/helpers/sidecarPidFile");
+
+function createUserDataDir(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ow-sidecar-pids-"));
+  userDataDir = dir;
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return path.join(dir, "sidecar-pids");
+}
+
+test("an unreadable PID entry does not hide valid sidecar entries", (t) => {
+  const pidDir = createUserDataDir(t);
+  fs.mkdirSync(pidDir);
+  fs.writeFileSync(path.join(pidDir, "qdrant.pid"), "1234");
+  fs.mkdirSync(path.join(pidDir, "broken.pid"));
+
+  assert.deepEqual(readAll(), [{ name: "qdrant", pid: 1234 }]);
+});
+
+test("an unreadable PID registry is treated as empty", (t) => {
+  const pidDir = createUserDataDir(t);
+  fs.writeFileSync(pidDir, "not a directory");
+
+  assert.deepEqual(readAll(), []);
+});
+
+test("missing, malformed, and unrelated entries are ignored", (t) => {
+  const pidDir = createUserDataDir(t);
+  assert.deepEqual(readAll(), []);
+
+  fs.mkdirSync(pidDir);
+  fs.writeFileSync(path.join(pidDir, "zero.pid"), "0");
+  fs.writeFileSync(path.join(pidDir, "fraction.pid"), "12.5");
+  fs.writeFileSync(path.join(pidDir, "text.pid"), "not-a-pid");
+  fs.writeFileSync(path.join(pidDir, "notes.txt"), "5678");
+
+  assert.deepEqual(readAll(), []);
+});
+
+test("valid PID entries still round-trip through write, read, and clear", (t) => {
+  createUserDataDir(t);
+
+  write("whisper", 4321);
+  assert.deepEqual(readAll(), [{ name: "whisper", pid: 4321 }]);
+
+  clear("whisper");
+  assert.deepEqual(readAll(), []);
+});


### PR DESCRIPTION
## Summary

- Treat the sidecar PID registry as best-effort when its directory cannot be enumerated.
- Skip individual unreadable PID entries while preserving valid entries.
- Add deterministic regression coverage for unreadable, missing, malformed, and valid registry states.

## Problem

The startup reaper calls `sidecarPidFile.readAll()` before managers or windows are initialized. A stale `.pid` entry that disappears, is a directory, or cannot be read throws from `readFileSync()`. That rejects `startApp()`, shows the fatal startup dialog, and exits the app.

Before this change, one damaged recovery entry also prevented later valid entries from being considered. After this change, unreadable recovery metadata is skipped and startup can continue.

## Root cause

`readAll()` checked whether the registry directory existed but left both `readdirSync()` and each `readFileSync()` outside an error boundary. The neighboring write and clear paths already treat this metadata as best-effort.

## Solution

Guard directory enumeration and return an empty registry when it cannot be read. Guard each `.pid` read independently so a bad entry cannot hide valid positive-integer PID entries.

## Scope and non-goals

This PR does not change sidecar signaling, process-command verification, shutdown ordering, PID validation, public APIs, dependencies, or lockfiles.

## Tests

Added `test/helpers/sidecarPidFile.test.js` covering:

- an unreadable entry alongside a valid entry;
- an unreadable registry path;
- missing, malformed, non-positive, fractional, and unrelated entries;
- the existing valid write/read/clear round trip.

The first regression failed before the production change with `EISDIR` from `readAll()`.

## Validation

- `npm ci --ignore-scripts` — passed (locked Node 24 install)
- `npm rebuild better-sqlite3` — passed
- `node --test test/helpers/sidecarPidFile.test.js` — 4 passed, 0 failed
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` — 869 tests: 863 passed, 6 expected FFmpeg-related skips, 0 failed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npx prettier --check src/helpers/sidecarPidFile.js test/helpers/sidecarPidFile.test.js` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed
- `node --check src/helpers/sidecarPidFile.js` — passed
- `node --check test/helpers/sidecarPidFile.test.js` — passed
- `git diff --check` and `git diff --cached --check` — passed

## Compatibility and risk

The success path and returned entry shape are unchanged. The only new behavior is converting filesystem read failures in best-effort recovery metadata into skipped entries. Local validation ran on macOS with Node 24.9.0; the filesystem logic is platform-neutral, but no packaged application build was run.

## Documentation

No documentation change is needed because this restores the existing best-effort lifecycle contract.

## Related issues and prior work

PR #694 introduced startup sidecar reaping for issue #683. That work is adjacent but did not cover unreadable registry entries.

Fixes #1373