### PR TITLE
feat(models): add Claude Opus 5 to the Anthropic provider

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2185,6 +2185,7 @@
         "openai_gpt_5_6_terra": "Ausgewogenes GPT-5.6 für die tägliche Arbeit",
         "openai_gpt_5_6_luna": "Schnellstes und günstigstes GPT-5.6",
         "openai_gpt_5_5": "Frontier-Modell für komplexes Reasoning",
+        "anthropic_claude_opus_5": "Leistungsstärkstes Opus-Modell, 1M Kontext",
         "anthropic_claude_opus_4_8": "Leistungsstarkes Opus-Modell für Ehrlichkeit und Zuverlässigkeit",
         "anthropic_claude_opus_4_7": "Leistungsstarkes Opus-Modell",
         "anthropic_claude_opus_4_6": "Vorherige Opus-Generation, 1M Kontext",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2185,6 +2185,7 @@
         "openai_gpt_5_6_terra": "Balanced GPT-5.6 for everyday work",
         "openai_gpt_5_6_luna": "Fastest, lowest-cost GPT-5.6",
         "openai_gpt_5_5": "Frontier model for complex reasoning",
+        "anthropic_claude_opus_5": "Most capable Opus model, 1M context",
         "anthropic_claude_opus_4_8": "Powerful Opus model tuned for honesty and reliability",
         "anthropic_claude_opus_4_7": "Powerful Opus model",
         "anthropic_claude_opus_4_6": "Previous Opus generation, 1M context",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2141,6 +2141,7 @@
         "openai_gpt_5_6_terra": "GPT-5.6 equilibrado para el trabajo diario",
         "openai_gpt_5_6_luna": "El GPT-5.6 más rápido y económico",
         "openai_gpt_5_5": "Modelo frontier para razonamiento complejo",
+        "anthropic_claude_opus_5": "El modelo Opus más capaz, contexto de 1M",
         "anthropic_claude_opus_4_8": "Potente modelo Opus enfocado en honestidad y fiabilidad",
         "anthropic_claude_opus_4_7": "Modelo Opus potente",
         "anthropic_claude_opus_4_6": "Generación anterior de Opus, contexto de 1M",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2185,6 +2185,7 @@
         "openai_gpt_5_6_terra": "GPT-5.6 équilibré pour le travail quotidien",
         "openai_gpt_5_6_luna": "Le GPT-5.6 le plus rapide et le plus économique",
         "openai_gpt_5_5": "Modèle frontier pour le raisonnement complexe",
+        "anthropic_claude_opus_5": "Le modèle Opus le plus performant, contexte 1M",
         "anthropic_claude_opus_4_8": "Modèle Opus puissant axé sur l'honnêteté et la fiabilité",
         "anthropic_claude_opus_4_7": "Modèle Opus puissant",
         "anthropic_claude_opus_4_6": "Génération Opus précédente, contexte 1M",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2093,6 +2093,7 @@
         "openai_gpt_5_6_terra": "GPT-5.6 bilanciato per il lavoro quotidiano",
         "openai_gpt_5_6_luna": "Il GPT-5.6 più veloce ed economico",
         "openai_gpt_5_5": "Modello frontier per ragionamento complesso",
+        "anthropic_claude_opus_5": "Il modello Opus più capace, contesto da 1M",
         "anthropic_claude_opus_4_8": "Potente modello Opus orientato a onestà e affidabilità",
         "anthropic_claude_opus_4_7": "Modello Opus potente",
         "anthropic_claude_opus_4_6": "Generazione Opus precedente, contesto da 1M",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2093,6 +2093,7 @@
         "openai_gpt_5_6_terra": "日常業務向けのバランス型 GPT-5.6",
         "openai_gpt_5_6_luna": "最速かつ最も低コストの GPT-5.6",
         "openai_gpt_5_5": "複雑な推論のためのフロンティアモデル",
+        "anthropic_claude_opus_5": "最も高性能な Opus モデル、100 万トークンコンテキスト",
         "anthropic_claude_opus_4_8": "誠実さと信頼性を重視した強力な Opus モデル",
         "anthropic_claude_opus_4_7": "高性能な Opus モデル",
         "anthropic_claude_opus_4_6": "前世代の Opus、100 万トークンコンテキスト",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2072,6 +2072,7 @@
         "openai_gpt_5_6_terra": "GPT-5.6 equilibrado para o trabalho do dia a dia",
         "openai_gpt_5_6_luna": "O GPT-5.6 mais rápido e econômico",
         "openai_gpt_5_5": "Modelo frontier para raciocínio complexo",
