### PR TITLE
fix(utils): safely parse transcript segments with nullish, whitespace, and non-object guards

### DIFF
--- a/src/utils/parseTranscriptSegments.ts
+++ b/src/utils/parseTranscriptSegments.ts
@@ -1,36 +1,36 @@
 import type { TranscriptSegment } from "../stores/meetingRecordingStore";
-import { normalizeTranscriptSegments } from "./transcriptSpeakerState";
-import logger from "./logger";
+import { normalizeTranscriptSegments } from "./transcriptSpeakerState.ts";
+import logger from "./logger.ts";
+
 export function parseTranscriptSegments(raw: string): TranscriptSegment[] {
-  if (!raw.startsWith("[")) return [];
+  if (typeof raw !== "string") return [];
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[")) return [];
+
   try {
-    const parsed = JSON.parse(raw) as Array<{
-      text: string;
-      source: "mic" | "system";
-      timestamp?: number;
-      speaker?: string;
-      speakerName?: string;
-      speakerIsPlaceholder?: boolean;
-      suggestedName?: string;
-      suggestedProfileId?: number;
-      speakerStatus?: TranscriptSegment["speakerStatus"];
-      speakerLocked?: TranscriptSegment["speakerLocked"];
-      speakerLockSource?: TranscriptSegment["speakerLockSource"];
-    }>;
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) return [];
+
+    const validItems = parsed.filter(
+      (s): s is Record<string, unknown> => s !== null && typeof s === "object"
+    );
+
     return normalizeTranscriptSegments(
-      parsed.map((s, i) => ({
+      validItems.map((s, i) => ({
         id: `stored-${i}`,
-        text: s.text,
-        source: s.source,
-        timestamp: s.timestamp,
-        speaker: s.speaker,
-        speakerName: s.speakerName,
-        speakerIsPlaceholder: s.speakerIsPlaceholder,
-        suggestedName: s.suggestedName,
-        suggestedProfileId: s.suggestedProfileId,
-        speakerStatus: s.speakerStatus,
-        speakerLocked: s.speakerLocked,
-        speakerLockSource: s.speakerLockSource,
+        text: typeof s.text === "string" ? s.text : "",
+        source: (s.source === "system" ? "system" : "mic") as "mic" | "system",
+        timestamp: typeof s.timestamp === "number" ? s.timestamp : undefined,
+        speaker: typeof s.speaker === "string" ? s.speaker : undefined,
+        speakerName: typeof s.speakerName === "string" ? s.speakerName : undefined,
+        speakerIsPlaceholder:
+          typeof s.speakerIsPlaceholder === "boolean" ? s.speakerIsPlaceholder : undefined,
+        suggestedName: typeof s.suggestedName === "string" ? s.suggestedName : undefined,
+        suggestedProfileId:
+          typeof s.suggestedProfileId === "number" ? s.suggestedProfileId : undefined,
+        speakerStatus: s.speakerStatus as TranscriptSegment["speakerStatus"],
+        speakerLocked: s.speakerLocked as TranscriptSegment["speakerLocked"],
+        speakerLockSource: s.speakerLockSource as TranscriptSegment["speakerLockSource"],
       }))
     );
   } catch (e) {

--- a/test/utils/parseTranscriptSegments.test.js
+++ b/test/utils/parseTranscriptSegments.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/parseTranscriptSegments.ts");
+
+test("parseTranscriptSegments safely handles nullish and non-string inputs", async () => {
+  const { parseTranscriptSegments } = await load();
+  assert.deepEqual(parseTranscriptSegments(null), []);
+  assert.deepEqual(parseTranscriptSegments(undefined), []);
+  assert.deepEqual(parseTranscriptSegments(123), []);
+});
+
+test("parseTranscriptSegments parses JSON arrays with leading whitespace or newlines", async () => {
+  const { parseTranscriptSegments } = await load();
+  const jsonWithWhitespace = `
+  [
+    {
+      "text": "Hello world",
+      "source": "mic",
+      "timestamp": 12345
+    }
+  ]
+  `;
+  const result = parseTranscriptSegments(jsonWithWhitespace);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].text, "Hello world");
+  assert.equal(result[0].source, "mic");
+  assert.equal(result[0].timestamp, 12345);
+});
+
+test("parseTranscriptSegments safely handles arrays with null or non-object elements", async () => {
+  const { parseTranscriptSegments } = await load();
+  const jsonWithNullElement = `[null, {"text": "Valid", "source": "system"}]`;
+  const result = parseTranscriptSegments(jsonWithNullElement);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].text, "Valid");
+  assert.equal(result[0].source, "system");
+});


### PR DESCRIPTION
## Summary
Fixes `parseTranscriptSegments` to safely handle nullish/non-string inputs, JSON strings with leading whitespace or newlines, and non-object array elements.

Fixes #1487

## Problem
When parsing stored or transmitted JSON transcript segment strings:
1. Passing `null`, `undefined`, or non-string inputs (which can occur from optional database fields or uninitialized props) throws an unhandled `TypeError: Cannot read properties of null (reading 'startsWith')`.
2. Valid JSON strings containing leading whitespace or newlines (e.g. `\n[\n  {...}\n]`) fail the `raw.startsWith("[")` check and return `[]`, silently dropping all transcript segments.
3. Arrays containing non-object elements (such as `null` or primitives) cause `TypeError: Cannot read properties of null (reading 'text')` during mapping.

## Root Cause
- `parseTranscriptSegments` assumed `raw` was always a string starting directly with `[`.
- It did not trim `raw` before validating the `[` prefix or check if `raw` was a string.
- It assumed `JSON.parse` output was an array of objects without filtering out non-object elements.

## Fix
1. Guard `raw` to ensure it is a string before calling `.trim()`.
2. Trim `raw` before checking for the `[` prefix.
3. Verify `Array.isArray(parsed)` and filter `parsed` for non-null object elements (`s !== null && typeof s === "object"`).
4. Safely extract properties with fallback types during mapping.

## Behavior Before vs After
- **Before:** Nullish input throws `TypeError`. JSON strings with leading whitespace/newlines return `[]` and drop transcript segments. Arrays with null elements throw `TypeError`.
- **After:** Nullish or non-string inputs return `[]`. Whitespace/newline-padded JSON strings parse correctly into `TranscriptSegment[]`. Non-object array elements are safely filtered out.

## Scope & Non-Goals
- Only modifies `parseTranscriptSegments` and adds unit tests.
- Does not modify database schemas or component interfaces.

## Tests Added
- `test/utils/parseTranscriptSegments.test.js`:
  - `parseTranscriptSegments safely handles nullish and non-string inputs`
  - `parseTranscriptSegments parses JSON arrays with leading whitespace or newlines`
  - `parseTranscriptSegments safely handles arrays with null or non-object elements`

## Validation Results
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/utils/parseTranscriptSegments.test.js` -> PASS
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` -> PASS (1055 tests passed)
- `npm run typecheck` -> PASS
- `npm run lint` -> PASS
- `npm run i18n:check` -> PASS
- `npm run build:renderer` -> PASS
- `git diff --check` -> PASS
- `npx prettier --check src/utils/parseTranscriptSegments.ts test/utils/parseTranscriptSegments.test.js` -> PASS
