### PR TITLE
fix(hotkeys): release a slot's registered accelerators on unregister

### DIFF
--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -324,19 +324,17 @@ class HotkeyManager extends EventEmitter {
       return;
     }
 
-    for (const hk of slot.hotkeys || []) {
-      if (
-        !isGlobeLikeHotkey(hk) &&
-        !isMouseButtonHotkey(hk) &&
-        !isRightSideModifier(hk) &&
-        !isModifierOnlyHotkey(hk)
-      ) {
-        const accel = normalizeToAccelerator(hk);
-        try {
-          globalShortcut.unregister(accel);
-        } catch {
-          // already unregistered
-        }
+    // Release exactly what was registered. `accelerators` mirrors `hotkeys`
+    // index-for-index and holds null for the entries a native listener owns, so
+    // it cannot drift from the platform rules in _registerSingleHotkey the way
+    // a re-derived list does — modifier-only combos only bypass globalShortcut
+    // on Windows.
+    for (const accel of slot.accelerators || []) {
+      if (!accel) continue;
+      try {
+        globalShortcut.unregister(accel);
+      } catch {
+        // already unregistered
       }
     }
     slot.hotkeys = [];

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -296,7 +296,7 @@ class HotkeyManager extends EventEmitter {
 
   unregisterSlot(slotName) {
     const slot = this.slots.get(slotName);
-    if (!slot || !(slot.hotkeys && slot.hotkeys.length)) return;
+    if (!slot || !(slot.hotkeys?.length || slot.accelerators?.length)) return;
 
     // On KDE (X11 or Wayland), persistent slots are managed via KGlobalAccel
     if (this.useKDE && this.kdeManager && slotName !== "cancel") {
@@ -324,11 +324,7 @@ class HotkeyManager extends EventEmitter {
       return;
     }
 
-    // Release exactly what was registered. `accelerators` mirrors `hotkeys`
-    // index-for-index and holds null for the entries a native listener owns, so
-    // it cannot drift from the platform rules in _registerSingleHotkey the way
-    // a re-derived list does — modifier-only combos only bypass globalShortcut
-    // on Windows.
+    // Release what was actually registered; native-listener entries are null.
     for (const accel of slot.accelerators || []) {
       if (!accel) continue;
       try {

--- a/test/helpers/hotkeySlotUnregister.test.js
+++ b/test/helpers/hotkeySlotUnregister.test.js
@@ -73,6 +73,9 @@ test("unregisterSlot never releases an accelerator the slot does not own", async
 
   await manager.registerSlot("agent", "F7", noop, { atomic: true });
   await manager.registerSlot("cancel", "F8", noop, { atomic: true });
+  // On Linux, registration defensively unregisters its own accelerator before
+  // registering it; only the teardown's unregister calls are under test here.
+  unregisterCalls.length = 0;
 
   manager.unregisterSlot("agent");
 

--- a/test/helpers/hotkeySlotUnregister.test.js
+++ b/test/helpers/hotkeySlotUnregister.test.js
@@ -1,0 +1,94 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Stub electron's globalShortcut before hotkeyManager loads so slot
+// registration can run outside Electron. `unregisterCalls` records every
+// accelerator teardown attempts, including ones that were never registered.
+const registered = new Map();
+const unregisterCalls = [];
+require.cache[require.resolve("electron")] = {
+  exports: {
+    globalShortcut: {
+      register(accelerator, callback) {
+        if (registered.has(accelerator)) return false;
+        registered.set(accelerator, callback);
+        return true;
+      },
+      unregister(accelerator) {
+        unregisterCalls.push(accelerator);
+        registered.delete(accelerator);
+      },
+      isRegistered(accelerator) {
+        return registered.has(accelerator);
+      },
+      unregisterAll() {
+        registered.clear();
+      },
+    },
+    BrowserWindow: class {},
+  },
+};
+
+const HotkeyManager = require("../../src/helpers/hotkeyManager.js");
+
+const noop = () => {};
+
+test.beforeEach(() => {
+  registered.clear();
+  unregisterCalls.length = 0;
+});
+
+test("unregisterSlot releases every accelerator the slot registered", async () => {
+  const manager = new HotkeyManager();
+
+  // "Control+Alt" is modifier-only. Only Windows diverts those to the native
+  // low-level listener; everywhere else globalShortcut owns them, so the
+  // teardown has to release them too.
+  await manager.registerSlot("agent", "F7,Control+Alt", noop);
+  const heldAfterRegister = [...registered.keys()];
+
+  manager.unregisterSlot("agent");
+
+  assert.deepEqual(
+    [...registered.keys()],
+    [],
+    `slot teardown left accelerators registered (held after register: ${heldAfterRegister.join(", ")})`
+  );
+  assert.deepEqual(manager.getSlotHotkeys("agent"), []);
+});
+
+test("a combo freed by unregisterSlot can be registered again", async () => {
+  const manager = new HotkeyManager();
+
+  await manager.registerSlot("agent", "Control+Alt", noop, { atomic: true });
+  manager.unregisterSlot("agent");
+
+  const reregistered = await manager.registerSlot("agent", "Control+Alt", noop, { atomic: true });
+  assert.equal(reregistered.success, true);
+  assert.deepEqual(manager.getSlotHotkeys("agent"), ["Control+Alt"]);
+});
+
+test("unregisterSlot never releases an accelerator the slot does not own", async () => {
+  const manager = new HotkeyManager();
+
+  await manager.registerSlot("agent", "F7", noop, { atomic: true });
+  await manager.registerSlot("cancel", "F8", noop, { atomic: true });
+
+  manager.unregisterSlot("agent");
+
+  assert.deepEqual(unregisterCalls, ["F7"]);
+  assert.deepEqual([...registered.keys()], ["F8"]);
+  assert.deepEqual(manager.getSlotHotkeys("cancel"), ["F8"]);
+});
+
+test("unregisterSlot on an already-cleared slot is a no-op", async () => {
+  const manager = new HotkeyManager();
+
+  await manager.registerSlot("agent", "F7", noop, { atomic: true });
+  manager.unregisterSlot("agent");
+  unregisterCalls.length = 0;
+
+  manager.unregisterSlot("agent");
+
+  assert.deepEqual(unregisterCalls, []);
+});

--- a/test/helpers/hotkeySlotUnregister.test.js
+++ b/test/helpers/hotkeySlotUnregister.test.js
@@ -41,19 +41,13 @@ test.beforeEach(() => {
 test("unregisterSlot releases every accelerator the slot registered", async () => {
   const manager = new HotkeyManager();
 
-  // "Control+Alt" is modifier-only. Only Windows diverts those to the native
-  // low-level listener; everywhere else globalShortcut owns them, so the
-  // teardown has to release them too.
-  await manager.registerSlot("agent", "F7,Control+Alt", noop);
-  const heldAfterRegister = [...registered.keys()];
+  // Only Windows diverts modifier-only combos to the native listener, so
+  // everywhere else globalShortcut owns "Control+Alt" and must release it.
+  await manager.registerSlot("agent", "F7,Control+Alt", noop, { atomic: true });
 
   manager.unregisterSlot("agent");
 
-  assert.deepEqual(
-    [...registered.keys()],
-    [],
-    `slot teardown left accelerators registered (held after register: ${heldAfterRegister.join(", ")})`
-  );
+  assert.deepEqual([...registered.keys()], []);
   assert.deepEqual(manager.getSlotHotkeys("agent"), []);
 });
 
@@ -73,8 +67,7 @@ test("unregisterSlot never releases an accelerator the slot does not own", async
 
   await manager.registerSlot("agent", "F7", noop, { atomic: true });
   await manager.registerSlot("cancel", "F8", noop, { atomic: true });
-  // On Linux, registration defensively unregisters its own accelerator before
-  // registering it; only the teardown's unregister calls are under test here.
+  // Linux registration defensively unregisters first; only teardown is under test.
   unregisterCalls.length = 0;
 
   manager.unregisterSlot("agent");
@@ -82,6 +75,18 @@ test("unregisterSlot never releases an accelerator the slot does not own", async
   assert.deepEqual(unregisterCalls, ["F7"]);
   assert.deepEqual([...registered.keys()], ["F8"]);
   assert.deepEqual(manager.getSlotHotkeys("cancel"), ["F8"]);
+});
+
+test("unregisterSlot skips hotkeys a native listener owns", async () => {
+  const manager = new HotkeyManager();
+
+  // "RightShift" gets a null accelerator on every platform.
+  await manager.registerSlot("dictation", "F7,RightShift", noop, { atomic: true });
+  unregisterCalls.length = 0;
+
+  manager.unregisterSlot("dictation");
+
+  assert.deepEqual(unregisterCalls, ["F7"]);
 });
 
 test("unregisterSlot on an already-cleared slot is a no-op", async () => {


### PR DESCRIPTION
## Summary

`HotkeyManager.unregisterSlot()` re-derived a slot's accelerators from `slot.hotkeys` using a platform-agnostic filter that skipped modifier-only combos. Registration only diverts those to the native listener on Windows, so on macOS and Linux the accelerator was never released and kept firing after the slot was cleared. The teardown now releases `slot.accelerators`, the record `setupShortcuts()` already maintains.

## Affected component

`src/helpers/hotkeyManager.js` — `HotkeyManager.unregisterSlot()`.

## Problem

`_registerSingleHotkey()` routes a hotkey to a native low-level listener (accelerator `null`) for Globe/Fn, mouse buttons, right-side single modifiers, and — **only on `win32`** — modifier-only combos:

```js
if (isModifierOnlyHotkey(hotkey) && process.platform === "win32") {
  // native listener
  return { success: true, hotkey, accelerator: null };
}
const accelerator = normalizeToAccelerator(hotkey);
const success = globalShortcut.register(accelerator, () => callback(hotkey));
```

`unregisterSlot()` applied the same four predicates with no platform condition, so `Control+Alt` on macOS/Linux was registered through `globalShortcut` but excluded from teardown. `setupShortcuts()` already tears the slot's previous bindings down from `slot.accelerators` — the two paths had drifted apart.

Because the slot's `hotkeys`/`accelerators` arrays were cleared anyway, the manager also lost the record: `_findSlotConflict()` stopped seeing the binding while the OS-level registration and its callback were still live.

## Minimal reproduction

```bash
ELECTRON_OVERRIDE_DIST_PATH=/tmp node - <<'NODE'
const registered = new Map();
require.cache[require.resolve("electron")] = {
  exports: {
    globalShortcut: {
      register(a, cb) { if (registered.has(a)) return false; registered.set(a, cb); return true; },
      unregister(a) { registered.delete(a); },
      isRegistered(a) { return registered.has(a); },
      unregisterAll() { registered.clear(); },
    },
    BrowserWindow: class {},
  },
};
const HotkeyManager = require("./src/helpers/hotkeyManager.js");
(async () => {
  const manager = new HotkeyManager();
  await manager.registerSlot("agent", "Control+Alt", () => {}, { atomic: true });
  console.log("after registerSlot: ", [...registered.keys()]);
  manager.unregisterSlot("agent");
  console.log("after unregisterSlot:", [...registered.keys()]);
})();
NODE
```

**Actual (before):**

```text
after registerSlot:  [ 'Control+Alt' ]
after unregisterSlot: [ 'Control+Alt' ]
```

**Expected (after):** the second line is `[]`.

In the app this is reached by pointing the Agent (or Voice Agent / Translation / Meeting) hotkey at a modifier-only combo and then clearing that field — `update-agent-hotkey` with an empty value calls `unregisterSlot("agent")`.

## Root cause

Two independent copies of the "which hotkeys reach `globalShortcut`" rule, one of which omitted the `win32` condition the registration path applies.

## Implementation

```js
for (const accel of slot.accelerators || []) {
  if (!accel) continue;
  try {
    globalShortcut.unregister(accel);
  } catch {
    // already unregistered
  }
}
```

`slot.accelerators` is written by `setupShortcuts()` index-for-index with `slot.hotkeys`, holding `null` for every hotkey a native listener owns, so the teardown can no longer diverge from the registration rules. This also mirrors how `setupShortcuts()` releases `previousAccelerators`.

## Why the fix is minimal

One loop replaced inside `unregisterSlot()`. The GNOME and KDE early-return branches above it, the slot-state reset below it, and every helper predicate (still used elsewhere in the file) are untouched. No signature, contract, IPC, or platform-branch changes.

## Regression tests

`test/helpers/hotkeySlotUnregister.test.js` (new, 5 tests), stubbing `globalShortcut` through `require.cache` like the existing `hotkeySlotRollback` test:

- `unregisterSlot` releases every accelerator the slot registered (`F7` plus modifier-only `Control+Alt`) — **fails on unmodified `main`**
- a combo freed by `unregisterSlot` can be registered again — **fails on unmodified `main`**
- `unregisterSlot` never releases an accelerator the slot does not own (asserts the exact `unregister` call list, so no over-release)
- `unregisterSlot` skips hotkeys a native listener owns (`F7,RightShift` releases only `F7`, pinning the `null`-accelerator entries out of the teardown)
- `unregisterSlot` on an already-cleared slot is a no-op (exactly-once teardown, no spurious calls)

No real global shortcut is registered, no window is created, and no keyboard event is emitted.

## Platforms and execution paths

The defect is macOS/Linux only; Windows already took the native-listener path for modifier-only combos and was unaffected. The tests exercise the globalShortcut path, which is what CI's `ubuntu-latest` runner takes, and stay correct on Windows (the modifier-only assertions become trivially true there because nothing is registered). Right-side single modifiers, Globe/Fn, and mouse-button hotkeys keep their `null` accelerator and are still never passed to `globalShortcut.unregister`. The GNOME (gsettings) and KDE (KGlobalAccel) branches return before this loop and are unchanged. Hyprland has no branch in `unregisterSlot` — it falls through, but its slots carry an empty `accelerators` list, so the loop is a no-op there.

## Lifecycle and cleanup

Each registered accelerator is now released exactly once per teardown, and never more than once — `slot.accelerators` is cleared immediately afterwards, so a repeated `unregisterSlot()` issues no calls. Callbacks are dropped with the registration instead of outliving it.

## Validation

Run in a clean worktree at `bf8b7e0b4e1de0c9779c63f4752bd80bdd39ee2c` (`npm ci --ignore-scripts` + `npm rebuild better-sqlite3`, per `.github/workflows/tests.yml`):

| Command | Result |
| --- | --- |
| `node --test test/helpers/hotkeySlotUnregister.test.js` (before fix) | 5 tests, 3 pass, **2 fail** |
| `node --test test/helpers/hotkeySlotUnregister.test.js` (after fix) | 5 tests, 5 pass, 0 fail |
| `node --test` over the hotkey suite (`hotkeySlotRollback`, `hotkeyList`, `hotkeyValidation`, `hotkeyLabels`, `nativeListenerKeys`) | 55 tests, 55 pass, 0 fail |
| `npm test` | 1112 tests, 0 fail |
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `git diff --check` | clean |

The 6 skips are environmental and identical before and after: 5 `linuxLauncherSandbox` tests that only run on Linux, and 1 FFmpeg-dependent audio test skipped because `--ignore-scripts` omits the bundled FFmpeg download.

**Not run:** `npm run format:check`. It fails on unmodified `upstream/main` at this commit for three files unrelated to this change (`components/notes/overview/OverviewNoteList.tsx`, `components/notes/ShareNoteDialog.tsx`, `hooks/useNoteDragAndDrop.ts`); reformatting them here would be out of scope. `npm run lint`, the ESLint half of that script, passes. Packaging (`npm run build`) was not run — it needs the platform binary downloads and this change touches no build or packaging config. Verifying the OS-level registration on a real desktop requires a running Electron app and was not attempted; the stubbed `globalShortcut` covers the manager's contract.

## Compatibility

No public API, IPC channel, or persisted-settings change. Slots whose hotkeys already produced a `null` accelerator behave exactly as before, and slots holding plain accelerators are released the same way as before — `normalizeToAccelerator()` is what produced the stored value in the first place.

## Non-goals

- `_findSlotConflict()` applies the same platform-agnostic classification when it compares accelerators across slots. It still catches the exact-hotkey-string case, so it is left alone rather than widening this change. Follow-up worth tracking: because `normalizeToAccelerator()` maps `RightControl → Control`, a slot holding `Control+Alt` and a slot requesting `RightControl+Alt` resolve to the same accelerator but are not reported as a conflict — the second registration just fails with a generic error. The durable fix is a single `acceleratorFor(hotkey)` shared by `_registerSingleHotkey()`, this teardown, and `_findSlotConflict()`.
- No change to which hotkeys are routed to native listeners, to `unregisterAll()`, or to the GNOME/KDE/Hyprland backends.

Fixes #1420

