### PR TITLE
fix(security): block IPv6 private and metadata enterprise endpoints

### DIFF
--- a/src/helpers/enterpriseProviderErrors.js
+++ b/src/helpers/enterpriseProviderErrors.js
@@ -167,6 +167,14 @@ function isPrivateIPv4(hostname) {
 function isPrivateIPv6(hostname) {
   if (hostname === "::1") return true;
   if (/^(fe80|fc[0-9a-f]{2}|fd[0-9a-f]{2}):/i.test(hostname)) return true;
+  // The URL parser rewrites an IPv4-mapped address to its hex form, so
+  // "::ffff:169.254.169.254" reaches us as "::ffff:a9fe:a9fe".
+  const mappedHex = hostname.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    return isPrivateIPv4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`);
+  }
   const mapped = hostname.match(/^::ffff:(.+)$/i);
   return mapped ? isPrivateIPv4(mapped[1]) : false;
 }
@@ -182,7 +190,9 @@ function validateEnterpriseEndpoint(endpoint) {
   if (url.protocol !== "https:") {
     throw new Error("Endpoint must use HTTPS.");
   }
-  const hostname = url.hostname.toLowerCase();
+  // URL.hostname keeps the brackets around an IPv6 literal ("[::1]"), which no
+  // isPrivateIPv6 branch can match — strip them or the whole IPv6 arm is dead.
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (
     BLOCKED_HOSTS.has(hostname) ||
     BLOCKED_SUFFIXES.some((suffix) => hostname.endsWith(suffix)) ||

--- a/test/helpers/enterpriseEndpointGuard.test.js
+++ b/test/helpers/enterpriseEndpointGuard.test.js
@@ -1,0 +1,71 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const originalLoad = Module._load;
+Module._load = function loadWithElectronStub(request, parent, isMain) {
+  if (request === "electron") {
+    return { app: { isReady: () => false, getPath: () => "", getAppPath: () => process.cwd() } };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const { validateEnterpriseEndpoint } = require("../../src/helpers/enterpriseProviderErrors");
+
+const rejects = (endpoint) => {
+  assert.throws(
+    () => validateEnterpriseEndpoint(endpoint),
+    /Private\/metadata endpoints are not allowed\./,
+    `expected ${endpoint} to be rejected`
+  );
+};
+
+const accepts = (endpoint) => {
+  assert.doesNotThrow(() => validateEnterpriseEndpoint(endpoint), `expected ${endpoint} to pass`);
+};
+
+test("IPv6 loopback and unique-local literals are rejected", () => {
+  rejects("https://[::1]/openai");
+  rejects("https://[fd00::1]/openai");
+  rejects("https://[fc00::1]/openai");
+  rejects("https://[fe80::1]/openai");
+});
+
+test("IPv4-mapped IPv6 literals are rejected after URL normalization", () => {
+  // WHATWG URL rewrites [::ffff:169.254.169.254] to [::ffff:a9fe:a9fe].
+  rejects("https://[::ffff:169.254.169.254]/openai");
+  rejects("https://[::ffff:127.0.0.1]/openai");
+  rejects("https://[::ffff:10.0.0.1]/openai");
+});
+
+test("public IPv6 endpoints are still accepted", () => {
+  accepts("https://[2606:4700:4700::1111]/openai");
+  accepts("https://[::ffff:8.8.8.8]/openai");
+});
+
+test("existing IPv4, metadata and suffix rules still hold", () => {
+  rejects("https://169.254.169.254/openai");
+  rejects("https://127.0.0.1/openai");
+  rejects("https://10.0.0.1/openai");
+  rejects("https://192.168.1.1/openai");
+  rejects("https://172.16.0.1/openai");
+  rejects("https://localhost/openai");
+  rejects("https://metadata.google.internal/openai");
+  rejects("https://foo.internal/openai");
+  // WHATWG URL expands the decimal form to 127.0.0.1.
+  rejects("https://2130706433/openai");
+});
+
+test("public https endpoints and empty input are accepted", () => {
+  accepts("https://myresource.openai.azure.com/");
+  accepts("https://8.8.8.8/openai");
+  accepts("");
+  accepts(undefined);
+});
+
+test("non-https endpoints are rejected", () => {
+  assert.throws(
+    () => validateEnterpriseEndpoint("http://myresource.openai.azure.com/"),
+    /Endpoint must use HTTPS\./
+  );
+});


### PR DESCRIPTION
## Summary

`validateEnterpriseEndpoint()` advertises an SSRF guard over private and metadata hosts, but its IPv6 half never runs. This makes the IPv6 checks actually fire, so `https://[::1]/`, `https://[fd00::1]/` and `https://[::ffff:169.254.169.254]/` are rejected the same way their IPv4 spellings already are.

Fixes #1439

## Problem

`src/helpers/enterpriseProviderErrors.js` guards the Azure endpoint on three IPC paths (`test-enterprise-connection`, `enterprise-stream-start`, and the enterprise generate handler). The IPv4 arm works; the IPv6 arm silently matches nothing:

```js
validateEnterpriseEndpoint("https://127.0.0.1/openai");              // throws  ✅
validateEnterpriseEndpoint("https://169.254.169.254/openai");        // throws  ✅

validateEnterpriseEndpoint("https://[::1]/openai");                  // returns ❌
validateEnterpriseEndpoint("https://[fd00::1]/openai");              // returns ❌
validateEnterpriseEndpoint("https://[fe80::1]/openai");              // returns ❌
validateEnterpriseEndpoint("https://[::ffff:169.254.169.254]/openai"); // returns ❌
```

## Root cause

Two consequences of what `URL.hostname` actually returns:

1. **Brackets are never stripped.** For an IPv6 literal the WHATWG URL parser keeps the brackets — `new URL("https://[::1]/").hostname === "[::1]"`. With a leading `[`, `isPrivateIPv6()` fails its `=== "::1"` comparison, fails `/^(fe80|fc..|fd..):/i`, and fails `/^::ffff:(.+)$/i`. It returns `false` for every input it can ever receive, so the whole IPv6 branch is dead code.

2. **IPv4-mapped addresses are normalized to hex.** The `::ffff:` branch expects a dotted quad, but the parser rewrites it: `new URL("https://[::ffff:169.254.169.254]/").hostname === "[::ffff:a9fe:a9fe]"`. So even with brackets removed, the metadata address the guard names in `BLOCKED_HOSTS` would still pass.

`src/utils/urlUtils.ts` already strips brackets (`h.replace(/^\[|\]$/g, "")`) in its own private-host check, which is what makes this look like an oversight rather than a deliberate difference.

## Fix

Two changes in `src/helpers/enterpriseProviderErrors.js`:

- `validateEnterpriseEndpoint()` strips the surrounding brackets from `url.hostname` before the host checks. Non-IPv6 hostnames never carry brackets, so nothing else changes.
- `isPrivateIPv6()` also recognizes the `::ffff:HHHH:HHHH` hex spelling of an IPv4-mapped address and decodes it back to a dotted quad for the existing `isPrivateIPv4()` check. The dotted-quad branch is kept for direct callers.

## Behavior before / after

| Endpoint | Before | After |
| --- | --- | --- |
| `https://[::1]/` | accepted | rejected |
| `https://[fd00::1]/`, `https://[fc00::1]/` | accepted | rejected |
| `https://[fe80::1]/` | accepted | rejected |
| `https://[::ffff:169.254.169.254]/` | accepted | rejected |
| `https://[::ffff:127.0.0.1]/`, `https://[::ffff:10.0.0.1]/` | accepted | rejected |
| `https://[2606:4700:4700::1111]/` | accepted | accepted |
| `https://[::ffff:8.8.8.8]/` | accepted | accepted |
| `https://myresource.openai.azure.com/` | accepted | accepted |
| IPv4 private / metadata / `.internal` / `localhost` | rejected | rejected |
| `http://…` (any host) | rejected | rejected |

## Scope and non-goals

Deliberately not included, to keep the diff to the reported defect:

- No new address ranges. The `fe80:` hextet check is left as-is rather than widened to `fe80::/10`.
- No changes to `BLOCKED_HOSTS` / `BLOCKED_SUFFIXES`.
- No DNS resolution, so the pre-existing "DNS rebinding is not mitigated" caveat in the doc comment still stands.
- No change to the error messages, the function signature, or any other exported behavior.

## Tests added

`test/helpers/enterpriseEndpointGuard.test.js` (new, 6 cases, plain `node --test`, no Electron binary or credentials needed — `electron` is stubbed through `Module._load` like the existing `clipboardRestore` test):

- IPv6 loopback / ULA / link-local literals are rejected — **fails on `main`**
- IPv4-mapped IPv6 literals are rejected after URL normalization — **fails on `main`**
- public IPv6 endpoints are still accepted (regression guard)
- existing IPv4, metadata, `.internal` suffix and decimal-IPv4 rules still hold (regression guard)
- public https endpoints and empty/undefined input are accepted (regression guard)
- non-https endpoints still fail with `Endpoint must use HTTPS.` (regression guard)

The first two cases fail against `main` and pass with this change; the other four pass both before and after.

## Validation

Node v24.9.0 / npm 11.6.0, macOS 15 (arm64). Dependencies from the existing install (`npm ci` was not re-run — the Electron post-install step is not reproducible in this sandbox; the suite is run with `ELECTRON_OVERRIDE_DIST_PATH`, the same way the existing Electron-dependent tests are).

| Command | Result |
| --- | --- |
| `node --test test/helpers/enterpriseEndpointGuard.test.js` (on `main`) | 4 pass, **2 fail** — the reproduction |
| `node --test test/helpers/enterpriseEndpointGuard.test.js` (with fix) | 6 pass, 0 fail |
| `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` | 1113 tests, **1107 pass, 0 fail, 6 skipped** (baseline on `main`: 1107 tests, 1101 pass, 0 fail, 6 skipped — same 6 Linux-launcher tests skip on macOS) |
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run i18n:check` | pass |
| `npm run build:renderer` | pass (`✓ built in 541ms`) |
| `git diff --check` | clean |
| `node --check` on both changed JS files | pass |
| `npx prettier --check` on both changed files | `All matched files use Prettier code style!` |

`npm run format:check` reports 3 files — `components/notes/overview/OverviewNoteList.tsx`, `components/notes/ShareNoteDialog.tsx`, `hooks/useNoteDragAndDrop.ts`. These are **pre-existing on `main`**: verified by running the same command in a clean worktree checked out at `bf8b7e0b`, which reports the identical 3 files. None are touched by this PR and they are deliberately left alone.

## Platform notes

The change is pure URL-parsing logic with no platform-specific behavior, and the tests need neither an Electron binary nor network access or credentials.