+        "anthropic_claude_opus_5": "O modelo Opus mais capaz, contexto de 1M",
         "anthropic_claude_opus_4_8": "Poderoso modelo Opus voltado para honestidade e confiabilidade",
         "anthropic_claude_opus_4_7": "Modelo Opus potente",
         "anthropic_claude_opus_4_6": "Geração anterior do Opus, contexto de 1M",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2109,6 +2109,7 @@
         "openai_gpt_5_6_terra": "Сбалансированная GPT-5.6 для повседневной работы",
         "openai_gpt_5_6_luna": "Самая быстрая и недорогая GPT-5.6",
         "openai_gpt_5_5": "Фронтирная модель для сложного рассуждения",
+        "anthropic_claude_opus_5": "Самая мощная модель Opus, контекст 1M",
         "anthropic_claude_opus_4_8": "Мощная модель Opus с упором на честность и надёжность",
         "anthropic_claude_opus_4_7": "Мощная модель Opus",
         "anthropic_claude_opus_4_6": "Предыдущее поколение Opus, контекст 1M",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2093,6 +2093,7 @@
         "openai_gpt_5_6_terra": "均衡的 GPT-5.6，适合日常工作",
         "openai_gpt_5_6_luna": "速度最快、成本最低的 GPT-5.6",
         "openai_gpt_5_5": "复杂推理前沿模型",
+        "anthropic_claude_opus_5": "最强大的 Opus 模型，1M 上下文",
         "anthropic_claude_opus_4_8": "强大的 Opus 模型，注重诚实与可靠",
         "anthropic_claude_opus_4_7": "强大的 Opus 模型",
         "anthropic_claude_opus_4_6": "上一代 Opus，1M 上下文",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2093,6 +2093,7 @@
         "openai_gpt_5_6_terra": "均衡的 GPT-5.6，適合日常工作",
         "openai_gpt_5_6_luna": "速度最快、成本最低的 GPT-5.6",
         "openai_gpt_5_5": "複雜推理前沿模型",
+        "anthropic_claude_opus_5": "最強大的 Opus 模型，1M 上下文",
         "anthropic_claude_opus_4_8": "強大的 Opus 模型，注重誠實與可靠",
         "anthropic_claude_opus_4_7": "強大的 Opus 模型",
         "anthropic_claude_opus_4_6": "上一代 Opus 模型，1M 上下文",

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -391,6 +391,12 @@
           "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5"
         },
         {
+          "id": "claude-opus-5",
+          "name": "Claude Opus 5",
+          "description": "Most capable Opus model, 1M context",
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_5"
+        },
+        {
           "id": "claude-opus-4-8",
           "name": "Claude Opus 4.8",
           "description": "Powerful Opus model tuned for honesty and reliability, 1M context",


### PR DESCRIPTION
## Summary

The Anthropic provider in `src/models/modelRegistryData.json` still tops out at Opus 4.8, even though `claude-sonnet-5` and `claude-fable-5` are already in the list, so Opus 5 never shows up in the model picker. This adds `claude-opus-5` right above `claude-opus-4-8` to keep the ordering newest-first, the same way Sonnet 5 sits above Sonnet 4.6, and adds the matching `anthropic_claude_opus_5` description key to all ten locale files.

Nothing else in the codebase enumerates Anthropic model ids, so this is registry plus translations and nothing more. One thing worth flagging separately: the BYOK Anthropic handler in `ipcHandlers.js` sends `temperature` on every request regardless of model, which #1417 says Opus 4.7 and later reject. That affects every current Anthropic model, not just Opus 5, so I left it alone here.

## Changes

- src/models/modelRegistryData.json: add `claude-opus-5` under `cloudProviders.anthropic`, placed above `claude-opus-4-8`
- src/locales/{en,it,de,es,fr,ja,pt,ru,zh-CN,zh-TW}/translation.json: add `models.descriptions.cloud.anthropic_claude_opus_5`, translated in each language
