### PR TITLE
fix(utils): format sub-1, non-finite, and negative byte values safely

### DIFF
--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,11 +1,11 @@
 export function formatBytes(bytes: number, decimals = 2): string {
-  if (bytes === 0) return "0 Bytes";
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 Bytes";
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))));
 
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }

--- a/test/helpers/formatBytes.test.js
+++ b/test/helpers/formatBytes.test.js
@@ -33,3 +33,14 @@ test("fractional values respect the decimals parameter, with negatives clamped t
   assert.equal(formatBytes(1536, 3), "1.5 KB");
   assert.equal(formatBytes(1536, -1), "2 KB");
 });
+
+test("negative, non-finite, and sub-1 byte values format safely without undefined units", async () => {
+  const { formatBytes } = await load();
+
+  assert.equal(formatBytes(-100), "0 Bytes");
+  assert.equal(formatBytes(-1), "0 Bytes");
+  assert.equal(formatBytes(NaN), "0 Bytes");
+  assert.equal(formatBytes(Infinity), "0 Bytes");
+  assert.equal(formatBytes(0.5), "0.5 Bytes");
+  assert.equal(formatBytes(0.1, 1), "0.1 Bytes");
+});


### PR DESCRIPTION
### Summary
Fix `formatBytes` when given non-finite numbers (`NaN`, `Infinity`), negative byte values, or sub-1 byte values so it safely returns `"0 Bytes"` or `"0.5 Bytes"` instead of `"NaN undefined"` or `"512 undefined"`.

### Problem
When rendering model download sizes, UI progress bars, or cache measurements, negative numbers, non-finite values (such as `NaN`), or sub-1 byte values caused `formatBytes` to return invalid strings like `"NaN undefined"` or `"512 undefined"`.

### Root Cause
`formatBytes` only checked `bytes === 0` and computed unit index `i = Math.floor(Math.log(bytes) / Math.log(k))`. For `bytes <= 0` or non-finite inputs, `Math.log` returns `NaN`. For `0 < bytes < 1`, `Math.log` returns a negative number, resulting in `i = -1`. In both cases, indexing `sizes[i]` yielded `undefined`.

### Fix
1. Guard against non-finite or non-positive numbers (`!Number.isFinite(bytes) || bytes <= 0`), returning `"0 Bytes"`.
2. Clamp unit index `i` between `0` and `sizes.length - 1` (`Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))))`).

### Behavior Before vs. After
- `formatBytes(-100)`: Before -> `"NaN undefined"` | After -> `"0 Bytes"`
- `formatBytes(NaN)`: Before -> `"NaN undefined"` | After -> `"0 Bytes"`
- `formatBytes(0.5)`: Before -> `"512 undefined"` | After -> `"0.5 Bytes"`
- `formatBytes(1536)`: Unchanged -> `"1.5 KB"`

### Scope and Explicit Non-Goals
- Scope: `src/utils/formatBytes.ts` and corresponding tests in `test/helpers/formatBytes.test.js`.
- Non-goals: No changes to external UI components or unrelated formatting functions.

### Tests Added
Added test cases in `test/helpers/formatBytes.test.js` covering negative byte values (`-100`, `-1`), non-finite values (`NaN`, `Infinity`), and sub-1 byte values (`0.5`, `0.1`).

### Exact Validation Commands & Results
- `node --test test/helpers/formatBytes.test.js` -> 4 tests passed, 0 failed
- `npm test` -> 992 tests passed, 0 failed
- `npm run typecheck` -> PASSED
- `npm run lint` -> PASSED
- `npm run format:check` -> PASSED
- `npm run i18n:check` -> PASSED
- `npm run build:renderer` -> PASSED
- `git diff --check` -> PASSED

Fixes #1446
