### PR TITLE
fix(cli): preserve UTF-8 request bodies

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -29,20 +29,26 @@ async function findAvailablePort() {
 
 function readJsonBody(req) {
   return new Promise((resolve, reject) => {
-    let raw = "";
-    // Count wire bytes per chunk: string concatenation decodes each Buffer
-    // chunk, so measuring the decoded string would rescan the whole body on
-    // every chunk and miscount sequences split across chunk boundaries.
+    // Buffer the raw chunks and decode once at the end: decoding per chunk
+    // corrupts multibyte sequences split across chunk boundaries.
+    const chunks = [];
     let receivedBytes = 0;
+    let rejected = false;
     req.on("data", (chunk) => {
-      raw += chunk;
-      receivedBytes += Buffer.byteLength(chunk);
+      if (rejected) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      receivedBytes += buffer.length;
       if (receivedBytes > MAX_REQUEST_BODY_BYTES) {
+        rejected = true;
         reject(new Error("Request body too large"));
         req.destroy();
+        return;
       }
+      chunks.push(buffer);
     });
     req.on("end", () => {
+      if (rejected) return;
+      const raw = Buffer.concat(chunks, receivedBytes).toString("utf8");
       if (!raw) return resolve({});
       try {
         resolve(JSON.parse(raw));

--- a/test/helpers/cliBridgeRequestBody.test.js
+++ b/test/helpers/cliBridgeRequestBody.test.js
@@ -1,7 +1,29 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+
+const originalLoad = Module._load;
+// Routes broadcast through the shared windowBroadcast module, which reaches for
+// Electron's BrowserWindow; capture the calls so they can be asserted here.
+const broadcasts = [];
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "./windowBroadcast") {
+    return {
+      broadcastToWindows: (channel, payload) => broadcasts.push({ channel, payload }),
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
 const CliBridge = require("../../src/helpers/cliBridge.js");
+
+Module._load = originalLoad;
+
+function flushImmediates() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 function makeRequest(body) {
   const request = new EventEmitter();
@@ -13,8 +35,9 @@ function makeRequest(body) {
   request.destroy = () => {
     request.destroyed = true;
   };
+  const chunks = Array.isArray(body) ? body : [body];
   setImmediate(() => {
-    request.emit("data", body);
+    for (const chunk of chunks) request.emit("data", chunk);
     request.emit("end");
   });
   return request;
@@ -64,4 +87,60 @@ test("CLI request body limit counts UTF-8 bytes, not JavaScript characters", asy
   });
   assert.equal(request.destroyed, true);
   assert.equal(saveCalls, 0);
+});
+
+test("multibyte content split across request chunks is preserved", async () => {
+  let savedContent = null;
+  const bridge = new CliBridge({
+    databaseManager: {
+      saveNote(_title, content) {
+        savedContent = content;
+        return { success: true, note: { id: 1 } };
+      },
+    },
+    _asyncVectorUpsert() {},
+    _asyncMirrorWrite() {},
+  });
+  bridge.token = "test-token";
+  bridge.port = 8200;
+
+  const content = "日本語のノート";
+  const body = Buffer.from(JSON.stringify({ content }));
+  const splitAt = Buffer.byteLength('{"content":"') + 1;
+  const request = makeRequest([body.subarray(0, splitAt), body.subarray(splitAt)]);
+  const response = makeResponse();
+  await bridge._handleRequest(request, response);
+  await flushImmediates();
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(savedContent, content);
+  assert.equal(broadcasts.at(-1)?.channel, "note-added");
+});
+
+test("a JSON body exactly at the byte limit is accepted", async () => {
+  let saveCalls = 0;
+  const bridge = new CliBridge({
+    databaseManager: {
+      saveNote() {
+        saveCalls += 1;
+        return { success: true, note: { id: 1 } };
+      },
+    },
+    _asyncVectorUpsert() {},
+    _asyncMirrorWrite() {},
+  });
+  bridge.token = "test-token";
+  bridge.port = 8200;
+
+  const wrapperBytes = Buffer.byteLength('{"content":""}');
+  const body = JSON.stringify({ content: "a".repeat(1 * 1024 * 1024 - wrapperBytes) });
+  assert.equal(Buffer.byteLength(body, "utf8"), 1 * 1024 * 1024);
+
+  const request = makeRequest(body);
+  const response = makeResponse();
+  await bridge._handleRequest(request, response);
+  await flushImmediates();
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(saveCalls, 1);
 });


### PR DESCRIPTION
## Summary

- preserve UTF-8 JSON payloads when a code point is split across incoming HTTP chunks
- enforce the CLI bridge 1 MiB request limit against the actual received bytes
- cover split multibyte input, oversized multibyte input, and the exact size boundary

## Root cause

`readJsonBody` appended each incoming `Buffer` directly to a string. That decoded every chunk independently, so a multibyte code point split at a transport boundary was replaced with invalid characters. The same conversion made the byte limit compare JavaScript string length instead of wire bytes.

The bridge now retains raw buffers, counts their byte lengths, and decodes once after the complete body arrives.

## Validation

- `node --test test/helpers/cliBridgeRequestBody.test.js`
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` (864 passed, 6 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run i18n:check`
- `node --check src/helpers/cliBridge.js`
- `node --check test/helpers/cliBridgeRequestBody.test.js`
- `git diff --check`