### PR TITLE
fix(widget): keep dictation overlay visible after display changes

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -152,25 +152,105 @@ const TRANSCRIPTION_PREVIEW_CONFIG = {
 };
 
 class WindowPositionUtil {
+  static getWorkArea(display) {
+    return display?.workArea || display?.bounds || null;
+  }
+
+  static clampBoundsToWorkArea(bounds, workArea) {
+    if (!bounds || !workArea) return bounds;
+
+    const maxX = workArea.x + workArea.width - bounds.width;
+    const maxY = workArea.y + workArea.height - bounds.height;
+    const x = maxX < workArea.x ? workArea.x : Math.max(workArea.x, Math.min(bounds.x, maxX));
+    const y = maxY < workArea.y ? workArea.y : Math.max(workArea.y, Math.min(bounds.y, maxY));
+
+    return {
+      ...bounds,
+      x: Math.round(x),
+      y: Math.round(y),
+      width: Math.round(bounds.width),
+      height: Math.round(bounds.height),
+    };
+  }
+
+  static getIntersectionArea(bounds, workArea) {
+    if (!bounds || !workArea) return 0;
+
+    const left = Math.max(bounds.x, workArea.x);
+    const top = Math.max(bounds.y, workArea.y);
+    const right = Math.min(bounds.x + bounds.width, workArea.x + workArea.width);
+    const bottom = Math.min(bounds.y + bounds.height, workArea.y + workArea.height);
+    const width = Math.max(0, right - left);
+    const height = Math.max(0, bottom - top);
+
+    return width * height;
+  }
+
+  static getBestVisibleDisplay(bounds, displays = []) {
+    let best = null;
+    let bestArea = 0;
+
+    for (const display of displays) {
+      const area = this.getIntersectionArea(bounds, this.getWorkArea(display));
+      if (area > bestArea) {
+        best = display;
+        bestArea = area;
+      }
+    }
+
+    return bestArea > 0 ? best : null;
+  }
+
+  static getReconciledMainWindowBounds(
+    currentBounds,
+    displays = [],
+    cursorDisplay = null,
+    position = "bottom-right"
+  ) {
+    if (!currentBounds || !Array.isArray(displays) || displays.length === 0) {
+      return null;
+    }
+
+    const visibleDisplay = this.getBestVisibleDisplay(currentBounds, displays);
+    if (visibleDisplay) {
+      return {
+        bounds: this.clampBoundsToWorkArea(currentBounds, this.getWorkArea(visibleDisplay)),
+        display: visibleDisplay,
+        reason: "visible-clamped",
+      };
+    }
+
+    const targetDisplay = cursorDisplay || displays[0];
+    return {
+      bounds: this.getMainWindowPosition(
+        targetDisplay,
+        { width: currentBounds.width, height: currentBounds.height },
+        position
+      ),
+      display: targetDisplay,
+      reason: "offscreen-moved-to-cursor-display",
+    };
+  }
+
   static getMainWindowPosition(display, customSize = null, position = "bottom-right") {
     const { width, height } = customSize || WINDOW_SIZES.BASE;
     const MARGIN = 4;
-    const workArea = display.workArea || display.bounds;
+    const workArea = this.getWorkArea(display);
 
     let x, y;
     if (position === "bottom-left") {
       x = workArea.x + MARGIN;
-      y = Math.max(0, workArea.y + workArea.height - height - MARGIN);
+      y = workArea.y + workArea.height - height - MARGIN;
     } else if (position === "center") {
       x = Math.round(workArea.x + (workArea.width - width) / 2);
-      y = Math.max(0, workArea.y + workArea.height - height - MARGIN);
+      y = workArea.y + workArea.height - height - MARGIN;
     } else {
       // bottom-right (default)
-      x = Math.max(0, workArea.x + workArea.width - width - MARGIN);
-      y = Math.max(0, workArea.y + workArea.height - height - MARGIN);
+      x = workArea.x + workArea.width - width - MARGIN;
+      y = workArea.y + workArea.height - height - MARGIN;
     }
 
-    return { x, y, width, height };
+    return this.clampBoundsToWorkArea({ x, y, width, height }, workArea);
   }
 
   static getNotificationPosition(display) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -49,9 +49,21 @@ class WindowManager {
     this._isDictatingToggle = false;
     this._pendingMeetingNoteNavigation = null;
     this._pendingNoteNavigation = null;
+    this._displayChangeDebounceId = null;
+    this._displayChangeHandlersRegistered = false;
+    this._displayChangeHandlers = [];
 
     app.on("before-quit", () => {
       this.isQuitting = true;
+      if (this._displayChangeDebounceId) {
+        clearTimeout(this._displayChangeDebounceId);
+        this._displayChangeDebounceId = null;
+      }
+      for (const { eventName, handler } of this._displayChangeHandlers) {
+        screen.off(eventName, handler);
+      }
+      this._displayChangeHandlers = [];
+      this._displayChangeHandlersRegistered = false;
       this.hotkeyManager.unregisterAll();
     });
   }
@@ -106,6 +118,7 @@ class WindowManager {
     await this.initializeHotkey();
     this.dragManager.setTargetWindow(this.mainWindow);
     MenuManager.setupMainMenu(() => this.openSettings());
+    this.registerDisplayChangeHandlers();
   }
 
   setMainWindowInteractivity(shouldCapture) {
@@ -144,6 +157,7 @@ class WindowManager {
     }
 
     const newSize = WINDOW_SIZES[sizeKey] || WINDOW_SIZES.BASE;
+    this.ensureMainWindowOnVisibleDisplay("before-resize");
     const currentBounds = this.mainWindow.getBounds();
     const position = this._panelStartPosition;
 
@@ -1050,12 +1064,88 @@ class WindowManager {
     this.agentWindow.setBounds(bounds);
   }
 
+  registerDisplayChangeHandlers() {
+    if (this._displayChangeHandlersRegistered) return;
+    this._displayChangeHandlersRegistered = true;
+
+    const scheduleReconcile = (reason) => {
+      if (this._displayChangeDebounceId) {
+        clearTimeout(this._displayChangeDebounceId);
+      }
+      this._displayChangeDebounceId = setTimeout(() => {
+        this._displayChangeDebounceId = null;
+        this.ensureMainWindowOnVisibleDisplay(reason);
+      }, 150);
+    };
+
+    for (const eventName of ["display-added", "display-removed", "display-metrics-changed"]) {
+      const handler = () => scheduleReconcile(eventName);
+      this._displayChangeHandlers.push({ eventName, handler });
+      screen.on(eventName, handler);
+    }
+  }
+
+  _describeDisplay(display) {
+    if (!display) return null;
+    return {
+      id: display.id,
+      bounds: display.bounds,
+      workArea: display.workArea,
+      scaleFactor: display.scaleFactor,
+    };
+  }
+
+  ensureMainWindowOnVisibleDisplay(reason = "manual") {
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return null;
+    if (this.dragManager?.isDragActive?.()) return null;
+
+    const currentBounds = this.mainWindow.getBounds();
+    const displays = screen.getAllDisplays();
+    const cursorPos = screen.getCursorScreenPoint();
+    const cursorDisplay = screen.getDisplayNearestPoint(cursorPos);
+    const decision = WindowPositionUtil.getReconciledMainWindowBounds(
+      currentBounds,
+      displays,
+      cursorDisplay,
+      this._panelStartPosition
+    );
+
+    if (!decision) return null;
+
+    const nextBounds = decision.bounds;
+    const changed =
+      currentBounds.x !== nextBounds.x ||
+      currentBounds.y !== nextBounds.y ||
+      currentBounds.width !== nextBounds.width ||
+      currentBounds.height !== nextBounds.height;
+
+    debugLogger.debug(
+      "Main window geometry reconciliation",
+      {
+        reason,
+        decision: decision.reason,
+        changed,
+        currentBounds,
+        nextBounds,
+        cursorPos,
+        targetDisplay: this._describeDisplay(decision.display),
+        displays: displays.map((display) => this._describeDisplay(display)),
+      },
+      "window"
+    );
+
+    if (changed) {
+      this.mainWindow.setBounds(nextBounds);
+    }
+
+    return { changed, bounds: nextBounds, reason: decision.reason };
+  }
+
   _repositionToCursorDisplay() {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
 
     const cursorPos = screen.getCursorScreenPoint();
     const cursorDisplay = screen.getDisplayNearestPoint(cursorPos);
-
     const currentBounds = this.mainWindow.getBounds();
     const currentDisplay = screen.getDisplayNearestPoint({
       x: currentBounds.x + currentBounds.width / 2,
@@ -1075,6 +1165,7 @@ class WindowManager {
   showDictationPanel(options = {}) {
     const { focus = false } = options;
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.ensureMainWindowOnVisibleDisplay("show");
       this._repositionToCursorDisplay();
 
       if (this.mainWindow.isMinimized()) {
@@ -1140,6 +1231,7 @@ class WindowManager {
     this.mainWindow.once("ready-to-show", () => {
       clearTimeout(showTimeout);
       this.enforceMainWindowOnTop();
+      this.ensureMainWindowOnVisibleDisplay("ready-to-show");
       if (!this.mainWindow.isVisible() && !this._floatingIconAutoHide) {
         if (typeof this.mainWindow.showInactive === "function") {
           this.mainWindow.showInactive();

--- a/test/helpers/windowPositionUtil.test.js
+++ b/test/helpers/windowPositionUtil.test.js
@@ -1,0 +1,69 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { WindowPositionUtil } = require("../../src/helpers/windowConfig.js");
+
+const display = (id, workArea) => ({ id, bounds: workArea, workArea });
+
+test("main window placement respects displays with negative coordinates", () => {
+  const leftDisplay = display(1, { x: -1920, y: 0, width: 1920, height: 1080 });
+  const topDisplay = display(2, { x: 0, y: -1200, width: 1920, height: 1200 });
+
+  assert.deepEqual(
+    WindowPositionUtil.getMainWindowPosition(leftDisplay, { width: 96, height: 96 }),
+    { x: -100, y: 980, width: 96, height: 96 }
+  );
+
+  assert.deepEqual(
+    WindowPositionUtil.getMainWindowPosition(topDisplay, { width: 96, height: 96 }),
+    { x: 1820, y: -100, width: 96, height: 96 }
+  );
+});
+
+test("reconciliation preserves a visible panel instead of moving it to the cursor display", () => {
+  const primary = display(1, { x: 0, y: 0, width: 1920, height: 1080 });
+  const secondary = display(2, { x: 1920, y: 0, width: 1920, height: 1080 });
+  const currentBounds = { x: 1700, y: 980, width: 96, height: 96 };
+
+  const result = WindowPositionUtil.getReconciledMainWindowBounds(
+    currentBounds,
+    [primary, secondary],
+    secondary,
+    "bottom-right"
+  );
+
+  assert.equal(result.display.id, primary.id);
+  assert.deepEqual(result.bounds, currentBounds);
+  assert.equal(result.reason, "visible-clamped");
+});
+
+test("reconciliation clamps a partly visible panel into its current display", () => {
+  const primary = display(1, { x: 0, y: 0, width: 1920, height: 1080 });
+  const cursorDisplay = display(2, { x: 0, y: 1080, width: 1920, height: 1080 });
+
+  const result = WindowPositionUtil.getReconciledMainWindowBounds(
+    { x: 1900, y: 1000, width: 96, height: 96 },
+    [primary, cursorDisplay],
+    cursorDisplay,
+    "bottom-right"
+  );
+
+  assert.equal(result.display.id, primary.id);
+  assert.deepEqual(result.bounds, { x: 1824, y: 984, width: 96, height: 96 });
+});
+
+test("reconciliation moves a fully off-screen panel to the cursor display", () => {
+  const primary = display(1, { x: 0, y: 0, width: 1920, height: 1080 });
+  const cursorDisplay = display(2, { x: 0, y: 1080, width: 1920, height: 1080 });
+
+  const result = WindowPositionUtil.getReconciledMainWindowBounds(
+    { x: 3440, y: 980, width: 96, height: 96 },
+    [primary, cursorDisplay],
+    cursorDisplay,
+    "bottom-right"
+  );
+
+  assert.equal(result.display.id, cursorDisplay.id);
+  assert.deepEqual(result.bounds, { x: 1820, y: 2060, width: 96, height: 96 });
+  assert.equal(result.reason, "offscreen-moved-to-cursor-display");
+});


### PR DESCRIPTION
## Summary

Reconcile the dictation overlay bounds when display topology or metrics change.

- preserve the overlay on its current display during geometry reconciliation if it is still visible
- clamp partially visible bounds back into the display work area
- move the overlay to the cursor display when it is fully off-screen
- keep the existing show behavior where the overlay follows the cursor display
- stop clamping main overlay placement to `0`, so negative-origin monitor layouts work
- avoid reconciling while the user is dragging the overlay
- add unit tests for negative-origin placement, visible preservation, partial clamping, and off-screen recovery

Related to #1110. Complements #977/#1286, but does not implement panel-aware X11/KDE work-area correction.

## Testing

- `node --test test/helpers/windowPositionUtil.test.js`
- `npm run lint`
- `npm run format`
- `npx prettier --check src/helpers/windowConfig.js src/helpers/windowManager.js test/helpers/windowPositionUtil.test.js`
- Electron runtime smoke-test with real `screen.getAllDisplays()`

Note: a full local `npm test` run is blocked in my environment after `electron-builder install-app-deps` rebuilt `better-sqlite3` for Electron ABI; Node-based database tests then fail with `ERR_DLOPEN_FAILED: Module did not self-register`. The focused geometry tests and lint pass.
