### PR TITLE
fix(meeting): align mic reference on helper capture and surface silent system audio

### DIFF
--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { app } = require("electron");
 
@@ -72,6 +73,11 @@ class DebugLogger {
       this.debug("Debug logging enabled", { logFile: this.logFile });
       this.info("System Info", {
         platform: process.platform,
+        // OS build decides which native capture APIs are usable (Windows
+        // process loopback, macOS audio tap), so it belongs in every report.
+        osRelease: os.release(),
+        osVersion: os.version(),
+        arch: process.arch,
         nodeVersion: process.version,
         electronVersion: process.versions.electron,
         appPath: app.getAppPath(),

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -27,6 +27,11 @@ const TINFOIL_REALTIME_MODEL = "voxtral-mini-4b-realtime";
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
 const { partitionPendingMicFinals, isWithinRetractWindow } = require("./meetingMicHoldback");
+const {
+  requiresMicReferenceAlignment,
+  SystemAudioSilenceMonitor,
+  SYSTEM_AUDIO_SILENCE_GRACE_MS,
+} = require("./meetingSystemAudio");
 const { applySmartSpacing } = require("./smartSpacing");
 const { applyAutoLearnSetting } = require("./autoLearnSetting");
 const { DEFAULT_RETENTION_SETTINGS, applyRetentionSettings } = require("./retentionSettings");
@@ -5384,16 +5389,22 @@ class IPCHandlers {
         if (newSystem) {
           const secrets = await fetchRealtimeToken(tokenEvent, options, { streams: 2 });
           pairs = [
-            { streaming: newMic, secret: secrets[0] },
-            { streaming: newSystem, secret: secrets[1] },
+            { streaming: newMic, secret: secrets[0], source: "mic" },
+            { streaming: newSystem, secret: secrets[1], source: "system" },
           ];
         } else {
-          pairs = [{ streaming: newMic, secret: await fetchRealtimeToken(tokenEvent, options) }];
+          pairs = [
+            {
+              streaming: newMic,
+              secret: await fetchRealtimeToken(tokenEvent, options),
+              source: "mic",
+            },
+          ];
         }
 
         await Promise.all(
-          pairs.map(({ streaming, secret }) =>
-            streaming.connect({ apiKey: secret, token: secret, ...connectOpts })
+          pairs.map(({ streaming, secret, source }) =>
+            streaming.connect({ apiKey: secret, token: secret, ...connectOpts, label: source })
           )
         );
 
@@ -5556,10 +5567,8 @@ class IPCHandlers {
       return "unsupported";
     };
 
-    const getMeetingSystemAudioMode = () => getMeetingSystemAudioCapabilityMode();
-
     const getMeetingSystemAudioPlan = async () => {
-      const mode = getMeetingSystemAudioMode();
+      const mode = getMeetingSystemAudioCapabilityMode();
       if (mode === "unsupported") {
         return { mode, strategy: "unsupported" };
       }
@@ -5586,7 +5595,8 @@ class IPCHandlers {
       return { mode, strategy: "unsupported" };
     };
 
-    const hasNativeMeetingSystemAudio = () => getMeetingSystemAudioMode() === "native";
+    const meetingMicNeedsReferenceAlignment = () =>
+      requiresMicReferenceAlignment(meetingSystemAudioStrategy);
 
     const isMeetingStreamingConnected = (systemAudioMode = getMeetingSystemAudioCapabilityMode()) =>
       !!this._meetingMicStreaming?.isConnected &&
@@ -5638,8 +5648,8 @@ class IPCHandlers {
       }
 
       await Promise.all(
-        pairs.map(({ ref, secret }) =>
-          this[ref].connect({ apiKey: secret, token: secret, ...connectOpts })
+        pairs.map(({ ref, secret, source }) =>
+          this[ref].connect({ apiKey: secret, token: secret, ...connectOpts, label: source })
         )
       );
 
@@ -5656,6 +5666,8 @@ class IPCHandlers {
     let meetingStartedAt = null;
     let meetingSendCounts = { mic: 0, system: 0 };
     const meetingEchoLeakDetector = new MeetingEchoLeakDetector();
+    const meetingSystemAudioSilence = new SystemAudioSilenceMonitor();
+    let meetingSystemAudioStrategy = null;
     let meetingReconnecting = false;
     let meetingReconnectCount = 0;
     const MAX_MEETING_RECONNECTS = 5;
@@ -6268,7 +6280,9 @@ class IPCHandlers {
       resetPendingMicFinals();
       meetingAecEnabled = false;
       meetingStartedAt = null;
+      meetingSystemAudioStrategy = null;
       meetingEchoLeakDetector.reset();
+      meetingSystemAudioSilence.reset();
     };
 
     let dictationPreviewMode = false;
@@ -6378,11 +6392,14 @@ class IPCHandlers {
       this._meetingMicStreaming = null;
       this._meetingSystemStreaming = null;
       meetingSendCounts = { mic: 0, system: 0 };
+      meetingMicStatsLogCount = 0;
+      meetingSystemAudioStrategy = null;
       meetingLiveSpeakerStartedAt = null;
       meetingPendingMicChunks = [];
       resetPendingMicFinals();
       meetingAecEnabled = false;
       meetingEchoLeakDetector.reset();
+      meetingSystemAudioSilence.reset();
       meetingReconnecting = false;
       meetingReconnectCount = 0;
       meetingConnectionOptions = null;
@@ -6600,6 +6617,7 @@ class IPCHandlers {
         const systemAudioPlan = await getMeetingSystemAudioPlan();
         let { mode: systemAudioMode, strategy: systemAudioStrategy } = systemAudioPlan;
         meetingEchoLeakDetector.reset();
+        meetingSystemAudioSilence.reset();
         meetingOneOnOneAttendee = resolveOneOnOneAttendeeForNote(options.noteId);
         meetingOneOnOneProfileBound = false;
         meetingNoteId = options.noteId ?? null;
@@ -6711,7 +6729,18 @@ class IPCHandlers {
 
       if (source === "system") {
         const receivedAt = Date.now();
-        meetingEchoLeakDetector.recordSystemChunk(outboundBuffer, receivedAt);
+        const systemRms = meetingEchoLeakDetector.recordSystemChunk(outboundBuffer, receivedAt);
+        if (meetingSystemAudioSilence.record(systemRms, receivedAt)) {
+          debugLogger.warn(
+            "Meeting system audio has been silent since capture started",
+            {
+              strategy: meetingSystemAudioStrategy,
+              graceMs: SYSTEM_AUDIO_SILENCE_GRACE_MS,
+              chunks: meetingSendCounts.system,
+            },
+            "meeting"
+          );
+        }
         if (meetingAecEnabled && !this.meetingAecManager?.processSystemBuffer(outboundBuffer)) {
           meetingAecEnabled = false;
         }
@@ -6737,7 +6766,7 @@ class IPCHandlers {
           return;
         }
 
-        if (!hasNativeMeetingSystemAudio()) {
+        if (!meetingMicNeedsReferenceAlignment()) {
           const analysis = meetingEchoLeakDetector.analyzeMicChunk(outboundBuffer);
           if (analysis?.shouldMute && !meetingAecEnabled) {
             if (!meetingLocalMode) {
@@ -6800,6 +6829,13 @@ class IPCHandlers {
       systemAudioStrategy,
       context
     ) => {
+      // The mic path reads the strategy that capture actually settled on, so
+      // every exit — including the fallbacks — has to record it.
+      const settle = (mode, strategy) => {
+        meetingSystemAudioStrategy = strategy;
+        return { systemAudioMode: mode, systemAudioStrategy: strategy };
+      };
+
       if (systemAudioMode === "native") {
         try {
           await startManagedMeetingSystemAudio(
@@ -6807,7 +6843,7 @@ class IPCHandlers {
             this.audioTapManager,
             "macOS system audio tap warning"
           );
-          return { systemAudioMode, systemAudioStrategy };
+          return settle(systemAudioMode, systemAudioStrategy);
         } catch (error) {
           debugLogger.warn(
             `Native system audio tap failed ${context}, falling back to mic-only`,
@@ -6815,7 +6851,7 @@ class IPCHandlers {
             "meeting"
           );
           await fallBackToMicOnly("native");
-          return { systemAudioMode: "unsupported", systemAudioStrategy: "unsupported" };
+          return settle("unsupported", "unsupported");
         }
       }
 
@@ -6826,7 +6862,7 @@ class IPCHandlers {
             this.windowsLoopbackAudioManager,
             "Windows system audio warning"
           );
-          return { systemAudioMode, systemAudioStrategy };
+          return settle(systemAudioMode, systemAudioStrategy);
         } catch (error) {
           debugLogger.warn(
             `Windows system audio helper failed ${context}, falling back to renderer loopback`,
@@ -6835,12 +6871,12 @@ class IPCHandlers {
           );
           // The renderer captures via Chromium's display-media loopback when
           // it sees the downgraded strategy in the start result.
-          return { systemAudioMode, systemAudioStrategy: "loopback" };
+          return settle(systemAudioMode, "loopback");
         }
       }
 
       if (systemAudioStrategy !== "pipewire-loopback") {
-        return { systemAudioMode, systemAudioStrategy };
+        return settle(systemAudioMode, systemAudioStrategy);
       }
 
       try {
@@ -6849,7 +6885,7 @@ class IPCHandlers {
           this.linuxPortalAudioManager,
           "Linux PipeWire system audio warning"
         );
-        return { systemAudioMode, systemAudioStrategy };
+        return settle(systemAudioMode, systemAudioStrategy);
       } catch (error) {
         debugLogger.warn(
           `Linux PipeWire helper failed ${context}, falling back to mic-only`,
@@ -6857,7 +6893,7 @@ class IPCHandlers {
           "meeting"
         );
         await fallBackToMicOnly("PipeWire");
-        return { systemAudioMode: "unsupported", systemAudioStrategy: "unsupported" };
+        return settle("unsupported", "unsupported");
       }
     };
 

--- a/src/helpers/meetingEchoLeakDetector.js
+++ b/src/helpers/meetingEchoLeakDetector.js
@@ -56,24 +56,28 @@ class MeetingEchoLeakDetector {
     this.micHistory = [];
   }
 
+  // Returns the chunk RMS so callers can gate on system-side level without
+  // rescanning the buffer.
   recordSystemChunk(buffer, timestampMs = Date.now()) {
     if (!buffer?.length) {
-      return;
+      return 0;
     }
 
     const samples = pcm16ToFloat32(buffer);
     if (!samples.length) {
-      return;
+      return 0;
     }
 
+    const rms = computeRms(samples);
     this.systemHistory.push({
       timestampMs,
       samples,
       durationMs: (samples.length / SAMPLE_RATE) * 1000,
-      rms: computeRms(samples),
+      rms,
     });
 
     this._trimHistory(timestampMs);
+    return rms;
   }
 
   analyzeMicChunk(buffer, timestampMs = Date.now()) {

--- a/src/helpers/meetingSystemAudio.js
+++ b/src/helpers/meetingSystemAudio.js
@@ -1,0 +1,55 @@
+// Capture strategies that run in a helper process (macOS CoreAudio tap,
+// Windows WASAPI process loopback, Linux PipeWire portal). Chromium's
+// display-media loopback ("loopback") instead delivers mic and system chunks
+// from the same renderer, already aligned.
+const HELPER_CAPTURE_STRATEGIES = new Set(["native", "wasapi-loopback", "pipewire-loopback"]);
+
+// A helper delivers system audio on its own schedule, so mic chunks must wait
+// for the reference to catch up before the echo detector can correlate them.
+// Keying this off the capability mode instead of the strategy silently
+// disabled alignment on Windows and Linux, where the mode is "loopback" for
+// both the helper and the renderer path.
+const requiresMicReferenceAlignment = (strategy) => HELPER_CAPTURE_STRATEGIES.has(strategy);
+
+const SYSTEM_AUDIO_SILENCE_GRACE_MS = 60000;
+// Same audibility floor the echo detector uses for its system-side VAD.
+const AUDIBLE_SYSTEM_RMS = 0.004;
+
+// The Windows and Linux helpers pad the stream with silence whenever no
+// application is rendering, so a dead capture and a quiet meeting look
+// identical by byte count. Report once when a full grace period of system
+// audio arrives without a single audible chunk.
+class SystemAudioSilenceMonitor {
+  constructor({ graceMs = SYSTEM_AUDIO_SILENCE_GRACE_MS, audibleRms = AUDIBLE_SYSTEM_RMS } = {}) {
+    this.graceMs = graceMs;
+    this.audibleRms = audibleRms;
+    this.reset();
+  }
+
+  reset() {
+    this.startedAt = null;
+    this.heardAudio = false;
+    this.reported = false;
+  }
+
+  record(rms, timestampMs) {
+    if (this.startedAt === null) {
+      this.startedAt = timestampMs;
+    }
+    if (rms >= this.audibleRms) {
+      this.heardAudio = true;
+      return false;
+    }
+    if (this.heardAudio || this.reported || timestampMs - this.startedAt < this.graceMs) {
+      return false;
+    }
+    this.reported = true;
+    return true;
+  }
+}
+
+module.exports = {
+  requiresMicReferenceAlignment,
+  SystemAudioSilenceMonitor,
+  SYSTEM_AUDIO_SILENCE_GRACE_MS,
+};

--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -47,6 +47,8 @@ class OpenAIRealtimeStreaming {
     this.isDisconnecting = false;
     this.audioBytesSent = 0;
     this.model = "gpt-4o-mini-transcribe";
+    this.label = null;
+    this.language = null;
     this.inputRate = SAMPLE_RATE;
     this.captureRate = SAMPLE_RATE;
     this.coldStartBuffer = [];
@@ -70,7 +72,17 @@ class OpenAIRealtimeStreaming {
   }
 
   async connect(options = {}) {
-    const { apiKey, model, preconfigured, inputRate, captureRate, createSocket } = options;
+    const {
+      apiKey,
+      model,
+      language,
+      label,
+      preconfigured,
+      sampleRate,
+      inputRate = sampleRate,
+      captureRate,
+      createSocket,
+    } = options;
     if (!apiKey) throw new Error("OpenAI API key is required");
 
     if (this.isConnected || this.isConnecting) {
@@ -84,6 +96,8 @@ class OpenAIRealtimeStreaming {
 
     this.isConnecting = true;
     this.model = model || "gpt-4o-mini-transcribe";
+    this.label = label || null;
+    this.language = language && language !== "auto" ? language : null;
     this.preconfigured = !!preconfigured;
     this.inputRate = inputRate || SAMPLE_RATE;
     this.captureRate = captureRate || this.inputRate;
@@ -94,7 +108,11 @@ class OpenAIRealtimeStreaming {
     this._sessionExpired = false;
 
     const url = "wss://api.openai.com/v1/realtime?intent=transcription";
-    debugLogger.debug("OpenAI Realtime connecting", { model: this.model });
+    debugLogger.debug("OpenAI Realtime connecting", {
+      model: this.model,
+      stream: this.label,
+      language: this.language,
+    });
 
     // Attested providers (Tinfoil) supply their socket via an async factory.
     let ws;
@@ -121,7 +139,7 @@ class OpenAIRealtimeStreaming {
       this.ws = ws;
 
       this.ws.on("open", () => {
-        debugLogger.debug("OpenAI Realtime WebSocket opened");
+        debugLogger.debug("OpenAI Realtime WebSocket opened", { stream: this.label });
       });
 
       this.ws.on("message", (data) => {
@@ -147,6 +165,7 @@ class OpenAIRealtimeStreaming {
           code,
           reason: reason?.toString(),
           wasActive,
+          stream: this.label,
         });
         if (this.pendingReject) {
           this.pendingReject(new Error(`WebSocket closed before ready (code: ${code})`));
@@ -187,7 +206,10 @@ class OpenAIRealtimeStreaming {
                   audio: {
                     input: {
                       format: { type: "audio/pcm", rate: this.inputRate },
-                      transcription: { model: this.model },
+                      transcription: {
+                        model: this.model,
+                        ...(this.language ? { language: this.language } : {}),
+                      },
                       turn_detection: {
                         type: "server_vad",
                         threshold: 0.6,
@@ -407,6 +429,7 @@ class OpenAIRealtimeStreaming {
       segments: this.completedSegments.length,
       textLength: this.getFullTranscript().length,
       readyState: this.ws?.readyState,
+      stream: this.label,
     });
 
     if (!this.ws) return { text: this.getFullTranscript() };

--- a/test/helpers/meetingSystemAudio.test.js
+++ b/test/helpers/meetingSystemAudio.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  requiresMicReferenceAlignment,
+  SystemAudioSilenceMonitor,
+} = require("../../src/helpers/meetingSystemAudio");
+
+const NOW = 1_000_000;
+const GRACE_MS = 60000;
+const SILENT = 0;
+const AUDIBLE = 0.05;
+
+test("helper-process capture strategies require mic reference alignment", () => {
+  // Windows and Linux report mode "loopback" for both the helper and the
+  // renderer path, so only the strategy can tell them apart.
+  assert.equal(requiresMicReferenceAlignment("native"), true);
+  assert.equal(requiresMicReferenceAlignment("wasapi-loopback"), true);
+  assert.equal(requiresMicReferenceAlignment("pipewire-loopback"), true);
+});
+
+test("renderer loopback and absent capture skip mic reference alignment", () => {
+  assert.equal(requiresMicReferenceAlignment("loopback"), false);
+  assert.equal(requiresMicReferenceAlignment("unsupported"), false);
+  assert.equal(requiresMicReferenceAlignment(null), false);
+});
+
+test("reports once after a full grace period of silence", () => {
+  const monitor = new SystemAudioSilenceMonitor();
+
+  assert.equal(monitor.record(SILENT, NOW), false);
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS - 1), false);
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS), true);
+  // A dead capture keeps delivering padded silence for the whole meeting; one
+  // warning is the signal, the rest would be noise.
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS * 2), false);
+});
+
+test("never reports once any audible chunk arrives", () => {
+  const monitor = new SystemAudioSilenceMonitor();
+
+  monitor.record(SILENT, NOW);
+  monitor.record(AUDIBLE, NOW + 1000);
+
+  // A far end that goes quiet for minutes after speaking is a normal meeting,
+  // not a broken capture.
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS * 3), false);
+});
+
+test("measures the grace period from the first chunk, not from construction", () => {
+  const monitor = new SystemAudioSilenceMonitor();
+
+  // Capture can start well after the monitor is created; the clock must start
+  // when audio actually begins flowing.
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS), false);
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS * 2), true);
+});
+
+test("reset re-arms the monitor for the next meeting", () => {
+  const monitor = new SystemAudioSilenceMonitor();
+
+  monitor.record(SILENT, NOW);
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS), true);
+
+  monitor.reset();
+  assert.equal(monitor.record(SILENT, NOW), false);
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS), true);
+});
+
+test("treats chunks exactly at the audibility floor as audio", () => {
+  const monitor = new SystemAudioSilenceMonitor({ audibleRms: 0.004 });
+
+  monitor.record(0.004, NOW);
+
+  assert.equal(monitor.record(SILENT, NOW + GRACE_MS), false);
+});

--- a/test/helpers/openaiRealtimeSession.test.js
+++ b/test/helpers/openaiRealtimeSession.test.js
@@ -1,0 +1,82 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const WebSocket = require("ws");
+const { WebSocketServer } = require("ws");
+
+const OpenAIRealtimeStreaming = require("../../src/helpers/openaiRealtimeStreaming");
+
+// Drives a real socket through the session handshake and hands back whatever
+// the client sent before it considered itself connected.
+async function captureSessionSetup(connectOptions) {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((resolve) => server.once("listening", resolve));
+  const url = `ws://127.0.0.1:${server.address().port}`;
+  const received = [];
+
+  server.on("connection", (socket) => {
+    socket.send(JSON.stringify({ type: "session.created" }));
+    socket.on("message", (data) => {
+      received.push(JSON.parse(data.toString()));
+      socket.send(JSON.stringify({ type: "session.updated" }));
+    });
+  });
+
+  const streaming = new OpenAIRealtimeStreaming();
+  try {
+    await streaming.connect({
+      apiKey: "test-key",
+      createSocket: async () => new WebSocket(url),
+      ...connectOptions,
+    });
+    // A preconfigured session never sends session.update, so there is nothing
+    // to wait for; give a stray message one tick to show up before asserting.
+    await new Promise((resolve) => setImmediate(resolve));
+    return received;
+  } finally {
+    streaming.cleanup();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+const sessionUpdateInput = (messages) => {
+  const update = messages.find((message) => message.type === "session.update");
+  return update?.session?.audio?.input;
+};
+
+test("pins the requested language on a self-configured session", async () => {
+  const messages = await captureSessionSetup({ language: "pl" });
+
+  // Without this the session falls back to auto-detect, which drifts into
+  // other languages on near-silent or bleed audio.
+  assert.equal(sessionUpdateInput(messages).transcription.language, "pl");
+});
+
+test("omits language when the user selected auto-detect", async () => {
+  const messages = await captureSessionSetup({ language: "auto" });
+
+  assert.equal("language" in sessionUpdateInput(messages).transcription, false);
+});
+
+test("omits language when none was requested", async () => {
+  const messages = await captureSessionSetup({});
+
+  assert.equal("language" in sessionUpdateInput(messages).transcription, false);
+});
+
+test("declares the rate given as sampleRate, and lets inputRate win", async () => {
+  // Meeting callers pass the rate as sampleRate, the name the other streaming
+  // clients take; dictation passes inputRate.
+  const bySampleRate = await captureSessionSetup({ sampleRate: 48000 });
+  assert.equal(sessionUpdateInput(bySampleRate).format.rate, 48000);
+
+  const byInputRate = await captureSessionSetup({ inputRate: 24000, sampleRate: 48000 });
+  assert.equal(sessionUpdateInput(byInputRate).format.rate, 24000);
+});
+
+test("leaves a preconfigured session untouched", async () => {
+  // The ephemeral token already carries language and noise reduction; a
+  // session.update here would strip them.
+  const messages = await captureSessionSetup({ language: "pl", preconfigured: true });
+
+  assert.deepEqual(messages, []);
+});


### PR DESCRIPTION
Investigation of a Windows debug log where a full 3.5-minute meeting produced **zero** system-audio transcripts. Both realtime sockets were healthy and received near-identical byte volume, but only one produced text:

```
disconnect  audioBytesSent 3974400  segments 12  textLength 922   ← mic
disconnect  audioBytesSent 3978240  segments  0  textLength   0   ← system
```

The system channel was delivering pure digital silence. Four independent confirmations: `systemSpeaking: false` on all 15 segments (the detector's VAD floor is only 0.004 RMS), `micCorrelation: "0.000"` on every one, `Diarization complete { segmentCount: 0 }` over 83s of audio, and every transcript arriving as `source: "mic"` — the remote party was only ever heard as speaker bleed.

Why the WASAPI process loopback returned silence is still unconfirmed. This PR fixes the real bugs found while tracing it and closes the diagnostic gaps that made it unconfirmable.

## Mic reference alignment was disabled on Windows and Linux

`hasNativeMeetingSystemAudio()` read the capability *mode*, which is `"loopback"` on Windows and Linux for **both** the helper and the renderer capture paths. Alignment therefore only ever engaged on macOS.

A helper process delivers system audio on its own schedule, so mic chunks must wait for the reference to catch up before the echo detector can correlate them. Without alignment, `analyzeMicChunk` runs against a system window that has not arrived yet. It was masked in this log only because the AEC helper happened to be running; whenever AEC is unavailable on Windows or Linux, bleed detection is silently dead.

Now keyed on the strategy capture actually settled on — `native`, `wasapi-loopback`, `pipewire-loopback`. `startMeetingSystemAudio` routes all six exits through a `settle()` helper so the fallback paths (notably the wasapi → renderer-loopback downgrade) record it too.

## Silent system audio was undetectable

The Windows and Linux helpers pad the stream with silence whenever no application is rendering, so a dead capture and a quiet meeting are identical by byte count — `convertRawPcmToWav`'s only guard (`stat.size === 0`) can never fire. A whole meeting gets recorded, FFmpeg and sherpa-onnx burn on 83s of zeros, and nothing reports it.

`SystemAudioSilenceMonitor` warns once when a full 60s grace period of system audio arrives with no audible chunk. It never fires if the far end speaks even once, so a normally quiet meeting stays silent. It reuses the RMS the echo detector already computes rather than rescanning 100 buffers/sec.

## Also fixed

- **`language` was dropped for BYOK realtime sessions.** `connect()` never destructured it and `session.update` omitted it, though callers pass it. Managed mode was fine (server token carries it); BYOK always ran auto-detect. Same failure surface as the hallucinated `"음식"` / `"Поток."` fragments in the log — auto-detect drifting on near-silent bleed audio.
- **`sampleRate` was ignored** by `connect()`, which reads `inputRate`. Harmless today only because both default to 24000.
- **Both sockets logged identically** — mic and system were distinguishable only by byte counts at disconnect. Now tagged `stream: mic|system`.
- **`System Info` omitted the OS build**, which is exactly what decides native capture availability. Now logs `osRelease`, `osVersion`, `arch`.
- **`meetingMicStatsLogCount` was never reset** (`meetingSendCounts` is, per meeting). After ~200 chunks in the app's lifetime the mic-level diagnostic goes dark permanently — likely why there is not a single mic-level line in the 3-minute log that motivated this.
- Removed `getMeetingSystemAudioMode`, a pure alias left with one caller.

## Tests

13 new tests. The realtime ones drive a real socket through the session handshake against a local `WebSocketServer` and assert on the `session.update` payload. Verified they fail against the pre-fix code:

```
✖ pins the requested language on a self-configured session
✖ declares the rate given as sampleRate, and lets inputRate win
```

Full suite: 1114 tests, 998 pass, 0 fail (116 pre-existing skips). Lint and Prettier clean.

## Deliberately out of scope

- **No user-facing warning for dead system audio.** Surfacing it needs i18n keys across 9 locale files plus component work. The `warn` log carries strategy, grace period, and chunk count — what a support log needs.
- **Dictation streaming still does not pin language.** Its call site never passes one and `dictationRealtimeStart`'s option type has no `language` field, so wiring it means touching the renderer, preload, types, and `fetchRealtimeToken`. The client-side fix is in place for whenever it is threaded through.

## Testing notes

- Windows and Linux: run a meeting with the native helper, confirm bleed detection still behaves with the AEC helper both available and unavailable.
- macOS: confirm no regression — alignment now engages once `startMeetingSystemAudio` settles rather than from the first chunk. Mic audio only reaches `sendMeetingAudio` after the start IPC resolves, so there should be no window, but worth a look.
- Confirm the silence warning fires on a meeting with system audio muted, and does **not** fire on a normal meeting where the far end is quiet for over a minute.