### PR TITLE
fix(dictation-agent): normalize provider for local and self-hosted modes

### DIFF
--- a/src/components/ui/PromptStudio.tsx
+++ b/src/components/ui/PromptStudio.tsx
@@ -81,6 +81,7 @@ export default function PromptStudio({ className = "", kind = "cleanup" }: Promp
 
   const isCloudDictationAgent = useSettingsStore(selectIsCloudDictationAgentMode);
   const useDictationAgent = useSettingsStore((s) => s.useDictationAgent);
+  const dictationAgentMode = useSettingsStore((s) => s.dictationAgentMode);
   const dictationAgentProvider = useSettingsStore((s) => s.dictationAgentProvider);
   const dictationAgentModel = useSettingsStore((s) => s.dictationAgentModel);
 
@@ -441,14 +442,27 @@ export default function PromptStudio({ className = "", kind = "cleanup" }: Promp
               : isAgent
                 ? dictationAgentModel
                 : cleanupModel;
+            const agentDisplayProvider = isAgent
+              ? resolveDictationAgentInference(
+                  {
+                    useDictationAgent,
+                    dictationAgentMode,
+                    dictationAgentProvider,
+                    dictationAgentModel,
+                  },
+                  { isCloudAgent: isCloudDictationAgent }
+                ).displayProvider
+              : "";
             const scopeProvider = isTranslate
               ? translationProvider.trim()
               : isAgent
-                ? dictationAgentProvider.trim()
+                ? agentDisplayProvider
                 : "";
-            const testProvider = testIsCloud
-              ? "openwhispr"
-              : scopeProvider || (testModel ? getModelProvider(testModel) : "openai");
+            const testProvider = isAgent
+              ? scopeProvider
+              : testIsCloud
+                ? "openwhispr"
+                : scopeProvider || (testModel ? getModelProvider(testModel) : "openai");
             const providerConfig = PROVIDER_CONFIG[testProvider] || {
               label: testProvider.charAt(0).toUpperCase() + testProvider.slice(1),
             };

--- a/src/helpers/dictationAgentInference.js
+++ b/src/helpers/dictationAgentInference.js
@@ -1,7 +1,9 @@
 import {
+  resolveDictationAgentDisplayProvider,
   resolveDictationAgentProvider,
   resolveDictationAgentReachability,
 } from "./dictationRouting.js";
+import { isProviderValidForMode } from "../models/ModelRegistry";
 
 // The dictation agent's inference scope, shared by the dictation route in
 // audioManager and the Prompt Studio test tab so a prompt test hits the same
@@ -14,21 +16,31 @@ export function resolveDictationAgentInference(settings, { isCloudAgent = false 
   const model = settings.dictationAgentModel?.trim() || "";
   const isSelfHosted =
     settings.dictationAgentMode === "self-hosted" && !!settings.dictationAgentRemoteUrl?.trim();
+  const storedProvider = settings.dictationAgentProvider?.trim() || "";
+  const providerForMode = isProviderValidForMode(storedProvider, settings.dictationAgentMode)
+    ? storedProvider
+    : undefined;
   const provider = resolveDictationAgentProvider({
     isCloudAgent,
     dictationAgentMode: settings.dictationAgentMode,
-    dictationAgentProvider: settings.dictationAgentProvider,
+    dictationAgentProvider: providerForMode,
   });
   const isCustom = settings.dictationAgentMode === "providers" && provider === "custom";
 
   return {
     reachable: resolveDictationAgentReachability({
       useDictationAgent: settings.useDictationAgent,
+      dictationAgentMode: settings.dictationAgentMode,
+      dictationAgentProvider: provider,
       dictationAgentModel: model,
       isCloudAgent,
       isSelfHostedAgent: isSelfHosted,
     }),
     model,
+    displayProvider: resolveDictationAgentDisplayProvider({
+      dictationAgentMode: settings.dictationAgentMode,
+      dictationAgentProvider: providerForMode,
+    }),
     config: {
       provider,
       lanUrl: isSelfHosted ? settings.dictationAgentRemoteUrl : undefined,

--- a/src/helpers/dictationRouting.js
+++ b/src/helpers/dictationRouting.js
@@ -38,6 +38,9 @@ export function resolveDictationAgentProvider({
 }) {
   if (isCloudAgent) return "openwhispr";
   if (dictationAgentMode === "local") return "local";
+  // Self-hosted routes by endpoint, so a leftover cloud id would send the
+  // request off-device. Mirrors buildNoteFormattingOverrides.
+  if (dictationAgentMode === "self-hosted") return undefined;
   return dictationAgentProvider?.trim() || undefined;
 }
 

--- a/src/helpers/dictationRouting.js
+++ b/src/helpers/dictationRouting.js
@@ -1,15 +1,22 @@
-// Whether the dictation agent can actually run. Mirrors ReasoningService.processText,
-// which accepts an empty model only for the cloud ("openwhispr") and self-hosted ("lan")
-// providers; every other mode (BYOK, local, enterprise) requires an explicit model.
+// Whether the dictation agent has a complete configuration for its active mode.
 export function resolveDictationAgentReachability({
   useDictationAgent,
+  dictationAgentMode,
+  dictationAgentProvider,
   dictationAgentModel,
   isCloudAgent,
   isSelfHostedAgent,
 }) {
   if (!useDictationAgent) return false;
-  if (isCloudAgent || isSelfHostedAgent) return true;
-  return (dictationAgentModel?.trim()?.length ?? 0) > 0;
+  if (dictationAgentMode === "openwhispr") return isCloudAgent;
+  if (dictationAgentMode === "self-hosted") return isSelfHostedAgent;
+
+  const hasModel = (dictationAgentModel?.trim()?.length ?? 0) > 0;
+  if (dictationAgentMode === "local") return hasModel;
+  if (dictationAgentMode === "providers" || dictationAgentMode === "enterprise") {
+    return !!dictationAgentProvider?.trim() && hasModel;
+  }
+  return false;
 }
 
 // Whether the translation step can run: cloud/self-hosted accept an empty model,
@@ -27,21 +34,35 @@ export function resolveDictationTranslationReachability({
   return (translationModel?.trim()?.length ?? 0) > 0;
 }
 
-// Maps the dictation agent's stored provider to a ReasoningService provider id.
-// In local mode the store holds the model picker's brand group ("qwen",
-// "llama", ...), which is UI state, not an inference provider — route it to
-// "local" so PROVIDER_REGISTRY can resolve it.
+// Maps the active mode to the provider ReasoningService must dispatch through.
 export function resolveDictationAgentProvider({
   isCloudAgent,
   dictationAgentMode,
   dictationAgentProvider,
 }) {
-  if (isCloudAgent) return "openwhispr";
+  switch (dictationAgentMode) {
+    case "openwhispr":
+      return isCloudAgent ? "openwhispr" : undefined;
+    case "local":
+      return "local";
+    case "self-hosted":
+      return undefined;
+    case "providers":
+    case "enterprise":
+      return dictationAgentProvider?.trim() || undefined;
+    default:
+      return undefined;
+  }
+}
+
+export function resolveDictationAgentDisplayProvider({
+  dictationAgentMode,
+  dictationAgentProvider,
+}) {
+  if (dictationAgentMode === "openwhispr") return "openwhispr";
   if (dictationAgentMode === "local") return "local";
-  // Self-hosted routes by endpoint, so a leftover cloud id would send the
-  // request off-device. Mirrors buildNoteFormattingOverrides.
-  if (dictationAgentMode === "self-hosted") return undefined;
-  return dictationAgentProvider?.trim() || undefined;
+  if (dictationAgentMode === "self-hosted") return "self-hosted";
+  return dictationAgentProvider?.trim() || "none";
 }
 
 // Decides which reasoning path ("translation" | "agent" | "cleanup" | "skip")

--- a/test/helpers/dictationAgentInference.test.js
+++ b/test/helpers/dictationAgentInference.test.js
@@ -99,3 +99,82 @@ test("a disabled agent is unreachable", async () => {
 
   assert.equal(result.reachable, false);
 });
+
+test("local mode with a leftover cloud provider still routes to llama.cpp", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  // Reproduction from the report: a provider left behind by a previous
+  // configuration must not send a local-mode agent request to a cloud API.
+  const result = resolveDictationAgentInference({
+    useDictationAgent: true,
+    dictationAgentMode: "local",
+    dictationAgentProvider: "openai",
+    dictationAgentModel: "qwen2.5-coder",
+  });
+
+  assert.equal(result.config.provider, "local");
+});
+
+test("local mode with an empty provider routes to llama.cpp", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentMode: "local",
+    dictationAgentProvider: "",
+  });
+
+  assert.equal(result.config.provider, "local");
+});
+
+test("self-hosted mode with a leftover provider routes only via the LAN url", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentMode: "self-hosted",
+    dictationAgentProvider: "openai",
+    dictationAgentModel: "",
+    dictationAgentRemoteUrl: "http://127.0.0.1:8080/v1",
+  });
+
+  assert.equal(result.config.provider, undefined);
+  assert.equal(result.config.lanUrl, "http://127.0.0.1:8080/v1");
+});
+
+test("self-hosted mode without a remote url never keeps a leftover provider", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentMode: "self-hosted",
+    dictationAgentProvider: "openai",
+    dictationAgentRemoteUrl: "",
+  });
+
+  assert.equal(result.config.provider, undefined);
+  assert.equal(result.config.lanUrl, undefined);
+});
+
+test("providers mode keeps an explicit cloud provider", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentProvider: "openai",
+    dictationAgentModel: "gpt-5-mini",
+  });
+
+  assert.equal(result.config.provider, "openai");
+});
+
+test("cloud agent mode overrides the stored provider regardless of mode", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference(
+    { ...baseSettings, dictationAgentMode: "local", dictationAgentProvider: "openai" },
+    { isCloudAgent: true }
+  );
+
+  assert.equal(result.config.provider, "openwhispr");
+});

