### PR TITLE
fix(dictation): Retry and surface silently dropped transcript segments

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -57,7 +57,7 @@ import {
 import { resolveDictationAgentInference } from "./dictationAgentInference";
 import { resolvePrompt } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
-import { evaluateFinishedRecording } from "./recordingValidation";
+import { evaluateFinishedRecording, withSalvageWarning } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
 import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
@@ -1004,12 +1004,14 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     this._batchSegments = [];
     const segmentsCount = segments.filter((segment) => segment?.size > 0).length;
     let audioBlob = null;
+    let salvagedRecording = false;
     try {
       audioBlob = await this.mergeRecordedSegments(segments);
     } catch (error) {
       logger.error("Failed to assemble recovered recording", { error: error.message }, "audio");
       // Salvage the largest segment rather than dropping the whole recording.
       audioBlob = this.getLargestRecordedSegment(segments);
+      salvagedRecording = !!audioBlob;
     }
     audioBlob = audioBlob || new Blob([], { type: this.recordingMimeType || "audio/webm" });
     this.lastAudioBlob = audioBlob;
@@ -1054,6 +1056,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     await this.processAudio(audioBlob, {
       durationSeconds,
+      ...(salvagedRecording ? { salvagedRecording: true } : {}),
       ...(previewStop?.streamed ? { streamedText: previewStop.text } : {}),
     });
   }
@@ -1326,6 +1329,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         model: activeModel || null,
       };
 
