### PR TITLE
fix(renderer): identify control panel by query

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -9,6 +9,7 @@ import WindowControls from "./components/WindowControls.tsx";
 import { Card, CardContent } from "./components/ui/card.tsx";
 import { useAuth } from "./hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
+import { isControlPanelWindow } from "./utils/windowContext.ts";
 
 const ControlPanel = React.lazy(() => import("./components/ControlPanel.tsx"));
 const OnboardingFlow = React.lazy(() => import("./components/OnboardingFlow.tsx"));
@@ -42,9 +43,7 @@ function MainApp() {
   const [postOnboardingSettingsSection, setPostOnboardingSettingsSection] = useState(undefined);
 
   const isAgentPanel = window.location.search.includes("agent=true");
-  const isControlPanel =
-    !isAgentPanel &&
-    (window.location.pathname.includes("control") || window.location.search.includes("panel=true"));
+  const isControlPanel = !isAgentPanel && isControlPanelWindow();
   const isDictationPanel = !isControlPanel && !isAgentPanel;
 
   useEffect(() => {

--- a/src/utils/windowContext.ts
+++ b/src/utils/windowContext.ts
@@ -1,9 +1,8 @@
-// The control panel loads with "control" in the path (packaged) or ?panel=true
-// (dev server); the dictation panel is the plain URL.
+// Window creation tags the control panel with ?panel=true in both development
+// and packaged builds; the dictation panel is the plain URL.
 export const isControlPanelWindow = (): boolean => {
   if (typeof window === "undefined") return false;
-  const { search, pathname } = window.location;
-  return pathname.includes("control") || search.includes("panel=true");
+  return new URLSearchParams(window.location.search).get("panel") === "true";
 };
 
 export const isDictationPanelWindow = (): boolean =>

--- a/test/helpers/windowContext.test.js
+++ b/test/helpers/windowContext.test.js
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/windowContext.ts");
+
+test("a packaged dictation window ignores control in its install path", async (t) => {
+  const originalWindow = globalThis.window;
+  t.after(() => {
+    globalThis.window = originalWindow;
+  });
+  globalThis.window = {
+    location: {
+      pathname:
+        "/Users/controller/Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html",
+      search: "",
+    },
+  };
+
+  const { isControlPanelWindow, isDictationPanelWindow } = await load();
+
+  assert.equal(isControlPanelWindow(), false);
+  assert.equal(isDictationPanelWindow(), true);
+});
+
+test("only the explicit panel=true query selects the control panel", async (t) => {
+  const originalWindow = globalThis.window;
+  t.after(() => {
+    globalThis.window = originalWindow;
+  });
+  globalThis.window = {
+    location: {
+      pathname: "/Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html",
+      search: "?panel=true",
+    },
+  };
+
+  const { isControlPanelWindow } = await load();
+
+  assert.equal(isControlPanelWindow(), true);
+
+  globalThis.window.location.search = "?notpanel=true";
+  assert.equal(isControlPanelWindow(), false);
+
+  globalThis.window.location.search = "?panel=trueish";
+  assert.equal(isControlPanelWindow(), false);
+});


### PR DESCRIPTION
## Summary

- identify the control panel only from the explicit `panel=true` query parameter
- reuse the shared window-role helper in `AppRouter`
- cover packaged paths containing `control` and exact query matching

## Problem

A packaged dictation window can render the control panel when any directory in its file URL contains the substring `control`, such as `/Users/controller/.../index.html`. Window creation already tags the actual control panel with `?panel=true`, so an untagged packaged URL should remain the dictation panel regardless of its install path.

## Root cause

Both `AppRouter` and `windowContext` inferred the window role with `pathname.includes("control")`. Because an Electron file URL contains the full installation path, unrelated directory names could satisfy that heuristic. The existing query check also used substring matching rather than parsing the parameter.

## Solution

Parse the window query and select the control panel only when the exact `panel` parameter equals `true`. `AppRouter` now calls the shared helper instead of maintaining a second copy of the routing predicate. Agent-panel precedence is unchanged.

## Tests

- `node --test test/helpers/windowContext.test.js` — passed (2 tests)
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` — passed (1,109 tests: 1,103 passed, 6 skipped, 0 failed)

## Validation

- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed; Vite reported the existing dynamic-import and chunk-size warnings
- `./node_modules/.bin/prettier --check src/AppRouter.jsx src/utils/windowContext.ts test/helpers/windowContext.test.js` — passed
- `git diff --check` — passed
- Pre-existing failure: `npm run format:check` reports formatting differences in `src/components/notes/overview/OverviewNoteList.tsx`, `src/components/notes/ShareNoteDialog.tsx`, and `src/hooks/useNoteDragAndDrop.ts`. The same three failures reproduce from a clean worktree at upstream `bf8b7e0b`; none is modified here.

## Compatibility and risk

The change is limited to renderer window-role detection and has no public API, persistence, or dependency impact. Control-panel windows created by the application continue to use `?panel=true`. Queryless windows and near matches such as `notpanel=true` or `panel=trueish` no longer route to the control panel.

## Documentation

No documentation change is required because this restores the existing internal window-creation contract and does not change a user-facing workflow or public API.

## Related issues and prior work

Fixes #1410.

Repository-wide searches across open and closed issues and pull requests for `windowContext`, control/dictation-panel routing, install paths, `panel=true`, wrong-window behavior, and username paths found no overlapping report or active fix. The superficially related #1227 concerned Windows paste focus, not renderer window-role selection.
