### PR TITLE
fix(tools): normalize whitespace and guard nullish inputs in resolveFolderId and resolveSpace

### DIFF
--- a/src/services/tools/utils.ts
+++ b/src/services/tools/utils.ts
@@ -9,35 +9,45 @@ export async function resolveFolderId(
   options: { createIfMissing?: boolean } = {},
   spaceId: number | null = null
 ): Promise<ResolveFolderResult> {
+  const normalized = typeof folderName === "string" ? folderName.trim() : "";
+  if (!normalized) {
+    return { error: "Folder name cannot be empty" };
+  }
+
   const folders = await window.electronAPI.getFolders(spaceId);
-  const match = folders.find((f) => f.name.toLowerCase() === folderName.toLowerCase());
+  const match = folders.find((f) => f.name.toLowerCase() === normalized.toLowerCase());
   if (match) return { folderId: match.id, created: false };
 
   if (!options.createIfMissing) {
     const available = folders.map((f) => f.name).join(", ");
-    return { error: `Folder "${folderName}" not found. Available folders: ${available}` };
+    return { error: `Folder "${normalized}" not found. Available folders: ${available}` };
   }
 
-  const result = await window.electronAPI.createFolder(folderName, spaceId);
+  const result = await window.electronAPI.createFolder(normalized, spaceId);
   if (result.success && result.folder) {
     return { folderId: result.folder.id, created: true };
   }
 
   const retry = await window.electronAPI.getFolders(spaceId);
-  const reMatch = retry.find((f) => f.name.toLowerCase() === folderName.toLowerCase());
+  const reMatch = retry.find((f) => f.name.toLowerCase() === normalized.toLowerCase());
   if (reMatch) return { folderId: reMatch.id, created: false };
 
-  return { error: result.error || `Failed to create folder "${folderName}"` };
+  return { error: result.error || `Failed to create folder "${normalized}"` };
 }
 
 type ResolveSpaceResult =
   { space: SpaceItem; error?: undefined } | { space?: undefined; error: string };
 
 export function resolveSpace(spaces: SpaceItem[], spaceName: string): ResolveSpaceResult {
-  const match = spaces.find((s) => s.name.toLowerCase() === spaceName.trim().toLowerCase());
+  const normalized = typeof spaceName === "string" ? spaceName.trim() : "";
+  if (!normalized) {
+    return { error: "Space name cannot be empty" };
+  }
+
+  const match = spaces.find((s) => s.name.toLowerCase() === normalized.toLowerCase());
   if (match) return { space: match };
   const available = spaces.map((s) => s.name).join(", ");
-  return { error: `Space "${spaceName}" not found. Available spaces: ${available}` };
+  return { error: `Space "${normalized}" not found. Available spaces: ${available}` };
 }
 
 type NoteByClientIdLookup = (

--- a/test/services/toolUtils.test.js
+++ b/test/services/toolUtils.test.js
@@ -47,3 +47,53 @@ test("unavailable, deleted, invalid, and failed local rows produce no clickable 
     null
   );
 });
