### PR TITLE
perf: prewarm push-to-talk microphone capture

### DIFF
--- a/main.js
+++ b/main.js
@@ -1209,6 +1209,7 @@ async function startApp() {
               return;
             }
             windowManager.showDictationPanel();
+            windowManager.sendPrepareDictation();
             const pressTime = now;
             globeKeyDownTime = pressTime;
             globeKeyIsRecording = false;
@@ -1266,6 +1267,9 @@ async function startApp() {
             globeKeyIsRecording = false;
             debugLogger?.debug("[Globe] Stopping dictation (push release)");
             windowManager.sendStopDictation();
+          } else {
+            windowManager.sendCancelDictationPreparation();
+            windowManager.hideDictationPanel();
           }
         }
       }
@@ -1291,6 +1295,7 @@ async function startApp() {
       if (wasRecording) {
         windowManager.sendCancelDictation();
       } else {
+        windowManager.sendCancelDictationPreparation();
         windowManager.hideDictationPanel();
       }
     });
@@ -1329,6 +1334,7 @@ async function startApp() {
         const now = Date.now();
         if (now - rightModLastStopTime < POST_STOP_COOLDOWN_MS) return;
         windowManager.showDictationPanel();
+        windowManager.sendPrepareDictation();
         const pressTime = now;
         rightModActiveKey = modifier;
         rightModDownTime = pressTime;
@@ -1357,6 +1363,7 @@ async function startApp() {
             rightModIsRecording = false;
             windowManager.sendStopDictation();
           } else {
+            windowManager.sendCancelDictationPreparation();
             windowManager.hideDictationPanel();
           }
         }
@@ -1415,6 +1422,7 @@ async function startApp() {
         const now = Date.now();
         if (now - mouseButtonLastStopTime < POST_STOP_COOLDOWN_MS) return;
         windowManager.showDictationPanel();
+        windowManager.sendPrepareDictation();
         const pressTime = now;
         mouseButtonActiveButton = button;
         mouseButtonDownTime = pressTime;
@@ -1449,6 +1457,7 @@ async function startApp() {
           mouseButtonIsRecording = false;
           windowManager.sendStopDictation();
         } else {
+          windowManager.sendCancelDictationPreparation();
           windowManager.hideDictationPanel();
         }
       }

--- a/preload.js
+++ b/preload.js
@@ -52,6 +52,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onToggleTranslation: registerListener("toggle-translation", (callback) => () => callback()),
   onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
   onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
+  onPrepareDictation: registerListener("prepare-dictation", (callback) => () => callback()),
+  onCancelDictationPreparation: registerListener(
+    "cancel-dictation-preparation",
+    (callback) => () => callback()
+  ),
 
   // Database functions
   saveTranscription: (text, rawText, options) =>

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -55,6 +55,7 @@ import { evaluateFinishedRecording } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
 import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
+import { PreparedMicCapture } from "./preparedMicCapture";
 
 const REASONING_CACHE_TTL = 30000; // 30 seconds
 const RECORDING_TIMESLICE_MS = 250; // flush chunks periodically so short recordings still carry audio frames. See #871.
