### PR TITLE
feat(realtime): allow a custom base URL for realtime transcription

### DIFF
--- a/src/helpers/dictationStreamingRouting.js
+++ b/src/helpers/dictationStreamingRouting.js
@@ -44,6 +44,14 @@ export function buildStreamingSessionOptions({
     environment: settings.cortiEnvironment,
     tenant: settings.cortiTenant,
   };
+  // Endpoint and credential must cross the IPC boundary together.
+  if (
+    providerName === "openai-realtime" &&
+    settings.cloudTranscriptionProvider === "custom" &&
+    settings.cloudTranscriptionMode === "byok"
+  ) {
+    options.baseUrl = settings.cloudTranscriptionBaseUrl;
+  }
   // Tinfoil realtime shows the live preview for normal dictation (#1120), but
   // assistant voice skips it because the Assistant panel owns that surface.
   if (providerName === "tinfoil-realtime" && !voiceAgentRequested) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -8083,6 +8083,8 @@ class IPCHandlers {
           const apiKey = await fetchRealtimeToken(event, {
             mode: options.mode,
             provider,
+            // Custom realtime keys off baseUrl; without it this falls back to OpenAI.
+            baseUrl: options.baseUrl,
           });
           if (provider === "tinfoil-realtime") {
             const model = options.model || TINFOIL_REALTIME_MODEL;

--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -1,5 +1,6 @@
 const WebSocket = require("ws");
 const debugLogger = require("./debugLogger");
+const { realtimeUrlFromBase } = require("./realtimeUrl");
 
 const WEBSOCKET_TIMEOUT_MS = 15000;
 const DISCONNECT_TIMEOUT_MS = 3000;
@@ -94,7 +95,14 @@ class OpenAIRealtimeStreaming {
       streamLabel,
       vadThreshold,
     } = options;
-    if (!apiKey) throw new Error(`${this.providerLabel} API key is required`);
+    // The base URL travels with its credential so the two cannot separate.
+    const connection =
+      apiKey && typeof apiKey === "object"
+        ? { key: apiKey.key || "", baseUrl: apiKey.baseUrl || "" }
+        : { key: apiKey || "", baseUrl: "" };
+    if (!connection.key && !connection.baseUrl) {
+      throw new Error(`${this.providerLabel} API key is required`);
+    }
 
     if (this.isConnected || this.isConnecting) {
       debugLogger.debug(`${this.providerLabel} already connected/connecting`, this._logContext());
@@ -121,15 +129,19 @@ class OpenAIRealtimeStreaming {
     this._sessionExpired = false;
     this._connectionLossNotified = false;
 
-    const url = "wss://api.openai.com/v1/realtime?intent=transcription";
-    debugLogger.debug(`${this.providerLabel} connecting`, this._logContext({ model: this.model }));
+    const url = realtimeUrlFromBase(connection.baseUrl, this.model);
+    debugLogger.debug(
+      `${this.providerLabel} connecting`,
+      this._logContext({ model: this.model, customBaseUrl: !!connection.baseUrl })
+    );
 
     // Attested providers (Tinfoil) supply their socket via an async factory.
     let ws;
     try {
+      const headers = connection.key ? { Authorization: `Bearer ${connection.key}` } : undefined;
       ws = createSocket
         ? await createSocketWithTimeout(createSocket, WEBSOCKET_TIMEOUT_MS)
-        : new WebSocket(url, { headers: { Authorization: `Bearer ${apiKey}` } });
+        : new WebSocket(url, headers ? { headers } : undefined);
     } catch (err) {
       this.isConnecting = false;
       this.cleanup();

--- a/src/helpers/realtimeTokenProviders.js
+++ b/src/helpers/realtimeTokenProviders.js
@@ -74,6 +74,13 @@ const REALTIME_TOKEN_PROVIDERS = {
 
   "openai-realtime": async ({ environmentManager, postServerToken }, options, streams) => {
     if (options.mode === "byok") {
+      // Empty keys are valid: the batch Custom path allows unauthenticated endpoints.
+      if (options.baseUrl) {
+        return duplicate(streams, {
+          key: environmentManager.getCustomTranscriptionKey?.() || "",
+          baseUrl: options.baseUrl,
+        });
+      }
       const apiKey = environmentManager.getOpenAIKey();
       if (!apiKey) throw new Error("No OpenAI API key configured. Add your key in Settings.");
       return duplicate(streams, apiKey);

--- a/src/helpers/realtimeUrl.js
+++ b/src/helpers/realtimeUrl.js
@@ -1,0 +1,74 @@
+// Pure URL helpers for the realtime transcription socket. Kept free of
+// electron/ws imports so it can be unit tested in plain node.
+
+const DEFAULT_REALTIME_URL = "wss://api.openai.com/v1/realtime?intent=transcription";
+const CUSTOM_REALTIME_BASE_URL_ERROR = "Custom realtime base URL is invalid or unsupported";
+
+function parseIPv4Literal(hostname) {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) return null;
+  const octets = [];
+  for (const part of parts) {
+    if (!/^(0|[1-9]\d{0,2})$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    octets.push(value);
+  }
+  return octets;
+}
+
+function isPrivateHost(hostname) {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h === "0.0.0.0" || h === "::1") return true;
+
+  const ipv4 = parseIPv4Literal(h);
+  if (ipv4) {
+    const [a, b] = ipv4;
+    if (a === 127 || a === 10) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 169 && b === 254) return true;
+  }
+
+  if (h.includes(":") && (h.startsWith("fe80") || h.startsWith("fc") || h.startsWith("fd"))) {
+    return true;
+  }
+  return h.endsWith(".local") || h.endsWith(".ts.net");
+}
+
+// Derive the realtime WebSocket URL from an OpenAI-compatible HTTP base URL.
+// Absence means the built-in OpenAI endpoint. A configured-but-invalid custom
+// URL fails closed: falling back to OpenAI would send audio (and potentially a
+// custom credential) to the wrong provider.
+function realtimeUrlFromBase(baseUrl, model) {
+  const base = String(baseUrl || "").trim();
+  if (!base) return DEFAULT_REALTIME_URL;
+
+  let url;
+  try {
+    url = new URL(base);
+  } catch {
+    throw new Error(CUSTOM_REALTIME_BASE_URL_ERROR);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(CUSTOM_REALTIME_BASE_URL_ERROR);
+  }
+  if (url.protocol === "http:" && !isPrivateHost(url.hostname)) {
+    throw new Error(CUSTOM_REALTIME_BASE_URL_ERROR);
+  }
+
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  const path = url.pathname.replace(/\/+$/, "");
+  url.pathname = /\/realtime$/i.test(path) ? path : `${path}/realtime`;
+  url.searchParams.set("intent", "transcription");
+  if (model) url.searchParams.set("model", model);
+  return url.toString();
+}
+
+module.exports = {
+  realtimeUrlFromBase,
+  DEFAULT_REALTIME_URL,
+  CUSTOM_REALTIME_BASE_URL_ERROR,
+};

--- a/test/helpers/customRealtimeRouting.test.js
+++ b/test/helpers/customRealtimeRouting.test.js
@@ -1,0 +1,81 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const loadRouting = () => import("../../src/helpers/dictationStreamingRouting.js");
+const loadTokens = () => import("../../src/helpers/realtimeTokenProviders.js");
+
+const deps = (customKey = "custom-key", openaiKey = "openai-key") => ({
+  environmentManager: {
+    getCustomTranscriptionKey: () => customKey,
+    getOpenAIKey: () => openaiKey,
+  },
+  postServerToken: async () => ({ clientSecret: "server-secret" }),
+});
+
+test("custom BYOK carries its base URL through the openai-realtime session options", async () => {
+  const { resolveStreamingProviderName, buildStreamingSessionOptions } = await loadRouting();
+  const settings = {
+    cloudTranscriptionProvider: "custom",
+    cloudTranscriptionModel: "gpt-4o-mini-transcribe",
+    cloudTranscriptionMode: "byok",
+    cloudTranscriptionBaseUrl: "https://speech.example.com/v1",
+  };
+  const providerName = resolveStreamingProviderName({
+    settings,
+    context: "dictation",
+    sttConfig: null,
+  });
+  assert.equal(providerName, "openai-realtime");
+  assert.equal(
+    buildStreamingSessionOptions({ providerName, settings, language: "en", keyterms: [] }).baseUrl,
+    "https://speech.example.com/v1"
+  );
+});
+
+test("non-custom OpenAI BYOK never inherits the custom base URL", async () => {
+  const { buildStreamingSessionOptions } = await loadRouting();
+  const options = buildStreamingSessionOptions({
+    providerName: "openai-realtime",
+    settings: {
+      cloudTranscriptionProvider: "openai",
+      cloudTranscriptionModel: "gpt-4o-mini-transcribe",
+      cloudTranscriptionMode: "byok",
+      cloudTranscriptionBaseUrl: "https://must-not-leak.example/v1",
+    },
+    language: "en",
+    keyterms: [],
+  });
+  assert.equal(Object.hasOwn(options, "baseUrl"), false);
+});
+
+test("custom realtime returns the Custom key and base URL as one connection credential", async () => {
+  const { fetchRealtimeTokenForProvider } = await loadTokens();
+  assert.deepEqual(
+    await fetchRealtimeTokenForProvider("openai-realtime", deps(), {
+      mode: "byok",
+      baseUrl: "https://speech.example.com/v1",
+    }),
+    { key: "custom-key", baseUrl: "https://speech.example.com/v1" }
+  );
+});
+
+test("unauthenticated custom realtime is allowed, matching the Custom batch path", async () => {
+  const { fetchRealtimeTokenForProvider } = await loadTokens();
+  assert.deepEqual(
+    await fetchRealtimeTokenForProvider("openai-realtime", deps(""), {
+      mode: "byok",
+      baseUrl: "http://localhost:8000/v1",
+    }),
+    { key: "", baseUrl: "http://localhost:8000/v1" }
+  );
+});
+
+test("ordinary OpenAI BYOK remains a plain OpenAI key", async () => {
+  const { fetchRealtimeTokenForProvider } = await loadTokens();
+  assert.equal(
+    await fetchRealtimeTokenForProvider("openai-realtime", deps("custom-key", "openai-key"), {
+      mode: "byok",
+    }),
+    "openai-key"
+  );
+});

--- a/test/helpers/realtimeUrlFromBase.test.js
+++ b/test/helpers/realtimeUrlFromBase.test.js
@@ -1,0 +1,69 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  realtimeUrlFromBase,
+  DEFAULT_REALTIME_URL,
+  CUSTOM_REALTIME_BASE_URL_ERROR,
+} = require("../../src/helpers/realtimeUrl.js");
+
+test("uses the exact OpenAI URL when no custom base is configured", () => {
+  assert.equal(realtimeUrlFromBase(undefined, "whisper"), DEFAULT_REALTIME_URL);
+  assert.equal(realtimeUrlFromBase("", "whisper"), DEFAULT_REALTIME_URL);
+  assert.ok(!DEFAULT_REALTIME_URL.includes("model="));
+});
+
+test("derives a wss URL from an https base and carries the custom model", () => {
+  const url = new URL(realtimeUrlFromBase("https://ai.example.com/v1", "whisper"));
+  assert.equal(url.protocol, "wss:");
+  assert.equal(url.host, "ai.example.com");
+  assert.equal(url.pathname, "/v1/realtime");
+  assert.equal(url.searchParams.get("intent"), "transcription");
+  assert.equal(url.searchParams.get("model"), "whisper");
+});
+
+test("allows plaintext http only for private/self-hosted hosts", () => {
+  for (const base of [
+    "http://localhost:8000/v1",
+    "http://127.0.0.1:8000/v1",
+    "http://192.168.1.20:8000/v1",
+    "http://100.64.0.10:8000/v1",
+    "http://speechbox.tailnet.ts.net/v1",
+  ]) {
+    assert.equal(new URL(realtimeUrlFromBase(base, "whisper")).protocol, "ws:");
+  }
+  assert.throws(
+    () => realtimeUrlFromBase("http://public.example.com/v1", "whisper"),
+    new Error(CUSTOM_REALTIME_BASE_URL_ERROR)
+  );
+});
+
+test("tolerates trailing slashes, path prefixes, and an existing /realtime suffix", () => {
+  assert.equal(
+    new URL(realtimeUrlFromBase("https://ai.example.com/v1///", "whisper")).pathname,
+    "/v1/realtime"
+  );
+  assert.equal(
+    new URL(realtimeUrlFromBase("https://gw.example.com/stt/v1", "whisper")).pathname,
+    "/stt/v1/realtime"
+  );
+  assert.equal(
+    new URL(realtimeUrlFromBase("https://ai.example.com/v1/realtime", "whisper")).pathname,
+    "/v1/realtime"
+  );
+});
+
+test("omits the model param when no model is given", () => {
+  const url = new URL(realtimeUrlFromBase("https://ai.example.com/v1", ""));
+  assert.equal(url.searchParams.get("model"), null);
+  assert.equal(url.searchParams.get("intent"), "transcription");
+});
+
+test("configured malformed and non-http custom bases fail closed", () => {
+  for (const base of ["not a url", "file:///etc/passwd", "ftp://example.com/v1"]) {
+    assert.throws(
+      () => realtimeUrlFromBase(base, "whisper"),
+      new Error(CUSTOM_REALTIME_BASE_URL_ERROR)
+    );
+  }
+});


### PR DESCRIPTION
## Why

The realtime dictation socket is pinned to `wss://api.openai.com/v1/realtime`. The batch path already supports an OpenAI-compatible server through the `custom` provider and `cloudTranscriptionBaseUrl`, so a self-hosted setup can use `/v1/audio/transcriptions` but never realtime.

This derives the socket URL from that same base URL, and keeps OpenAI as the default when none is set.

## What changed

- `realtimeUrl.js` (new): dependency-free `realtimeUrlFromBase()`, maps `http(s)` to `ws(s)` and appends `/realtime`.
- `openaiRealtimeStreaming.js`: accepts a structured connection credential and uses the helper.
- `realtimeTokenProviders.js`: returns the Custom key and base URL together.
- `dictationStreamingRouting.js`: carries `baseUrl` into the session options for custom BYOK.
- `ipcHandlers.js`: forwards `baseUrl` to the token provider on the dictation connect path.

`realtimeUrl.js` is a separate module because `openaiRealtimeStreaming.js` requires `debugLogger`, which requires electron, so a plain `node --test` file cannot import it. Happy to inline it.

Two behaviours worth flagging:

- `model` goes in the query string only for custom bases. Some OpenAI-compatible servers require it there to open the socket, whereas OpenAI selects the model via `session.update`. This leaves OpenAI's URL byte-for-byte unchanged.
- A base URL that is not parseable `http(s)` falls back to OpenAI rather than throwing, so a malformed setting degrades to today's behaviour instead of breaking dictation.

## Verified against a self-hosted server

Tested with [Speaches](https://speaches.ai), driving the app rather than only the unit tests.

The query-string behaviour is not hypothetical:

| Request | Result |
|---|---|
| `ws://<base>/v1/realtime` | 403 Forbidden |
| `ws://<base>/v1/realtime?model=<model>` | 101 Switching Protocols |

With the change in place, the server negotiates the session:

```
WebSocket /v1/realtime?intent=transcription&model=... [accepted]
Sent session.created event
Sent session.updated event
```

An earlier version of this description claimed self-hosted servers might reject the current `session.update` payload. That was wrong and I removed it. The GA shape is accepted; the older `transcription_session.update` shape is what gets rejected. No payload change is needed.

The second commit is required for the feature to work at all. `connectDictationStreaming` rebuilt the token-provider options by hand and passed only `mode` and `provider`, so `baseUrl` never reached `realtimeTokenProviders`. The Custom branch there keys off `baseUrl`, so a self-hosted session fell through to the OpenAI branch and failed with "No OpenAI API key configured" before opening a socket. The meeting call sites forward `options` wholesale, so dictation was the only path that dropped it.

## Tests

`node --test` over the realtime, dictation-routing, token-provider and streaming-lifecycle suites: 164 passing, 0 failing.
