### PR TITLE
fix(hotkeys): normalize left-side modifier tokens and fix side extraction in isLeftRightMix

### DIFF
--- a/src/utils/hotkeyValidator.ts
+++ b/src/utils/hotkeyValidator.ts
@@ -37,11 +37,49 @@ const RIGHT_SIDE_MODIFIERS = new Set([
   "rightsuper",
   "rightmeta",
   "rightwin",
+  "controlright",
+  "ctrlright",
+  "altright",
+  "optionright",
+  "shiftright",
+  "commandright",
+  "cmdright",
+  "superright",
+  "metaright",
+  "winright",
+]);
+
+const LEFT_SIDE_MODIFIERS = new Set([
+  "leftcontrol",
+  "leftctrl",
+  "leftalt",
+  "leftoption",
+  "leftshift",
+  "leftcommand",
+  "leftcmd",
+  "leftsuper",
+  "leftmeta",
+  "leftwin",
+  "controlleft",
+  "ctrlleft",
+  "altleft",
+  "optionleft",
+  "shiftleft",
+  "commandleft",
+  "cmdleft",
+  "superleft",
+  "metaleft",
+  "winleft",
 ]);
 
 function isRightSideModifier(part: string): boolean {
   const normalized = part.replace(/[-_ ]/g, "").toLowerCase();
   return RIGHT_SIDE_MODIFIERS.has(normalized);
+}
+
+function isLeftSideModifier(part: string): boolean {
+  const normalized = part.replace(/[-_ ]/g, "").toLowerCase();
+  return LEFT_SIDE_MODIFIERS.has(normalized);
 }
 
 const SPECIAL_KEYS = new Set(
@@ -353,6 +391,18 @@ function normalizeModifier(part: string, platform: Platform): string | null {
     }
   }
 
+  // Handle left-side modifiers (e.g., LeftControl, ControlLeft, LeftOption)
+  if (isLeftSideModifier(part)) {
+    if (lowered.includes("control") || lowered.includes("ctrl")) return "LeftControl";
+    if (lowered.includes("alt") || lowered.includes("option"))
+      return platform === "darwin" ? "LeftOption" : "LeftAlt";
+    if (lowered.includes("shift")) return "LeftShift";
+    if (lowered.includes("command") || lowered.includes("cmd")) return "LeftCommand";
+    if (lowered.includes("super") || lowered.includes("meta") || lowered.includes("win")) {
+      return platform === "darwin" ? "LeftCommand" : "LeftSuper";
+    }
+  }
+
   return null;
 }
 
