### PR TITLE
fix: correct misleading Settings -> General path in translation hotkey hint

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3343,7 +3343,7 @@
       "title": "Translation Prompt",
       "description": "Customize how the model translates your dictation"
     },
-    "hotkeyHint": "Set the hotkey under Settings → General → Translation Hotkey",
+    "hotkeyHint": "Set the hotkey under Settings → Hotkeys → Translation Hotkey",
     "targetsLabel": "Target languages",
     "addTarget": "Add language…",
     "activeTarget": "Active target language",


### PR DESCRIPTION
Fixes #1413.

## Why
The translation hotkey hint incorrectly instructed users to look under "Settings → General → Translation Hotkey". Because the Hotkeys section was previously split out from the old "General" (Preferences) tab, the text became outdated and sent users hunting for a section that doesn't exist.

## What
This PR updates the user-facing text in the English translation file to correctly point to: `Settings → Hotkeys → Translation Hotkey`. 

- A broader codebase search was conducted, confirming there are no other stray user-facing references to the non-existent "General" settings section.
- Foreign locale files were left untouched, as standard translation workflows (e.g. Crowdin/i18next) will pick up the English string change and prompt translators to update their respective locales organically.
