### PR TITLE
fix(parakeet): normalize non-PCM16 WAV input

### DIFF
--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -196,6 +196,7 @@ function parseWavFormat(wavBuffer) {
 
     if (chunkId === "fmt ") {
       return {
+        audioFormat: wavBuffer.readUInt16LE(offset + 8),
         channels: wavBuffer.readUInt16LE(offset + 10),
         sampleRate: wavBuffer.readUInt32LE(offset + 12),
         bitsPerSample: wavBuffer.readUInt16LE(offset + 22),

--- a/src/helpers/parakeetServer.js
+++ b/src/helpers/parakeetServer.js
@@ -53,10 +53,15 @@ class ParakeetServerManager {
   async _ensureWav(audioBuffer) {
     if (isWavFormat(audioBuffer)) {
       const format = parseWavFormat(audioBuffer);
-      if (format?.sampleRate === SAMPLE_RATE && format?.channels === 1) {
+      if (
+        format?.audioFormat === 1 &&
+        format?.bitsPerSample === 16 &&
+        format?.sampleRate === SAMPLE_RATE &&
+        format?.channels === 1
+      ) {
         return { wavBuffer: audioBuffer, filesToCleanup: [] };
       }
-      debugLogger.debug("WAV input needs resampling", { format });
+      debugLogger.debug("WAV input needs normalization", { format });
     }
 
     const ffmpegPath = getFFmpegPath();

--- a/test/helpers/parakeetWavNormalization.test.js
+++ b/test/helpers/parakeetWavNormalization.test.js
@@ -1,0 +1,125 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { REQUIRED_MODEL_FILES } = require("../../src/helpers/parakeetModelInfo");
+
+const MODEL_NAME = "parakeet-tdt-0.6b-v3";
+
+function createFloat32Wav(sampleValue, sampleCount = 160) {
+  const dataSize = sampleCount * 4;
+  const wav = Buffer.alloc(44 + dataSize);
+
+  wav.write("RIFF", 0);
+  wav.writeUInt32LE(36 + dataSize, 4);
+  wav.write("WAVE", 8);
+  wav.write("fmt ", 12);
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(3, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(16000, 24);
+  wav.writeUInt32LE(64000, 28);
+  wav.writeUInt16LE(4, 32);
+  wav.writeUInt16LE(32, 34);
+  wav.write("data", 36);
+  wav.writeUInt32LE(dataSize, 40);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    wav.writeFloatLE(sampleValue, 44 + index * 4);
+  }
+
+  return wav;
+}
+
+function createPcm16Wav(sampleValue, sampleCount = 160) {
+  const dataSize = sampleCount * 2;
+  const wav = Buffer.alloc(44 + dataSize);
+
+  wav.write("RIFF", 0);
+  wav.writeUInt32LE(36 + dataSize, 4);
+  wav.write("WAVE", 8);
+  wav.write("fmt ", 12);
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(16000, 24);
+  wav.writeUInt32LE(32000, 28);
+  wav.writeUInt16LE(2, 32);
+  wav.writeUInt16LE(16, 34);
+  wav.write("data", 36);
+  wav.writeUInt32LE(dataSize, 40);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    wav.writeInt16LE(Math.round(sampleValue * 32767), 44 + index * 2);
+  }
+
+  return wav;
+}
+
+test("transcribes audible mono 16 kHz float32 WAV input", async () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-parakeet-wav-test-"));
+  const originalLoad = Module._load;
+  let ffmpegUtils;
+  Module._load = function loadWithElectronStub(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        app: {
+          getPath: () => tempHome,
+          isReady: () => false,
+        },
+      };
+    }
+    if (request === "./ffmpegUtils" && parent?.filename.endsWith("parakeetServer.js")) {
+      return {
+        ...ffmpegUtils,
+        getFFmpegPath: () => "/mock/ffmpeg",
+        convertToWav: async (_inputPath, outputPath) => {
+          fs.writeFileSync(outputPath, createPcm16Wav(0.5));
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  let ParakeetServerManager;
+  try {
+    ffmpegUtils = require("../../src/helpers/ffmpegUtils");
+    ParakeetServerManager = require("../../src/helpers/parakeetServer");
+  } finally {
+    Module._load = originalLoad;
+  }
+
+  try {
+    const modelDir = path.join(
+      tempHome,
+      ".cache",
+      "openwhispr",
+      "parakeet-models",
+      MODEL_NAME
+    );
+    fs.mkdirSync(modelDir, { recursive: true });
+    for (const file of REQUIRED_MODEL_FILES) {
+      fs.writeFileSync(path.join(modelDir, file), "");
+    }
+
+    let receivedSamples;
+    const manager = new ParakeetServerManager();
+    manager.wsServer = {
+      start: async () => {},
+      transcribe: async (samples) => {
+        receivedSamples = Buffer.from(samples);
+        return { text: "audible", elapsed: 0 };
+      },
+    };
+
+    const result = await manager.transcribe(createFloat32Wav(0.5), { modelName: MODEL_NAME });
+
+    assert.equal(result.text, "audible");
+    assert.ok(receivedSamples);
+    assert.ok(Math.abs(receivedSamples.readFloatLE(0) - 0.5) < 0.001);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- normalize mono 16 kHz WAV files unless they are signed PCM16
- cover float32 WAV import through the public Parakeet transcription path

## Problem

A valid mono 16 kHz IEEE-float WAV bypassed FFmpeg because the fast path checked only sample rate and channel count. The PCM16-only decoder then interpreted the float bytes as signed 8-bit samples, which could turn audible input into silence and return an empty transcription.

## Root cause

`parseWavFormat()` exposed the bit depth but not the WAV audio-format code, and `ParakeetServerManager._ensureWav()` ignored both fields when deciding whether the input was already ready for inference.

## Solution

Expose the WAV audio-format code and restrict passthrough to format code 1, 16-bit, mono, 16 kHz input. All other WAV formats use the existing FFmpeg normalization path before sample decoding.

## Tests

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/parakeetWavNormalization.test.js` — 1 passed, 0 failed; confirmed red before the fix (`'' !== 'audible'`)
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/audioSegmentMerge.test.js test/helpers/parakeetModelRegistry.test.js test/helpers/parakeetOnlineStream.test.js test/helpers/parakeetWsResult.test.js` — 26 passed, 0 failed
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` — 816 passed, 50 skipped, 0 failed; skips are existing `better-sqlite3` Node/Electron ABI exclusions

## Validation

- `npm run format:check` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed
- `node --check src/helpers/ffmpegUtils.js && node --check src/helpers/parakeetServer.js && node --check test/helpers/parakeetWavNormalization.test.js` — passed
- `git diff --check` — passed

## Compatibility and risk

PCM16 mono/16 kHz input keeps the existing zero-conversion fast path. Other WAV encodings now take the existing FFmpeg path already used for non-WAV, non-16 kHz, and non-mono inputs. `parseWavFormat()` gains one additive field; no existing field or caller contract is removed.

## Documentation

No documentation change is needed because supported import formats and user-facing behavior are unchanged; this corrects normalization inside the existing WAV import path.

## Related issues and prior work

Fixes #1375.

PR #1238 added sample-rate/channel normalization and the current WAV metadata parser. This patch closes the separate encoding/bit-depth gap in that fast path.