### PR TITLE
fix(control-panel): remember window state across launches

### DIFF
--- a/main.js
+++ b/main.js
@@ -418,6 +418,12 @@ function initializeCoreManagers() {
   debugLogger.refreshLogLevel();
 
   windowManager = new WindowManager();
+  // Wired at construction: second-instance and activate can open the panel
+  // before startApp's async phase reaches the other windowManager setters.
+  windowManager.setControlPanelStateStore({
+    get: () => environmentManager.getControlPanelWindowState(),
+    save: (state) => environmentManager.saveControlPanelWindowState(state),
+  });
   hotkeyManager = windowManager.hotkeyManager;
   databaseManager = new DatabaseManager();
   clipboardManager = new ClipboardManager();
@@ -957,10 +963,6 @@ async function startApp() {
   windowManager.setActivationModeCache(environmentManager.getActivationMode());
   windowManager.setFloatingIconAutoHide(environmentManager.getFloatingIconAutoHide());
   windowManager.setPanelStartPosition(environmentManager.getPanelStartPosition());
-  windowManager.setControlPanelStateStore({
-    get: () => environmentManager.getControlPanelWindowState(),
-    save: (state) => environmentManager.saveControlPanelWindowState(state),
-  });
 
   ipcMain.on("activation-mode-changed", (_event, mode) => {
     windowManager.setActivationModeCache(mode);

--- a/main.js
+++ b/main.js
@@ -957,6 +957,10 @@ async function startApp() {
   windowManager.setActivationModeCache(environmentManager.getActivationMode());
   windowManager.setFloatingIconAutoHide(environmentManager.getFloatingIconAutoHide());
   windowManager.setPanelStartPosition(environmentManager.getPanelStartPosition());
+  windowManager.setControlPanelStateStore({
+    get: () => environmentManager.getControlPanelWindowState(),
+    save: (state) => environmentManager.saveControlPanelWindowState(state),
+  });
 
   ipcMain.on("activation-mode-changed", (_event, mode) => {
     windowManager.setActivationModeCache(mode);

--- a/src/helpers/controlPanelWindowState.js
+++ b/src/helpers/controlPanelWindowState.js
@@ -1,0 +1,120 @@
+// Control panel window-state policy.
+//
+// Pure logic for persisting and restoring the control panel's bounds:
+// (de)serialization for the .env-backed settings store and resolution of a
+// saved state against the currently attached displays. Electron touchpoints
+// stay thin in windowManager.js so this module is testable without a window.
+
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function clampNumber(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+// Overlap/clamp math stays local for now; fold into the shared display
+// resolver once the widget display-selection work lands.
+function rectsOverlap(a, b) {
+  const overlapWidth = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
+  const overlapHeight = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
+  return overlapWidth > 0 && overlapHeight > 0;
+}
+
+function clampIntoWorkArea(rect, workArea) {
+  const width = Math.min(rect.width, workArea.width);
+  const height = Math.min(rect.height, workArea.height);
+  return {
+    x: clampNumber(rect.x, workArea.x, workArea.x + workArea.width - width),
+    y: clampNumber(rect.y, workArea.y, workArea.y + workArea.height - height),
+    width,
+    height,
+  };
+}
+
+function centerInWorkArea(rect, workArea) {
+  const width = Math.min(rect.width, workArea.width);
+  const height = Math.min(rect.height, workArea.height);
+  return {
+    x: Math.round(workArea.x + (workArea.width - width) / 2),
+    y: Math.round(workArea.y + (workArea.height - height) / 2),
+    width,
+    height,
+  };
+}
+
+function hasWorkArea(display) {
+  return Boolean(
+    display &&
+    display.workArea &&
+    isFiniteNumber(display.workArea.x) &&
+    isFiniteNumber(display.workArea.y) &&
+    isFiniteNumber(display.workArea.width) &&
+    isFiniteNumber(display.workArea.height)
+  );
+}
+
+export function normalizeControlPanelWindowState(candidate) {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  const { x, y, width, height } = candidate;
+  if (
+    !isFiniteNumber(x) ||
+    !isFiniteNumber(y) ||
+    !isFiniteNumber(width) ||
+    !isFiniteNumber(height)
+  ) {
+    return null;
+  }
+  const roundedWidth = Math.round(width);
+  const roundedHeight = Math.round(height);
+  if (roundedWidth < 1 || roundedHeight < 1) return null;
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: roundedWidth,
+    height: roundedHeight,
+    isMaximized: candidate.isMaximized === true,
+    displayId: isFiniteNumber(candidate.displayId) ? candidate.displayId : null,
+  };
+}
+
+export function parseControlPanelWindowState(raw) {
+  if (typeof raw !== "string" || raw === "") return null;
+  let candidate;
+  try {
+    candidate = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return normalizeControlPanelWindowState(candidate);
+}
+
+export function serializeControlPanelWindowState(state) {
+  const normalized = normalizeControlPanelWindowState(state);
+  return normalized ? JSON.stringify(normalized) : "";
+}
+
+export function resolveControlPanelWindowState(saved, displays, primaryDisplay) {
+  const state = normalizeControlPanelWindowState(saved);
+  if (!state) return { bounds: null, maximize: false };
+
+  const maximize = state.isMaximized;
+  const usable = Array.isArray(displays) ? displays.filter(hasWorkArea) : [];
+  if (usable.length === 0) return { bounds: null, maximize };
+
+  const bounds = { x: state.x, y: state.y, width: state.width, height: state.height };
+  // Partial overlap with any work area counts as visible; fully off-screen does not.
+  if (usable.some((display) => rectsOverlap(bounds, display.workArea))) {
+    return { bounds, maximize };
+  }
+
+  const savedDisplay =
+    state.displayId === null ? undefined : usable.find((display) => display.id === state.displayId);
+  if (savedDisplay) {
+    return { bounds: clampIntoWorkArea(bounds, savedDisplay.workArea), maximize };
+  }
+
+  // Saved display is gone: keep the size, fall back to centering on the primary.
+  const fallback = hasWorkArea(primaryDisplay) ? primaryDisplay : usable[0];
+  return { bounds: centerInWorkArea(bounds, fallback.workArea), maximize };
+}

--- a/src/helpers/controlPanelWindowState.js
+++ b/src/helpers/controlPanelWindowState.js
@@ -5,6 +5,9 @@
 // saved state against the currently attached displays. Electron touchpoints
 // stay thin in windowManager.js so this module is testable without a window.
 
+// Below this the panel is unusable, so a broken store falls back to the default size.
+const MIN_RESTORABLE_SIZE = { width: 320, height: 240 };
+
 function isFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
@@ -21,9 +24,15 @@ function rectsOverlap(a, b) {
   return overlapWidth > 0 && overlapHeight > 0;
 }
 
+function fitSizeToWorkArea(rect, workArea) {
+  return {
+    width: Math.min(rect.width, workArea.width),
+    height: Math.min(rect.height, workArea.height),
+  };
+}
+
 function clampIntoWorkArea(rect, workArea) {
-  const width = Math.min(rect.width, workArea.width);
-  const height = Math.min(rect.height, workArea.height);
+  const { width, height } = fitSizeToWorkArea(rect, workArea);
   return {
     x: clampNumber(rect.x, workArea.x, workArea.x + workArea.width - width),
     y: clampNumber(rect.y, workArea.y, workArea.y + workArea.height - height),
@@ -33,8 +42,7 @@ function clampIntoWorkArea(rect, workArea) {
 }
 
 function centerInWorkArea(rect, workArea) {
-  const width = Math.min(rect.width, workArea.width);
-  const height = Math.min(rect.height, workArea.height);
+  const { width, height } = fitSizeToWorkArea(rect, workArea);
   return {
     x: Math.round(workArea.x + (workArea.width - width) / 2),
     y: Math.round(workArea.y + (workArea.height - height) / 2),
@@ -67,7 +75,9 @@ export function normalizeControlPanelWindowState(candidate) {
   }
   const roundedWidth = Math.round(width);
   const roundedHeight = Math.round(height);
-  if (roundedWidth < 1 || roundedHeight < 1) return null;
+  if (roundedWidth < MIN_RESTORABLE_SIZE.width || roundedHeight < MIN_RESTORABLE_SIZE.height) {
+    return null;
+  }
   return {
     x: Math.round(x),
     y: Math.round(y),

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -6,6 +6,10 @@ const debugLogger = require("./debugLogger");
 const { normalizeUiLanguage } = require("./i18nMain");
 const secretCrypto = require("./secretCrypto");
 const { BYOK_API_KEYS } = require("../config/secretKeys");
+const {
+  parseControlPanelWindowState,
+  serializeControlPanelWindowState,
+} = require("./controlPanelWindowState");
 
 const SECRET_KEYS = [
   ...BYOK_API_KEYS.map((k) => k.env),
@@ -43,6 +47,7 @@ const PERSISTED_KEYS = [
   "ACTIVATION_MODE",
   "FLOATING_ICON_AUTO_HIDE",
   "PANEL_START_POSITION",
+  "CONTROL_PANEL_WINDOW_STATE",
   "START_MINIMIZED",
   "UI_LANGUAGE",
   "WHISPER_CUDA_ENABLED",
@@ -485,6 +490,19 @@ class EnvironmentManager {
 
   savePanelStartPosition(position) {
     const result = this._saveKey("PANEL_START_POSITION", position);
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getControlPanelWindowState() {
+    return parseControlPanelWindowState(this._getKey("CONTROL_PANEL_WINDOW_STATE"));
+  }
+
+  saveControlPanelWindowState(state) {
+    const result = this._saveKey(
+      "CONTROL_PANEL_WINDOW_STATE",
+      serializeControlPanelWindowState(state)
+    );
     this.saveAllKeysToEnvFile().catch(() => {});
     return result;
   }

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -19,6 +19,7 @@ const {
   WINDOW_SIZES,
   WindowPositionUtil,
 } = require("./windowConfig");
+const { resolveControlPanelWindowState } = require("./controlPanelWindowState");
 
 class WindowManager {
   constructor() {
@@ -55,6 +56,9 @@ class WindowManager {
     this._isDictatingToggle = false;
     this._pendingMeetingNoteNavigation = null;
     this._pendingNoteNavigation = null;
+    this._controlPanelStateStore = null;
+    this._controlPanelNormalBounds = null;
+    this._controlPanelSaveTimer = null;
 
     app.on("before-quit", () => {
       this.isQuitting = true;
@@ -610,6 +614,10 @@ class WindowManager {
     }
   }
 
+  setControlPanelStateStore(store) {
+    this._controlPanelStateStore = store;
+  }
+
   setHotkeyListeningMode(enabled) {
     this.hotkeyManager.setListeningMode(enabled);
   }
@@ -674,7 +682,11 @@ class WindowManager {
       return;
     }
 
-    this.controlPanelWindow = new BrowserWindow(CONTROL_PANEL_CONFIG);
+    const restored = this._resolveControlPanelRestoreState();
+    this.controlPanelWindow = new BrowserWindow(
+      restored.bounds ? { ...CONTROL_PANEL_CONFIG, ...restored.bounds } : CONTROL_PANEL_CONFIG
+    );
+    this._controlPanelNormalBounds = restored.bounds;
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
@@ -721,20 +733,35 @@ class WindowManager {
 
     this.controlPanelWindow.once("ready-to-show", () => {
       clearVisibilityTimer();
+      this._trackControlPanelNormalBounds();
+      // Normal bounds are already applied, so unmaximize returns to the saved rect.
+      if (restored.maximize) {
+        this.controlPanelWindow.maximize();
+      }
       this.controlPanelWindow.show();
       this.controlPanelWindow.focus();
       dockManager.setControlPanelVisible(true);
     });
 
+    const schedulePanelStatePersist = () => this._scheduleControlPanelStatePersist();
+    this.controlPanelWindow.on("resize", schedulePanelStatePersist);
+    this.controlPanelWindow.on("move", schedulePanelStatePersist);
+    this.controlPanelWindow.on("maximize", schedulePanelStatePersist);
+    this.controlPanelWindow.on("unmaximize", schedulePanelStatePersist);
+
     this.controlPanelWindow.on("close", (event) => {
       if (!this.isQuitting) {
         event.preventDefault();
         this.hideControlPanelToTray();
+        return;
       }
+      this._persistControlPanelState();
     });
 
     this.controlPanelWindow.on("closed", () => {
       clearVisibilityTimer();
+      clearTimeout(this._controlPanelSaveTimer);
+      this._controlPanelSaveTimer = null;
       this.controlPanelWindow = null;
       dockManager.setControlPanelVisible(false);
     });
@@ -787,6 +814,67 @@ class WindowManager {
 
   async loadControlPanel() {
     await this.loadWindowContent(this.controlPanelWindow, true);
+  }
+
+  _resolveControlPanelRestoreState() {
+    // Restore must never prevent the panel from opening.
+    try {
+      const saved = this._controlPanelStateStore ? this._controlPanelStateStore.get() : null;
+      return resolveControlPanelWindowState(
+        saved,
+        screen.getAllDisplays(),
+        screen.getPrimaryDisplay()
+      );
+    } catch (error) {
+      debugLogger.error(
+        "Failed to resolve control panel window state",
+        { error: error.message },
+        "window"
+      );
+      return { bounds: null, maximize: false };
+    }
+  }
+
+  _trackControlPanelNormalBounds() {
+    const win = this.controlPanelWindow;
+    if (!win || win.isDestroyed()) return;
+    // Meeting-mode snap is transient programmatic placement, not user intent.
+    if (this._preMeetingBounds) return;
+    if (win.isMaximized() || win.isMinimized() || win.isFullScreen()) return;
+    this._controlPanelNormalBounds = win.getNormalBounds();
+  }
+
+  _scheduleControlPanelStatePersist() {
+    if (!this._controlPanelStateStore) return;
+    clearTimeout(this._controlPanelSaveTimer);
+    // Debounced so a crash loses at most the last half second of movement.
+    this._controlPanelSaveTimer = setTimeout(() => this._persistControlPanelState(), 500);
+  }
+
+  _persistControlPanelState() {
+    clearTimeout(this._controlPanelSaveTimer);
+    this._controlPanelSaveTimer = null;
+    const win = this.controlPanelWindow;
+    if (!win || win.isDestroyed() || !this._controlPanelStateStore) return;
+    this._trackControlPanelNormalBounds();
+    const bounds = this._controlPanelNormalBounds;
+    if (!bounds) return;
+    let displayId = null;
+    try {
+      // Best-effort display hint; null only skips the clamp-to-display fallback.
+      displayId = screen.getDisplayMatching(bounds)?.id ?? null;
+    } catch {
+      displayId = null;
+    }
+    try {
+      this._controlPanelStateStore.save({ ...bounds, isMaximized: win.isMaximized(), displayId });
+    } catch (error) {
+      debugLogger.error(
+        "Failed to persist control panel window state",
+        { error: error.message },
+        "window"
+      );
+    }
   }
 
   async createAgentWindow() {
@@ -1174,6 +1262,7 @@ class WindowManager {
       return;
     }
 
+    this._persistControlPanelState();
     this.controlPanelWindow.hide();
     dockManager.setControlPanelVisible(false);
   }

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -59,9 +59,12 @@ class WindowManager {
     this._controlPanelStateStore = null;
     this._controlPanelNormalBounds = null;
     this._controlPanelSaveTimer = null;
+    this._lastPersistedControlPanelState = null;
 
     app.on("before-quit", () => {
       this.isQuitting = true;
+      // The normal quit path exits via app.exit(), which skips window close events.
+      this._persistControlPanelState();
       this.hotkeyManager.unregisterAll();
     });
   }
@@ -762,6 +765,8 @@ class WindowManager {
       clearVisibilityTimer();
       clearTimeout(this._controlPanelSaveTimer);
       this._controlPanelSaveTimer = null;
+      // Snap state dies with its window; a stale flag would freeze bounds tracking.
+      this._preMeetingBounds = null;
       this.controlPanelWindow = null;
       dockManager.setControlPanelVisible(false);
     });
@@ -866,8 +871,13 @@ class WindowManager {
     } catch {
       displayId = null;
     }
+    const payload = { ...bounds, isMaximized: win.isMaximized(), displayId };
+    const payloadKey = JSON.stringify(payload);
+    // Close and quit paths often persist right after a debounce flush; skip identical writes.
+    if (payloadKey === this._lastPersistedControlPanelState) return;
     try {
-      this._controlPanelStateStore.save({ ...bounds, isMaximized: win.isMaximized(), displayId });
+      this._controlPanelStateStore.save(payload);
+      this._lastPersistedControlPanelState = payloadKey;
     } catch (error) {
       debugLogger.error(
         "Failed to persist control panel window state",

--- a/test/helpers/controlPanelWindowState.test.js
+++ b/test/helpers/controlPanelWindowState.test.js
@@ -44,11 +44,21 @@ test("parse rejects malformed JSON, wrong shapes, and non-finite numbers", async
   }
 });
 
-test("parse drops zero and negative sizes", async () => {
+test("parse drops zero, negative, and below-floor sizes", async () => {
   const { parseControlPanelWindowState } = await load();
 
   assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":0,"height":800}'), null);
   assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":1200,"height":-1}'), null);
+  assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":319,"height":800}'), null);
+  assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":1200,"height":239}'), null);
+  assert.deepEqual(parseControlPanelWindowState('{"x":0,"y":0,"width":320,"height":240}'), {
+    x: 0,
+    y: 0,
+    width: 320,
+    height: 240,
+    isMaximized: false,
+    displayId: null,
+  });
 });
 
 test("serialize returns empty string for invalid state so the store key is deleted", async () => {

--- a/test/helpers/controlPanelWindowState.test.js
+++ b/test/helpers/controlPanelWindowState.test.js
@@ -1,0 +1,193 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/controlPanelWindowState.js");
+
+const PRIMARY = { id: 1, workArea: { x: 0, y: 0, width: 2560, height: 1400 }, scaleFactor: 1 };
+const SIDE = { id: 2, workArea: { x: 2560, y: 0, width: 1920, height: 1080 }, scaleFactor: 1 };
+const DISPLAYS = [PRIMARY, SIDE];
+
+const savedState = (overrides = {}) => ({
+  x: 100,
+  y: 120,
+  width: 1200,
+  height: 800,
+  isMaximized: false,
+  displayId: 1,
+  ...overrides,
+});
+
+test("serialize and parse round-trip a normal state", async () => {
+  const { serializeControlPanelWindowState, parseControlPanelWindowState } = await load();
+
+  const state = savedState();
+  assert.deepEqual(parseControlPanelWindowState(serializeControlPanelWindowState(state)), state);
+});
+
+test("parse rejects malformed JSON, wrong shapes, and non-finite numbers", async () => {
+  const { parseControlPanelWindowState } = await load();
+
+  for (const raw of [
+    undefined,
+    null,
+    "",
+    "not-json",
+    "42",
+    '"string"',
+    "[1,2,3]",
+    "{}",
+    '{"x":0,"y":0,"width":"1200","height":800}',
+    '{"x":null,"y":0,"width":1200,"height":800}',
+    '{"x":0,"y":0,"width":1e999,"height":800}',
+  ]) {
+    assert.equal(parseControlPanelWindowState(raw), null);
+  }
+});
+
+test("parse drops zero and negative sizes", async () => {
+  const { parseControlPanelWindowState } = await load();
+
+  assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":0,"height":800}'), null);
+  assert.equal(parseControlPanelWindowState('{"x":0,"y":0,"width":1200,"height":-1}'), null);
+});
+
+test("serialize returns empty string for invalid state so the store key is deleted", async () => {
+  const { serializeControlPanelWindowState } = await load();
+
+  assert.equal(serializeControlPanelWindowState(null), "");
+  assert.equal(serializeControlPanelWindowState({ x: 0, y: 0, width: NaN, height: 800 }), "");
+});
+
+test("serialized state survives a KEY=value line in the env store", async () => {
+  const { serializeControlPanelWindowState, parseControlPanelWindowState } = await load();
+  const dotenv = require("dotenv");
+
+  const state = savedState({ x: -400, y: 0, displayId: 123456789 });
+  const line = `CONTROL_PANEL_WINDOW_STATE=${serializeControlPanelWindowState(state)}\n`;
+  const parsedEnv = dotenv.parse(line);
+  assert.deepEqual(parseControlPanelWindowState(parsedEnv.CONTROL_PANEL_WINDOW_STATE), state);
+});
+
+test("no saved state resolves to the default config path", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  for (const saved of [null, undefined, {}, { x: 1, y: 2 }]) {
+    assert.deepEqual(resolveControlPanelWindowState(saved, DISPLAYS, PRIMARY), {
+      bounds: null,
+      maximize: false,
+    });
+  }
+});
+
+test("bounds fully inside an attached display restore as-is", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const resolved = resolveControlPanelWindowState(savedState(), DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved, {
+    bounds: { x: 100, y: 120, width: 1200, height: 800 },
+    maximize: false,
+  });
+});
+
+test("one pixel of overlap still counts as visible", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const saved = savedState({ x: -1199, y: 0 });
+  const resolved = resolveControlPanelWindowState(saved, DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: -1199, y: 0, width: 1200, height: 800 });
+});
+
+test("an edge-adjacent window with zero overlap is off-screen", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const saved = savedState({ x: -1200, y: 0, displayId: 1 });
+  const resolved = resolveControlPanelWindowState(saved, DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: 0, y: 0, width: 1200, height: 800 });
+});
+
+test("off-screen bounds clamp into the saved display when it is still attached", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const saved = savedState({ x: 9000, y: -3000, displayId: 2 });
+  const resolved = resolveControlPanelWindowState(saved, DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: 3280, y: 0, width: 1200, height: 800 });
+});
+
+test("off-screen bounds center on the primary when the saved display is gone", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const saved = savedState({ x: 9000, y: 9000, displayId: 77 });
+  const resolved = resolveControlPanelWindowState(saved, [PRIMARY], PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: 680, y: 300, width: 1200, height: 800 });
+});
+
+test("oversized bounds shrink to the primary work area when the saved display is gone", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const laptop = { id: 5, workArea: { x: 0, y: 0, width: 1440, height: 900 }, scaleFactor: 1 };
+  const saved = savedState({ x: 4000, y: 0, width: 1600, height: 1000, displayId: 77 });
+  const resolved = resolveControlPanelWindowState(saved, [laptop], laptop);
+  assert.deepEqual(resolved.bounds, { x: 0, y: 0, width: 1440, height: 900 });
+});
+
+test("maximized flag survives restore, clamp, and fallback paths", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const visible = resolveControlPanelWindowState(
+    savedState({ isMaximized: true }),
+    DISPLAYS,
+    PRIMARY
+  );
+  assert.equal(visible.maximize, true);
+
+  const clamped = resolveControlPanelWindowState(
+    savedState({ x: 9000, y: -3000, displayId: 2, isMaximized: true }),
+    DISPLAYS,
+    PRIMARY
+  );
+  assert.equal(clamped.maximize, true);
+
+  const centered = resolveControlPanelWindowState(
+    savedState({ x: 9000, y: 9000, displayId: 77, isMaximized: true }),
+    [PRIMARY],
+    PRIMARY
+  );
+  assert.equal(centered.maximize, true);
+});
+
+test("a window spanning two displays restores untouched", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const saved = savedState({ x: 2000, y: 100, width: 1600, height: 800 });
+  const resolved = resolveControlPanelWindowState(saved, DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: 2000, y: 100, width: 1600, height: 800 });
+});
+
+test("DIP bounds left outside a rescaled work area clamp back in", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  // Same physical panel, scale went 1 -> 2, so the DIP work area halved.
+  const rescaled = { id: 1, workArea: { x: 0, y: 0, width: 1280, height: 700 }, scaleFactor: 2 };
+  const saved = savedState({ x: 1400, y: 800, width: 1200, height: 800, displayId: 1 });
+  const resolved = resolveControlPanelWindowState(saved, [rescaled], rescaled);
+  assert.deepEqual(resolved.bounds, { x: 80, y: 0, width: 1200, height: 700 });
+});
+
+test("an empty display list falls back to the default config path but keeps the flag", async () => {
+  const { resolveControlPanelWindowState } = await load();
+
+  const resolved = resolveControlPanelWindowState(savedState({ isMaximized: true }), [], null);
+  assert.deepEqual(resolved, { bounds: null, maximize: true });
+});
+
+test("non-numeric display ids are ignored instead of matching a display", async () => {
+  const { parseControlPanelWindowState, resolveControlPanelWindowState } = await load();
+
+  const parsed = parseControlPanelWindowState(
+    '{"x":9000,"y":9000,"width":1200,"height":800,"displayId":"2"}'
+  );
+  assert.equal(parsed.displayId, null);
+
+  const resolved = resolveControlPanelWindowState(parsed, DISPLAYS, PRIMARY);
+  assert.deepEqual(resolved.bounds, { x: 680, y: 300, width: 1200, height: 800 });
+});


### PR DESCRIPTION
## Summary
The control panel reopens at the hardcoded 1200x800, centered and unmaximized, no matter how it was left: nothing in `createControlPanelWindow` (windowManager.js) ever saves bounds. This adds automatic window-state memory through the existing settings store. A `CONTROL_PANEL_WINDOW_STATE` key in `environment.js` holds the normal bounds (`getNormalBounds()`), maximized flag, and display id, saved debounced on move/resize and on close/hide-to-tray. On create the saved state is validated against the attached displays: partial overlap restores as-is, fully off-screen bounds clamp into the saved display, and when that display is gone the panel keeps its size and centers on the primary. Bounds apply first and maximize runs after, so unmaximize returns to the remembered rect. With no saved state the config passes through untouched, so first run behaves exactly as today.

The validation logic is pure (`controlPanelWindowState.js`, same shape as `dockPolicy.js`) and unit-tested across the display matrix; the visual restore was smoke-checked. On Wayland position restore is a no-op (compositors ignore client positioning), size and maximized state still apply.

Fixes #1270

## Changes
- src/helpers/controlPanelWindowState.js: pure parse/serialize/resolve logic with display-overlap validation and clamping
- src/helpers/windowManager.js: restore bounds on create, maximize after bounds, debounced saves on move/resize/maximize/unmaximize, save on close and hide-to-tray, ignore transient meeting-mode snaps
- src/helpers/environment.js: CONTROL_PANEL_WINDOW_STATE persisted key with get/save accessors
- main.js: wire the environment-backed store into windowManager
- test/helpers/controlPanelWindowState.test.js: matrix tests for visibility, clamping, display-gone fallback, DPI rescale, maximized flag, and corrupt store values