### PR TITLE
fix: omit temperature for Anthropic models that reject it

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3980,12 +3980,15 @@ class IPCHandlers {
             throw new Error("No model specified for Anthropic API call");
           }
 
+          // Claude models from Opus 4.7 onward reject `temperature` with a 400;
+          // the renderer derives support from the model registry.
+          const useTemperature = config?.supportsTemperature === true;
           const requestBody = {
             model: modelId,
             messages: [{ role: "user", content: userPrompt }],
             system: systemPrompt,
             max_tokens: config?.maxTokens || Math.max(100, Math.min(text.length * 2, 4096)),
-            temperature: config?.temperature || 0.3,
+            ...(useTemperature ? { temperature: config?.temperature ?? 0.3 } : {}),
           };
 
           const response = await proxyFetch("https://api.anthropic.com/v1/messages", {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -370,61 +370,71 @@
           "id": "claude-fable-5",
           "name": "Claude Fable 5",
           "description": "Anthropic's most capable model, Mythos-class, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_fable_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_fable_5",
+          "supportsTemperature": false
         },
         {
           "id": "claude-sonnet-5",
           "name": "Claude Sonnet 5",
           "description": "Fast, capable agentic model at lower cost",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_5",
+          "supportsTemperature": false
         },
         {
           "id": "claude-sonnet-4-6",
           "name": "Claude Sonnet 4.6",
           "description": "Balanced performance",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_6"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_6",
+          "supportsTemperature": true
         },
         {
           "id": "claude-haiku-4-5",
           "name": "Claude Haiku 4.5",
           "description": "Fast with near-frontier intelligence",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_haiku_4_5",
+          "supportsTemperature": true
         },
         {
           "id": "claude-opus-5",
           "name": "Claude Opus 5",
           "description": "Most capable Opus model, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_5",
+          "supportsTemperature": false
         },
         {
           "id": "claude-opus-4-8",
           "name": "Claude Opus 4.8",
           "description": "Powerful Opus model tuned for honesty and reliability, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_8"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_8",
+          "supportsTemperature": false
         },
         {
           "id": "claude-opus-4-7",
           "name": "Claude Opus 4.7",
           "description": "Powerful Opus model, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_7"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_7",
+          "supportsTemperature": false
         },
         {
           "id": "claude-opus-4-6",
           "name": "Claude Opus 4.6",
           "description": "Previous Opus generation, 1M context",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_6"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_6",
+          "supportsTemperature": true
         },
         {
           "id": "claude-sonnet-4-5",
           "name": "Claude Sonnet 4.5",
           "description": "Previous Sonnet generation",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_sonnet_4_5",
+          "supportsTemperature": true
         },
         {
           "id": "claude-opus-4-5",
           "name": "Claude Opus 4.5",
           "description": "Earlier Opus model",
-          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_5"
+          "descriptionKey": "models.descriptions.cloud.anthropic_claude_opus_4_5",
+          "supportsTemperature": true
         }
       ]
     },

--- a/src/services/ai/inferenceProviders/anthropic.ts
+++ b/src/services/ai/inferenceProviders/anthropic.ts
@@ -1,4 +1,5 @@
 import type { InferenceProvider } from "./types";
+import { getCloudModel } from "../../../models/ModelRegistry";
 import { wrapCleanupTranscript } from "../../../config/prompts";
 import logger from "../../../utils/logger";
 
@@ -16,6 +17,9 @@ export const anthropicProvider: InferenceProvider = {
 
     const systemPrompt = config.systemPrompt || ctx.getSystemPrompt(agentName);
     const userContent = config.systemPrompt ? text : wrapCleanupTranscript(text);
+    // Claude models from Opus 4.7 onward reject `temperature` with a 400, so
+    // unknown models default to omitting it, which every model accepts.
+    const supportsTemperature = getCloudModel(model)?.supportsTemperature ?? false;
     const result = await window.electronAPI.processAnthropicReasoning(
       userContent,
       model,
@@ -23,6 +27,7 @@ export const anthropicProvider: InferenceProvider = {
       {
         ...config,
         systemPrompt,
+        supportsTemperature,
       }
     );
 

--- a/test/helpers/anthropicSamplingFlags.test.js
+++ b/test/helpers/anthropicSamplingFlags.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const modelData = require("../../src/models/modelRegistryData.json");
+
+const anthropicModels = modelData.cloudProviders.find((p) => p.id === "anthropic").models;
+
+test("every Anthropic model declares sampling support explicitly", () => {
+  for (const model of anthropicModels) {
+    assert.equal(
+      typeof model.supportsTemperature,
+      "boolean",
+      `${model.id} is missing supportsTemperature`
+    );
+  }
+});
+
+test("models from Opus 4.7 onward do not receive temperature", () => {
+  for (const id of [
+    "claude-fable-5",
+    "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+  ]) {
+    const model = anthropicModels.find((m) => m.id === id);
+    assert.equal(model.supportsTemperature, false, id);
+  }
+});
+
+test("legacy Anthropic families keep temperature", () => {
+  for (const id of [
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-opus-4-6",
+    "claude-sonnet-4-5",
+    "claude-opus-4-5",
+  ]) {
+    const model = anthropicModels.find((m) => m.id === id);
+    assert.equal(model.supportsTemperature, true, id);
+  }
+});


### PR DESCRIPTION
## Summary
Anthropic removed the sampling parameters from Opus 4.7 onward: the API returns 400 "\`temperature\` is deprecated for this model" as soon as the field is present. The \`process-anthropic-reasoning\` handler in \`ipcHandlers.js\` sends \`temperature\` unconditionally, so cleanup and agent reasoning fail for every request on Claude Fable 5, Sonnet 5, Opus 5, Opus 4.8 and Opus 4.7 with a BYOK Anthropic key. The fix mirrors what the enterprise path already does: the registry declares \`supportsTemperature\` per model, the anthropic provider passes it through IPC, and the handler only includes the parameter when supported. Unknown models omit it, which every model accepts.

## Changes
- \`src/models/modelRegistryData.json\`: explicit \`supportsTemperature\` on all Anthropic models, false from Opus 4.7 onward.
- \`src/services/ai/inferenceProviders/anthropic.ts\`: look up the flag from the registry and forward it to the IPC handler.
- \`src/helpers/ipcHandlers.js\`: include \`temperature\` only when supported; \`?? 0.3\` instead of \`|| 0.3\` so cleanup's temperature 0 is no longer coerced to 0.3.
- \`test/helpers/anthropicSamplingFlags.test.js\`: guards that every Anthropic registry entry declares the flag and that the per-family values are right.