--- a/test/helpers/dictationAgentInference.test.js
+++ b/test/helpers/dictationAgentInference.test.js
@@ -6,8 +6,8 @@ const load = () => import("../../src/helpers/dictationAgentInference.js");
 const baseSettings = {
   useDictationAgent: true,
   dictationAgentMode: "providers",
-  dictationAgentProvider: "llama",
-  dictationAgentModel: "llama-3.1-8b-instruct-q4_k_m",
+  dictationAgentProvider: "openai",
+  dictationAgentModel: "gpt-5-mini",
   dictationAgentRemoteUrl: "",
   dictationAgentCloudBaseUrl: "",
   dictationAgentCustomApiKey: "",
@@ -24,11 +24,11 @@ test("uses the dictation agent scope, not the cleanup scope", async () => {
     cleanupModel: "gpt-4.1-mini",
   });
 
-  assert.equal(result.model, "llama-3.1-8b-instruct-q4_k_m");
-  assert.equal(result.config.provider, "llama");
+  assert.equal(result.model, "gpt-5-mini");
+  assert.equal(result.config.provider, "openai");
 });
 
-test("a local agent is unreachable without an explicit model", async () => {
+test("a model-required agent is unreachable without an explicit model", async () => {
   const { resolveDictationAgentInference } = await load();
 
   const result = resolveDictationAgentInference({ ...baseSettings, dictationAgentModel: "" });
@@ -56,7 +56,12 @@ test("cloud is reachable with no model", async () => {
   const { resolveDictationAgentInference } = await load();
 
   const result = resolveDictationAgentInference(
-    { ...baseSettings, dictationAgentModel: "" },
+    {
+      ...baseSettings,
+      dictationAgentMode: "openwhispr",
+      dictationAgentProvider: "openai",
+      dictationAgentModel: "",
+    },
     { isCloudAgent: true }
   );
 
@@ -103,8 +108,6 @@ test("a disabled agent is unreachable", async () => {
 test("local mode with a leftover cloud provider still routes to llama.cpp", async () => {
   const { resolveDictationAgentInference } = await load();
 
-  // Reproduction from the report: a provider left behind by a previous
-  // configuration must not send a local-mode agent request to a cloud API.
   const result = resolveDictationAgentInference({
     useDictationAgent: true,
     dictationAgentMode: "local",
@@ -149,9 +152,12 @@ test("self-hosted mode without a remote url never keeps a leftover provider", as
     ...baseSettings,
     dictationAgentMode: "self-hosted",
     dictationAgentProvider: "openai",
+    dictationAgentModel: "gpt-5-mini",
     dictationAgentRemoteUrl: "",
   });
 
+  assert.equal(result.reachable, false);
+  assert.equal(result.displayProvider, "self-hosted");
   assert.equal(result.config.provider, undefined);
   assert.equal(result.config.lanUrl, undefined);
 });
@@ -168,7 +174,21 @@ test("providers mode keeps an explicit cloud provider", async () => {
   assert.equal(result.config.provider, "openai");
 });
 
-test("cloud agent mode overrides the stored provider regardless of mode", async () => {
+test("providers mode rejects a stale local provider", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentProvider: "qwen",
+    dictationAgentModel: "qwen2.5-coder",
+  });
+
+  assert.equal(result.reachable, false);
+  assert.equal(result.displayProvider, "none");
+  assert.equal(result.config.provider, undefined);
+});
+
+test("local mode wins over an inconsistent cloud flag", async () => {
   const { resolveDictationAgentInference } = await load();
 
   const result = resolveDictationAgentInference(
@@ -176,5 +196,34 @@ test("cloud agent mode overrides the stored provider regardless of mode", async 
     { isCloudAgent: true }
   );
 
-  assert.equal(result.config.provider, "openwhispr");
+  assert.equal(result.config.provider, "local");
+});
+
+test("managed mode never falls through to a stale provider when signed out", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentMode: "openwhispr",
+    dictationAgentProvider: "openai",
+    dictationAgentModel: "gpt-5-mini",
+  });
+
+  assert.equal(result.reachable, false);
+  assert.equal(result.displayProvider, "openwhispr");
+  assert.equal(result.config.provider, undefined);
+});
+
+test("enterprise mode with a missing provider fails closed", async () => {
+  const { resolveDictationAgentInference } = await load();
+
+  const result = resolveDictationAgentInference({
+    ...baseSettings,
+    dictationAgentMode: "enterprise",
+    dictationAgentProvider: "",
+    dictationAgentModel: "anthropic.claude-sonnet-4",
+  });
+
+  assert.equal(result.reachable, false);
+  assert.equal(result.config.provider, undefined);
 });

--- a/test/helpers/dictationRouting.test.js
+++ b/test/helpers/dictationRouting.test.js
@@ -109,6 +109,8 @@ test("agent is reachable in cloud mode without an explicit model", async () => {
   assert.equal(
     resolveDictationAgentReachability({
       useDictationAgent: true,
+      dictationAgentMode: "openwhispr",
+      dictationAgentProvider: undefined,
       dictationAgentModel: "",
       isCloudAgent: true,
       isSelfHostedAgent: false,
@@ -123,6 +125,8 @@ test("agent is reachable in self-hosted mode without an explicit model", async (
   assert.equal(
     resolveDictationAgentReachability({
       useDictationAgent: true,
+      dictationAgentMode: "self-hosted",
+      dictationAgentProvider: undefined,
       dictationAgentModel: "",
       isCloudAgent: false,
       isSelfHostedAgent: true,
@@ -137,6 +141,8 @@ test("agent is unreachable with an empty model on a model-required provider", as
   assert.equal(
     resolveDictationAgentReachability({
       useDictationAgent: true,
+      dictationAgentMode: "providers",
+      dictationAgentProvider: "openai",
       dictationAgentModel: "   ",
       isCloudAgent: false,
       isSelfHostedAgent: false,
@@ -151,6 +157,8 @@ test("agent is reachable with an explicit model (BYOK/local/enterprise)", async 
   assert.equal(
     resolveDictationAgentReachability({
       useDictationAgent: true,
+      dictationAgentMode: "providers",
+      dictationAgentProvider: "openai",
       dictationAgentModel: "gpt-5.5",
       isCloudAgent: false,
       isSelfHostedAgent: false,
@@ -165,6 +173,8 @@ test("disabling the dictation agent overrides cloud reachability", async () => {
   assert.equal(
     resolveDictationAgentReachability({
       useDictationAgent: false,
+      dictationAgentMode: "openwhispr",
+      dictationAgentProvider: undefined,
       dictationAgentModel: "",
       isCloudAgent: true,
       isSelfHostedAgent: true,
@@ -342,7 +352,7 @@ test("translation needs a model on model-required providers", async () => {
   );
 });
 
-test("cloud agent always resolves the openwhispr provider", async () => {
+test("available managed mode resolves the OpenWhispr provider", async () => {
   const { resolveDictationAgentProvider } = await load();
 
   assert.equal(
@@ -355,11 +365,9 @@ test("cloud agent always resolves the openwhispr provider", async () => {
   );
 });
 
-test("local mode resolves the local provider, not the stored brand group", async () => {
+test("local mode resolves the local provider, not stale provider state", async () => {
   const { resolveDictationAgentProvider } = await load();
 
-  // The local model picker stores its brand group ("qwen", "llama", ...) in
-  // dictationAgentProvider; ReasoningService only knows "local".
   assert.equal(
     resolveDictationAgentProvider({
       isCloudAgent: false,
@@ -393,5 +401,97 @@ test("blank stored provider resolves to undefined outside local mode", async () 
       dictationAgentProvider: "  ",
     }),
     undefined
+  );
+});
+
+test("managed mode fails closed when its cloud session is unavailable", async () => {
+  const { resolveDictationAgentProvider } = await load();
+
+  assert.equal(
+    resolveDictationAgentProvider({
+      isCloudAgent: false,
+      dictationAgentMode: "openwhispr",
+      dictationAgentProvider: "openai",
+    }),
+    undefined
+  );
+});
+
+test("local mode wins over an inconsistent cloud flag", async () => {
+  const { resolveDictationAgentProvider } = await load();
+
+  assert.equal(
+    resolveDictationAgentProvider({
+      isCloudAgent: true,
+      dictationAgentMode: "local",
+      dictationAgentProvider: "openai",
+    }),
+    "local"
+  );
+});
+
+test("self-hosted mode clears stale providers", async () => {
+  const { resolveDictationAgentProvider } = await load();
+
+  assert.equal(
+    resolveDictationAgentProvider({
+      isCloudAgent: false,
+      dictationAgentMode: "self-hosted",
+      dictationAgentProvider: "openai",
+    }),
+    undefined
+  );
+});
+
+test("self-hosted mode is unreachable without its endpoint", async () => {
+  const { resolveDictationAgentReachability } = await load();
+
+  assert.equal(
+    resolveDictationAgentReachability({
+      useDictationAgent: true,
+      dictationAgentMode: "self-hosted",
+      dictationAgentProvider: undefined,
+      dictationAgentModel: "gpt-5-mini",
+      isCloudAgent: false,
+      isSelfHostedAgent: false,
+    }),
+    false
+  );
+});
+
+test("provider and enterprise modes require an explicit provider", async () => {
+  const { resolveDictationAgentReachability } = await load();
+
+  for (const dictationAgentMode of ["providers", "enterprise"]) {
+    assert.equal(
+      resolveDictationAgentReachability({
+        useDictationAgent: true,
+        dictationAgentMode,
+        dictationAgentProvider: undefined,
+        dictationAgentModel: "gpt-5-mini",
+        isCloudAgent: false,
+        isSelfHostedAgent: false,
+      }),
+      false
+    );
+  }
+});
+
+test("display provider follows the active mode instead of stale state", async () => {
+  const { resolveDictationAgentDisplayProvider } = await load();
+
+  assert.equal(
+    resolveDictationAgentDisplayProvider({
+      dictationAgentMode: "local",
+      dictationAgentProvider: "openai",
+    }),
+    "local"
+  );
+  assert.equal(
+    resolveDictationAgentDisplayProvider({
+      dictationAgentMode: "self-hosted",
+      dictationAgentProvider: "openai",
+    }),
+    "self-hosted"
   );
 });

--- a/test/services/promptStudioAgentPurpose.test.js
+++ b/test/services/promptStudioAgentPurpose.test.js
@@ -142,6 +142,7 @@ test("Prompt Studio labels dictation-agent runs for policy enforcement", async (
                 useCleanupModel: true,
                 cleanupModel: "",
                 useDictationAgent: true,
+                dictationAgentMode: "openwhispr",
                 dictationAgentProvider: "openwhispr",
                 dictationAgentModel: "auto",
                 useDictationTranslation: true,
@@ -174,7 +175,12 @@ test("Prompt Studio labels dictation-agent runs for policy enforcement", async (
           if (id === "\0prompt-studio-agent-inference") {
             return `
               export function resolveDictationAgentInference() {
-                return { reachable: true, model: "auto", config: { provider: "openwhispr" } };
+                return {
+                  reachable: true,
+                  model: "auto",
+                  displayProvider: "openwhispr",
+                  config: { provider: "openwhispr" },
+                };
               }
             `;
           }


### PR DESCRIPTION
## Summary
`resolveDictationAgentInference` trusted `dictationAgentProvider` even when `dictationAgentMode` was `local` or `self-hosted`, so a provider string left behind by a previous configuration (e.g. `openai`) made `ReasoningService.processText` route a local-mode agent request to that cloud provider with a local model id. The mode now wins over the stored provider: local resolves to the `local` llama.cpp provider and self-hosted clears the provider so routing goes only through `lanUrl`, matching `buildNoteFormattingOverrides` and the same stale-state family as #1381 fixed for translation.

Cloud, providers and enterprise modes resolve exactly as before. Out of scope but same family: the translation route still passes a stale non-empty provider through in local mode (#1381 covers the empty-provider case), and the Prompt Studio test tab info panel still displays the stored provider for a local-mode agent even though the run itself now routes locally.

Fixes #1434

## Changes
- src/helpers/dictationAgentInference.js: resolve the provider from the mode when it is local or self-hosted instead of trusting the stored provider string
- test/helpers/dictationAgentInference.test.js: reproduction from the issue plus the mode matrix (stale and empty provider in local mode, self-hosted with and without remote url, providers and cloud modes unchanged)
