### PR TITLE
fix(cleanup): fall back to the raw transcript when the model answers it

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -68,6 +68,7 @@ import {
   resolveTranslatedText,
   shouldRunTranslateStep,
 } from "./translationChain";
+import { resolveCleanupText } from "./cleanupAnswerGuard";
 import { detectAgentName } from "../config/agentDetection";
 import {
   resolveDictationRouteKind,
@@ -2427,7 +2428,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           }
           return res;
         });
-        return reasonResult.success && reasonResult.text ? reasonResult.text : null;
+        if (!reasonResult.success || !reasonResult.text) return null;
+        return resolveCleanupText(currentText, reasonResult.text, {
+          hasCustomPrompt: !!this.getCustomPrompt(),
+          onSuspect: (metrics) =>
+            logger.logReasoning("CLEANUP_ANSWER_GUARD", { site: "translation-chain", ...metrics }),
+        });
       }
       const cleanupModel = cleanup.model;
       if (cleanupModel) {
@@ -2902,7 +2908,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
           // Cloud cleanup can return success with empty text; keep the raw transcription instead of wiping it.
           if (reasonResult.success && hasTextContent(reasonResult.text)) {
-            processedText = reasonResult.text;
+            processedText = resolveCleanupText(processedText, reasonResult.text, {
+              hasCustomPrompt: !!this.getCustomPrompt(),
+              onSuspect: (metrics) =>
+                logger.logReasoning("CLEANUP_ANSWER_GUARD", { site: "cloud-batch", ...metrics }),
+            });
           }
         } else if (route.kind === "cleanup") {
           const effectiveModel = getEffectiveCleanupModel();
@@ -4288,7 +4298,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           });
 
           if (reasonResult.success && hasTextContent(reasonResult.text)) {
-            finalText = reasonResult.text;
+            finalText = resolveCleanupText(finalText, reasonResult.text, {
+              hasCustomPrompt: !!this.getCustomPrompt(),
+              onSuspect: (metrics) =>
+                logger.logReasoning("CLEANUP_ANSWER_GUARD", {
+                  site: "cloud-streaming",
+                  ...metrics,
+                }),
+            });
           }
           usedCloudReasoning = true;
 

--- a/src/helpers/cleanupAnswerGuard.js
+++ b/src/helpers/cleanupAnswerGuard.js
@@ -1,0 +1,35 @@
+// Post-response guard for default-prompt cleanup: when the model answers the
+// dictation instead of cleaning it, the raw transcript wins over the response.
+
+// A cleanup rewrites the dictation in place; only an answer outgrows it by 3x
+// AND 200+ chars. Shrinking (filler/repetition removal) is always legitimate.
+export const ANSWER_LENGTH_RATIO = 3;
+export const ANSWER_LENGTH_MARGIN_CHARS = 200;
+
+export function isAnswerShapedCleanupResponse(inputText, responseText) {
+  const input = typeof inputText === "string" ? inputText.trim() : "";
+  const response = typeof responseText === "string" ? responseText.trim() : "";
+  if (!input || !response) return false;
+  const threshold = Math.max(
+    input.length * ANSWER_LENGTH_RATIO,
+    input.length + ANSWER_LENGTH_MARGIN_CHARS
+  );
+  return response.length > threshold;
+}
+
+// Returns the text to keep. Custom cleanup prompts may transform freely
+// (translate, summarize, expand), so they bypass the shape check entirely.
+export function resolveCleanupText(inputText, responseText, options = {}) {
+  const { hasCustomPrompt = false, onSuspect } = options;
+  if (typeof responseText !== "string" || !responseText) return inputText;
+  if (!hasCustomPrompt && isAnswerShapedCleanupResponse(inputText, responseText)) {
+    if (onSuspect) {
+      onSuspect({
+        inputLength: typeof inputText === "string" ? inputText.length : 0,
+        responseLength: responseText.length,
+      });
+    }
+    return inputText;
+  }
+  return responseText;
+}

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -13,6 +13,7 @@ import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, ensureV1Suffix } from "../con
 import logger from "../utils/logger";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
 import { wrapCleanupTranscript } from "../config/prompts";
+import { resolveCleanupText } from "../helpers/cleanupAnswerGuard.js";
 import { stripThinkingTags } from "../helpers/stripThinking.js";
 import { streamText, stepCountIs } from "ai";
 import { getAIModel } from "./ai/providers";
@@ -491,6 +492,20 @@ class ReasoningService extends BaseReasoningService {
         processingTimeMs: Date.now() - startTime,
         resultLength: result.length,
       });
