### PR TITLE
fix(dictionary): normalize untrimmed agent names in agentNameDictionaryChanges

### DIFF
--- a/src/helpers/agentNameDictionary.js
+++ b/src/helpers/agentNameDictionary.js
@@ -13,10 +13,12 @@
  */
 export function agentNameDictionaryChanges(dictionary, newName, oldName) {
   const words = Array.isArray(dictionary) ? dictionary : [];
-  const trimmed = newName.trim();
+  const trimmedNew = typeof newName === "string" ? newName.trim() : "";
+  const trimmedOld = typeof oldName === "string" ? oldName.trim() : "";
 
   return {
-    add: trimmed && !words.includes(trimmed) ? [trimmed] : [],
-    remove: oldName && oldName !== newName && words.includes(oldName) ? [oldName] : [],
+    add: trimmedNew && !words.includes(trimmedNew) ? [trimmedNew] : [],
+    remove:
+      trimmedOld && trimmedOld !== trimmedNew && words.includes(trimmedOld) ? [trimmedOld] : [],
   };
 }

--- a/test/helpers/agentNameDictionary.test.js
+++ b/test/helpers/agentNameDictionary.test.js
@@ -54,3 +54,22 @@ test("never names a word outside the agent name itself", async () => {
   const { add, remove } = agentNameDictionaryChanges(dictionary, "Jarvis", "OpenWhispr");
   assert.deepEqual([...add, ...remove].sort(), ["Jarvis", "OpenWhispr"]);
 });
+
+test("does not remove agent name when only surrounding whitespace changes", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(agentNameDictionaryChanges(["OpenWhispr"], "  OpenWhispr  ", "OpenWhispr"), {
+    add: [],
+    remove: [],
+  });
+});
+
+test("removes previous agent name when oldName contains surrounding whitespace", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(
+    agentNameDictionaryChanges(["OpenWhispr", "Alice"], "Jarvis", "  OpenWhispr  "),
+    {
+      add: ["Jarvis"],
+      remove: ["OpenWhispr"],
+    }
+  );
+});


### PR DESCRIPTION
## Summary

This PR normalizes `newName` and `oldName` by trimming surrounding whitespace before computing dictionary additions and removals in `agentNameDictionaryChanges`.

Fixes #1441

## Problem & Root Cause

`agentNameDictionaryChanges(dictionary, newName, oldName)` trimmed `newName` when building `add`, but evaluated `oldName !== newName` and `words.includes(oldName)` without trimming `oldName` or comparing trimmed values.

This led to two correctness bugs:

1. **Accidental Agent Name Removal:** Updating or saving an agent name with surrounding whitespace (e.g., `oldName = "MyAgent"`, `newName = " MyAgent "`) caused `oldName !== newName` to be `true` and `words.includes("MyAgent")` to be `true`. `add` evaluated to `[]` while `remove` returned `["MyAgent"]`, completely deleting the agent's name from the custom dictionary.
2. **Orphaned Dictionary Entries:** Renaming an agent whose `oldName` had surrounding whitespace (e.g. `oldName = " MyAgent "`, `newName = "Jarvis"`) caused `words.includes(" MyAgent ")` to fail because dictionary entries are stored trimmed (`"MyAgent"`). `remove` returned `[]`, leaving `"MyAgent"` orphaned in SQLite on rename.

## Fix

- Normalize `newName` and `oldName` using `trim()` before equality comparisons and dictionary membership checks in `agentNameDictionaryChanges`.
- Added unit tests covering untrimmed `oldName` and whitespace-only name updates.

## Behavior Before & After

- **Before:**
  - `agentNameDictionaryChanges(["MyAgent"], " MyAgent ", "MyAgent")` returned `{ add: [], remove: ["MyAgent"] }`.
  - `agentNameDictionaryChanges(["MyAgent", "Alice"], "Jarvis", " MyAgent ")` returned `{ add: ["Jarvis"], remove: [] }`.
- **After:**
  - `agentNameDictionaryChanges(["MyAgent"], " MyAgent ", "MyAgent")` returns `{ add: [], remove: [] }`.
  - `agentNameDictionaryChanges(["MyAgent", "Alice"], "Jarvis", " MyAgent ")` returns `{ add: ["Jarvis"], remove: ["MyAgent"] }`.

## Validation

All repository checks executed successfully:

- `node --test test/helpers/agentNameDictionary.test.js` (9/9 passed)
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` (993/993 passed)
- `npm run typecheck` (clean)
- `npm run lint` (clean)
- `npm run format:check` (passed for edited files)
- `npm run i18n:check` (clean)
- `npm run build:renderer` (clean)
- `git diff --check` (clean)