+      result = withSalvageWarning(result, metadata.salvagedRecording);
       this.onTranscriptionComplete?.(result);
 
       if (result?.source === "openwhispr") {

--- a/src/helpers/parakeetServer.js
+++ b/src/helpers/parakeetServer.js
@@ -139,17 +139,27 @@ class ParakeetServerManager {
       for (let offset = 0; offset < samples.length; offset += maxSegmentBytes) {
         const end = Math.min(offset + maxSegmentBytes, samples.length);
         const segment = samples.subarray(offset, end);
-        const result = await this.wsServer.transcribe(segment, SAMPLE_RATE);
+        let result = await this.wsServer.transcribe(segment, SAMPLE_RATE);
         totalElapsed += result.elapsed || 0;
         if (result.truncated) truncated = true;
-        if (result.text) {
-          texts.push(result.text);
-        } else {
-          debugLogger.warn("Parakeet segment returned empty text", {
+        if (!result.text && computeFloat32RMS(segment) >= SILENCE_RMS_THRESHOLD) {
+          // An empty decode of audible audio silently amputates the transcript
+          // (#1435: dictation openings dropped); retry once before conceding.
+          debugLogger.warn("Parakeet segment returned empty text, retrying", {
             segmentIndex: offset / maxSegmentBytes,
             segmentDuration: segment.length / BYTES_PER_SAMPLE / SAMPLE_RATE,
           });
+          result = await this.wsServer.transcribe(segment, SAMPLE_RATE);
+          totalElapsed += result.elapsed || 0;
+          if (result.truncated) truncated = true;
+          if (!result.text) {
+            truncated = true;
+            debugLogger.warn("Parakeet segment still empty after retry; transcript truncated", {
+              segmentIndex: offset / maxSegmentBytes,
+            });
+          }
         }
+        if (result.text) texts.push(result.text);
       }
 
       const text = texts.join(" ");

--- a/src/helpers/parakeetServer.js
+++ b/src/helpers/parakeetServer.js
@@ -117,14 +117,16 @@ class ParakeetServerManager {
 
       if (samples.length <= maxSegmentBytes) {
         const result = await this.wsServer.transcribe(samples, SAMPLE_RATE);
-        if (!result.text?.trim()) {
-          debugLogger.warn("Parakeet returned empty text for non-silent audio", {
-            durationSeconds,
-            rms,
-            samplesBytes: samples.length,
-          });
-        }
-        return result;
+        if (result.text?.trim()) return result;
+        // The RMS gate above already established audible audio, so an empty
+        // decode here loses the whole dictation — retry once before giving up.
+        debugLogger.warn("Parakeet returned empty text for non-silent audio, retrying", {
+          durationSeconds,
+          rms,
+          samplesBytes: samples.length,
+        });
+        const retry = await this.wsServer.transcribe(samples, SAMPLE_RATE);
+        return { ...retry, elapsed: (result.elapsed || 0) + (retry.elapsed || 0) };
       }
 
       debugLogger.debug("Parakeet segmenting long audio", {
@@ -141,7 +143,6 @@ class ParakeetServerManager {
         const segment = samples.subarray(offset, end);
         let result = await this.wsServer.transcribe(segment, SAMPLE_RATE);
         totalElapsed += result.elapsed || 0;
-        if (result.truncated) truncated = true;
         if (!result.text && computeFloat32RMS(segment) >= SILENCE_RMS_THRESHOLD) {
           // An empty decode of audible audio silently amputates the transcript
           // (#1435: dictation openings dropped); retry once before conceding.
@@ -151,7 +152,6 @@ class ParakeetServerManager {
           });
           result = await this.wsServer.transcribe(segment, SAMPLE_RATE);
           totalElapsed += result.elapsed || 0;
-          if (result.truncated) truncated = true;
           if (!result.text) {
             truncated = true;
             debugLogger.warn("Parakeet segment still empty after retry; transcript truncated", {
@@ -159,6 +159,8 @@ class ParakeetServerManager {
             });
           }
         }
+        // Latched after the retry so a discarded attempt's truncation dies with it.
+        if (result.truncated) truncated = true;
         if (result.text) texts.push(result.text);
       }
 

--- a/src/helpers/recordingValidation.js
+++ b/src/helpers/recordingValidation.js
@@ -12,3 +12,12 @@ export function evaluateFinishedRecording({ blobSize, receivedAudioData } = {}) 
   }
   return { usable: true, reason: null };
 }
+
+// A salvaged recording (segment merge failed, only the largest segment was
+// kept) yields a transcript missing the dropped segments' audio. Mark the
+// result so the renderer shows its partial-transcription warning; an existing
+// warning (e.g. a truncated decode) already does.
+export function withSalvageWarning(result, salvaged) {
+  if (!salvaged || !result?.success || result.warning) return result;
+  return { ...result, warning: "salvaged-recording" };
+}

--- a/test/helpers/parakeetServer.test.js
+++ b/test/helpers/parakeetServer.test.js
@@ -66,6 +66,16 @@ test("audio at or under the 15s cap decodes in one request", async () => {
   assert.deepEqual(fake.calls, [10 * SAMPLE_RATE * 4]);
 });
 
+test("retries a single-request decode when audible audio decodes to empty", async () => {
+  const fake = fakeWsServer([{ text: "" }, { text: "hello" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 10 }]));
+
+  assert.equal(result.text, "hello");
+  assert.deepEqual(fake.calls, [10 * SAMPLE_RATE * 4, 10 * SAMPLE_RATE * 4]);
+});
+
 test("retries once when an audible segment decodes to empty text", async () => {
   const fake = fakeWsServer([{ text: "" }, { text: "one" }, { text: "two" }, { text: "three" }]);
   const manager = managerWith(fake);
@@ -75,6 +85,21 @@ test("retries once when an audible segment decodes to empty text", async () => {
   assert.equal(result.text, "one two three");
   assert.ok(!result.truncated, "a recovered retry must not flag truncation");
   assert.deepEqual(fake.calls, [SEGMENT_BYTES, SEGMENT_BYTES, SEGMENT_BYTES, SAMPLE_RATE * 4]);
+});
+
+test("a truncated empty first attempt does not taint a successful retry", async () => {
+  const fake = fakeWsServer([
+    { text: "", truncated: true },
+    { text: "one" },
+    { text: "two" },
+    { text: "three" },
+  ]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 31 }]));
+
+  assert.equal(result.text, "one two three");
+  assert.ok(!result.truncated, "the discarded attempt's truncation must not survive recovery");
 });
 
 test("flags truncation when an audible segment stays empty after the retry", async () => {

--- a/test/helpers/parakeetServer.test.js
+++ b/test/helpers/parakeetServer.test.js
@@ -1,0 +1,101 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const ParakeetServerManager = require("../../src/helpers/parakeetServer");
+
+const SAMPLE_RATE = 16000;
+const SEGMENT_BYTES = 15 * SAMPLE_RATE * 4; // float32, mirrors MAX_SEGMENT_SECONDS
+
+// Minimal 16kHz mono 16-bit WAV so _ensureWav uses the buffer as-is (no FFmpeg).
+function wavFromSeconds(spans) {
+  const totalSamples = spans.reduce((sum, span) => sum + span.seconds * SAMPLE_RATE, 0);
+  const dataSize = totalSamples * 2;
+  const buf = Buffer.alloc(44 + dataSize);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36 + dataSize, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(SAMPLE_RATE, 24);
+  buf.writeUInt32LE(SAMPLE_RATE * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(dataSize, 40);
+  let offset = 44;
+  for (const span of spans) {
+    const amplitude = span.silent ? 0 : 8000;
+    for (let i = 0; i < span.seconds * SAMPLE_RATE; i++) {
+      buf.writeInt16LE(i % 2 === 0 ? amplitude : -amplitude, offset);
+      offset += 2;
+    }
+  }
+  return buf;
+}
+
+function fakeWsServer(responses) {
+  const calls = [];
+  return {
+    calls,
+    async start() {},
+    async transcribe(samplesBuffer) {
+      calls.push(samplesBuffer.length);
+      const next = responses.shift();
+      assert.ok(next, "unexpected extra transcribe call");
+      return { elapsed: 1, ...next };
+    },
+  };
+}
+
+function managerWith(fake) {
+  const manager = new ParakeetServerManager();
+  manager.isModelDownloaded = () => true;
+  manager.wsServer = fake;
+  return manager;
+}
+
+test("audio at or under the 15s cap decodes in one request", async () => {
+  const fake = fakeWsServer([{ text: "hello" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 10 }]));
+
+  assert.equal(result.text, "hello");
+  assert.deepEqual(fake.calls, [10 * SAMPLE_RATE * 4]);
+});
+
+test("retries once when an audible segment decodes to empty text", async () => {
+  const fake = fakeWsServer([{ text: "" }, { text: "one" }, { text: "two" }, { text: "three" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 31 }]));
+
+  assert.equal(result.text, "one two three");
+  assert.ok(!result.truncated, "a recovered retry must not flag truncation");
+  assert.deepEqual(fake.calls, [SEGMENT_BYTES, SEGMENT_BYTES, SEGMENT_BYTES, SAMPLE_RATE * 4]);
+});
+
+test("flags truncation when an audible segment stays empty after the retry", async () => {
+  const fake = fakeWsServer([{ text: "" }, { text: "" }, { text: "two" }, { text: "three" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 31 }]));
+
+  assert.equal(result.text, "two three");
+  assert.equal(result.truncated, true);
+});
+
+test("a silent segment decoding to empty is not retried or flagged", async () => {
+  const fake = fakeWsServer([{ text: "alpha" }, { text: "" }, { text: "omega" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(
+    wavFromSeconds([{ seconds: 15 }, { seconds: 15, silent: true }, { seconds: 1 }])
+  );
+
+  assert.equal(result.text, "alpha omega");
+  assert.ok(!result.truncated, "silence is not data loss");
+  assert.equal(fake.calls.length, 3);
+});

--- a/test/helpers/recordingValidation.test.js
+++ b/test/helpers/recordingValidation.test.js
@@ -52,3 +52,31 @@ test("treats missing / undefined args as unusable (defensive, does not throw)", 
     reason: "empty-container",
   });
 });
+
+test("withSalvageWarning attaches a warning to a successful salvaged transcription", async () => {
+  const { withSalvageWarning } = await load();
+  assert.deepEqual(withSalvageWarning({ success: true, text: "hi" }, true), {
+    success: true,
+    text: "hi",
+    warning: "salvaged-recording",
+  });
+});
+
+test("withSalvageWarning leaves non-salvaged results untouched", async () => {
+  const { withSalvageWarning } = await load();
+  const result = { success: true, text: "hi" };
+  assert.equal(withSalvageWarning(result, false), result);
+});
+
+test("withSalvageWarning keeps an existing warning", async () => {
+  const { withSalvageWarning } = await load();
+  const result = { success: true, text: "hi", warning: "truncated" };
+  assert.equal(withSalvageWarning(result, true), result);
+});
+
+test("withSalvageWarning ignores failed or missing results", async () => {
+  const { withSalvageWarning } = await load();
+  const failed = { success: false, message: "no audio" };
+  assert.equal(withSalvageWarning(failed, true), failed);
+  assert.equal(withSalvageWarning(null, true), null);
+});


### PR DESCRIPTION
## What & why

Users on Windows report the opening of longer dictations silently missing from the pasted transcript while the live preview shows the full text (#1435, and the residual loss in #1454 after the VAD fix). Investigation traced the only silent-loss paths to two places where audio loss produced no user-visible signal: the offline Parakeet segmented decode drops any segment that returns empty text, and a failed multi-segment merge after mic recovery silently salvages just the largest segment. Since only leading segments are full-length hard cuts, both failure shapes eat the start of a dictation and never the tail. This MR makes both paths retry or warn instead of losing words invisibly — reusing the existing truncated → warning → partial-transcription toast plumbing, so no new i18n keys are needed. The underlying Windows-side trigger for the empty decodes is still being confirmed with a reporter (debug-log request on #1435); this change makes the failure self-healing when transient and visible when not.