### PR TITLE
fix(diarization): assign gap segments to the nearest speaker cluster

### DIFF
--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -471,7 +471,8 @@ class DiarizationManager {
         const segStart = seg.timestamp;
         const segEnd = nextSystemTimestampAt(index) ?? segStart + 2.5;
         const midpoint = segStart + (segEnd - segStart) / 2;
-        let bestSpeaker = null;
+        let overlapSpeaker = null;
+        let nearestSpeaker = null;
         let bestOverlap = 0;
         let bestDistance = Number.POSITIVE_INFINITY;
 
@@ -479,7 +480,7 @@ class DiarizationManager {
           const overlap = Math.min(segEnd, dSeg.end) - Math.max(segStart, dSeg.start);
           if (overlap > bestOverlap) {
             bestOverlap = overlap;
-            bestSpeaker = dSeg.speaker;
+            overlapSpeaker = dSeg.speaker;
           }
 
           const distance =
@@ -489,11 +490,16 @@ class DiarizationManager {
                 ? midpoint - dSeg.end
                 : 0;
 
-          if (!bestSpeaker && distance < bestDistance) {
+          if (distance < bestDistance) {
             bestDistance = distance;
-            bestSpeaker = dSeg.speaker;
+            nearestSpeaker = dSeg.speaker;
           }
         }
+
+        // Overlap decides outright; the nearest cluster is only the fallback for
+        // a segment that lands between clusters. Tracking the two candidates
+        // separately keeps the fallback from freezing on the first cluster.
+        const bestSpeaker = overlapSpeaker ?? nearestSpeaker;
 
         if (bestSpeaker) {
           applyConfirmedSpeaker(enriched, {

--- a/test/helpers/diarizationSpeakerMerge.test.js
+++ b/test/helpers/diarizationSpeakerMerge.test.js
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// mergeWithTranscript is pure, but diarization.js pulls in helpers that reach
+// for electron at load time. Stub the pieces they touch so the merge rules can
+// be exercised outside Electron.
+require.cache[require.resolve("electron")] = {
+  exports: {
+    app: {
+      getPath: () => "/tmp",
+      getAppPath: () => process.cwd(),
+      isPackaged: false,
+    },
+    net: {},
+  },
+};
+
+const DiarizationManager = require("../../src/helpers/diarization.js");
+
+const systemSegment = (timestamp, text) => ({ source: "system", timestamp, text });
+
+test("a segment between clusters takes the nearest cluster, not the first", () => {
+  const manager = new DiarizationManager();
+
+  // Midpoint 51.25s: 46.25s past speaker_0, 8.75s before speaker_1.
+  const merged = manager.mergeWithTranscript(
+    [systemSegment(50, "so where did we land on pricing")],
+    [
+      { start: 0, end: 5, speaker: "speaker_0" },
+      { start: 60, end: 70, speaker: "speaker_1" },
+    ]
+  );
+
+  assert.equal(merged[0].speaker, "speaker_1");
+});
+
+test("a segment past the last cluster belongs to that cluster", () => {
+  const manager = new DiarizationManager();
+
+  const merged = manager.mergeWithTranscript(
+    [systemSegment(100, "one last thing before we wrap")],
+    [
+      { start: 0, end: 5, speaker: "speaker_0" },
+      { start: 60, end: 70, speaker: "speaker_1" },
+    ]
+  );
+
+  assert.equal(merged[0].speaker, "speaker_1");
+});
+
+test("the largest overlapping cluster still wins over the nearest one", () => {
+  const manager = new DiarizationManager();
+
+  // The segment spans 50s–52.5s. speaker_0 overlaps 0.5s and starts exactly at
+  // the segment, so it is both the first cluster and a zero-distance match;
+  // speaker_1 overlaps 2s and must win on overlap.
+  const merged = manager.mergeWithTranscript(
+    [systemSegment(50, "that matches what I saw")],
+    [
+      { start: 50, end: 50.5, speaker: "speaker_0" },
+      { start: 50.5, end: 53, speaker: "speaker_1" },
+    ]
+  );
+
+  assert.equal(merged[0].speaker, "speaker_1");
+});
+
+test("mic segments stay owned by you and survive an empty diarization run", () => {
+  const manager = new DiarizationManager();
+
+  const withClusters = manager.mergeWithTranscript(
+    [{ source: "mic", timestamp: 1, text: "morning" }],
+    [{ start: 0, end: 5, speaker: "speaker_0" }]
+  );
+  assert.equal(withClusters[0].speaker, "you");
+
+  const withoutClusters = manager.mergeWithTranscript([systemSegment(1, "morning")], []);
+  assert.equal(withoutClusters[0].speaker, undefined);
+});


### PR DESCRIPTION
## Summary

`DiarizationManager.mergeWithTranscript()` falls back to the nearest speaker cluster when no cluster overlaps a transcript segment. The fallback was guarded by `!bestSpeaker`, so it locked onto the first cluster it saw and never compared distances. Gap segments were therefore labelled with whichever speaker the diarizer emitted first.

## Affected component

`src/helpers/diarization.js` — `DiarizationManager.mergeWithTranscript()`, the offline post-meeting merge of the transcript with sherpa-onnx diarization output.

## Problem

`bestDistance` starts at `Infinity`, so the first non-overlapping cluster always satisfies `distance < bestDistance` and sets `bestSpeaker`. From the second iteration on, `!bestSpeaker` is false and no closer cluster can replace it:

```js
if (!bestSpeaker && distance < bestDistance) {
  bestDistance = distance;
  bestSpeaker = dSeg.speaker;
}
```

The overlap branch above it could still override the choice, so only segments with no overlapping cluster at all were affected — pauses between speech, cross-talk the diarizer did not cluster, and anything past the last cluster.

## Minimal reproduction

```bash
ELECTRON_OVERRIDE_DIST_PATH=/tmp node - <<'NODE'
require.cache[require.resolve("electron")] = {
  exports: { app: { getPath: () => "/tmp", getAppPath: () => process.cwd(), isPackaged: false } },
};
const DiarizationManager = require("./src/helpers/diarization.js");
const manager = new DiarizationManager();
console.log(
  manager.mergeWithTranscript(
    [{ source: "system", timestamp: 50, text: "so where did we land on pricing" }],
    [
      { start: 0, end: 5, speaker: "speaker_0" },
      { start: 60, end: 70, speaker: "speaker_1" },
    ]
  )[0].speaker
);
NODE
```

The segment spans 50s–52.5s; its midpoint is 46.25s past `speaker_0` and 8.75s before `speaker_1`.

**Actual (before):** `speaker_0`
**Expected (after):** `speaker_1`

## Root cause

One boolean guard conflated "a candidate has been chosen" with "an overlapping cluster has been found", collapsing a nearest-neighbour search into a first-match search.

## Implementation

Track the overlap candidate and the nearest candidate in separate variables and pick between them once the scan finishes:

```js
const bestSpeaker = overlapSpeaker ?? nearestSpeaker;
```

Overlap precedence is unchanged — an overlapping cluster still wins, and among overlapping clusters the largest overlap still wins. Only the previously unreachable nearest-cluster comparison now runs.

## Why the fix is minimal

Six lines inside the existing loop. No signature, contract, or caller changes; no new dependencies; `applyConfirmedSpeaker`, the speaker renumbering map, the mic-segment branch, and the `nextSystemTimestampAt` window are all untouched.

## Regression tests

`test/helpers/diarizationSpeakerMerge.test.js` (new, 4 tests):

- a segment between clusters takes the nearest cluster, not the first — **fails on unmodified `main`**
- a segment past the last cluster belongs to that cluster — **fails on unmodified `main`**
- the largest overlapping cluster still wins over the nearest one (guards overlap precedence: the first cluster is also a zero-distance match, so it would win if the fallback ever outranked overlap)
- mic segments stay owned by `you` and survive an empty diarization run (guards the untouched branches)

The tests stub `electron` via `require.cache`, matching the existing helper tests. `mergeWithTranscript` is pure, so no diarization binary, model, audio file, or network access is involved.

## Platforms and execution paths

Pure merge logic with no platform branches — identical on macOS, Windows and Linux. The change is confined to the offline post-meeting path (`ipcHandlers.js` calls it after `diarize()`); the live speaker-identification path does not go through it.

## Lifecycle and cleanup

No resources, listeners, timers, processes, or temporary files are involved. The function stays a pure transform that returns new segment objects and does not mutate its inputs.

## Validation

Run in a clean worktree at `bf8b7e0b4e1de0c9779c63f4752bd80bdd39ee2c` (`npm ci --ignore-scripts` + `npm rebuild better-sqlite3`, per `.github/workflows/tests.yml`):

| Command | Result |
| --- | --- |
| `node --test test/helpers/diarizationSpeakerMerge.test.js` (before fix) | 4 tests, 2 pass, **2 fail** |
| `node --test test/helpers/diarizationSpeakerMerge.test.js` (after fix) | 4 tests, 4 pass, 0 fail — repeated 3× |
| `npm test` | 1111 tests, 1105 pass, 0 fail, 6 skipped |
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `git diff --check` | clean |

The 6 skips are environmental and identical before and after: 5 `linuxLauncherSandbox` tests that only run on Linux, and 1 FFmpeg-dependent audio test skipped because `--ignore-scripts` omits the bundled FFmpeg download.

**Not run:** `npm run format:check`. It fails on unmodified `upstream/main` at this commit for three files unrelated to this change (`components/notes/overview/OverviewNoteList.tsx`, `components/notes/ShareNoteDialog.tsx`, `hooks/useNoteDragAndDrop.ts`); reformatting them here would be out of scope. `npm run lint`, which is the ESLint half of that script, passes. Packaging (`npm run build`) was not run — it requires the platform binary downloads and this change does not touch build or packaging config.

## Compatibility

No public API, IPC contract, database schema, or stored-transcript format changes. Segments that overlap a cluster keep their existing label, so previously correct assignments are unaffected; only the gap-segment fallback changes, and existing saved transcripts are untouched.

## Non-goals

- The live speaker-identification path in `ipcHandlers.js` is not changed.
- Clustering quality, `capSpeakerClusters`, and the `segStart + 2.5` segment-length assumption are left as they are.
- No change to how speakers are renumbered or displayed.

Fixes #1421
