### PR TITLE
fix(linux): keep meeting notifications interactive on Linux

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -131,6 +131,13 @@ class WindowManager {
     if (!this.notificationWindow || this.notificationWindow.isDestroyed()) {
       return;
     }
+
+    // Electron cannot forward hover events on Linux, so returning to click-through
+    // would prevent this overlay from receiving the next mouse enter.
+    if (process.platform === "linux") {
+      return;
+    }
+
     if (interactive) {
       this.notificationWindow.setIgnoreMouseEvents(false);
     } else {


### PR DESCRIPTION
## Summary
Keep meeting notification windows interactive on Linux so they can receive subsequent hover events and expose the close and start notes button.

macOS and Windows retain their existing click-through behavior.

## Verification Video

https://github.com/user-attachments/assets/c026ce9c-53d8-4b35-9fe0-e32a37ff09ed


fixes #1456 