### PR TITLE
feat(macos): menu-bar-only mode that hides the Dock icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
 - **devServerManager.js**: Vite dev server integration
 - **dockManager.js**: Single owner of the macOS Dock icon
   - The icon follows the control panel: it appears when the panel opens and goes away when the panel closes to the tray, so no other caller (in particular the dictation panel's hide path) can resurrect it
+  - Menu-bar-only mode (#1380): the `HIDE_DOCK_ICON` env setting (Settings → General → Startup, macOS only) overrides everything — the icon never appears, even while the control panel is open. Also reachable by right-clicking the Dock icon itself (`app.dock.setMenu` in `main.js`), which syncs the renderer toggle via the `hide-dock-icon-changed` event
   - Every path that surfaces or hides the control panel (tray, app menu, deep links, `activate`, `ready-to-show`, `hideControlPanelToTray`) reports that state explicitly
   - Never derive that state from the window's `show`/`hide` events: on macOS those are occlusion events, so they also fire when the panel is merely covered by another window, minimized, or on another Space, and the icon flickers as the user switches windows
   - Decision logic lives in `dockPolicy.js` (pure, unit-tested in `test/helpers/dockPolicy.test.js`)

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const {
   BrowserWindow,
   dialog,
   ipcMain,
+  Menu,
   net,
   session,
   systemPreferences,
@@ -908,12 +909,53 @@ async function startApp() {
     environmentManager.saveStartMinimized(enabled);
   });
 
+  const applyHideDockIcon = (enabled) => {
+    if (debugLogger) debugLogger.info("Hide dock icon changed", { enabled });
+    environmentManager.saveHideDockIcon(enabled);
+    dockManager.setHideDockIcon(enabled);
+    // dock.hide() turns the app into an accessory process, which can drop the
+    // control panel behind other windows — and the user is likely in it,
+    // having just flipped the toggle. Bring it back.
+    if (enabled && isLiveWindow(windowManager?.controlPanelWindow)) {
+      windowManager.controlPanelWindow.show();
+      windowManager.controlPanelWindow.focus();
+    }
+  };
+
+  ipcMain.on("hide-dock-icon-changed", (_event, enabled) => {
+    applyHideDockIcon(enabled);
+  });
+
   ipcMain.on("panel-start-position-changed", (_event, position) => {
     windowManager.setPanelStartPosition(position);
     environmentManager.savePanelStartPosition(position);
   });
 
-  dockManager.init();
+  dockManager.init({ hideDockIcon: environmentManager.getHideDockIcon() });
+
+  // Right-clicking the Dock icon offers menu-bar-only mode directly (#1380),
+  // the way Tailscale and similar background apps do. The icon is only
+  // visible while the control panel is open, so a live renderer exists to
+  // receive the sync event and keep the Settings toggle honest.
+  if (process.platform === "darwin" && app.dock) {
+    const refreshDockMenu = () => {
+      app.dock.setMenu(
+        Menu.buildFromTemplate([
+          {
+            label: i18nMain.t("dockMenu.hideDockIcon"),
+            click: () => {
+              applyHideDockIcon(true);
+              if (isLiveWindow(windowManager?.controlPanelWindow)) {
+                windowManager.controlPanelWindow.webContents.send("hide-dock-icon-changed", true);
+              }
+            },
+          },
+        ])
+      );
+    };
+    refreshDockMenu();
+    i18nMain.on("languageChanged", refreshDockMenu);
+  }
 
   // In development, wait for Vite dev server to be ready
   if (process.env.NODE_ENV === "development") {

--- a/preload.js
+++ b/preload.js
@@ -819,6 +819,13 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Start minimized
   notifyStartMinimizedChanged: (enabled) => ipcRenderer.send("start-minimized-changed", enabled),
 
+  // Menu-bar-only mode (macOS)
+  notifyHideDockIconChanged: (enabled) => ipcRenderer.send("hide-dock-icon-changed", enabled),
+  onHideDockIconChanged: registerListener(
+    "hide-dock-icon-changed",
+    (callback) => (_event, enabled) => callback(enabled)
+  ),
+
   // Auto-start management
   getAutoStartEnabled: () => ipcRenderer.invoke("get-auto-start-enabled"),
   setAutoStartEnabled: (enabled) => ipcRenderer.invoke("set-auto-start-enabled", enabled),

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -211,6 +211,15 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   // never incrementally indexed before the upsert-from-cloud handler gained a
   // vector upsert. Delayed so the Qdrant sidecar has time to come up; if it
   // isn't ready yet the flag stays unset and the next launch retries.
+  // Keep the Settings toggle honest when menu-bar-only mode is enabled from
+  // the Dock icon's context menu (main-process origin, #1380).
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onHideDockIconChanged?.((enabled: boolean) => {
+      useSettingsStore.getState().setHideDockIcon(enabled);
+    });
+    return () => unsubscribe?.();
+  }, []);
+
   useEffect(() => {
     if (Number(localStorage.getItem("semanticReindexVersion")) >= SEMANTIC_REINDEX_VERSION) return;
     const timer = setTimeout(() => {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -797,6 +797,8 @@ export default function SettingsPage({
     setFloatingIconAutoHide,
     startMinimized,
     setStartMinimized,
+    hideDockIcon,
+    setHideDockIcon,
     panelStartPosition,
     setPanelStartPosition,
     cloudBackupEnabled,
@@ -2742,6 +2744,16 @@ export default function SettingsPage({
                     <Toggle checked={startMinimized} onChange={setStartMinimized} />
                   </SettingsRow>
                 </SettingsPanelRow>
+                {platform === "darwin" && (
+                  <SettingsPanelRow>
+                    <SettingsRow
+                      label={t("settingsPage.general.startup.hideDockIcon")}
+                      description={t("settingsPage.general.startup.hideDockIconDescription")}
+                    >
+                      <Toggle checked={hideDockIcon} onChange={setHideDockIcon} />
+                    </SettingsRow>
+                  </SettingsPanelRow>
+                )}
               </SettingsPanel>
             </div>
 

--- a/src/helpers/dockManager.js
+++ b/src/helpers/dockManager.js
@@ -13,12 +13,15 @@ const { resolveDockVisibility } = require("./dockPolicy");
 class DockManager {
   constructor() {
     this._controlPanelVisible = false;
+    this._hideDockIcon = false;
   }
 
   // Called once at startup, before any window exists: hides the Dock icon
   // until the control panel opens, so tray-only launches never show one.
-  init() {
+  // hideDockIcon carries the persisted menu-bar-only setting (#1380).
+  init({ hideDockIcon = false } = {}) {
     this._controlPanelVisible = false;
+    this._hideDockIcon = !!hideDockIcon;
     this._applyVisibility();
   }
 
@@ -28,10 +31,18 @@ class DockManager {
     this._applyVisibility();
   }
 
+  // Menu-bar-only mode. Applied immediately, so flipping the setting while
+  // the control panel is open hides or restores the icon on the spot.
+  setHideDockIcon(enabled) {
+    this._hideDockIcon = !!enabled;
+    this._applyVisibility();
+  }
+
   _applyVisibility() {
     const visible = resolveDockVisibility({
       platform: process.platform,
       controlPanelVisible: this._controlPanelVisible,
+      hideDockIcon: this._hideDockIcon,
     });
     if (visible === null || !app.dock) return;
 

--- a/src/helpers/dockPolicy.js
+++ b/src/helpers/dockPolicy.js
@@ -7,10 +7,14 @@
 // Hiding the dictation panel must never touch the Dock. The panel is hidden
 // outright rather than minimized into the Dock, so there is nothing to restore
 // from there.
+//
+// Menu-bar-only mode (#1380) overrides all of it: with hideDockIcon set the
+// icon never appears, control panel or not, and the tray is the only way in.
 
 // Whether the Dock icon should be visible right now.
 // Returns null off macOS, where there is no Dock to act on.
-export function resolveDockVisibility({ platform, controlPanelVisible }) {
+export function resolveDockVisibility({ platform, controlPanelVisible, hideDockIcon }) {
   if (platform !== "darwin") return null;
+  if (hideDockIcon) return false;
   return !!controlPanelVisible;
 }

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -42,6 +42,7 @@ const PERSISTED_KEYS = [
   "MEETING_KEY",
   "ACTIVATION_MODE",
   "FLOATING_ICON_AUTO_HIDE",
+  "HIDE_DOCK_ICON",
   "PANEL_START_POSITION",
   "START_MINIMIZED",
   "UI_LANGUAGE",
@@ -461,6 +462,16 @@ class EnvironmentManager {
 
   saveFloatingIconAutoHide(enabled) {
     const result = this._saveKey("FLOATING_ICON_AUTO_HIDE", String(enabled));
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getHideDockIcon() {
+    return this._getKey("HIDE_DOCK_ICON") === "true";
+  }
+
+  saveHideDockIcon(enabled) {
+    const result = this._saveKey("HIDE_DOCK_ICON", String(enabled));
     this.saveAllKeysToEnvFile().catch(() => {});
     return result;
   }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -334,6 +334,8 @@ function useSettingsInternal() {
     setFloatingIconAutoHide: store.setFloatingIconAutoHide,
     startMinimized: store.startMinimized,
     setStartMinimized: store.setStartMinimized,
+    hideDockIcon: store.hideDockIcon,
+    setHideDockIcon: store.setHideDockIcon,
     panelStartPosition: store.panelStartPosition,
     setPanelStartPosition: store.setPanelStartPosition,
     preferBuiltInMic: store.preferBuiltInMic,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -37,6 +37,9 @@
     "quit": "OpenWhispr beenden",
     "tooltip": "OpenWhispr – Sprachdiktat"
   },
+  "dockMenu": {
+    "hideDockIcon": "Dock-Symbol ausblenden (nur Menüleiste)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "OpenWhispr beenden",
@@ -1796,7 +1799,9 @@
         "title": "Autostart",
         "description": "Steuern Sie das Verhalten von OpenWhispr beim Start",
         "startMinimized": "Minimiert starten",
-        "startMinimizedDescription": "Starten, ohne das Einstellungsfenster anzuzeigen"
+        "startMinimizedDescription": "Starten, ohne das Einstellungsfenster anzuzeigen",
+        "hideDockIcon": "Dock-Symbol ausblenden (nur Menüleiste)",
+        "hideDockIconDescription": "OpenWhispr als Menüleisten-App ohne Dock-Symbol ausführen. Die App verschwindet auch aus dem Cmd+Tab-Umschalter — öffne sie über das Menüleisten-Symbol."
       },
       "waylandPaste": {
         "title": "Wayland-Einfügen einrichten",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -37,6 +37,9 @@
     "quit": "Quit OpenWhispr",
     "tooltip": "OpenWhispr - Voice Dictation"
   },
+  "dockMenu": {
+    "hideDockIcon": "Hide Dock icon (menu bar only)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Quit OpenWhispr",
@@ -1796,7 +1799,9 @@
         "title": "Startup",
         "description": "Control how OpenWhispr behaves when it launches",
         "startMinimized": "Start minimized",
-        "startMinimizedDescription": "Launch without showing the control panel window"
+        "startMinimizedDescription": "Launch without showing the control panel window",
+        "hideDockIcon": "Hide Dock icon (menu bar only)",
+        "hideDockIconDescription": "Run OpenWhispr as a menu bar app with no Dock icon. It also leaves the Cmd+Tab switcher — use the menu bar icon to open it."
       },
       "waylandPaste": {
         "title": "Wayland Paste Setup",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -37,6 +37,9 @@
     "quit": "Salir de OpenWhispr",
     "tooltip": "OpenWhispr - Dictado por voz"
   },
+  "dockMenu": {
+    "hideDockIcon": "Ocultar icono del Dock (solo barra de menús)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Salir de OpenWhispr",
@@ -1566,7 +1569,9 @@
         "title": "Inicio",
         "description": "Controla el comportamiento de OpenWhispr al iniciar",
         "startMinimized": "Iniciar minimizado",
-        "startMinimizedDescription": "Iniciar sin mostrar la ventana del panel de control"
+        "startMinimizedDescription": "Iniciar sin mostrar la ventana del panel de control",
+        "hideDockIcon": "Ocultar icono del Dock (solo barra de menús)",
+        "hideDockIconDescription": "Ejecutar OpenWhispr como app de la barra de menús, sin icono en el Dock. También desaparece del selector Cmd+Tab; usa el icono de la barra de menús para abrirla."
       },
       "waylandPaste": {
         "title": "Configuración de pegado en Wayland",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -37,6 +37,9 @@
     "quit": "Quitter OpenWhispr",
     "tooltip": "OpenWhispr - Dictée vocale"
   },
+  "dockMenu": {
+    "hideDockIcon": "Masquer l'icône du Dock (barre de menus uniquement)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Quitter OpenWhispr",
@@ -1796,7 +1799,9 @@
         "title": "Démarrage",
         "description": "Contrôlez le comportement d'OpenWhispr au lancement",
         "startMinimized": "Démarrer réduit",
-        "startMinimizedDescription": "Lancer sans afficher la fenêtre du panneau de contrôle"
+        "startMinimizedDescription": "Lancer sans afficher la fenêtre du panneau de contrôle",
+        "hideDockIcon": "Masquer l'icône du Dock (barre de menus uniquement)",
+        "hideDockIconDescription": "Exécuter OpenWhispr comme app de la barre de menus, sans icône dans le Dock. Elle disparaît aussi du sélecteur Cmd+Tab ; utilisez l'icône de la barre de menus pour l'ouvrir."
       },
       "waylandPaste": {
         "title": "Configuration du collage Wayland",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -37,6 +37,9 @@
     "quit": "Esci da OpenWhispr",
     "tooltip": "OpenWhispr - Dettatura vocale"
   },
+  "dockMenu": {
+    "hideDockIcon": "Nascondi icona nel Dock (solo barra dei menu)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Esci da OpenWhispr",
@@ -1518,7 +1521,9 @@
         "title": "Avvio",
         "description": "Controlla il comportamento di OpenWhispr all'avvio",
         "startMinimized": "Avvia ridotto a icona",
-        "startMinimizedDescription": "Avvia senza mostrare la finestra del pannello di controllo"
+        "startMinimizedDescription": "Avvia senza mostrare la finestra del pannello di controllo",
+        "hideDockIcon": "Nascondi icona nel Dock (solo barra dei menu)",
+        "hideDockIconDescription": "Esegui OpenWhispr come app della barra dei menu, senza icona nel Dock. Scompare anche dal selettore Cmd+Tab: usa l'icona nella barra dei menu per aprirla."
       },
       "waylandPaste": {
         "title": "Configurazione incolla su Wayland",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -37,6 +37,9 @@
     "quit": "OpenWhispr を終了",
     "tooltip": "OpenWhispr - 音声ディクテーション"
   },
+  "dockMenu": {
+    "hideDockIcon": "Dock アイコンを隠す（メニューバーのみ）"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "OpenWhispr を終了",
@@ -1518,7 +1521,9 @@
         "title": "起動設定",
         "description": "OpenWhispr の起動時の動作を制御",
         "startMinimized": "最小化で起動",
-        "startMinimizedDescription": "コントロールパネルウィンドウを表示せずに起動"
+        "startMinimizedDescription": "コントロールパネルウィンドウを表示せずに起動",
+        "hideDockIcon": "Dock アイコンを隠す（メニューバーのみ）",
+        "hideDockIconDescription": "OpenWhispr を Dock アイコンなしのメニューバーアプリとして実行します。Cmd+Tab の切り替えにも表示されなくなるため、メニューバーのアイコンから開いてください。"
       },
       "waylandPaste": {
         "title": "Wayland 貼り付け設定",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -37,6 +37,9 @@
     "quit": "Sair do OpenWhispr",
     "tooltip": "OpenWhispr - Ditado por voz"
   },
+  "dockMenu": {
+    "hideDockIcon": "Ocultar ícone do Dock (apenas barra de menus)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Sair do OpenWhispr",
@@ -1497,7 +1500,9 @@
         "title": "Inicialização",
         "description": "Controle o comportamento do OpenWhispr ao iniciar",
         "startMinimized": "Iniciar minimizado",
-        "startMinimizedDescription": "Iniciar sem mostrar a janela do painel de controle"
+        "startMinimizedDescription": "Iniciar sem mostrar a janela do painel de controle",
+        "hideDockIcon": "Ocultar ícone do Dock (apenas barra de menus)",
+        "hideDockIconDescription": "Executar o OpenWhispr como app da barra de menus, sem ícone no Dock. Ele também sai do alternador Cmd+Tab — use o ícone da barra de menus para abri-lo."
       },
       "waylandPaste": {
         "title": "Configuração de colagem no Wayland",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -37,6 +37,9 @@
     "quit": "Закрыть OpenWhispr",
     "tooltip": "OpenWhispr — голосовая диктовка"
   },
+  "dockMenu": {
+    "hideDockIcon": "Скрыть значок в Dock (только строка меню)"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "Закрыть OpenWhispr",
@@ -1524,7 +1527,9 @@
         "title": "Автозапуск",
         "description": "Управляйте поведением OpenWhispr при запуске",
         "startMinimized": "Запуск в свёрнутом виде",
-        "startMinimizedDescription": "Запускать без отображения окна панели управления"
+        "startMinimizedDescription": "Запускать без отображения окна панели управления",
+        "hideDockIcon": "Скрыть значок в Dock (только строка меню)",
+        "hideDockIconDescription": "Запускать OpenWhispr как приложение строки меню без значка в Dock. Оно также исчезает из переключателя Cmd+Tab — открывайте его через значок в строке меню."
       },
       "waylandPaste": {
         "title": "Настройка вставки в Wayland",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -37,6 +37,9 @@
     "quit": "退出 OpenWhispr",
     "tooltip": "OpenWhispr - 语音听写"
   },
+  "dockMenu": {
+    "hideDockIcon": "隐藏 Dock 图标（仅菜单栏）"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "退出 OpenWhispr",
@@ -1518,7 +1521,9 @@
         "title": "启动",
         "description": "控制 OpenWhispr 启动时的行为",
         "startMinimized": "启动时最小化",
-        "startMinimizedDescription": "启动时不显示控制面板窗口"
+        "startMinimizedDescription": "启动时不显示控制面板窗口",
+        "hideDockIcon": "隐藏 Dock 图标（仅菜单栏）",
+        "hideDockIconDescription": "将 OpenWhispr 作为菜单栏应用运行，不显示 Dock 图标。应用也会从 Cmd+Tab 切换器中消失——请通过菜单栏图标打开。"
       },
       "waylandPaste": {
         "title": "Wayland 粘贴设置",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -37,6 +37,9 @@
     "quit": "結束 OpenWhispr",
     "tooltip": "OpenWhispr - 語音輸入"
   },
+  "dockMenu": {
+    "hideDockIcon": "隱藏 Dock 圖示（僅選單列）"
+  },
   "menu": {
     "appLabel": "OpenWhispr",
     "quit": "結束 OpenWhispr",
@@ -1518,7 +1521,9 @@
         "title": "啟動",
         "description": "控制 OpenWhispr 啟動時的行為",
         "startMinimized": "啟動時最小化",
-        "startMinimizedDescription": "啟動時不顯示控制面板視窗"
+        "startMinimizedDescription": "啟動時不顯示控制面板視窗",
+        "hideDockIcon": "隱藏 Dock 圖示（僅選單列）",
+        "hideDockIconDescription": "將 OpenWhispr 作為選單列應用程式執行，不顯示 Dock 圖示。應用程式也會從 Cmd+Tab 切換器中消失——請透過選單列圖示開啟。"
       },
       "waylandPaste": {
         "title": "Wayland 貼上設定",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -135,6 +135,7 @@ const BOOLEAN_SETTINGS = new Set([
   "pauseMediaOnDictation",
   "floatingIconAutoHide",
   "startMinimized",
+  "hideDockIcon",
   "meetingProcessDetection",
   "speakerDiarizationEnabled",
   "dictationSileroEnabled",
@@ -425,6 +426,7 @@ export interface SettingsState
   pauseMediaOnDictation: boolean;
   floatingIconAutoHide: boolean;
   startMinimized: boolean;
+  hideDockIcon: boolean;
   gcalAccounts: GoogleCalendarAccount[];
   gcalConnected: boolean;
   gcalEmail: string;
@@ -681,6 +683,7 @@ export interface SettingsState
   setPauseMediaOnDictation: (value: boolean) => void;
   setFloatingIconAutoHide: (enabled: boolean) => void;
   setStartMinimized: (enabled: boolean) => void;
+  setHideDockIcon: (enabled: boolean) => void;
   setGcalAccounts: (accounts: GoogleCalendarAccount[]) => void;
   setNotificationsEnabled: (value: boolean) => void;
   setNotifyMeetingDetection: (value: boolean) => void;
@@ -1034,6 +1037,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   pauseMediaOnDictation: readBoolean("pauseMediaOnDictation", false),
   floatingIconAutoHide: readBoolean("floatingIconAutoHide", false),
   startMinimized: readBoolean("startMinimized", false),
+  hideDockIcon: readBoolean("hideDockIcon", false),
   notificationsEnabled: readBoolean("notificationsEnabled", true),
   notifyMeetingDetection: readBoolean("notifyMeetingDetection", true),
   notifyCalendarReminders: readBoolean("notifyCalendarReminders", true),
@@ -1663,6 +1667,15 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     set({ startMinimized: enabled });
     if (isBrowser) {
       window.electronAPI?.notifyStartMinimizedChanged?.(enabled);
+    }
+  },
+
+  setHideDockIcon: (enabled: boolean) => {
+    if (get().hideDockIcon === enabled) return;
+    if (isBrowser) localStorage.setItem("hideDockIcon", String(enabled));
+    set({ hideDockIcon: enabled });
+    if (isBrowser) {
+      window.electronAPI?.notifyHideDockIconChanged?.(enabled);
     }
   },
 

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1514,6 +1514,8 @@ declare global {
       notifyFloatingIconAutoHideChanged?: (enabled: boolean) => void;
       onFloatingIconAutoHideChanged?: (callback: (enabled: boolean) => void) => () => void;
       notifyStartMinimizedChanged?: (enabled: boolean) => void;
+      notifyHideDockIconChanged?: (enabled: boolean) => void;
+      onHideDockIconChanged?: (callback: (enabled: boolean) => void) => () => void;
       notifyPanelStartPositionChanged?: (position: string) => void;
 
       // Auto-start at login

--- a/test/helpers/dockPolicy.test.js
+++ b/test/helpers/dockPolicy.test.js
@@ -27,3 +27,40 @@ test("there is no Dock to act on outside macOS", async () => {
     assert.equal(resolveDockVisibility({ platform, controlPanelVisible: true }), null);
   }
 });
+
+test("menu-bar-only mode keeps the icon hidden even with the control panel open", async () => {
+  const { resolveDockVisibility } = await load();
+
+  // #1380: with hideDockIcon set, nothing may surface the icon — not even the
+  // control panel, which normally owns it.
+  assert.equal(
+    resolveDockVisibility({ platform: "darwin", controlPanelVisible: true, hideDockIcon: true }),
+    false
+  );
+  assert.equal(
+    resolveDockVisibility({ platform: "darwin", controlPanelVisible: false, hideDockIcon: true }),
+    false
+  );
+});
+
+test("menu-bar-only mode off preserves follow-the-panel behavior", async () => {
+  const { resolveDockVisibility } = await load();
+
+  assert.equal(
+    resolveDockVisibility({ platform: "darwin", controlPanelVisible: true, hideDockIcon: false }),
+    true
+  );
+  // Callers that predate the setting pass no hideDockIcon at all.
+  assert.equal(resolveDockVisibility({ platform: "darwin", controlPanelVisible: true }), true);
+});
+
+test("menu-bar-only mode changes nothing off macOS", async () => {
+  const { resolveDockVisibility } = await load();
+
+  for (const platform of ["win32", "linux"]) {
+    assert.equal(
+      resolveDockVisibility({ platform, controlPanelVisible: true, hideDockIcon: true }),
+      null
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Adds an off-by-default **"Hide Dock icon (menu bar only)"** setting (Settings → General → Startup, shown on macOS only). When enabled, OpenWhispr runs as a pure menu bar app: the Dock icon never appears, even while the control panel is open.

Closes #1380.

## Approach

Runtime `app.dock.hide()` through the existing centralized Dock policy — **not** build-time `LSUIElement`. Flipping `LSUIElement` in `Info.plist` would force menu-bar-only mode on every user unconditionally, and as the issue notes, patching the plist post-install trips Gatekeeper ("app is damaged").

The codebase already routes every Dock decision through `dockPolicy.js` / `dockManager.js` ("the icon follows the control panel"). This PR adds one override to that pure policy function:

- `hideDockIcon` unset/false → existing behavior, icon follows the control panel
- `hideDockIcon` true → icon never shows, tray is the only way in

## Wiring

- Persisted as `HIDE_DOCK_ICON` in the userData `.env` (same pattern as `START_MINIMIZED`), so the main process knows it **at startup, before any window exists** — a menu-bar-only launch never flashes a Dock icon.
- Live apply: toggling the setting hides/restores the icon immediately, no restart.
- `dock.hide()` demotes the app to an accessory process, which can drop the control panel behind other windows — and the user is *in* the panel at that moment, having just flipped the toggle. The IPC handler re-`show()`s and re-`focus()`es the panel after hiding.
- The setting row is rendered only on macOS; Windows/Linux users never see it, and the policy returns `null` (no Dock to act on) off-macOS regardless of the flag.

## Dock context menu

Right-clicking the Dock icon offers **"Hide Dock icon (menu bar only)"** directly, the way Tailscale and similar background apps do — the moment the icon bothers you, the fix is on the icon. The menu is built via `app.dock.setMenu` with `i18nMain` labels and rebuilds on UI language change.

Enabling it from the Dock menu keeps the Settings toggle honest: main pushes a `hide-dock-icon-changed` event to the control panel renderer, which updates the settings store. The Dock icon is only visible while the control panel is open, so a live renderer always exists to receive that event.

## Trade-off, stated in the UI

With the Dock icon hidden, macOS also removes the app from the Cmd+Tab switcher. The setting description says this explicitly and points at the menu bar icon, so nobody "loses" the app.

## Tests

- `test/helpers/dockPolicy.test.js` extended (6 cases total): menu-bar-only wins over an open control panel, absent/false flag preserves follow-the-panel behavior exactly, and the flag changes nothing off macOS.
- **Live-verified against the real macOS Dock**, driving the actual `dockManager` and asserting `app.dock.isVisible()` after each transition (with waits for Electron's documented 1s hide-after-show throttle):

| Transition | Expected | Observed |
| --- | --- | --- |
| Startup with setting on | hidden | hidden |
| Control panel opens, setting on | hidden | hidden |
| Setting turned off, panel open | visible | visible |
| Setting turned back on, panel open | hidden | hidden |
| Setting off, panel closed | hidden | hidden |

- Dock menu smoke-tested live in Electron: the `dockMenu.hideDockIcon` label resolves (not the raw key) in en/de/ja, `app.dock.setMenu` accepts the template, and the `languageChanged` event that triggers the rebuild fires.
- Dock context menu **manually confirmed in the real macOS Dock**: right-click → click the item → icon visible `true` → `false`. The item renders above macOS's own separator and `Options` submenu, which is the only position available — `app.dock` exposes just `setMenu`/`getMenu`, with no API to add entries inside the system-owned `Options` submenu.

`npm run lint`, `npm run format:check` (my files), `npm run typecheck`, and `npm test` (994 pass, 0 fail) are green on Node 24. Setting label/description and the Dock menu item translated in all 10 UI languages.

Unlike my #1431, this is a macOS-only feature verified end-to-end on macOS hardware — no untested platform surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