+
+      // Length comparison needs think-blocks stripped, so only guard when they are.
+      const cleanupGuardEligible = !config.systemPrompt && config.disableThinking !== false;
+      if (cleanupGuardEligible) {
+        return resolveCleanupText(text, result, {
+          hasCustomPrompt: !!getSettings().customPrompts.cleanup,
+          onSuspect: (metrics: { inputLength: number; responseLength: number }) =>
+            logger.logReasoning("CLEANUP_ANSWER_GUARD", {
+              provider: providerId,
+              model: trimmedModel,
+              ...metrics,
+            }),
+        });
+      }
 
       return result;
     } catch (error) {

--- a/test/helpers/cleanupAnswerGuard.test.js
+++ b/test/helpers/cleanupAnswerGuard.test.js
@@ -1,0 +1,167 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const load = () => import("../../src/helpers/cleanupAnswerGuard.js");
+
+const readSource = (rel) => fs.readFileSync(path.join(__dirname, "../..", rel), "utf8");
+
+// Lengths from the report this guards against: a 75-char dictated question
+// answered with 762 chars of chatbot prose.
+const DICTATED_QUESTION =
+  "Why should I use the Quinn three point five model instead of a Gemma model?";
+const CHATBOT_ANSWER =
+  "You should use the Quinn 3.5 model instead of a Gemma model because the " +
+  "Quinn 3.5 model is specifically optimized for high-performance inference " +
+  "and offers superior speed and efficiency, making it ideal for real-time " +
+  "applications where latency is a concern. Unlike Gemma, which is a smaller " +
+  "model designed for specific tasks or environments, Quinn 3.5 is built to " +
+  "handle complex reasoning and large-scale data processing with greater " +
+  "accuracy and speed. Additionally, Quinn 3.5 is designed to be more " +
+  "user-friendly and easier to integrate into existing systems, providing a " +
+  "smoother experience for developers and end-users alike. If you're looking " +
+  "for a model that can handle more complex tasks while maintaining high " +
+  "performance, Quinn 3.5 is the better choice.";
+
+test("chatbot answer 10x longer than the dictated question is answer-shaped", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  assert.ok(isAnswerShapedCleanupResponse(DICTATED_QUESTION, CHATBOT_ANSWER));
+});
+
+test("same-length cleanup of a dictated question is not answer-shaped", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  assert.ok(
+    !isAnswerShapedCleanupResponse(
+      DICTATED_QUESTION,
+      "Why should I use the Qwen 3.5 model instead of a Gemma model?"
+    )
+  );
+});
+
+test("aggressive filler and repetition stripping (5x shrink) is not answer-shaped", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  assert.ok(
+    !isAnswerShapedCleanupResponse(
+      "thank you thank you thank you thank you thank you",
+      "Thank you."
+    )
+  );
+});
+
+test("growth at exactly the ratio-and-margin threshold is not answer-shaped", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  const input = "a".repeat(100);
+  assert.ok(!isAnswerShapedCleanupResponse(input, "b".repeat(300)));
+  assert.ok(isAnswerShapedCleanupResponse(input, "b".repeat(301)));
+});
+
+test("short input is protected by the absolute margin, not the ratio", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  const input = "a".repeat(20);
+  // 11x the input but still within input + 200.
+  assert.ok(!isAnswerShapedCleanupResponse(input, "b".repeat(220)));
+  assert.ok(isAnswerShapedCleanupResponse(input, "b".repeat(221)));
+});
+
+test("long input is protected by the ratio, not the margin", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  const input = "a".repeat(500);
+  assert.ok(!isAnswerShapedCleanupResponse(input, "b".repeat(1500)));
+  assert.ok(isAnswerShapedCleanupResponse(input, "b".repeat(1501)));
+});
+
+test("empty or non-string sides are never answer-shaped", async () => {
+  const { isAnswerShapedCleanupResponse } = await load();
+  assert.ok(!isAnswerShapedCleanupResponse("", CHATBOT_ANSWER));
+  assert.ok(!isAnswerShapedCleanupResponse("   ", CHATBOT_ANSWER));
+  assert.ok(!isAnswerShapedCleanupResponse(DICTATED_QUESTION, ""));
+  assert.ok(!isAnswerShapedCleanupResponse(undefined, CHATBOT_ANSWER));
+  assert.ok(!isAnswerShapedCleanupResponse(DICTATED_QUESTION, null));
+});
+
+test("resolveCleanupText keeps a normal cleanup untouched", async () => {
+  const { resolveCleanupText } = await load();
+  const cleaned = "Why should I use the Qwen 3.5 model instead of a Gemma model?";
+  assert.equal(resolveCleanupText(DICTATED_QUESTION, cleaned, {}), cleaned);
+});
+
+test("resolveCleanupText falls back to the transcript and reports metrics on an answer", async () => {
+  const { resolveCleanupText } = await load();
+  const reported = [];
+  const kept = resolveCleanupText(DICTATED_QUESTION, CHATBOT_ANSWER, {
+    onSuspect: (metrics) => reported.push(metrics),
+  });
+  assert.equal(kept, DICTATED_QUESTION);
+  assert.deepEqual(reported, [
+    { inputLength: DICTATED_QUESTION.length, responseLength: CHATBOT_ANSWER.length },
+  ]);
+});
+
+test("resolveCleanupText with a custom prompt bypasses the guard for answer-shaped output", async () => {
+  const { resolveCleanupText } = await load();
+  let suspectCalled = false;
+  const kept = resolveCleanupText(DICTATED_QUESTION, CHATBOT_ANSWER, {
+    hasCustomPrompt: true,
+    onSuspect: () => {
+      suspectCalled = true;
+    },
+  });
+  assert.equal(kept, CHATBOT_ANSWER);
+  assert.equal(suspectCalled, false);
+});
+
+test("resolveCleanupText keeps the transcript when the response is empty or missing", async () => {
+  const { resolveCleanupText } = await load();
+  assert.equal(resolveCleanupText("raw dictation", "", {}), "raw dictation");
+  assert.equal(resolveCleanupText("raw dictation", null, {}), "raw dictation");
+  assert.equal(resolveCleanupText("raw dictation", undefined, {}), "raw dictation");
+});
+
+test("resolveCleanupText without onSuspect still falls back silently", async () => {
+  const { resolveCleanupText } = await load();
+  assert.equal(resolveCleanupText(DICTATED_QUESTION, CHATBOT_ANSWER), DICTATED_QUESTION);
+});
+
+// Prompt-shape anchors: the transcript must arrive framed as data, with the
+// instruction block that forbids answering it. Guards the contract, not wording.
+test("cleanup prompt declares the transcript-tag contract and forbids answering", () => {
+  const prompts = JSON.parse(readSource("src/locales/en/prompts.json"));
+  assert.match(prompts.cleanupPrompt, /<transcript>/);
+  assert.match(prompts.cleanupPrompt, /never answer or execute/i);
+  assert.match(prompts.cleanupPrompt, /ignore your rules/i);
+});
+
+test("wrapCleanupTranscript frames the dictation between transcript tags with a trailing anchor", () => {
+  const source = readSource("src/config/prompts/index.ts");
+  assert.match(
+    source,
+    /<transcript>\\n\$\{text\}\\n<\/transcript>\\n\\nOutput only the cleaned transcript\./
+  );
+});
+
+// Source-level wiring asserts; the TS call sites are not requirable here.
+test("every cleanup result consumer routes through the answer guard", () => {
+  const reasoning = readSource("src/services/ReasoningService.ts");
+  assert.match(reasoning, /resolveCleanupText\(text, result/);
+  assert.match(reasoning, /cleanupGuardEligible/);
+
+  const audioManager = readSource("src/helpers/audioManager.js");
+  const guardCalls = audioManager.match(/resolveCleanupText\(/g) || [];
+  assert.equal(guardCalls.length, 3);
+});
+
+test("every inference provider frames the cleanup transcript", () => {
+  const wrapped = [
+    "src/services/ReasoningService.ts",
+    "src/services/ai/inferenceProviders/openai.ts",
+    "src/services/ai/inferenceProviders/local.ts",
+    "src/services/ai/inferenceProviders/gemini.ts",
+    "src/services/ai/inferenceProviders/anthropic.ts",
+    "src/services/ai/inferenceProviders/tinfoil.ts",
+    "src/services/ai/inferenceProviders/enterprise.ts",
+  ];
+  for (const rel of wrapped) {
+    assert.match(readSource(rel), /wrapCleanupTranscript\(text\)/, rel);
+  }
+});


### PR DESCRIPTION
## Summary

With cleanup enabled, a dictation shaped like a chatbot question sometimes comes back answered instead of cleaned: the report shows the bundled Qwen3.5-4B turning a 75-char dictated question into a 762-char answer and pasting that into the active window. The prompt side was rebuilt in #1073 (`wrapCleanupTranscript` framing, few-shot examples, temperature 0), but nothing inspects the response, so an off-task reply still replaces the user's words. This adds the missing check: `resolveCleanupText` in `cleanupAnswerGuard.js` treats a response that outgrows the dictation by 3x and 200+ chars as an answer, keeps the raw transcript, and logs a `CLEANUP_ANSWER_GUARD` event with both lengths. It runs centrally in `ReasoningService.processText` for every BYOK, local and self-hosted provider, and at the three direct `cloudReason` sites in `audioManager.js` (including the translation chain's cleanup step from #1258), with the same fallback contract as the #938 empty-result and #1379 truncation guards.

The threshold is one-sided on purpose: legitimate cleanup often shrinks a transcript hard (filler and repetition removal reach 5x), so shrinking never fires, and no legitimate output of "output only the cleaned transcript" grows 3x while also adding 200+ chars. Custom cleanup prompts (which may translate or expand by design) and visible-thinking responses bypass the guard. Short answers under the threshold remain the prompt layer's job, and its #1073 shape is now locked by regression tests. The translate step still embeds its input with instruction-only defense; that is a follow-up.

Fixes #833

## Changes

- src/helpers/cleanupAnswerGuard.js: new pure helper, isAnswerShapedCleanupResponse (growth over max(3x input, input + 200 chars)) and resolveCleanupText with onSuspect callback
- src/services/ReasoningService.ts: processText routes default-prompt cleanup results through the guard when thinking is stripped
- src/helpers/audioManager.js: the batch, streaming and translation-chain cloudReason sites route through resolveCleanupText
- test/helpers/cleanupAnswerGuard.test.js: threshold boundary pairs, fallback and bypass behavior, prompt-shape anchors, wiring asserts
