### PR TITLE
fix(export): default nullish speakerMappings in transcript formatters

### DIFF
--- a/src/helpers/transcriptFormatter.js
+++ b/src/helpers/transcriptFormatter.js
@@ -1,8 +1,8 @@
 const { i18nMain } = require("./i18nMain");
 
-function resolveSpeaker(seg, speakerMappings) {
+function resolveSpeaker(seg, speakerMappings = {}) {
   if (seg.speakerName && !seg.speakerIsPlaceholder) return seg.speakerName;
-  if (seg.speaker && speakerMappings[seg.speaker]) return speakerMappings[seg.speaker];
+  if (seg.speaker && speakerMappings?.[seg.speaker]) return speakerMappings[seg.speaker];
   if (seg.speaker === "you") return "You";
   if (seg.speaker) {
     const num = parseInt(seg.speaker.replace("speaker_", ""), 10);
@@ -74,7 +74,7 @@ function extractMetadata(note) {
   return { title, dateStr, participants };
 }
 
-function formatTxt(note, segments, speakerMappings) {
+function formatTxt(note, segments, speakerMappings = {}) {
   const merged = mergeSegments(segments);
   const { title, dateStr, participants } = extractMetadata(note);
 
@@ -90,7 +90,7 @@ function formatTxt(note, segments, speakerMappings) {
   return lines.join("\n");
 }
 
-function formatSrt(segments, speakerMappings) {
+function formatSrt(segments, speakerMappings = {}) {
   const merged = mergeSegments(segments);
   const entries = [];
   for (let i = 0; i < merged.length; i++) {
@@ -104,7 +104,7 @@ function formatSrt(segments, speakerMappings) {
   return entries.join("\n");
 }
 
-function formatJson(note, segments, speakerMappings) {
+function formatJson(note, segments, speakerMappings = {}) {
   const merged = mergeSegments(segments);
   const { title, dateStr } = extractMetadata(note);
 
@@ -133,7 +133,7 @@ function formatJson(note, segments, speakerMappings) {
   );
 }
 
-function formatMd(note, segments, speakerMappings) {
+function formatMd(note, segments, speakerMappings = {}) {
   const merged = mergeSegments(segments);
   const { title, dateStr, participants } = extractMetadata(note);
 

--- a/test/helpers/transcriptFormatter.test.js
+++ b/test/helpers/transcriptFormatter.test.js
@@ -177,3 +177,29 @@ test("a manually named segment does not absorb the adjacent un-named one", () =>
   assert.ok(txtOutput.includes("[00:00:00] Alice:\nAlice said this."));
   assert.ok(txtOutput.includes("[00:00:01] You:\nAnd this is me talking."));
 });
+
+test("formatters handle omitted, undefined, or null speakerMappings gracefully", () => {
+  const note = { title: "Test Note", created_at: "2026-01-01T00:00:00Z" };
+  const segments = [{ speaker: "speaker_0", timestamp: 0, text: "Hello world" }];
+
+  for (const nullishMappings of [undefined, null]) {
+    const txt = formatTxt(note, segments, nullishMappings);
+    assert.match(txt, /Speaker 1:\nHello world/);
+
+    const srt = formatSrt(segments, nullishMappings);
+    assert.match(srt, /Speaker 1: Hello world/);
+
+    const json = formatJson(note, segments, nullishMappings);
+    assert.ok(JSON.parse(json).speakers.includes("Speaker 1"));
+
+    const md = formatMd(note, segments, nullishMappings);
+    assert.match(md, /\*\*Speaker 1\*\*/);
+  }
+
+  // Also test omitting the speakerMappings argument entirely
+  const txtOmitted = formatTxt(note, segments);
+  assert.match(txtOmitted, /Speaker 1:\nHello world/);
+
+  const srtOmitted = formatSrt(segments);
+  assert.match(srtOmitted, /Speaker 1: Hello world/);
+});


### PR DESCRIPTION
## Summary
Fixes an unhandled `TypeError` in `src/helpers/transcriptFormatter.js` when `formatTxt`, `formatSrt`, `formatJson`, or `formatMd` is called with omitted, `undefined`, or `null` `speakerMappings` on transcript segments containing speaker keys (e.g., `speaker: "speaker_0"`).

Fixes #1445

## Problem
In `src/helpers/transcriptFormatter.js`, `resolveSpeaker(seg, speakerMappings)` performed direct property lookup `speakerMappings[seg.speaker]` without checking if `speakerMappings` is non-nullish:

```javascript
function resolveSpeaker(seg, speakerMappings) {
  if (seg.speakerName && !seg.speakerIsPlaceholder) return seg.speakerName;
  if (seg.speaker && speakerMappings[seg.speaker]) return speakerMappings[seg.speaker];
  ...
}
```

When callers or background processes invoked `formatTxt(note, segments)`, `formatSrt(segments)`, `formatJson(note, segments)`, or `formatMd(note, segments)` without passing a `speakerMappings` dictionary (or passing `null`/`undefined`), `resolveSpeaker` threw an unhandled exception:
`TypeError: Cannot read properties of undefined (reading 'speaker_0')` (or `null`).

## Root Cause
`resolveSpeaker` did not default `speakerMappings = {}` and lacked nullish checks before property access, assuming callers would always pass a valid non-null object.

## Fix
1. Default `speakerMappings = {}` in `resolveSpeaker` and safe optional chaining `speakerMappings?.[seg.speaker]`.
2. Default `speakerMappings = {}` in `formatTxt`, `formatSrt`, `formatJson`, and `formatMd`.
3. Add unit test coverage in `test/helpers/transcriptFormatter.test.js` verifying that all four formatting functions handle omitted, `undefined`, and `null` `speakerMappings` arguments gracefully.

## Behavior Before and After
- **Before**: Calling `formatTxt(note, segments)`, `formatSrt(segments)`, `formatJson(note, segments)`, or `formatMd(note, segments)` with omitted/`undefined`/`null` `speakerMappings` on segments containing speaker labels throws `TypeError: Cannot read properties of undefined (reading 'speaker_0')`.
- **After**: Omitted, `undefined`, or `null` `speakerMappings` default to `{}` and format speaker-labeled segments cleanly into their fallback display names (e.g. `Speaker 1`).

## Scope & Non-Goals
- **In scope**: Defensive parameter handling and unit tests for `transcriptFormatter.js`.
- **Non-goals**: Modifying speaker mapping resolution logic or changing export formatting templates.

## Tests Added
- Unit test `formatters handle omitted, undefined, or null speakerMappings gracefully` in `test/helpers/transcriptFormatter.test.js`.

## Validation Commands and Results
```bash
$ ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/transcriptFormatter.test.js
✔ TXT and Markdown exports include participant display names (12.06ms)
✔ participants without a display name fall back to their email (0.24ms)
✔ merged same-speaker SRT cues keep the first segment's start time (0.16ms)
✔ same-speaker merging still uses the latest segment for the rolling gap (0.72ms)
✔ same-speaker segments at the merge threshold remain separate cues (0.10ms)
✔ the final merged SRT cue ends relative to its last segment, not its first (0.09ms)
✔ SRT timestamps roll sub-second rounding into the next second (0.07ms)
✔ every cue in a multi-cue SRT rolls its own sub-second rounding (0.08ms)
✔ JSON duration reflects the last merged segment's timestamp (0.20ms)
✔ consecutive speaker-less segments within 2s merge across SRT, TXT and Markdown exports (0.29ms)
✔ a manually named segment does not absorb the adjacent un-named one (0.16ms)
✔ formatters handle omitted, undefined, or null speakerMappings gracefully (0.46ms)
ℹ tests 12 | pass 12 | fail 0

$ npm test
ℹ tests 1108 | pass 1102 | skipped 6 | fail 0

$ npm run typecheck
> cd src && tsc --noEmit (passed)

$ npm run lint
> eslint . && cd src && eslint . (passed)

$ npm run i18n:check
> node scripts/check-i18n.js (passed)

$ npm run build:renderer
> cd src && vite build (built successfully)

$ git diff --check
(clean pass)
```

## Platform / Environment Limitations
None. Pure JavaScript helper with unit test coverage.