+
+test("resolveFolderId normalizes whitespace and matches existing folders case-insensitively", async () => {
+  const { resolveFolderId } = await load();
+  global.window = {
+    electronAPI: {
+      getFolders: async () => [{ id: 10, name: "Work" }],
+      createFolder: async () => ({ success: true, folder: { id: 20, name: "NewFolder" } }),
+    },
+  };
+
+  const match = await resolveFolderId("  work  ");
+  assert.deepEqual(match, { folderId: 10, created: false });
+});
+
+test("resolveFolderId trims folder name before creating missing folders", async () => {
+  const { resolveFolderId } = await load();
+  let createdName = null;
+  global.window = {
+    electronAPI: {
+      getFolders: async () => [],
+      createFolder: async (name) => {
+        createdName = name;
+        return { success: true, folder: { id: 15, name } };
+      },
+    },
+  };
+
+  const res = await resolveFolderId("  Projects  ", { createIfMissing: true });
+  assert.deepEqual(res, { folderId: 15, created: true });
+  assert.equal(createdName, "Projects");
+});
+
+test("resolveFolderId guards against nullish, empty, and whitespace-only inputs", async () => {
+  const { resolveFolderId } = await load();
+
+  assert.deepEqual(await resolveFolderId(null), { error: "Folder name cannot be empty" });
+  assert.deepEqual(await resolveFolderId(undefined), { error: "Folder name cannot be empty" });
+  assert.deepEqual(await resolveFolderId(""), { error: "Folder name cannot be empty" });
+  assert.deepEqual(await resolveFolderId("   "), { error: "Folder name cannot be empty" });
+});
+
+test("resolveSpace normalizes whitespace and guards nullish or empty inputs", async () => {
+  const { resolveSpace } = await load();
+  const spaces = [{ id: 1, name: "Engineering" }];
+
+  assert.deepEqual(resolveSpace(spaces, "  engineering  "), { space: spaces[0] });
+  assert.deepEqual(resolveSpace(spaces, null), { error: "Space name cannot be empty" });
+  assert.deepEqual(resolveSpace(spaces, undefined), { error: "Space name cannot be empty" });
+  assert.deepEqual(resolveSpace(spaces, "   "), { error: "Space name cannot be empty" });
+});


### PR DESCRIPTION
### Summary
Normalizes leading and trailing whitespace and adds nullish/empty input guards in `resolveFolderId` and `resolveSpace` (`src/services/tools/utils.ts`).

### Problem
In `src/services/tools/utils.ts`:
1. `resolveFolderId` did not trim whitespace from `folderName` prior to case-insensitive lookup against existing folders or prior to calling `createFolder`. When an LLM tool call provided a folder name with surrounding spaces (e.g. `"  Work  "`), `resolveFolderId` failed to match an existing folder named `"Work"` and created a duplicate folder with surrounding spaces.
2. Neither `resolveFolderId` nor `resolveSpace` guarded against `null`, `undefined`, empty (`""`), or whitespace-only (`"   "`) input strings, resulting in uncaught `TypeError` crashes or creation of blank/whitespace folder names.

### Root Cause
`resolveFolderId` directly invoked `.toLowerCase()` on the raw `folderName` without `.trim()`, whereas `resolveSpace` called `.trim()` inline without prior type or empty checks.

### Fix
1. In `resolveFolderId`, normalize `folderName` to a trimmed string (`typeof folderName === "string" ? folderName.trim() : ""`). If empty, return `{ error: "Folder name cannot be empty" }`. Use the normalized name for lookup, error messages, and `createFolder`.
2. In `resolveSpace`, normalize `spaceName` to a trimmed string (`typeof spaceName === "string" ? spaceName.trim() : ""`). If empty, return `{ error: "Space name cannot be empty" }`.

### Behavior Before & After
- **Before**: `resolveFolderId("  Work  ")` created a duplicate folder `"  Work  "` even if `"Work"` existed. `resolveFolderId(null)` or `resolveFolderId("   ")` threw a `TypeError` or created a whitespace folder.
- **After**: `resolveFolderId("  Work  ")` matches existing folder `"Work"`. Nullish or whitespace-only inputs cleanly return `{ error: "Folder name cannot be empty" }`.

### Scope & Non-Goals
- Modifies only `src/services/tools/utils.ts` and adds unit tests to `test/services/toolUtils.test.js`.
- No changes to API contracts or database schema.

### Tests Added
- `test/services/toolUtils.test.js`:
  - `resolveFolderId normalizes whitespace and matches existing folders case-insensitively`
  - `resolveFolderId trims folder name before creating missing folders`
  - `resolveFolderId guards against nullish, empty, and whitespace-only inputs`
  - `resolveSpace normalizes whitespace and guards nullish or empty inputs`

### Validation Commands & Results
- `node --test test/services/toolUtils.test.js` -> 6/6 passed
- `npm test` -> 1022/1022 passed
- `npm run typecheck` -> Passed
- `npm run lint` -> Passed
- `npm run i18n:check` -> Passed
- `npm run build:renderer` -> Passed
- `git diff --check` -> Passed

Fixes #1476
