### PR TITLE
fix(calendar): re-arm next meeting timer when resetting provider reminder state

### DIFF
--- a/src/helpers/calendarReminderScheduler.js
+++ b/src/helpers/calendarReminderScheduler.js
@@ -161,6 +161,8 @@ class CalendarReminderScheduler {
     for (const key of this.notifiedMeetings) {
       if (key.startsWith(prefix)) this.notifiedMeetings.delete(key);
     }
+
+    this.scheduleNextMeeting();
   }
 }
 

--- a/test/helpers/calendarReminderScheduler.test.js
+++ b/test/helpers/calendarReminderScheduler.test.js
@@ -86,3 +86,30 @@ test("reconciling a provider clears an active event removed by a snapshot", () =
   assert.equal(promptCount, 1, "a periodic snapshot must not re-fire an old reminder");
   scheduler.stop();
 });
+
+test("resetting a provider re-arms the next meeting timer for upcoming events", () => {
+  const futureEvent = {
+    id: "meeting-future",
+    provider: "google",
+    summary: "Future meeting",
+    start_time: new Date(Date.now() + 600_000).toISOString(),
+    end_time: new Date(Date.now() + 1200_000).toISOString(),
+  };
+  const databaseManager = {
+    getUpcomingEvents: () => [futureEvent],
+    getActiveEvents: () => [],
+  };
+  const scheduler = new CalendarReminderScheduler(databaseManager);
+
+  scheduler.scheduleNextMeeting();
+  assert.notEqual(scheduler.nextMeetingTimer, null);
+
+  scheduler.reset("apple");
+  assert.notEqual(
+    scheduler.nextMeetingTimer,
+    null,
+    "reset(provider) must re-arm the next meeting timer"
+  );
+
+  scheduler.stop();
+});


### PR DESCRIPTION
### Problem
When `CalendarReminderScheduler.prototype.reset(provider)` is invoked (such as when Google or Apple Calendar completes a sync), it clears `nextMeetingTimer` to clean up timer references. However, unless `this.activeMeeting?.provider` matched the specific provider being reset, `reset(provider)` returned without calling `this.scheduleNextMeeting()`.

As a result, if upcoming calendar events existed and a background sync or settings refresh completed for another calendar provider, `nextMeetingTimer` was cleared and set to `null`, silently stopping future meeting reminder notifications until another calendar mutation occurred.

### Root Cause
`CalendarReminderScheduler.prototype.reset(provider)` cleared `this.nextMeetingTimer` on line 150 of `src/helpers/calendarReminderScheduler.js`, but failed to call `this.scheduleNextMeeting()` before returning.

### Solution
Added `this.scheduleNextMeeting()` at the end of `reset(provider)` so that upcoming events across all calendar providers are properly re-evaluated and scheduled whenever state for a single provider is reset.

### Changes Made
- `src/helpers/calendarReminderScheduler.js`: Call `this.scheduleNextMeeting()` at the end of `reset(provider)`.
- `test/helpers/calendarReminderScheduler.test.js`: Added regression test verifying `nextMeetingTimer` is re-armed after `reset(provider)`.

### Validation
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/calendarReminderScheduler.test.js` (4/4 passed)
- `npm run typecheck` (Passed)
- `npm run lint` (Passed)
- `npm run format:check` (Passed)
- `npm run i18n:check` (Passed)
- `git diff --check` (Passed)

Fixes #1485
