### PR TITLE
fix: recording UI not rendering on correct virtual macOS desktop

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -53,7 +53,6 @@ const MAIN_WINDOW_CONFIG = {
   show: false,
   skipTaskbar: true,
   focusable: false,
-  visibleOnAllWorkspaces: process.platform !== "win32",
   fullScreenable: false,
   hasShadow: false,
   acceptsFirstMouse: true,
@@ -116,7 +115,6 @@ const NOTIFICATION_WINDOW_CONFIG = {
     contextIsolation: true,
     sandbox: true,
   },
-  visibleOnAllWorkspaces: process.platform !== "win32",
   type: FLOATING_OVERLAY_TYPE,
 };
 
@@ -147,7 +145,6 @@ const TRANSCRIPTION_PREVIEW_CONFIG = {
     contextIsolation: true,
     sandbox: true,
   },
-  visibleOnAllWorkspaces: process.platform !== "win32",
   type: FLOATING_OVERLAY_TYPE,
 };
 
@@ -216,6 +213,10 @@ class WindowPositionUtil {
 
       if (window.isVisible()) {
         window.setAlwaysOnTop(true, "floating", 1);
+        window.setVisibleOnAllWorkspaces(true, {
+          visibleOnFullScreen: true,
+          skipTransformProcessType: true,
+        });
       }
     } else if (process.platform === "win32") {
       window.setAlwaysOnTop(true, "pop-up-menu");
@@ -246,7 +247,6 @@ const AGENT_OVERLAY_CONFIG = {
   fullScreenable: false,
   acceptsFirstMouse: true,
   type: FLOATING_OVERLAY_TYPE,
-  visibleOnAllWorkspaces: process.platform !== "win32",
   webPreferences: {
     preload: path.join(__dirname, "..", "..", "preload.js"),
     nodeIntegration: false,


### PR DESCRIPTION
Fixes #1391.

## Why
On macOS, users with multiple virtual desktops (Spaces) noticed that if they started recording on one desktop and switched to another, the recording UI (and other floating overlay windows) did not follow them to the active screen.

## What
This PR fixes the macOS window persistence issue across spaces. 

In Electron, defining `visibleOnAllWorkspaces: true` as a boolean inside the initial `BrowserWindow` config can cause a bug where macOS ignores subsequent calls to `.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })` because it caches the state.

- Removed the boolean `visibleOnAllWorkspaces: process.platform !== "win32"` from the configuration objects (`MAIN_WINDOW_CONFIG`, `TRANSCRIPTION_PREVIEW_CONFIG`, etc.) in `windowConfig.js`.
- Enforced the property explicitly inside `WindowPositionUtil.setupAlwaysOnTop()` exactly when `window.isVisible()` is true.
- By cleanly relying on the native method call with `{ visibleOnFullScreen: true, skipTransformProcessType: true }`, the overlays now properly hook into the macOS Space system and follow the active virtual desktop seamlessly.
