### PR TITLE
fix(export): normalize meeting transcript timestamps for markdown exports (Fixes #1472)

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2045,7 +2045,7 @@ class IPCHandlers {
         if (format === "txt") {
           exportContent = transcriptFormatter.formatTxt(note, segments, speakerMappings);
         } else if (format === "srt") {
-          exportContent = transcriptFormatter.formatSrt(segments, speakerMappings);
+          exportContent = transcriptFormatter.formatSrt(segments, speakerMappings, note);
         } else if (format === "md") {
           exportContent = transcriptFormatter.formatMd(note, segments, speakerMappings);
         } else {

--- a/src/helpers/transcriptFormatter.js
+++ b/src/helpers/transcriptFormatter.js
@@ -21,6 +21,54 @@ function speakerKey(seg) {
   return [seg.speaker || "", named, seg.speaker ? "" : seg.source || ""].join("\u0000");
 }
 
+function parseNoteDate(createdAt) {
+  if (createdAt == null || createdAt === "") {
+    return new Date(NaN);
+  }
+  if (typeof createdAt === "number") {
+    return new Date(createdAt);
+  }
+
+  const value = String(createdAt).trim();
+  if (/[zZ]|[+-]\d{2}:\d{2}$/.test(value)) {
+    return new Date(value);
+  }
+
+  // SQLite CURRENT_TIMESTAMP is UTC without a timezone suffix.
+  return new Date(value.includes("T") ? `${value}Z` : `${value.replace(" ", "T")}Z`);
+}
+
+function resolveRecordingStartMs(segments, note) {
+  const segmentTimestamps = segments
+    .map((seg) => seg.timestamp)
+    .filter((ts) => typeof ts === "number" && Number.isFinite(ts));
+
+  if (segmentTimestamps.length > 0) {
+    return Math.min(...segmentTimestamps);
+  }
+
+  const noteDate = parseNoteDate(note?.created_at);
+  return Number.isNaN(noteDate.getTime()) ? null : noteDate.getTime();
+}
+
+function normalizeSegmentTimestamps(segments, note) {
+  const startMs = resolveRecordingStartMs(segments, note);
+  if (startMs == null || startMs <= 1e9) {
+    return segments;
+  }
+
+  return segments.map((seg) => {
+    const normalized = { ...seg };
+    if (typeof seg.timestamp === "number" && Number.isFinite(seg.timestamp)) {
+      normalized.timestamp = (seg.timestamp - startMs) / 1000;
+    }
+    if (typeof seg.endTimestamp === "number" && Number.isFinite(seg.endTimestamp)) {
+      normalized.endTimestamp = (seg.endTimestamp - startMs) / 1000;
+    }
+    return normalized;
+  });
+}
+
 function mergeSegments(segments) {
   const merged = [];
   let lastTimestamp = null;
@@ -59,7 +107,7 @@ function formatSrtTimestamp(seconds) {
 
 function extractMetadata(note) {
   const title = note.title || "Untitled";
-  const noteDate = new Date(note.created_at);
+  const noteDate = parseNoteDate(note.created_at);
   const dateStr =
     noteDate.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" }) +
     " " +
@@ -75,7 +123,7 @@ function extractMetadata(note) {
 }
 
 function formatTxt(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr, participants } = extractMetadata(note);
 
   const lines = [title, dateStr];
@@ -90,8 +138,8 @@ function formatTxt(note, segments, speakerMappings) {
   return lines.join("\n");
 }
 
-function formatSrt(segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+function formatSrt(segments, speakerMappings, note = {}) {
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const entries = [];
   for (let i = 0; i < merged.length; i++) {
     const seg = merged[i];
@@ -105,7 +153,7 @@ function formatSrt(segments, speakerMappings) {
 }
 
 function formatJson(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr } = extractMetadata(note);
 
   const speakersSet = new Set();
@@ -134,7 +182,7 @@ function formatJson(note, segments, speakerMappings) {
 }
 
 function formatMd(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr, participants } = extractMetadata(note);
 
   const lines = [`# ${title}`, "", `**Date:** ${dateStr}`];
@@ -148,4 +196,11 @@ function formatMd(note, segments, speakerMappings) {
   return lines.join("\n");
 }
 
-module.exports = { formatTxt, formatSrt, formatJson, formatMd };
+module.exports = {
+  formatTxt,
+  formatSrt,
+  formatJson,
+  formatMd,
+  parseNoteDate,
+  normalizeSegmentTimestamps,
+};

--- a/test/helpers/transcriptFormatter.test.js
+++ b/test/helpers/transcriptFormatter.test.js
@@ -177,3 +177,26 @@ test("a manually named segment does not absorb the adjacent un-named one", () =>
   assert.ok(txtOutput.includes("[00:00:00] Alice:\nAlice said this."));
   assert.ok(txtOutput.includes("[00:00:01] You:\nAnd this is me talking."));
 });
+
+test("epoch-millisecond segment timestamps export relative to the recording start", () => {
+  const recordingStartMs = 1_754_310_000_000;
+  const segments = [
+    { speaker: "speaker_0", timestamp: recordingStartMs, text: "Opening." },
+    { speaker: "speaker_1", timestamp: recordingStartMs + 477_000, text: "Closing." },
+  ];
+  const note = {
+    title: "Meeting",
+    created_at: "2026-08-04 13:02:00",
+  };
+
+  const mdOutput = formatMd(note, segments, {});
+  assert.match(mdOutput, /`00:00:00`/);
+  assert.match(mdOutput, /`00:07:57`/);
+});
+
+test("SQLite UTC note timestamps are parsed as UTC before local formatting", () => {
+  const { parseNoteDate } = require("../../src/helpers/transcriptFormatter");
+  const parsed = parseNoteDate("2026-08-04 13:02:00");
+
+  assert.equal(parsed.toISOString(), "2026-08-04T13:02:00.000Z");
+});


### PR DESCRIPTION
## Summary

- Normalize epoch-millisecond meeting segment timestamps to recording-relative offsets before TXT/SRT/JSON/Markdown export.
- Parse SQLite UTC note timestamps explicitly so export headers render in local time instead of appearing one hour behind BST.

## Root cause

Diarization finalization already subtracts recording start before merge, but export-transcript read raw 
ote.transcript JSON and passed epoch-ms values into ormatTimestamp(), which expects seconds from zero. That produced giant hour fields like `496069042:26:40`.

## Verification

\\\
cd openwhispr-wt/1472-markdown-export-timestamps
node --test test/helpers/transcriptFormatter.test.js
# 13 pass (includes epoch-ms normalization + UTC created_at parsing)
\\\

## AI assistance

AI-assisted (Cursor). Stan Shih reviewed the diff.

Fixes #1472

Made with [Cursor](https://cursor.com)