### PR TITLE
fix(reasoning): stop custom DeepSeek cleanup failing with a 400

### DIFF
--- a/src/services/ai/thinkingSuppressionDialects.ts
+++ b/src/services/ai/thinkingSuppressionDialects.ts
@@ -71,6 +71,8 @@ export function suppressThinking(
   // #1260); thinking: {type} is its native switch. Family facts don't apply —
   // deepseek models on other hosts (e.g. Tinfoil) accept the generic shape.
   if (providerKey === "deepseek") {
+    // A preset effort is also a 400 alongside the thinking switch, so drop it.
+    delete requestBody.reasoning_effort;
     requestBody.thinking = { type: "disabled" };
     return;
   }

--- a/test/helpers/thinkingSuppressionDialects.test.js
+++ b/test/helpers/thinkingSuppressionDialects.test.js
@@ -159,6 +159,24 @@ test("mistral tolerates a missing model without throwing", async () => {
   assert.deepEqual(body, { reasoning_effort: "none" });
 });
 
+test("deepseek strips a reasoning_effort preset by earlier request shaping", async () => {
+  const { suppressThinking } = await load();
+
+  const body = { reasoning_effort: "low" };
+  suppressThinking(body, "deepseek", "deepseek-v4-pro");
+
+  assert.deepEqual(body, { thinking: { type: "disabled" } });
+});
+
+test("deepseek tolerates a missing model without throwing", async () => {
+  const { suppressThinking } = await load();
+
+  const body = {};
+  suppressThinking(body, "deepseek", undefined);
+
+  assert.deepEqual(body, { thinking: { type: "disabled" } });
+});
+
 test("detectEndpointDialect maps the mistral api base to max_tokens and temperature", async () => {
   const { detectEndpointDialect } = await load();
 
@@ -180,12 +198,56 @@ test("detectEndpointDialect matches mistral hosts regardless of scheme, case, po
   assert.equal(detectEndpointDialect("https://api.mistral.ai/v1/chat/completions")?.key, "mistral");
 });
 
+test("detectEndpointDialect matches deepseek hosts regardless of scheme, case, port or path", async () => {
+  const { detectEndpointDialect } = await load();
+
+  assert.equal(detectEndpointDialect("api.deepseek.com")?.key, "deepseek");
+  assert.equal(detectEndpointDialect("https://deepseek.com")?.key, "deepseek");
+  assert.equal(detectEndpointDialect("https://API.DeepSeek.COM/v1/")?.key, "deepseek");
+  assert.equal(detectEndpointDialect("https://api.deepseek.com:443/v1")?.key, "deepseek");
+  assert.equal(detectEndpointDialect("https://api.deepseek.com/chat/completions")?.key, "deepseek");
+});
+
 test("detectEndpointDialect rejects lookalike hosts", async () => {
   const { detectEndpointDialect } = await load();
 
   assert.equal(detectEndpointDialect("https://api.openai.com/v1"), null);
   assert.equal(detectEndpointDialect("https://notmistral.ai"), null);
   assert.equal(detectEndpointDialect("https://mistral.ai.evil.com"), null);
+  assert.equal(detectEndpointDialect("https://notdeepseek.com"), null);
+  assert.equal(detectEndpointDialect("https://deepseek.com.evil.com"), null);
+  assert.equal(detectEndpointDialect("https://api.deepseek.evil.com"), null);
+});
+
+// The custom provider has no dialect of its own: the endpoint host decides,
+// mirroring applyThinkingSuppression's `detectEndpointDialect(url)?.key ?? provider`.
+test("custom provider pointed at the deepseek api gets the deepseek shape", async () => {
+  const { detectEndpointDialect, suppressThinking } = await load();
+
+  const providerKey = detectEndpointDialect("https://api.deepseek.com/v1")?.key ?? "custom";
+  const body = { model: "deepseek-v4-flash", messages: [] };
+  suppressThinking(body, providerKey, "deepseek-v4-flash");
+
+  assert.deepEqual(body, {
+    model: "deepseek-v4-flash",
+    messages: [],
+    thinking: { type: "disabled" },
+  });
+});
+
+test("custom provider on a non-deepseek endpoint keeps the legacy shape untouched", async () => {
+  const { detectEndpointDialect, suppressThinking } = await load();
+
+  const providerKey = detectEndpointDialect("https://llm.example.com/v1")?.key ?? "custom";
+  assert.equal(providerKey, "custom");
+
+  const body = {};
+  suppressThinking(body, providerKey, "gpt-5.2");
+
+  assert.deepEqual(body, {
+    reasoning_effort: "none",
+    chat_template_kwargs: { enable_thinking: false },
+  });
 });
 
 test("detectEndpointDialect returns null for unparseable or missing input", async () => {


### PR DESCRIPTION
## Summary

With "Disable thinking output" on, a custom provider pointed at `api.deepseek.com` gets the generic OpenAI-compat suppression shape from `suppressThinking`: `reasoning_effort: "none"` plus `chat_template_kwargs`. DeepSeek V4 rejects that with a 400 (`unknown variant 'none'`), so cleanup fails and dictation pastes the raw transcript. Per the official docs (https://api-docs.deepseek.com/guides/thinking_mode), DeepSeek's switch is the top-level `thinking: {"type": "disabled"}` object, and `reasoning_effort` only accepts `high`/`max` (`low`/`medium`/`xhigh` are remapped, there is no `none`).

Same family as the Groq (#1211) and Mistral (#1213) dialects: `detectEndpointDialect` now recognises `deepseek.com` hosts, and the new branch in `suppressThinking` sends `thinking: {"type": "disabled"}`, strips any preset `reasoning_effort` (DeepSeek also 400s when it is combined with a disabled thinking switch), and never sends `chat_template_kwargs`. Detection is host based only, so custom endpoints on other hosts keep the legacy shape. The dialect table also switches DeepSeek requests to `max_tokens` plus `temperature` (both documented, previously `max_completion_tokens`, which DeepSeek ignores) and skips the `/responses` probe.

Fixes #1260

## Changes

- src/services/ai/thinkingSuppressionDialects.ts: recognise `deepseek.com`/`*.deepseek.com` hosts as an endpoint dialect and add the deepseek branch in `suppressThinking` that sets `thinking: {"type": "disabled"}` and deletes `reasoning_effort`.
- test/helpers/thinkingSuppressionDialects.test.js: cover the deepseek request shape, the `reasoning_effort` strip, host detection variants and lookalike rejection, and the custom provider path on deepseek and non-deepseek endpoints.
