### PR TITLE
fix(hotkeys): preserve hotkeys ending in + during list parsing

### DIFF
--- a/src/helpers/hotkeyList.js
+++ b/src/helpers/hotkeyList.js
@@ -25,8 +25,9 @@ function parseHotkeyList(value) {
   const result = [];
   for (let i = 0; i < raw.length; i++) {
     let hotkey = raw[i].trim();
-    // A non-final segment ending in "+" lost its comma key to the split.
-    if (hotkey.endsWith("+") && i < raw.length - 1) {
+    // A non-final segment ending in "+" lost its comma key to the split only if
+    // the next raw element was empty (the trailing comma key produced an empty string).
+    if (hotkey.endsWith("+") && i < raw.length - 1 && raw[i + 1].trim() === "") {
       hotkey += HOTKEY_LIST_SEPARATOR;
     }
     if (!hotkey || seen.has(hotkey)) continue;

--- a/src/utils/hotkeys.ts
+++ b/src/utils/hotkeys.ts
@@ -24,7 +24,7 @@ export function parseHotkeyList(value?: string | null): string[] {
   const result: string[] = [];
   for (let i = 0; i < raw.length; i++) {
     let hotkey = raw[i].trim();
-    if (hotkey.endsWith("+") && i < raw.length - 1) {
+    if (hotkey.endsWith("+") && i < raw.length - 1 && raw[i + 1].trim() === "") {
       hotkey += ",";
     }
     if (!hotkey || seen.has(hotkey)) continue;

--- a/test/helpers/hotkeyLabels.test.js
+++ b/test/helpers/hotkeyLabels.test.js
@@ -123,3 +123,11 @@ test("isValidHotkeyFormat rejects empty input and combos with empty parts", asyn
   assert.equal(isValidHotkeyFormat("Ctrl+"), false);
   assert.equal(isValidHotkeyFormat("+K"), false);
 });
+
+test("parseHotkeyList preserves hotkeys ending with '+' when followed by another hotkey", async () => {
+  const { parseHotkeyList } = await load();
+
+  assert.deepEqual(parseHotkeyList("Control++,F8"), ["Control++", "F8"]);
+  assert.deepEqual(parseHotkeyList("Control+,,F8"), ["Control+,", "F8"]);
+  assert.deepEqual(parseHotkeyList("Control++,Control+,"), ["Control++", "Control+,"]);
+});

--- a/test/helpers/hotkeyList.test.js
+++ b/test/helpers/hotkeyList.test.js
@@ -62,3 +62,10 @@ test("round-trips lists containing comma-key hotkeys", () => {
   assert.equal(serialized, "Control+,,F8,GLOBE");
   assert.deepEqual(parseHotkeyList(serialized), list);
 });
+
+test("preserves hotkeys ending with '+' when followed by another hotkey in a list or array", () => {
+  assert.deepEqual(parseHotkeyList("Control++,F8"), ["Control++", "F8"]);
+  assert.deepEqual(parseHotkeyList(["Control++", "F8"]), ["Control++", "F8"]);
+  assert.deepEqual(parseHotkeyList("Control++,,F8"), ["Control++,", "F8"]);
+  assert.deepEqual(parseHotkeyList("Command++,Control+,,"), ["Command++", "Control+,"]);
+});


### PR DESCRIPTION
## Summary
Fixes an issue where `parseHotkeyList` mutated hotkeys ending in `+` (such as `Control++`, `Command++`, `Alt++`, or `Shift++`) into a trailing-comma accelerator (`Control++,`) when present in a multi-hotkey string list or array.

## Problem
`parseHotkeyList("Control++,F8")` and `parseHotkeyList(["Control++", "F8"])` returned `["Control++,", "F8"]` instead of `["Control++", "F8"]`. The corrupted hotkey string (`Control++,`) is invalid and fails to register or trigger.

## Root Cause
`parseHotkeyList` checked `if (hotkey.endsWith("+") && i < raw.length - 1)` to detect if a segment lost its comma key during `.split(",")`. However, when splitting `"Control++,F8"`, `raw[0]` is `"Control++"` and `raw[1]` is `"F8"`. Because it did not verify whether `raw[i + 1]` was empty (the empty string produced when splitting on a real comma key like `"Control+,"`), it misidentified the list item separator `,` as part of the hotkey accelerator.

## Fix
Updated `parseHotkeyList` in both `src/helpers/hotkeyList.js` and `src/utils/hotkeys.ts` to check `raw[i + 1].trim() === ""` before appending `,`, ensuring `+` keys (e.g. `Control++`) remain intact when followed by another hotkey in a list or array.

## Behavior Before and After
- **Before**:
  - `parseHotkeyList("Control++,F8")` ➔ `["Control++,", "F8"]`
  - `parseHotkeyList(["Control++", "F8"])` ➔ `["Control++,", "F8"]`
- **After**:
  - `parseHotkeyList("Control++,F8")` ➔ `["Control++", "F8"]`
  - `parseHotkeyList(["Control++", "F8"])` ➔ `["Control++", "F8"]`
  - `parseHotkeyList("Control+,")` ➔ `["Control+,"]` (comma key hotkey unchanged)
  - `parseHotkeyList("Control+,,F8")` ➔ `["Control+,", "F8"]` (comma key in list unchanged)

## Scope and Non-Goals
- Scope: `src/helpers/hotkeyList.js` and `src/utils/hotkeys.ts` (`parseHotkeyList`).
- Non-Goals: No changes to single-hotkey accelerators or shortcut registration logic.

## Tests Added
- `test/helpers/hotkeyList.test.js`: Added unit tests verifying `parseHotkeyList` with `Control++` in comma-separated strings and arrays.
- `test/helpers/hotkeyLabels.test.js`: Added unit tests for the TypeScript twin in `src/utils/hotkeys.ts`.

## Validation Commands and Results
1. `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/hotkeyList.test.js test/helpers/hotkeyLabels.test.js`
   - Outcome: Passed (26/26 tests passed)
2. `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test`
   - Outcome: Passed (1103/1103 tests passed, 0 failed, 6 skipped)
3. `npm run typecheck`
   - Outcome: Passed cleanly
4. `npm run lint`
   - Outcome: Passed cleanly
5. `npm run i18n:check`
   - Outcome: Passed cleanly
6. `npm run build:renderer`
   - Outcome: Passed cleanly (built in 377ms)
7. `git diff --check`
   - Outcome: Passed with no whitespace errors

Fixes #1432
