### PR TITLE
fix(members): safely handle null or missing email in filterMemberCandidates

### DIFF
--- a/src/lib/memberCandidates.ts
+++ b/src/lib/memberCandidates.ts
@@ -11,7 +11,7 @@ export function orderMemberCandidates<M extends { user_id: string }>(
   return [...self, ...members.filter((m) => m.user_id !== currentUserId)];
 }
 
-export function filterMemberCandidates<M extends { name?: string | null; email: string }>(
+export function filterMemberCandidates<M extends { name?: string | null; email?: string | null }>(
   members: M[],
   search: string
 ): M[] {
@@ -20,6 +20,6 @@ export function filterMemberCandidates<M extends { name?: string | null; email: 
   return members.filter(
     (member) =>
       (member.name ?? "").toLowerCase().includes(query) ||
-      member.email.toLowerCase().includes(query)
+      (member.email ?? "").toLowerCase().includes(query)
   );
 }

--- a/test/lib/memberCandidates.test.js
+++ b/test/lib/memberCandidates.test.js
@@ -32,3 +32,15 @@ test("filterMemberCandidates: matches names and emails case-insensitively", () =
   assert.deepEqual(filterMemberCandidates(members, "grace@"), [members[1]]);
   assert.equal(filterMemberCandidates(members, ""), members);
 });
+
+test("filterMemberCandidates: safely tolerates null or missing email properties", () => {
+  const members = [
+    { user_id: "1", name: "Bob Martin", email: null },
+    { user_id: "2", name: "Charlie", email: undefined },
+    { user_id: "3", name: "Diana Prince", email: "diana@example.com" },
+  ];
+
+  assert.deepEqual(filterMemberCandidates(members, "bob"), [members[0]]);
+  assert.deepEqual(filterMemberCandidates(members, "diana"), [members[2]]);
+  assert.deepEqual(filterMemberCandidates(members, "example"), [members[2]]);
+});


### PR DESCRIPTION
## Summary

Fixes an issue where `filterMemberCandidates` throws an uncaught `TypeError: Cannot read properties of null (reading 'toLowerCase')` when searching candidate lists containing members with `null` or `undefined` `email` properties.

Fixes #1449

## Problem & Root Cause

`filterMemberCandidates` accepts a list of candidate members and filters them case-insensitively by name and email when a user types into a member search field (such as `MemberPickList`).

While `member.name` was safely guarded with `(member.name ?? "")`, `member.email` directly called `member.email.toLowerCase()`. If any candidate member object returned from the API or local cache has a nullish `email` property (`null` or `undefined`), filtering candidate lists with any non-empty search query caused an unhandled runtime `TypeError`. Additionally, the TypeScript interface signature required `email: string` instead of allowing optional/nullish email `email?: string | null`.

## Fix

- Updated `filterMemberCandidates` in `src/lib/memberCandidates.ts` to type `email` as `email?: string | null` and safely use `(member.email ?? "").toLowerCase()`.
- Added unit tests in `test/lib/memberCandidates.test.js` covering candidate objects with `null` or `undefined` emails.

## Behavior Before & After

- **Before**: Filtering candidate lists containing members with `null` or `undefined` emails threw `TypeError: Cannot read properties of null (reading 'toLowerCase')`.
- **After**: Nullish email properties default safely to an empty string, matching member name filtering and preventing UI component crashes.

## Scope & Non-goals

- **In Scope**: Defensive type signature and nullish handling for member email filtering in `src/lib/memberCandidates.ts` and associated unit tests.
- **Non-goals**: Modifying member search components or altering non-filtering candidate ordering.

## Tests & Validation

Ran full repository validation checks on Node.js 24:
- `node --test test/lib/memberCandidates.test.js` (4/4 tests passed)
- `npm test` (1108/1108 tests passed)
- `npm run typecheck` (Passed)
- `npm run lint` (Passed)
- `npm run i18n:check` (Passed)
- `npm run build:renderer` (Passed)
- `git diff --check` (Passed)