@@ -398,26 +448,35 @@ function isLeftRightMix(parts: string[]): boolean {
   const sidesByModifier = new Map<string, Set<string>>();
 
   const patterns = [
-    /^(left|right)[-_ ]?(ctrl|control|alt|option|shift|command|cmd|super|meta)$/i,
-    /^(ctrl|control|alt|option|shift|command|cmd|super|meta)[-_ ]?(left|right)$/i,
+    {
+      regex: /^(left|right)[-_ ]?(ctrl|control|alt|option|shift|command|cmd|super|meta|win)$/i,
+      sideIndex: 1,
+      modIndex: 2,
+    },
+    {
+      regex: /^(ctrl|control|alt|option|shift|command|cmd|super|meta|win)[-_ ]?(left|right)$/i,
+      sideIndex: 2,
+      modIndex: 1,
+    },
   ];
 
   for (const rawPart of parts) {
     const part = rawPart.replace(/\s+/g, "");
-    for (const pattern of patterns) {
-      const match = part.match(pattern);
+    for (const { regex, sideIndex, modIndex } of patterns) {
+      const match = part.match(regex);
       if (match) {
-        const side = match[1].toLowerCase().includes("left") ? "left" : "right";
-        const modifier = match[2]?.toLowerCase() || match[1]?.toLowerCase();
-        if (!modifier) continue;
+        const side = match[sideIndex].toLowerCase().includes("left") ? "left" : "right";
+        const rawModifier = match[modIndex].toLowerCase();
         const normalizedModifier =
-          modifier === "ctrl"
+          rawModifier === "ctrl"
             ? "control"
-            : modifier === "cmd"
+            : rawModifier === "cmd"
               ? "command"
-              : modifier === "option"
+              : rawModifier === "option"
                 ? "alt"
-                : modifier;
+                : rawModifier === "win" || rawModifier === "meta"
+                  ? "super"
+                  : rawModifier;
         const set = sidesByModifier.get(normalizedModifier) ?? new Set<string>();
         set.add(side);
         sidesByModifier.set(normalizedModifier, set);

--- a/test/helpers/hotkeyValidation.test.js
+++ b/test/helpers/hotkeyValidation.test.js
@@ -173,3 +173,33 @@ test("normalizeHotkey canonicalizes key token spellings", async () => {
   assert.equal(normalizeHotkey("Ctrl+f9", "win32"), "Control+F9");
   assert.equal(normalizeHotkey("", "darwin"), "");
 });
+
+test("left-side modifier tokens normalize to canonical Left modifier forms and pass compound validation", async () => {
+  const { normalizeHotkey, validateHotkey } = await load();
+
+  assert.equal(normalizeHotkey("ControlLeft+K", "darwin"), "LeftControl+K");
+  assert.equal(normalizeHotkey("ShiftLeft+Space", "win32"), "LeftShift+Space");
+
+  assert.equal(validateHotkey("ControlLeft+K", "darwin").valid, true);
+  assert.equal(validateHotkey("ShiftLeft+Space", "win32").valid, true);
+
+  const singleLeft = validateHotkey("ControlLeft", "darwin");
+  assert.equal(singleLeft.valid, false);
+  assert.equal(singleLeft.errorCode, "LEFT_MODIFIER_ONLY");
+});
+
+test("mixing left and right versions of the same modifier is rejected across prefix and suffix formats", async () => {
+  const { validateHotkey } = await load();
+
+  const prefixMix = validateHotkey("LeftControl+RightControl", "darwin");
+  assert.equal(prefixMix.valid, false);
+  assert.equal(prefixMix.errorCode, "LEFT_RIGHT_MIX");
+
+  const suffixMix = validateHotkey("ControlLeft+ControlRight", "darwin");
+  assert.equal(suffixMix.valid, false);
+  assert.equal(suffixMix.errorCode, "LEFT_RIGHT_MIX");
+
+  const crossMix = validateHotkey("LeftControl+ControlRight", "win32");
+  assert.equal(crossMix.valid, false);
+  assert.equal(crossMix.errorCode, "LEFT_RIGHT_MIX");
+});


### PR DESCRIPTION
### Summary
Normalize left-side modifier tokens (e.g. `ControlLeft`, `LeftControl`, `ShiftLeft`, `LeftShift`) in `hotkeyValidator.ts` and correct side extraction indexing in `isLeftRightMix` so left-side modifier hotkeys pass validation and mixed left/right modifiers are properly detected regardless of token naming format.

### Problem
1. Hotkeys using left-side modifier tokens (`ControlLeft`, `LeftControl`, `ShiftLeft`, `LeftShift`, `AltLeft`, `LeftAlt`, `OptionLeft`, `LeftOption`, `CommandLeft`, `LeftCommand`, `SuperLeft`, `LeftSuper`) were not handled in `normalizeModifier()`. As a result, compound shortcuts using left-side modifiers (e.g. `ControlLeft+K`) were rejected as invalid with `NO_MODIFIER_OR_SPECIAL` ("Shortcuts must include a modifier...").
2. Single left-side modifier inputs (`ControlLeft`, `LeftControl`) returned `NO_MODIFIER_OR_SPECIAL` instead of returning the specific `LEFT_MODIFIER_ONLY` error code ("Single modifier hotkeys must use the right-side key...").
3. `isLeftRightMix()` used regex pattern `/^(ctrl|...)[-_ ]?(left|right)$/i` where group 1 was the modifier and group 2 was the side, but line 410 hardcoded checking `match[1].includes("left")`. Since `match[1]` was the modifier name (e.g. `"ctrl"`), `side` was set to `"right"` for all suffix-formatted tokens, breaking left/right mix detection for hotkeys like `ControlLeft+ControlRight`.

### Root Cause
- `normalizeModifier()` only checked `isRightSideModifier()`. Left-side modifier tokens were unhandled and returned `null`.
- `isLeftRightMix()` iterated regex patterns without pairing the match array indices with the specific regex capture layout.

### Fix
1. Added `LEFT_SIDE_MODIFIERS` set and `isLeftSideModifier()` helper.
2. Expanded `normalizeModifier()` to map left-side tokens to canonical `Left<Mod>` names (e.g., `LeftControl`, `LeftShift`, `LeftAlt`, `LeftCommand`, `LeftSuper`).
3. Refactored `isLeftRightMix()` to map regex patterns with explicit `sideIndex` and `modIndex` capture properties so side and modifier names are correctly extracted for both prefix (`LeftCtrl`) and suffix (`CtrlLeft`) formats.

### Behavior Before and After
- **Before:**
  - `validateHotkey("ControlLeft+K", "darwin")` -> `{ valid: false, errorCode: "NO_MODIFIER_OR_SPECIAL" }`
  - `validateHotkey("ControlLeft", "darwin")` -> `{ valid: false, errorCode: "NO_MODIFIER_OR_SPECIAL" }`
  - `validateHotkey("ControlLeft+ControlRight", "darwin")` -> `{ valid: false, errorCode: "NO_MODIFIER_OR_SPECIAL" }`
- **After:**
  - `validateHotkey("ControlLeft+K", "darwin")` -> `{ valid: true }`
  - `validateHotkey("ControlLeft", "darwin")` -> `{ valid: false, errorCode: "LEFT_MODIFIER_ONLY" }`
  - `validateHotkey("ControlLeft+ControlRight", "darwin")` -> `{ valid: false, errorCode: "LEFT_RIGHT_MIX" }`

### Scope and Non-Goals
- Scope: `src/utils/hotkeyValidator.ts` normalization and validation rules.
- Non-goals: Native OS event taps or key recording UI logic.

### Tests Added
Added unit tests in `test/helpers/hotkeyValidation.test.js` covering:
- Canonical normalization of left-side modifier tokens (`ControlLeft+K` -> `LeftControl+K`).
- Validation of compound shortcuts with left-side modifiers (`ControlLeft+K`, `ShiftLeft+Space`).
- Verification that single left-side modifiers return `LEFT_MODIFIER_ONLY`.
- Mixed left/right modifier rejection across prefix (`LeftControl+RightControl`), suffix (`ControlLeft+ControlRight`), and mixed formats (`LeftControl+ControlRight`).

### Validation Commands & Results
- `node --test test/helpers/hotkeyValidation.test.js`: Passed (20/20 tests passed).
- `npm test`: Passed (993/993 tests passed).
- `npm run typecheck`: Passed.
- `npm run lint`: Passed.
- `npm run format:check`: 3 pre-existing formatting warnings in unrelated `src/components/notes/` files; changed files formatted cleanly (`npx prettier --check` passed).
- `npm run i18n:check`: Passed.
- `npm run build:renderer`: Passed (vite build completed).
- `git diff --check`: Passed (no whitespace errors).

Fixes #1436