@@ -270,6 +271,7 @@ class AudioManager {
     this.micCaptureStatus = "inactive";
     this.cachedApiKey = null;
     this.cachedApiKeyProvider = null;
+    this.preparedMicCapture = new PreparedMicCapture();
 
     this._onApiKeyChanged = () => {
       this.cachedApiKey = null;
@@ -284,6 +286,7 @@ class AudioManager {
       this.validatedSelectedMicDeviceId = null;
       this.micDriverWarmedUp = false;
       this.rejectedMicDeviceId = null;
+      this.preparedMicCapture.cancel();
     };
     navigator.mediaDevices?.addEventListener?.("devicechange", this._onDeviceChange);
     this.cachedTranscriptionEndpoint = null;
@@ -671,21 +674,34 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  // Briefly acquire and release the mic so the OS audio driver is warm before
-  // the first real recording, reducing cold-start empty captures. See #871.
-  async warmupMicDriver() {
-    if (this.micDriverWarmedUp) return;
-    // Skip while a recording is active so we don't double-acquire the mic. See #871.
-    if (this.isRecording || this.isProcessing || this.mediaRecorder?.state === "recording") return;
-    try {
-      const constraints = await this.getAudioConstraints();
-      const tempStream = await navigator.mediaDevices.getUserMedia(constraints);
-      tempStream.getTracks().forEach((track) => track.stop());
-      this.micDriverWarmedUp = true;
-      logger.debug("Microphone driver pre-warmed", {}, "audio");
-    } catch (e) {
-      logger.debug("Mic driver warmup failed (non-critical)", { error: e.message }, "audio");
+  // Acquire the mic while a push-to-talk hold is being confirmed, then hand the
+  // same stream to startRecording instead of opening the device twice.
+  async prepareMicCapture() {
+    if (this.isRecording || this.isProcessing || this.mediaRecorder?.state === "recording") {
+      return null;
     }
+    try {
+      const prepared = await this.preparedMicCapture.prepare(async () => {
+        const constraints = await this.getAudioConstraints();
+        const stream = await this.acquireHealthyMicStream(
+          await navigator.mediaDevices.getUserMedia(constraints),
+          constraints
+        );
+        return { stream, constraints };
+      });
+      if (prepared) {
+        this.micDriverWarmedUp = true;
+        logger.debug("Microphone capture prepared", {}, "audio");
+      }
+      return prepared;
+    } catch (e) {
+      logger.debug("Mic capture preparation failed (non-critical)", { error: e.message }, "audio");
+      return null;
+    }
+  }
+
+  cancelPreparedMicCapture() {
+    this.preparedMicCapture.cancel();
   }
 
   // Recovers a dead/muted capture: retries the same device, then hops to the OS default,
@@ -732,11 +748,17 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         return false;
       }
 
-      const constraints = await this.getAudioConstraints(forceDefaultMic);
-      const micStream = await this.acquireHealthyMicStream(
-        await navigator.mediaDevices.getUserMedia(constraints),
-        constraints
-      );
+      const startRequestedAt = performance.now();
+      const prepared = forceDefaultMic ? null : await this.preparedMicCapture.take();
+      const constraints =
+        prepared?.constraints ?? (await this.getAudioConstraints(forceDefaultMic));
+      const micStream =
+        prepared?.stream ??
+        (await this.acquireHealthyMicStream(
+          await navigator.mediaDevices.getUserMedia(constraints),
+          constraints
+        ));
+      const micReadyAt = performance.now();
 
       const audioTrack = micStream.getAudioTracks()[0];
 
@@ -801,6 +823,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         isProcessing: false,
         micCaptureStatus: "active",
       });
+      logger.info(
+        "Recording start timing",
+        {
+          micReadyMs: Math.round(micReadyAt - startRequestedAt),
+          totalMs: Math.round(performance.now() - startRequestedAt),
+          usedPreparedCapture: !!prepared,
+        },
+        "audio"
+      );
 
       const {
         showTranscriptionPreview,
@@ -3366,14 +3397,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       this.stopRequestedDuringStreamingStart = false;
 
       const t0 = performance.now();
-      const constraints = await this.getAudioConstraints(forceDefaultMic);
+      const prepared = forceDefaultMic ? null : await this.preparedMicCapture.take();
+      const constraints =
+        prepared?.constraints ?? (await this.getAudioConstraints(forceDefaultMic));
       const tConstraints = performance.now();
 
       // 1. Get mic stream (can take 10-15s on cold macOS mic driver)
-      const rawStream = await navigator.mediaDevices.getUserMedia(constraints);
+      const rawStream =
+        prepared?.stream ?? (await navigator.mediaDevices.getUserMedia(constraints));
       const tMedia = performance.now();
 
-      const stream = await this.acquireHealthyMicStream(rawStream, constraints);
+      const stream = prepared?.stream
+        ? prepared.stream
+        : await this.acquireHealthyMicStream(rawStream, constraints);
 
       const audioTrack = stream.getAudioTracks()[0];
 
@@ -4097,6 +4133,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   cleanup() {
     this.micRecovery.stop();
+    this.preparedMicCapture.cancel();
     this.lastAudioBlob = null;
     this.lastAudioMetadata = null;
     if (this.isStreaming) {

--- a/src/helpers/preparedMicCapture.js
+++ b/src/helpers/preparedMicCapture.js
@@ -1,0 +1,52 @@
+export class PreparedMicCapture {
+  constructor(stopStream = (stream) => stream?.getTracks?.().forEach((track) => track.stop())) {
+    this.stopStream = stopStream;
+    this.generation = 0;
+    this.prepared = null;
+    this.pending = null;
+  }
+
+  prepare(acquire) {
+    if (this.prepared) return Promise.resolve(this.prepared);
+    if (this.pending) return this.pending;
+
+    const generation = this.generation;
+    const pending = Promise.resolve()
+      .then(acquire)
+      .then((prepared) => {
+        if (generation !== this.generation) {
+          this.stopStream(prepared?.stream);
+          return null;
+        }
+        this.prepared = prepared;
+        return prepared;
+      })
+      .finally(() => {
+        if (this.pending === pending) this.pending = null;
+      });
+
+    this.pending = pending;
+    return pending;
+  }
+
+  async take() {
+    if (this.pending) {
+      try {
+        await this.pending;
+      } catch {
+        // The caller can fall back to a normal acquisition.
+      }
+    }
+    const prepared = this.prepared;
+    this.prepared = null;
+    this.generation += 1;
+    return prepared;
+  }
+
+  cancel() {
+    this.generation += 1;
+    this.stopStream(this.prepared?.stream);
+    this.prepared = null;
+    this.pending = null;
+  }
+}

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -278,6 +278,7 @@ class WindowManager {
 
     if (this.textEditMonitor) this.textEditMonitor.captureTargetPid();
     this.showDictationPanel();
+    this.sendPrepareDictation();
 
     const safetyTimeoutId = setTimeout(() => {
       if (this.macCompoundPushState?.active) {
@@ -325,6 +326,7 @@ class WindowManager {
     if (wasRecording) {
       this.sendStopDictation();
     } else {
+      this.sendCancelDictationPreparation();
       this.hideDictationPanel();
     }
   }
@@ -343,6 +345,8 @@ class WindowManager {
 
     if (wasRecording) {
       this.sendStopDictation();
+    } else {
+      this.sendCancelDictationPreparation();
     }
     this.hideDictationPanel();
 
@@ -402,6 +406,7 @@ class WindowManager {
     const downTime = Date.now();
 
     this.showDictationPanel();
+    this.sendPrepareDictation();
 
     this.winPushState = {
       active: true,
@@ -438,6 +443,7 @@ class WindowManager {
     if (wasRecording) {
       this.sendStopDictation();
     } else {
+      this.sendCancelDictationPreparation();
       this.hideDictationPanel();
     }
   }
@@ -492,6 +498,19 @@ class WindowManager {
     }
   }
 
+  sendPrepareDictation() {
+    if (this.hotkeyManager.isInListeningMode()) return;
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send("prepare-dictation");
+    }
+  }
+
+  sendCancelDictationPreparation() {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send("cancel-dictation-preparation");
+    }
+  }
+
   sendStopDictation() {
     if (this.hotkeyManager.isInListeningMode()) {
       return;
@@ -508,6 +527,7 @@ class WindowManager {
       return;
     }
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send("cancel-dictation-preparation");
       this.mainWindow.webContents.send("cancel-hotkey-pressed");
       this._isDictatingToggle = false;
       this.meetingDetectionEngine?.setUserRecording(false);

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -18,6 +18,7 @@ export const useAudioRecording = (toast, options = {}) => {
   const [partialTranscript, setPartialTranscript] = useState("");
   const audioManagerRef = useRef(null);
   const startLockRef = useRef(false);
+  const stopRequestedDuringStartRef = useRef(false);
   const stopLockRef = useRef(false);
   const wasRecordingRef = useRef(false);
   const wasMicUnavailableRef = useRef(false);
@@ -27,6 +28,7 @@ export const useAudioRecording = (toast, options = {}) => {
     async ({ voiceAgentRequested = false, translationRequested = false } = {}) => {
       if (startLockRef.current) return false;
       startLockRef.current = true;
+      stopRequestedDuringStartRef.current = false;
       try {
         if (!audioManagerRef.current) return false;
 
@@ -48,6 +50,20 @@ export const useAudioRecording = (toast, options = {}) => {
           ? await audioManagerRef.current.startStreamingRecording()
           : await audioManagerRef.current.startRecording();
 
+        if (!didStart) stopRequestedDuringStartRef.current = false;
+
+        if (didStart && stopRequestedDuringStartRef.current) {
+          stopRequestedDuringStartRef.current = false;
+          window.electronAPI?.unregisterCancelHotkey?.();
+          if (audioManagerRef.current.getState().isStreaming) {
+            await audioManagerRef.current.stopStreamingRecording();
+          } else {
+            audioManagerRef.current.stopRecording();
+          }
+          void playStopCue();
+          return didStart;
+        }
+
         // A quick tap can end the recording inside the start call itself (deferred
         // streaming stop) — don't pause media for a recording that already ended. See #1060.
         if (didStart && audioManagerRef.current.getState().isRecording) {
@@ -67,6 +83,10 @@ export const useAudioRecording = (toast, options = {}) => {
   );
 
   const performStopRecording = useCallback(async () => {
+    if (startLockRef.current) {
+      stopRequestedDuringStartRef.current = true;
+      return true;
+    }
     if (stopLockRef.current) return false;
     stopLockRef.current = true;
     try {
@@ -264,11 +284,10 @@ export const useAudioRecording = (toast, options = {}) => {
       translationRequested = false,
     } = {}) => {
       if (!audioManagerRef.current) return;
-      // Lazily warm the mic driver on first dictation use, not at launch. See #871.
-      audioManagerRef.current.warmupMicDriver?.();
       const currentState = audioManagerRef.current.getState();
 
       if (!currentState.isRecording && !currentState.isProcessing) {
+        audioManagerRef.current.prepareMicCapture?.();
         await performStartRecording({ voiceAgentRequested, translationRequested });
       } else if (currentState.isRecording) {
         await performStopRecording();
@@ -276,7 +295,7 @@ export const useAudioRecording = (toast, options = {}) => {
     };
 
     const handleStart = async () => {
-      audioManagerRef.current?.warmupMicDriver?.();
+      audioManagerRef.current?.prepareMicCapture?.();
       await performStartRecording();
     };
 
@@ -304,6 +323,14 @@ export const useAudioRecording = (toast, options = {}) => {
       onToggle?.();
     });
 
+    const disposePrepare = window.electronAPI.onPrepareDictation?.(() => {
+      audioManagerRef.current?.prepareMicCapture?.();
+    });
+
+    const disposeCancelPreparation = window.electronAPI.onCancelDictationPreparation?.(() => {
+      audioManagerRef.current?.cancelPreparedMicCapture?.();
+    });
+
     const disposeStop = window.electronAPI.onStopDictation?.(() => {
       handleStop();
       onToggle?.();
@@ -328,6 +355,8 @@ export const useAudioRecording = (toast, options = {}) => {
       disposeVoiceAgentToggle?.();
       disposeTranslationToggle?.();
       disposeStart?.();
+      disposePrepare?.();
+      disposeCancelPreparation?.();
       disposeStop?.();
       disposeNoAudio?.();
       if (audioManagerRef.current) {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -727,6 +727,8 @@ declare global {
       onToggleTranslation?: (callback: () => void) => () => void;
       onStartDictation?: (callback: () => void) => () => void;
       onStopDictation?: (callback: () => void) => () => void;
+      onPrepareDictation?: (callback: () => void) => () => void;
+      onCancelDictationPreparation?: (callback: () => void) => () => void;
 
       // STT config
       getSttConfig?: () => Promise<{

--- a/test/helpers/preparedMicCapture.test.js
+++ b/test/helpers/preparedMicCapture.test.js
@@ -1,0 +1,72 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/preparedMicCapture.js");
+
+test("take reuses the in-flight prepared capture", async () => {
+  const { PreparedMicCapture } = await load();
+  let resolveAcquire;
+  let acquisitions = 0;
+  const capture = new PreparedMicCapture();
+  const stream = { getTracks: () => [] };
+
+  capture.prepare(
+    () =>
+      new Promise((resolve) => {
+        acquisitions += 1;
+        resolveAcquire = resolve;
+      })
+  );
+  const taken = capture.take();
+  await Promise.resolve();
+  resolveAcquire({ stream, constraints: { audio: true } });
+
+  assert.equal((await taken).stream, stream);
+  assert.equal(acquisitions, 1);
+});
+
+test("cancel stops a prepared stream", async () => {
+  const { PreparedMicCapture } = await load();
+  let stopped = 0;
+  const stream = { getTracks: () => [{ stop: () => (stopped += 1) }] };
+  const capture = new PreparedMicCapture();
+
+  await capture.prepare(async () => ({ stream, constraints: { audio: true } }));
+  capture.cancel();
+
+  assert.equal(stopped, 1);
+  assert.equal(await capture.take(), null);
+});
+
+test("cancel during acquisition stops the stream when it arrives", async () => {
+  const { PreparedMicCapture } = await load();
+  let resolveAcquire;
+  let stopped = 0;
+  const stream = { getTracks: () => [{ stop: () => (stopped += 1) }] };
+  const capture = new PreparedMicCapture();
+
+  const preparation = capture.prepare(
+    () =>
+      new Promise((resolve) => {
+        resolveAcquire = resolve;
+      })
+  );
+  await Promise.resolve();
+  capture.cancel();
+  resolveAcquire({ stream, constraints: { audio: true } });
+
+  assert.equal(await preparation, null);
+  assert.equal(stopped, 1);
+  assert.equal(await capture.take(), null);
+});
+
+test("take falls back cleanly when preparation fails", async () => {
+  const { PreparedMicCapture } = await load();
+  const capture = new PreparedMicCapture();
+  const preparation = capture.prepare(async () => {
+    throw new Error("device busy");
+  });
+
+  await assert.rejects(preparation, /device busy/);
+  assert.equal(await capture.take(), null);
+});


### PR DESCRIPTION
## Summary
- acquire the microphone during the existing 150 ms push-to-talk hold guard
- reuse the prepared stream for batch and streaming recordings instead of reopening the device
- cancel pending or prepared capture on quick taps, interruptions, device changes, and cleanup
- defer a release that arrives while recording startup is still in flight
- log batch recording startup timing for field verification

## Verification
- npm run typecheck
- npm run lint
- npm test (1111 tests: 995 passed, 116 skipped, 0 failed)
- prepared microphone tests (4 passed)
- Prettier check on all changed files

This preserves the existing 150 ms hold threshold and activation behavior.