### PR TITLE
fix(meetings): bind diarization results to their recording note

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -77,6 +77,7 @@ import {
 } from "../../utils/transcriptSpeakerState";
 import NoteParticipants from "./NoteParticipants";
 import type { CalendarAttendee } from "../../types/calendar";
+import { matchesMeetingDiarizationTarget } from "../../utils/meetingDiarizationTarget";
 
 const CHIP_BUTTON_CLASS =
   "inline-flex items-center gap-1.5 text-[11px] px-1.5 py-0.5 rounded-md border border-border/70 dark:border-white/25 text-foreground/50 dark:text-foreground/35 hover:text-foreground/60 hover:border-border/60 hover:bg-foreground/3 dark:hover:text-foreground/40 dark:hover:border-white/10 dark:hover:bg-white/3 transition-all duration-150 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring/30";
@@ -527,36 +528,29 @@ export default function NoteEditor({
 
   useEffect(() => {
     const expectedSession = diarizationSessionId;
-    const cleanup = window.electronAPI?.onMeetingDiarizationComplete?.(async (data) => {
-      if (!expectedSession || data?.sessionId !== expectedSession) return;
+    const cleanup = window.electronAPI?.onMeetingDiarizationComplete?.((data) => {
+      if (
+        !matchesMeetingDiarizationTarget(data, {
+          sessionId: expectedSession,
+          noteId: note.id,
+          clientNoteId: note.client_note_id,
+        })
+      ) {
+        return;
+      }
 
       setIsDiarizing(false);
 
       if (!data?.segments?.length) return;
 
-      // Store segments outlive their recording — only use them for the note they belong to.
-      const { recordingNoteId, segments: liveSegments } = useMeetingRecordingStore.getState();
-      const persisted = await window.electronAPI?.getNote?.(note.id);
-      const existing = persisted?.transcript
-        ? parseTranscriptSegments(persisted.transcript)
-        : recordingNoteId === note.id && liveSegments.length > 0
-          ? liveSegments
-          : displaySegmentsRef.current;
-
       const enriched = mergeTranscriptSegments(
-        existing,
+        displaySegmentsRef.current,
         data.segments.map((s: any, i: number) => ({
           ...s,
           id: s.id || `diarized-${i}`,
         }))
       );
       setDiarizedSegments(enriched);
-
-      window.electronAPI.updateNote(note.id, { transcript: serializeTranscriptSegments(enriched) });
-
-      if (data.speakerEmbeddings) {
-        window.electronAPI?.saveNoteSpeakerEmbeddings?.(note.id, data.speakerEmbeddings);
-      }
 
       const autoMappings: Record<string, string> = {};
       for (const s of enriched) {
@@ -567,7 +561,7 @@ export default function NoteEditor({
       }
     });
     return () => cleanup?.();
-  }, [note.id, diarizationSessionId]);
+  }, [note.client_note_id, note.id, diarizationSessionId]);
 
   const persistDisplaySegments = useCallback(
     async (nextSegments: TranscriptSegment[], updateOverlay = true) => {

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -208,6 +208,7 @@ export default function PersonalNotesView({
   const [showStructureIntro, setShowStructureIntro] = useState(false);
 
   const isTranscribing = useMeetingRecordingStore((s) => s.isRecording);
+  const isStoppingRecording = useMeetingRecordingStore((s) => s.isStopping);
   const diarizationSessionId = useMeetingRecordingStore((s) => s.diarizationSessionId);
   const recordingNoteId = useMeetingRecordingStore((s) => s.recordingNoteId);
   const sessionDiarizationEnabled = useMeetingRecordingStore((s) => s.sessionDiarizationEnabled);
@@ -325,6 +326,7 @@ export default function PersonalNotesView({
     const seedSegments = note?.transcript ? parseTranscriptSegments(note.transcript) : [];
     await storeStartRecording({
       noteId,
+      clientNoteId: note?.client_note_id ?? null,
       noteTitle: note?.title ?? null,
       folderId: note?.folder_id ?? null,
       seedSegments,
@@ -614,9 +616,11 @@ export default function PersonalNotesView({
   useEffect(() => {
     if (!meetingRecordingRequest || activeNoteId !== meetingRecordingRequest.noteId) return;
     const note = activeNote?.id === meetingRecordingRequest.noteId ? activeNote : null;
+    if (!note?.client_note_id) return;
     const seedSegments = note?.transcript ? parseTranscriptSegments(note.transcript) : [];
     storeStartRecording({
       noteId: meetingRecordingRequest.noteId,
+      clientNoteId: note?.client_note_id ?? null,
       noteTitle: note?.title ?? null,
       folderId: note?.folder_id ?? meetingRecordingRequest.folderId ?? null,
       seedSegments,
@@ -748,7 +752,7 @@ export default function PersonalNotesView({
               onContentChange={handleContentChange}
               isSaving={isSaving}
               isRecording={isActiveNoteRecording}
-              isProcessing={false}
+              isProcessing={isStoppingRecording}
               onStartRecording={startRecording}
               onStopRecording={stopRecording}
               onExportNote={handleExportNote}

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -42,6 +42,13 @@ const {
   canAutoRelabelSpeaker,
   isSpeakerLocked,
 } = require("./speakerAssignmentPolicy");
+const {
+  matchesMeetingNoteIdentity,
+  persistMeetingDiarizationResult,
+  resolveMeetingNoteIdentity,
+  snapshotMeetingNoteIdentity,
+} = require("./meetingDiarizationPersistence");
+const { MeetingSessionLifecycle } = require("./meetingSessionLifecycle");
 const { downsample24kTo16k, pcm16ToWav } = require("../utils/audioUtils");
 const postMigrationDetector = require("./postMigrationDetector");
 const {
@@ -1383,7 +1390,9 @@ class IPCHandlers {
         setImmediate(() => broadcastToWindows("note-updated", result.note));
         this._asyncVectorUpsert(result.note);
         this._asyncMirrorWrite(result.note);
-        if (updates.participants) this._tryAutoLabelOneOnOne(id);
+        if (updates.participants) {
+          this._tryAutoLabelOneOnOne(snapshotMeetingNoteIdentity(this.databaseManager, id));
+        }
       }
       return result;
     });
@@ -4959,6 +4968,7 @@ class IPCHandlers {
     let meetingTranscriptionStartInProgress = false;
     let meetingTranscriptionPrepareInProgress = false;
     let meetingTranscriptionPreparePromise = null;
+    const meetingSessionLifecycle = new MeetingSessionLifecycle();
 
     const DUPLICATE_TRANSCRIPT_WINDOW_MS = 6000;
     const DUPLICATE_TRANSCRIPT_MERGE_LIMIT = 3;
@@ -5749,6 +5759,7 @@ class IPCHandlers {
     let meetingOneOnOneAttendee = null;
     let meetingOneOnOneProfileBound = false;
     let meetingNoteId = null;
+    let meetingNoteIdentity = null;
 
     const getLiveSpeakerProfiles = () => {
       const attendees = this._getNoteNonSelfParticipants(meetingNoteId);
@@ -6292,6 +6303,7 @@ class IPCHandlers {
       meetingOneOnOneAttendee = null;
       meetingOneOnOneProfileBound = false;
       meetingNoteId = null;
+      meetingNoteIdentity = null;
       meetingLocalMode = false;
       meetingLocalBuffers = { mic: [], system: [] };
       if (meetingDiarizationStream) {
@@ -6568,7 +6580,7 @@ class IPCHandlers {
     };
 
     // Pre-warm: fetch tokens + connect WebSockets before user hits record
-    ipcMain.handle("meeting-transcription-prepare", async (event, options = {}) => {
+    const handleMeetingTranscriptionPrepare = async (event, options = {}) => {
       if (meetingTranscriptionPrepareInProgress || meetingTranscriptionStartInProgress) {
         debugLogger.debug("Meeting transcription prepare already in progress, ignoring");
         return { success: false, error: "Operation in progress" };
@@ -6612,9 +6624,15 @@ class IPCHandlers {
       })();
 
       return meetingTranscriptionPreparePromise;
-    });
+    };
+    ipcMain.handle("meeting-transcription-prepare", (event, options = {}) =>
+      meetingSessionLifecycle.run(() => handleMeetingTranscriptionPrepare(event, options))
+    );
 
     ipcMain.handle("meeting-transcription-cancel", async () => {
+      if (meetingSessionLifecycle.isStopping) {
+        return { success: false, reason: "operation-in-progress" };
+      }
       if (isMeetingStreamingConnected() || meetingLocalTimer) {
         return { success: false, reason: "recording-active" };
       }
@@ -6624,7 +6642,7 @@ class IPCHandlers {
       return { success: true };
     });
 
-    ipcMain.handle("meeting-transcription-start", async (event, options = {}) => {
+    const handleMeetingTranscriptionStart = async (event, options = {}) => {
       // Wait for any in-flight prepare to finish before starting
       if (meetingTranscriptionPreparePromise) {
         debugLogger.debug("Meeting transcription start: waiting for in-flight prepare");
@@ -6649,6 +6667,26 @@ class IPCHandlers {
         meetingOneOnOneAttendee = resolveOneOnOneAttendeeForNote(options.noteId);
         meetingOneOnOneProfileBound = false;
         meetingNoteId = options.noteId ?? null;
+        const expectedClientNoteId = options.clientNoteId ?? null;
+        try {
+          meetingNoteIdentity = resolveMeetingNoteIdentity(
+            this.databaseManager,
+            meetingNoteId,
+            expectedClientNoteId
+          );
+        } catch (error) {
+          meetingNoteIdentity = null;
+          debugLogger.warn("Failed to snapshot meeting note identity", {
+            noteId: meetingNoteId,
+            error: error.message,
+          });
+        }
+        const noteTargetChanged =
+          (meetingNoteId == null) !== (expectedClientNoteId == null) ||
+          (meetingNoteId != null && meetingNoteIdentity == null);
+        if (noteTargetChanged) {
+          throw new Error("Meeting note changed before recording could start");
+        }
 
         // Seed the speaker cap from the note/calendar participants up front so live
         // identification isn't stuck at the default if the renderer never pushes a config.
@@ -6750,7 +6788,10 @@ class IPCHandlers {
       } finally {
         meetingTranscriptionStartInProgress = false;
       }
-    });
+    };
+    ipcMain.handle("meeting-transcription-start", (event, options = {}) =>
+      meetingSessionLifecycle.start(() => handleMeetingTranscriptionStart(event, options))
+    );
 
     const sendMeetingAudio = (audioBuffer, source) => {
       const outboundBuffer = Buffer.isBuffer(audioBuffer) ? audioBuffer : Buffer.from(audioBuffer);
@@ -6911,7 +6952,18 @@ class IPCHandlers {
       sendMeetingAudio(audioBuffer, source);
     });
 
-    ipcMain.handle("meeting-transcription-stop", async () => {
+    const handleMeetingTranscriptionStop = async () => {
+      // Snapshot the complete session owner before teardown yields. A later
+      // start is queued behind this operation and cannot replace these values.
+      const sessionContext = {
+        localMode: meetingLocalMode,
+        diarizationWin: meetingLocalWin || this.windowManager.controlPanelWindow,
+        speakerConfig: this.activeMeetingSpeakerConfig
+          ? { ...this.activeMeetingSpeakerConfig }
+          : null,
+        noteIdentity: meetingNoteIdentity ? { ...meetingNoteIdentity } : null,
+      };
+
       this.meetingDetectionEngine?.setUserRecording(false);
       try {
         if (this.audioTapManager) {
@@ -6930,9 +6982,8 @@ class IPCHandlers {
         const liveSpeakerState = await stopLiveSpeakerIdentification().catch(() => null);
 
         const diarizationSessionId = `diar-${Date.now()}`;
-        const diarizationWin = meetingLocalWin || this.windowManager.controlPanelWindow;
 
-        if (meetingLocalMode) {
+        if (sessionContext.localMode) {
           if (meetingLocalTimer) {
             clearInterval(meetingLocalTimer);
             meetingLocalTimer = null;
@@ -6947,8 +6998,6 @@ class IPCHandlers {
             await captureMeetingDiarizationState();
           const transcript =
             buildOrderedTranscriptText(diarizationSegments) || meetingLocalTranscript;
-          const sessionSpeakerConfigSnapshot = this.activeMeetingSpeakerConfig;
-          const noteIdSnapshot = meetingNoteId;
           this.activeMeetingSpeakerConfig = null;
           resetMeetingLocalState();
 
@@ -6958,10 +7007,10 @@ class IPCHandlers {
             diarizationPcmPath,
             diarizationStartedAt,
             diarizationSegments,
-            diarizationWin,
+            sessionContext.diarizationWin,
             liveSpeakerState,
-            sessionSpeakerConfigSnapshot,
-            noteIdSnapshot
+            sessionContext.speakerConfig,
+            sessionContext.noteIdentity
           );
 
           return { success: true, transcript, diarizationSessionId };
@@ -6974,8 +7023,6 @@ class IPCHandlers {
           buildOrderedTranscriptText(diarizationSegments) ||
           [results[0]?.text, results[1]?.text].filter(Boolean).join(" ");
 
-        const sessionSpeakerConfigSnapshot = this.activeMeetingSpeakerConfig;
-        const noteIdSnapshot = meetingNoteId;
         this.activeMeetingSpeakerConfig = null;
 
         // Fire-and-forget background diarization (or notify skip)
@@ -6984,10 +7031,10 @@ class IPCHandlers {
           diarizationPcmPath,
           diarizationStartedAt,
           diarizationSegments,
-          diarizationWin,
+          sessionContext.diarizationWin,
           liveSpeakerState,
-          sessionSpeakerConfigSnapshot,
-          noteIdSnapshot
+          sessionContext.speakerConfig,
+          sessionContext.noteIdentity
         );
 
         return { success: true, transcript, diarizationSessionId };
@@ -6995,7 +7042,10 @@ class IPCHandlers {
         debugLogger.error("Meeting transcription stop error", { error: error.message });
         return { success: false, error: error.message };
       }
-    });
+    };
+    ipcMain.handle("meeting-transcription-stop", () =>
+      meetingSessionLifecycle.stop(handleMeetingTranscriptionStop)
+    );
 
     const streamingStartFailure = (err) => {
       const result = { success: false, error: err.message };
@@ -9427,7 +9477,7 @@ class IPCHandlers {
         buffers[speakerId] = Buffer.from(new Float32Array(arr).buffer);
       }
       this.databaseManager.saveNoteSpeakerEmbeddings(noteId, buffers);
-      this._tryAutoLabelOneOnOne(noteId);
+      this._tryAutoLabelOneOnOne(snapshotMeetingNoteIdentity(this.databaseManager, noteId));
       return { success: true };
     });
   }
@@ -9501,9 +9551,11 @@ class IPCHandlers {
     });
   }
 
-  _tryAutoLabelOneOnOne(noteId) {
+  _tryAutoLabelOneOnOne(noteIdentity) {
     setImmediate(async () => {
+      const noteId = noteIdentity?.noteId ?? null;
       try {
+        if (!matchesMeetingNoteIdentity(this.databaseManager, noteIdentity)) return;
         const note = this.databaseManager.getNote(noteId);
         const other = this._resolveOneOnOneOtherParticipant(note?.participants);
         if (!other) return;
@@ -9589,11 +9641,21 @@ class IPCHandlers {
     }
   }
 
-  _reconcileLiveSpeakerState(liveSpeakerState, speakerEmbeddingsMap, enrichedSegments) {
-    if (!liveSpeakerState || !speakerEmbeddingsMap) {
+  _reconcileLiveSpeakerState(
+    liveSpeakerState,
+    speakerEmbeddingsMap,
+    enrichedSegments,
+    noteIdentity
+  ) {
+    if (
+      !liveSpeakerState ||
+      !speakerEmbeddingsMap ||
+      !matchesMeetingNoteIdentity(this.databaseManager, noteIdentity)
+    ) {
       return new Set();
     }
 
+    const noteId = noteIdentity.noteId;
     const speakerEmbeddings = require("./speakerEmbeddings");
     const reconciledSpeakers = new Set();
     const usedLiveSpeakers = new Set();
@@ -9607,7 +9669,7 @@ class IPCHandlers {
         noteId: data?.noteId ?? null,
         embedding: Array.isArray(data?.embedding) ? new Float32Array(data.embedding) : null,
       }))
-      .filter((entry) => entry.embedding);
+      .filter((entry) => entry.embedding && (entry.noteId == null || entry.noteId === noteId));
 
     const getMappingsForNote = (noteId) => {
       if (!noteMappings.has(noteId)) {
@@ -9645,27 +9707,17 @@ class IPCHandlers {
       let displayName = bestEntry.displayName;
       let profileId = bestEntry.profileId;
 
-      if (bestEntry.noteId) {
-        const liveMapping = getMappingsForNote(bestEntry.noteId).find(
+      if (bestEntry.noteId === noteId) {
+        const liveMapping = getMappingsForNote(noteId).find(
           (mapping) => mapping.speaker_id === bestEntry.speakerId
         );
         if (liveMapping) {
           displayName = liveMapping.display_name || displayName;
           profileId = liveMapping.profile_id ?? profileId;
-          this.databaseManager.setSpeakerMapping(
-            bestEntry.noteId,
-            mappedId,
-            profileId,
-            displayName
-          );
-          this.databaseManager.removeSpeakerMapping(bestEntry.noteId, bestEntry.speakerId);
+          this.databaseManager.setSpeakerMapping(noteId, mappedId, profileId, displayName);
+          this.databaseManager.removeSpeakerMapping(noteId, bestEntry.speakerId);
         } else if (displayName) {
-          this.databaseManager.setSpeakerMapping(
-            bestEntry.noteId,
-            mappedId,
-            profileId,
-            displayName
-          );
+          this.databaseManager.setSpeakerMapping(noteId, mappedId, profileId, displayName);
         }
       }
 
@@ -9712,18 +9764,72 @@ class IPCHandlers {
     win,
     liveSpeakerState = null,
     sessionConfig = null,
-    noteId = null
+    noteIdentity = null
   ) {
     const send = (payload) => {
-      if (win && !win.isDestroyed()) {
-        win.webContents.send("meeting-diarization-complete", { sessionId, ...payload });
-      }
+      // This event is a best-effort UI refresh. Main-process persistence is
+      // authoritative if the renderer has not rebound its listener yet.
+      setImmediate(() => {
+        if (win && !win.isDestroyed()) {
+          win.webContents.send("meeting-diarization-complete", {
+            ...payload,
+            sessionId,
+            noteId: noteIdentity?.noteId ?? null,
+            clientNoteId: noteIdentity?.clientNoteId ?? null,
+          });
+        }
+      });
     };
+
+    const persistAndSend = (payload) => {
+      let eventPayload = payload;
+      if (payload.segments?.length) {
+        try {
+          const result = persistMeetingDiarizationResult({
+            databaseManager: this.databaseManager,
+            identity: noteIdentity,
+            segments: payload.segments,
+            speakerEmbeddings: payload.speakerEmbeddings,
+            onNoteUpdated: (note) => {
+              setImmediate(() => broadcastToWindows("note-updated", note));
+              this._asyncVectorUpsert(note);
+              this._asyncMirrorWrite(note);
+            },
+            onSpeakerEmbeddingsSaved: (identity) => this._tryAutoLabelOneOnOne(identity),
+          });
+
+          if (result.status === "persisted") {
+            eventPayload = { ...payload, segments: result.segments };
+            if (result.embeddingError) {
+              debugLogger.warn("Meeting speaker embeddings could not be persisted", {
+                noteId: noteIdentity?.noteId ?? null,
+                error: result.embeddingError.message,
+              });
+            }
+          } else {
+            eventPayload = { ...payload, segments: [] };
+            debugLogger.warn("Meeting diarization result was not persisted", {
+              noteId: noteIdentity?.noteId ?? null,
+              reason: result.reason,
+            });
+          }
+        } catch (error) {
+          eventPayload = { ...payload, segments: [] };
+          debugLogger.error("Meeting diarization persistence failed", {
+            noteId: noteIdentity?.noteId ?? null,
+            error: error.message,
+          });
+        }
+      }
+      send(eventPayload);
+    };
+
+    const noteId = noteIdentity?.noteId ?? null;
 
     const diarizationEnabled = (sessionConfig?.enabled ?? this.speakerDiarizationEnabled) !== false;
 
     if (!diarizationEnabled || !this.diarizationManager?.isAvailable() || !rawPcmPath) {
-      send({
+      persistAndSend({
         segments: transcriptSegments.map((segment, index) => ({
           ...segment,
           id: segment.id || `segment-${index}`,
@@ -9828,7 +9934,8 @@ class IPCHandlers {
         const reconciledSpeakers = this._reconcileLiveSpeakerState(
           liveSpeakerState,
           speakerEmbeddingsMap,
-          enrichedSegments
+          enrichedSegments,
+          noteIdentity
         );
 
         if (speakerEmbeddingsMap) {
@@ -9892,10 +9999,10 @@ class IPCHandlers {
           }
         }
 
-        send({ segments: enrichedSegments, speakerEmbeddings: speakerEmbeddingsMap });
+        persistAndSend({ segments: enrichedSegments, speakerEmbeddings: speakerEmbeddingsMap });
       } catch (err) {
         debugLogger.warn("Background diarization failed", { error: err.message });
-        send({ segments: [] });
+        persistAndSend({ segments: [] });
       } finally {
         try {
           fs.unlinkSync(rawPcmPath);

--- a/src/helpers/meetingDiarizationPersistence.js
+++ b/src/helpers/meetingDiarizationPersistence.js
@@ -1,0 +1,118 @@
+const {
+  mergeTranscriptSegments,
+  serializeTranscriptSegments,
+} = require("./transcriptSpeakerStateCore");
+
+function snapshotMeetingNoteIdentity(databaseManager, noteId) {
+  if (!Number.isInteger(noteId) || noteId <= 0) return null;
+
+  const note = databaseManager.getNote(noteId);
+  if (!note || note.deleted_at || !note.client_note_id) return null;
+
+  return Object.freeze({ noteId: note.id, clientNoteId: note.client_note_id });
+}
+
+function matchesMeetingNoteIdentity(databaseManager, identity) {
+  if (!identity?.noteId || !identity.clientNoteId) return false;
+  const note = databaseManager.getNote(identity.noteId);
+  return !!note && !note.deleted_at && note.client_note_id === identity.clientNoteId;
+}
+
+function resolveMeetingNoteIdentity(databaseManager, noteId, expectedClientNoteId) {
+  if (noteId == null && expectedClientNoteId == null) return null;
+  if (!Number.isInteger(noteId) || !expectedClientNoteId) return null;
+
+  const identity = snapshotMeetingNoteIdentity(databaseManager, noteId);
+  return identity?.clientNoteId === expectedClientNoteId ? identity : null;
+}
+
+function parseStoredTranscript(raw) {
+  if (typeof raw !== "string" || !raw.startsWith("[")) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((segment, index) => ({ ...segment, id: `stored-${index}` }));
+  } catch {
+    return [];
+  }
+}
+
+function embeddingBuffers(speakerEmbeddings) {
+  const buffers = {};
+  for (const [speakerId, values] of Object.entries(speakerEmbeddings || {})) {
+    buffers[speakerId] = Buffer.from(new Float32Array(values).buffer);
+  }
+  return buffers;
+}
+
+function persistMeetingDiarizationResult({
+  databaseManager,
+  identity,
+  segments,
+  speakerEmbeddings = null,
+  onNoteUpdated,
+  onSpeakerEmbeddingsSaved,
+}) {
+  if (!identity?.noteId || !identity.clientNoteId) {
+    return { status: "skipped", reason: "missing-identity" };
+  }
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return { status: "skipped", reason: "empty-segments" };
+  }
+
+  const current = databaseManager.getNote(identity.noteId);
+  if (!current) return { status: "skipped", reason: "missing-note" };
+  if (current.deleted_at) return { status: "skipped", reason: "deleted-note" };
+  if (current.client_note_id !== identity.clientNoteId) {
+    return { status: "skipped", reason: "identity-changed" };
+  }
+
+  const existing = parseStoredTranscript(current.transcript);
+  const incoming = segments.map((segment, index) => ({
+    ...segment,
+    id: segment.id || `diarized-${index}`,
+  }));
+  const mergedSegments = mergeTranscriptSegments(existing, incoming);
+  const update = databaseManager.updateNote(identity.noteId, {
+    transcript: serializeTranscriptSegments(mergedSegments),
+  });
+  if (!update?.success || !update.note) {
+    return { status: "skipped", reason: "update-failed" };
+  }
+
+  let embeddingsSaved = false;
+  let embeddingError = null;
+  if (speakerEmbeddings && Object.keys(speakerEmbeddings).length > 0) {
+    try {
+      databaseManager.saveNoteSpeakerEmbeddings(
+        identity.noteId,
+        embeddingBuffers(speakerEmbeddings)
+      );
+      embeddingsSaved = true;
+    } catch (error) {
+      embeddingError = error;
+    }
+  }
+
+  onNoteUpdated?.(update.note);
+  if (embeddingsSaved) onSpeakerEmbeddingsSaved?.({ ...identity });
+
+  return {
+    status: "persisted",
+    note: update.note,
+    segments: mergedSegments,
+    embeddingsSaved,
+    embeddingError,
+  };
+}
+
+module.exports = {
+  mergeTranscriptSegments,
+  matchesMeetingNoteIdentity,
+  parseStoredTranscript,
+  persistMeetingDiarizationResult,
+  resolveMeetingNoteIdentity,
+  serializeTranscript: serializeTranscriptSegments,
+  snapshotMeetingNoteIdentity,
+};

--- a/src/helpers/meetingSessionLifecycle.js
+++ b/src/helpers/meetingSessionLifecycle.js
@@ -1,0 +1,91 @@
+/**
+ * Serializes meeting start/stop operations in call order.
+ *
+ * Recording setup and teardown touch shared audio/session state. Keeping the
+ * queue here makes that ownership rule explicit and independently testable.
+ */
+class MeetingSessionLifecycle {
+  constructor() {
+    this._tail = Promise.resolve();
+    this._stopPromise = null;
+    this._pendingCount = 0;
+    this._lastSessionOperationKind = null;
+  }
+
+  /**
+   * @template T
+   * @param {() => T | Promise<T>} operation
+   * @returns {Promise<T>}
+   */
+  _enqueue(operation) {
+    this._pendingCount += 1;
+    const result = this._tail.then(operation, operation);
+    const tracked = result.finally(() => {
+      this._pendingCount -= 1;
+    });
+    this._tail = tracked.then(
+      () => undefined,
+      () => undefined
+    );
+    return tracked;
+  }
+
+  /**
+   * @template T
+   * @param {() => T | Promise<T>} operation
+   * @returns {Promise<T>}
+   */
+  start(operation) {
+    this._lastSessionOperationKind = "start";
+    return this._enqueue(operation);
+  }
+
+  /**
+   * Queue an operation that touches meeting session resources without starting
+   * or stopping a recording (for example, connection pre-warming).
+   *
+   * @template T
+   * @param {() => T | Promise<T>} operation
+   * @returns {Promise<T>}
+   */
+  run(operation) {
+    return this._enqueue(operation);
+  }
+
+  /**
+   * @template T
+   * @param {() => T | Promise<T>} operation
+   * @returns {Promise<T>}
+   */
+  stop(operation) {
+    if (this._stopPromise && this._lastSessionOperationKind === "stop") {
+      return this._stopPromise;
+    }
+
+    this._lastSessionOperationKind = "stop";
+    const result = this._enqueue(operation);
+    const tracked = result.finally(() => {
+      if (this._stopPromise === tracked) this._stopPromise = null;
+    });
+    this._stopPromise = tracked;
+    this._tail = tracked.then(
+      () => undefined,
+      () => undefined
+    );
+    return tracked;
+  }
+
+  whenIdle() {
+    return this._tail;
+  }
+
+  get isStopping() {
+    return this._stopPromise !== null;
+  }
+
+  get hasPendingOperations() {
+    return this._pendingCount > 0;
+  }
+}
+
+module.exports = { MeetingSessionLifecycle };

--- a/src/helpers/transcriptSpeakerStateCore.js
+++ b/src/helpers/transcriptSpeakerStateCore.js
@@ -1,0 +1,176 @@
+const SPEAKER_STATE_FIELDS = [
+  "speaker",
+  "speakerName",
+  "speakerIsPlaceholder",
+  "suggestedName",
+  "suggestedProfileId",
+  "speakerStatus",
+  "speakerLocked",
+  "speakerLockSource",
+];
+
+const normalizeText = (text) =>
+  String(text || "")
+    .trim()
+    .replace(/\s+/g, " ");
+
+const getSegmentMatchKey = (segment) =>
+  [segment.source, segment.timestamp ?? "", normalizeText(segment.text)].join("|");
+
+const canonicalizeTranscriptSpeakerStatus = (status, speakerLocked, speakerLockSource) => {
+  if (speakerLocked || speakerLockSource === "user") return "locked";
+
+  switch (status) {
+    case "provisional":
+    case "confirmed":
+    case "suggested":
+    case "locked":
+      return status;
+    case "suggested_profile":
+      return "suggested";
+    case "user_locked":
+      return "locked";
+    case "uncertain_overlap":
+      return "provisional";
+    default:
+      return undefined;
+  }
+};
+
+const pickSpeakerStatus = (segment) => {
+  const normalizedStatus = canonicalizeTranscriptSpeakerStatus(
+    segment.speakerStatus,
+    segment.speakerLocked,
+    segment.speakerLockSource
+  );
+  if (normalizedStatus) return normalizedStatus;
+  if (segment.suggestedName && !segment.speakerName) return "suggested";
+  if (segment.source === "system" && segment.speakerIsPlaceholder) return "provisional";
+  if (segment.speaker && segment.speaker !== "you") return "confirmed";
+  return undefined;
+};
+
+const isTranscriptSpeakerLocked = (segment) =>
+  !!segment.speakerLocked ||
+  segment.speakerLockSource === "user" ||
+  canonicalizeTranscriptSpeakerStatus(segment.speakerStatus) === "locked";
+
+const normalizeTranscriptSegment = (segment) => {
+  const speakerStatus = pickSpeakerStatus(segment);
+  const speakerLocked =
+    !!segment.speakerLocked || segment.speakerLockSource === "user" || speakerStatus === "locked";
+  return {
+    ...segment,
+    speakerStatus,
+    speakerLocked,
+    speakerLockSource: speakerLocked
+      ? (segment.speakerLockSource ?? "user")
+      : segment.speakerLockSource,
+  };
+};
+
+const normalizeTranscriptSegments = (segments) => segments.map(normalizeTranscriptSegment);
+
+const mergeSpeakerFields = (existing, incoming) => {
+  const merged = { ...incoming };
+
+  for (const field of SPEAKER_STATE_FIELDS) {
+    if (merged[field] === undefined && existing[field] !== undefined) {
+      merged[field] = existing[field];
+    }
+  }
+
+  if (isTranscriptSpeakerLocked(existing)) {
+    // Keep the user's name/lock but let diarization refine the speaker cluster,
+    // so one locked label cannot freeze a bucket that diarization later splits.
+    for (const field of SPEAKER_STATE_FIELDS) {
+      if (field === "speaker" || field === "speakerIsPlaceholder") continue;
+      if (existing[field] !== undefined) merged[field] = existing[field];
+    }
+  }
+
+  return normalizeTranscriptSegment(merged);
+};
+
+const mergeTranscriptSegments = (existingSegments, incomingSegments) => {
+  if (incomingSegments.length === 0) return normalizeTranscriptSegments(existingSegments);
+  if (existingSegments.length === 0) {
+    return incomingSegments.map((segment, index) =>
+      normalizeTranscriptSegment({ ...segment, id: segment.id || `merged-${index}` })
+    );
+  }
+
+  const existingById = new Map();
+  const existingByKey = new Map();
+  existingSegments.forEach((segment, index) => {
+    if (segment.id) existingById.set(segment.id, index);
+    const key = getSegmentMatchKey(segment);
+    const bucket = existingByKey.get(key);
+    if (bucket) bucket.push(index);
+    else existingByKey.set(key, [index]);
+  });
+
+  const usedIndexes = new Set();
+  const enrichedByIndex = new Map();
+  const unmatchedIncoming = [];
+
+  incomingSegments.forEach((segment, index) => {
+    const findUnused = (candidates) =>
+      candidates?.find((candidateIndex) => !usedIndexes.has(candidateIndex));
+
+    let matchIndex = segment.id ? existingById.get(segment.id) : undefined;
+    if (matchIndex !== undefined && usedIndexes.has(matchIndex)) matchIndex = undefined;
+    if (matchIndex === undefined) {
+      matchIndex = findUnused(existingByKey.get(getSegmentMatchKey(segment)));
+    }
+    if (matchIndex === undefined) {
+      const fallbackIndex = existingSegments.findIndex(
+        (candidate, existingIndex) =>
+          !usedIndexes.has(existingIndex) &&
+          candidate.source === segment.source &&
+          candidate.text === segment.text
+      );
+      if (fallbackIndex >= 0) matchIndex = fallbackIndex;
+    }
+
+    if (matchIndex !== undefined) {
+      usedIndexes.add(matchIndex);
+      enrichedByIndex.set(matchIndex, mergeSpeakerFields(existingSegments[matchIndex], segment));
+    } else {
+      unmatchedIncoming.push(
+        normalizeTranscriptSegment({ ...segment, id: segment.id || `merged-${index}` })
+      );
+    }
+  });
+
+  const preserved = existingSegments.map(
+    (segment, index) => enrichedByIndex.get(index) ?? normalizeTranscriptSegment(segment)
+  );
+  return [...preserved, ...unmatchedIncoming];
+};
+
+const serializeTranscriptSegments = (segments) =>
+  JSON.stringify(
+    segments.map((segment) => ({
+      text: segment.text,
+      source: segment.source,
+      timestamp: segment.timestamp,
+      speaker: segment.speaker,
+      speakerName: segment.speakerName,
+      speakerIsPlaceholder: segment.speakerIsPlaceholder,
+      suggestedName: segment.suggestedName,
+      suggestedProfileId: segment.suggestedProfileId,
+      speakerStatus: segment.speakerStatus,
+      speakerLocked: segment.speakerLocked,
+      speakerLockSource: segment.speakerLockSource,
+    }))
+  );
+
+module.exports = {
+  canonicalizeTranscriptSpeakerStatus,
+  isTranscriptSpeakerLocked,
+  mergeTranscriptSegments,
+  normalizeTranscriptSegment,
+  normalizeTranscriptSegments,
+  serializeTranscriptSegments,
+};

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -26,6 +26,7 @@ import {
   type TranscriptSpeakerLockSource,
   type TranscriptSpeakerStatus,
 } from "../utils/transcriptSpeakerState";
+import { MeetingSessionLifecycle } from "../helpers/meetingSessionLifecycle";
 
 export interface TranscriptSegment {
   id: string;
@@ -61,6 +62,7 @@ interface RecentSystemSpeaker {
 interface MeetingRecordingState {
   isRecording: boolean;
   isTranscribing: boolean;
+  isStopping: boolean;
   recordingNoteId: number | null;
   recordingNoteTitle: string | null;
   recordingFolderId: number | null;
@@ -431,6 +433,7 @@ let systemProcessor: AudioWorkletNode | null = null;
 let systemStream: MediaStream | null = null;
 let isRecordingFlag = false;
 let isStartingFlag = false;
+const meetingSessionLifecycle = new MeetingSessionLifecycle();
 let isPrepared = false;
 let segmentsRefValue: TranscriptSegment[] = [];
 let preparePromise: Promise<void> | null = null;
@@ -445,6 +448,7 @@ let pushConfigTimeout: ReturnType<typeof setTimeout> | null = null;
 export const useMeetingRecordingStore = create<MeetingRecordingState>()(() => ({
   isRecording: false,
   isTranscribing: false,
+  isStopping: false,
   recordingNoteId: null,
   recordingNoteTitle: null,
   recordingFolderId: null,
@@ -672,7 +676,7 @@ async function cleanup(): Promise<void> {
   isStartingFlag = false;
 }
 
-export async function prepareTranscription(): Promise<void> {
+async function prepareTranscriptionInternal(): Promise<void> {
   if (isPrepared || isRecordingFlag || isStartingFlag) return;
   if (preparePromise) return preparePromise;
 
@@ -709,8 +713,13 @@ export async function prepareTranscription(): Promise<void> {
   await promise;
 }
 
+export function prepareTranscription(): Promise<void> {
+  return meetingSessionLifecycle.run(prepareTranscriptionInternal);
+}
+
 export interface StartRecordingArgs {
   noteId: number | null;
+  clientNoteId: string | null;
   noteTitle: string | null;
   folderId: number | null;
   seedSegments?: TranscriptSegment[];
@@ -718,7 +727,7 @@ export interface StartRecordingArgs {
   expectedCount?: number | null;
 }
 
-export async function startRecording(args: StartRecordingArgs): Promise<void> {
+async function startRecordingInternal(args: StartRecordingArgs): Promise<void> {
   if (isRecordingFlag || isStartingFlag) return;
   isStartingFlag = true;
 
@@ -791,6 +800,7 @@ export async function startRecording(args: StartRecordingArgs): Promise<void> {
       window.electronAPI?.meetingTranscriptionStart?.({
         ...getMeetingTranscriptionOptions(),
         noteId: args.noteId ?? null,
+        clientNoteId: args.clientNoteId ?? null,
       }),
       getMeetingMicConstraints().then(async (constraints) => {
         try {
@@ -1242,23 +1252,19 @@ export async function startRecording(args: StartRecordingArgs): Promise<void> {
   }
 }
 
+export function startRecording(args: StartRecordingArgs): Promise<void> {
+  return meetingSessionLifecycle.start(() => startRecordingInternal(args));
+}
+
 export interface StopRecordingResult {
   diarizationSessionId: string | null;
 }
 
-export async function stopRecording(): Promise<StopRecordingResult> {
-  if (!isRecordingFlag) {
-    return { diarizationSessionId: null };
-  }
-
-  isRecordingFlag = false;
-  isStartingFlag = false;
-  useMeetingRecordingStore.setState({ isRecording: false, isTranscribing: false });
-
-  await cleanup();
-
+async function stopRecordingInternal(): Promise<StopRecordingResult> {
   let diarizationSessionId: string | null = null;
   try {
+    await cleanup();
+
     const result = await window.electronAPI?.meetingTranscriptionStop?.();
     if (result?.diarizationSessionId) {
       diarizationSessionId = result.diarizationSessionId;
@@ -1272,18 +1278,35 @@ export async function stopRecording(): Promise<StopRecordingResult> {
   } catch (err) {
     useMeetingRecordingStore.setState({ error: (err as Error).message });
     logger.error("Meeting transcription stop failed", { error: (err as Error).message }, "meeting");
+  } finally {
+    useMeetingRecordingStore.setState({
+      isStopping: false,
+      micPartial: "",
+      systemPartial: "",
+      systemPartialSpeakerId: null,
+      systemPartialSpeakerName: null,
+      currentMicLevel: 0,
+    });
   }
-
-  useMeetingRecordingStore.setState({
-    micPartial: "",
-    systemPartial: "",
-    systemPartialSpeakerId: null,
-    systemPartialSpeakerName: null,
-    currentMicLevel: 0,
-  });
 
   logger.info("Meeting transcription stopped", {}, "meeting");
   return { diarizationSessionId };
+}
+
+export function stopRecording(): Promise<StopRecordingResult> {
+  if (!isRecordingFlag && !isStartingFlag && !meetingSessionLifecycle.hasPendingOperations) {
+    return Promise.resolve({ diarizationSessionId: null });
+  }
+
+  isRecordingFlag = false;
+  isStartingFlag = false;
+  useMeetingRecordingStore.setState({
+    isRecording: false,
+    isTranscribing: false,
+    isStopping: true,
+  });
+
+  return meetingSessionLifecycle.stop(stopRecordingInternal);
 }
 
 export function lockSpeaker(speakerId: string, displayName: string): void {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -2103,6 +2103,7 @@ declare global {
         model?: string;
         language?: string;
         noteId?: number | null;
+        clientNoteId?: string | null;
       }) => Promise<{
         success: boolean;
         error?: string;
@@ -2178,6 +2179,8 @@ declare global {
       onMeetingDiarizationComplete?: (
         callback: (data: {
           sessionId?: string;
+          noteId: number | null;
+          clientNoteId: string | null;
           segments: Array<{
             id: string;
             text: string;

--- a/src/utils/meetingDiarizationTarget.ts
+++ b/src/utils/meetingDiarizationTarget.ts
@@ -1,0 +1,17 @@
+interface DiarizationIdentity {
+  sessionId?: string | null;
+  noteId?: number | null;
+  clientNoteId?: string | null;
+}
+
+export function matchesMeetingDiarizationTarget(
+  result: DiarizationIdentity | null | undefined,
+  target: DiarizationIdentity
+): boolean {
+  return (
+    !!result?.sessionId &&
+    result.sessionId === target.sessionId &&
+    result.noteId === target.noteId &&
+    result.clientNoteId === target.clientNoteId
+  );
+}

--- a/src/utils/transcriptSpeakerState.ts
+++ b/src/utils/transcriptSpeakerState.ts
@@ -1,4 +1,11 @@
 import type { TranscriptSegment } from "../stores/meetingRecordingStore";
+import {
+  isTranscriptSpeakerLocked as isTranscriptSpeakerLockedCore,
+  mergeTranscriptSegments as mergeTranscriptSegmentsCore,
+  normalizeTranscriptSegment as normalizeTranscriptSegmentCore,
+  normalizeTranscriptSegments as normalizeTranscriptSegmentsCore,
+  serializeTranscriptSegments as serializeTranscriptSegmentsCore,
+} from "../helpers/transcriptSpeakerStateCore";
 
 export type TranscriptSpeakerStatus = "provisional" | "confirmed" | "suggested" | "locked";
 export type TranscriptSpeakerLockSource = "user" | "diarization" | "suggestion";
@@ -16,71 +23,14 @@ const SPEAKER_STATE_FIELDS = [
 
 type SpeakerStateField = (typeof SPEAKER_STATE_FIELDS)[number];
 
-const normalizeText = (text: string) => text.trim().replace(/\s+/g, " ");
+export const isTranscriptSpeakerLocked = (segment: TranscriptSegment): boolean =>
+  isTranscriptSpeakerLockedCore(segment);
 
-const getSegmentMatchKey = (segment: TranscriptSegment) =>
-  [segment.source, segment.timestamp ?? "", normalizeText(segment.text)].join("|");
+export const normalizeTranscriptSegment = (segment: TranscriptSegment): TranscriptSegment =>
+  normalizeTranscriptSegmentCore(segment);
 
-const canonicalizeTranscriptSpeakerStatus = (
-  status?: string,
-  speakerLocked?: boolean,
-  speakerLockSource?: TranscriptSpeakerLockSource
-): TranscriptSpeakerStatus | undefined => {
-  if (speakerLocked || speakerLockSource === "user") {
-    return "locked";
-  }
-
-  switch (status) {
-    case "provisional":
-    case "confirmed":
-    case "suggested":
-    case "locked":
-      return status;
-    case "suggested_profile":
-      return "suggested";
-    case "user_locked":
-      return "locked";
-    case "uncertain_overlap":
-      return "provisional";
-    default:
-      return undefined;
-  }
-};
-
-const pickSpeakerStatus = (segment: TranscriptSegment): TranscriptSpeakerStatus | undefined => {
-  const normalizedStatus = canonicalizeTranscriptSpeakerStatus(
-    segment.speakerStatus,
-    segment.speakerLocked,
-    segment.speakerLockSource
-  );
-  if (normalizedStatus) return normalizedStatus;
-  if (segment.suggestedName && !segment.speakerName) return "suggested";
-  if (segment.source === "system" && segment.speakerIsPlaceholder) return "provisional";
-  if (segment.speaker && segment.speaker !== "you") return "confirmed";
-  return undefined;
-};
-
-export const isTranscriptSpeakerLocked = (segment: TranscriptSegment) =>
-  !!segment.speakerLocked ||
-  segment.speakerLockSource === "user" ||
-  canonicalizeTranscriptSpeakerStatus(segment.speakerStatus) === "locked";
-
-export const normalizeTranscriptSegment = (segment: TranscriptSegment): TranscriptSegment => {
-  const speakerStatus = pickSpeakerStatus(segment);
-  const speakerLocked =
-    !!segment.speakerLocked || segment.speakerLockSource === "user" || speakerStatus === "locked";
-  return {
-    ...segment,
-    speakerStatus,
-    speakerLocked,
-    speakerLockSource: speakerLocked
-      ? (segment.speakerLockSource ?? "user")
-      : segment.speakerLockSource,
-  };
-};
-
-export const normalizeTranscriptSegments = (segments: TranscriptSegment[]) =>
-  segments.map((segment) => normalizeTranscriptSegment(segment));
+export const normalizeTranscriptSegments = (segments: TranscriptSegment[]): TranscriptSegment[] =>
+  normalizeTranscriptSegmentsCore(segments);
 
 export const applyTranscriptSpeakerPatch = (
   segment: TranscriptSegment,
@@ -99,110 +49,10 @@ export const lockTranscriptSpeaker = (
     speakerLockSource: "user",
   });
 
-const mergeSpeakerFields = (existing: TranscriptSegment, incoming: TranscriptSegment) => {
-  const merged = { ...incoming } as TranscriptSegment;
-  const existingFields = existing as Record<SpeakerStateField, unknown>;
-  const mergedFields = merged as Record<SpeakerStateField, unknown>;
-
-  for (const field of SPEAKER_STATE_FIELDS) {
-    if (mergedFields[field] === undefined && existingFields[field] !== undefined) {
-      mergedFields[field] = existingFields[field];
-    }
-  }
-
-  if (isTranscriptSpeakerLocked(existing)) {
-    // Keep the user's name/lock but let diarization refine the speaker cluster, so one
-    // locked label can't freeze a bucket diarization splits into multiple speakers.
-    for (const field of SPEAKER_STATE_FIELDS) {
-      if (field === "speaker" || field === "speakerIsPlaceholder") continue;
-      if (existingFields[field] !== undefined) {
-        mergedFields[field] = existingFields[field];
-      }
-    }
-  }
-
-  return normalizeTranscriptSegment(merged);
-};
-
 export const mergeTranscriptSegments = (
   existingSegments: TranscriptSegment[],
   incomingSegments: TranscriptSegment[]
-) => {
-  if (incomingSegments.length === 0) {
-    return normalizeTranscriptSegments(existingSegments);
-  }
-  if (existingSegments.length === 0) {
-    return incomingSegments.map((segment, index) =>
-      normalizeTranscriptSegment({ ...segment, id: segment.id || `merged-${index}` })
-    );
-  }
-
-  const existingById = new Map<string, number>();
-  const existingByKey = new Map<string, number[]>();
-
-  existingSegments.forEach((segment, index) => {
-    if (segment.id) existingById.set(segment.id, index);
-    const key = getSegmentMatchKey(segment);
-    const bucket = existingByKey.get(key);
-    if (bucket) bucket.push(index);
-    else existingByKey.set(key, [index]);
-  });
-
-  const usedIndexes = new Set<number>();
-  const enrichedByIndex = new Map<number, TranscriptSegment>();
-  const unmatchedIncoming: TranscriptSegment[] = [];
-
-  incomingSegments.forEach((segment, index) => {
-    const findUnused = (candidates?: number[]) =>
-      candidates?.find((candidateIndex) => !usedIndexes.has(candidateIndex));
-
-    let matchIndex = segment.id ? existingById.get(segment.id) : undefined;
-    if (matchIndex !== undefined && usedIndexes.has(matchIndex)) matchIndex = undefined;
-
-    if (matchIndex === undefined) {
-      matchIndex = findUnused(existingByKey.get(getSegmentMatchKey(segment)));
-    }
-
-    if (matchIndex === undefined) {
-      const fallbackIndex = existingSegments.findIndex(
-        (candidate, existingIndex) =>
-          !usedIndexes.has(existingIndex) &&
-          candidate.source === segment.source &&
-          candidate.text === segment.text
-      );
-      if (fallbackIndex >= 0) matchIndex = fallbackIndex;
-    }
-
-    if (matchIndex !== undefined) {
-      usedIndexes.add(matchIndex);
-      enrichedByIndex.set(matchIndex, mergeSpeakerFields(existingSegments[matchIndex], segment));
-    } else {
-      unmatchedIncoming.push(
-        normalizeTranscriptSegment({ ...segment, id: segment.id || `merged-${index}` })
-      );
-    }
-  });
-
-  const preserved = existingSegments.map(
-    (segment, index) => enrichedByIndex.get(index) ?? normalizeTranscriptSegment(segment)
-  );
-
-  return [...preserved, ...unmatchedIncoming];
-};
+) => mergeTranscriptSegmentsCore(existingSegments, incomingSegments) as TranscriptSegment[];
 
 export const serializeTranscriptSegments = (segments: TranscriptSegment[]) =>
-  JSON.stringify(
-    segments.map((segment) => ({
-      text: segment.text,
-      source: segment.source,
-      timestamp: segment.timestamp,
-      speaker: segment.speaker,
-      speakerName: segment.speakerName,
-      speakerIsPlaceholder: segment.speakerIsPlaceholder,
-      suggestedName: segment.suggestedName,
-      suggestedProfileId: segment.suggestedProfileId,
-      speakerStatus: segment.speakerStatus,
-      speakerLocked: segment.speakerLocked,
-      speakerLockSource: segment.speakerLockSource,
-    }))
-  );
+  serializeTranscriptSegmentsCore(segments);

--- a/test/helpers/meetingDiarizationPersistence.test.js
+++ b/test/helpers/meetingDiarizationPersistence.test.js
@@ -1,0 +1,271 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  matchesMeetingNoteIdentity,
+  persistMeetingDiarizationResult,
+  resolveMeetingNoteIdentity,
+  snapshotMeetingNoteIdentity,
+} = require("../../src/helpers/meetingDiarizationPersistence");
+
+const segment = (text, timestamp, extra = {}) => ({
+  id: `live-${timestamp}`,
+  text,
+  source: "system",
+  timestamp,
+  ...extra,
+});
+
+const storedTranscript = (...segments) =>
+  JSON.stringify(segments.map(({ id: _id, ...stored }) => stored));
+
+function createDatabase(notes) {
+  const rows = new Map(notes.map((note) => [note.id, structuredClone(note)]));
+  const embeddings = new Map();
+  const writes = [];
+
+  return {
+    getNote(id) {
+      const row = rows.get(id);
+      return row ? structuredClone(row) : null;
+    },
+    updateNote(id, updates) {
+      const current = rows.get(id);
+      if (!current) return { success: false };
+      const note = { ...current, ...updates, sync_status: "pending" };
+      rows.set(id, note);
+      writes.push({ id, updates: structuredClone(updates) });
+      return { success: true, note: structuredClone(note) };
+    },
+    saveNoteSpeakerEmbeddings(id, values) {
+      embeddings.set(id, values);
+    },
+    read(id) {
+      return structuredClone(rows.get(id));
+    },
+    embeddings,
+    rows,
+    writes,
+  };
+}
+
+function note(id, clientNoteId, transcript = "[]") {
+  return {
+    id,
+    client_note_id: clientNoteId,
+    transcript,
+    deleted_at: null,
+    sync_status: "synced",
+  };
+}
+
+test("snapshots both numeric and stable client identity for a live note", () => {
+  const databaseManager = createDatabase([note(7, "client-a")]);
+
+  assert.deepEqual(snapshotMeetingNoteIdentity(databaseManager, 7), {
+    noteId: 7,
+    clientNoteId: "client-a",
+  });
+  assert.equal(snapshotMeetingNoteIdentity(databaseManager, 99), null);
+  assert.equal(
+    matchesMeetingNoteIdentity(databaseManager, { noteId: 7, clientNoteId: "client-a" }),
+    true
+  );
+  assert.equal(
+    matchesMeetingNoteIdentity(databaseManager, { noteId: 7, clientNoteId: "replaced" }),
+    false
+  );
+  assert.deepEqual(resolveMeetingNoteIdentity(databaseManager, 7, "client-a"), {
+    noteId: 7,
+    clientNoteId: "client-a",
+  });
+  assert.equal(resolveMeetingNoteIdentity(databaseManager, 7, "replaced"), null);
+});
+
+test("a delayed A completion changes only A while B is active", () => {
+  const aBefore = storedTranscript(segment("A live", 1));
+  const bBefore = storedTranscript(segment("B live", 2));
+  const databaseManager = createDatabase([
+    note(1, "client-a", aBefore),
+    note(2, "client-b", bBefore),
+  ]);
+
+  const result = persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [segment("A live", 1, { speaker: "speaker_0" })],
+    speakerEmbeddings: { speaker_0: [0.25, 0.5] },
+  });
+
+  assert.equal(result.status, "persisted");
+  assert.equal(JSON.parse(databaseManager.read(1).transcript)[0].speaker, "speaker_0");
+  assert.equal(databaseManager.read(2).transcript, bBefore);
+  assert.deepEqual(
+    databaseManager.writes.map(({ id }) => id),
+    [1]
+  );
+  assert.equal(databaseManager.embeddings.has(1), true);
+  assert.equal(databaseManager.embeddings.has(2), false);
+});
+
+test("overlapping jobs remain isolated when B completes before A", () => {
+  const databaseManager = createDatabase([
+    note(1, "client-a", storedTranscript(segment("A", 1))),
+    note(2, "client-b", storedTranscript(segment("B", 2))),
+  ]);
+
+  persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 2, clientNoteId: "client-b" },
+    segments: [segment("B", 2, { speaker: "speaker_b" })],
+  });
+  persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [segment("A", 1, { speaker: "speaker_a" })],
+  });
+
+  assert.equal(JSON.parse(databaseManager.read(1).transcript)[0].speaker, "speaker_a");
+  assert.equal(JSON.parse(databaseManager.read(2).transcript)[0].speaker, "speaker_b");
+  assert.deepEqual(
+    databaseManager.writes.map(({ id }) => id),
+    [2, 1]
+  );
+});
+
+test("latest user speaker locks survive the background merge", () => {
+  const locked = segment("Hello", 10, {
+    speaker: "speaker_live",
+    speakerName: "Alex",
+    speakerStatus: "locked",
+    speakerLocked: true,
+    speakerLockSource: "user",
+  });
+  const databaseManager = createDatabase([note(1, "client-a", storedTranscript(locked))]);
+
+  const result = persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [
+      segment("Hello", 10, {
+        speaker: "speaker_diarized",
+        speakerName: "Automatic guess",
+        speakerStatus: "confirmed",
+        speakerLocked: false,
+      }),
+    ],
+  });
+
+  assert.equal(result.status, "persisted");
+  const [merged] = JSON.parse(databaseManager.read(1).transcript);
+  assert.equal(merged.speaker, "speaker_diarized");
+  assert.equal(merged.speakerName, "Alex");
+  assert.equal(merged.speakerStatus, "locked");
+  assert.equal(merged.speakerLocked, true);
+  assert.equal(merged.speakerLockSource, "user");
+});
+
+test("missing, deleted, and replaced target identities are never written", () => {
+  const deleted = { ...note(2, "client-deleted"), deleted_at: "2026-08-07T12:00:00Z" };
+  const databaseManager = createDatabase([note(1, "client-new"), deleted]);
+
+  const attempts = [
+    { noteId: 99, clientNoteId: "missing" },
+    { noteId: 2, clientNoteId: "client-deleted" },
+    { noteId: 1, clientNoteId: "client-old" },
+  ];
+  const reasons = attempts.map(
+    (identity) =>
+      persistMeetingDiarizationResult({
+        databaseManager,
+        identity,
+        segments: [segment("stale", 1)],
+        speakerEmbeddings: { speaker_0: [1] },
+      }).reason
+  );
+
+  assert.deepEqual(reasons, ["missing-note", "deleted-note", "identity-changed"]);
+  assert.equal(databaseManager.writes.length, 0);
+  assert.equal(databaseManager.embeddings.size, 0);
+});
+
+test("persistence has no renderer dependency and runs normal update hooks", () => {
+  const databaseManager = createDatabase([note(1, "client-a")]);
+  const updated = [];
+  const embeddingTargets = [];
+
+  const result = persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [segment("offline completion", 1)],
+    speakerEmbeddings: { speaker_0: [0.5] },
+    onNoteUpdated: (value) => updated.push(value),
+    onSpeakerEmbeddingsSaved: (identity) => embeddingTargets.push(identity),
+  });
+
+  assert.equal(result.status, "persisted");
+  assert.equal(updated.length, 1);
+  assert.equal(updated[0].id, 1);
+  assert.equal(updated[0].sync_status, "pending");
+  assert.deepEqual(embeddingTargets, [{ noteId: 1, clientNoteId: "client-a" }]);
+});
+
+test("legacy and inferred speaker states use the renderer's canonical merge policy", () => {
+  const databaseManager = createDatabase([
+    note(
+      1,
+      "client-a",
+      storedTranscript(
+        segment("locked", 1, { speakerName: "Alex", speakerStatus: "user_locked" }),
+        segment("suggested", 2, { suggestedName: "Richard", speakerStatus: "suggested_profile" }),
+        segment("overlap", 3, { speakerStatus: "uncertain_overlap" }),
+        segment("placeholder", 4, { speaker: "speaker_3", speakerIsPlaceholder: true })
+      )
+    ),
+  ]);
+
+  const result = persistMeetingDiarizationResult({
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [
+      segment("locked", 1, { speaker: "speaker_0" }),
+      segment("suggested", 2, { speaker: "speaker_1" }),
+      segment("overlap", 3, { speaker: "speaker_2" }),
+      segment("placeholder", 4, { speaker: "speaker_3" }),
+    ],
+  });
+
+  assert.equal(result.status, "persisted");
+  const canonical = JSON.parse(databaseManager.read(1).transcript);
+  assert.deepEqual(
+    canonical.map(({ speakerStatus, speakerLocked, speakerLockSource }) => ({
+      speakerStatus,
+      speakerLocked,
+      speakerLockSource,
+    })),
+    [
+      { speakerStatus: "locked", speakerLocked: true, speakerLockSource: "user" },
+      { speakerStatus: "suggested", speakerLocked: false, speakerLockSource: undefined },
+      { speakerStatus: "provisional", speakerLocked: false, speakerLockSource: undefined },
+      { speakerStatus: "provisional", speakerLocked: false, speakerLockSource: undefined },
+    ]
+  );
+});
+
+test("re-delivering the same completion is idempotent", () => {
+  const databaseManager = createDatabase([
+    note(1, "client-a", storedTranscript(segment("once", 1))),
+  ]);
+  const completion = {
+    databaseManager,
+    identity: { noteId: 1, clientNoteId: "client-a" },
+    segments: [segment("once", 1, { speaker: "speaker_0" })],
+  };
+
+  persistMeetingDiarizationResult(completion);
+  persistMeetingDiarizationResult(completion);
+
+  const persisted = JSON.parse(databaseManager.read(1).transcript);
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].speaker, "speaker_0");
+});

--- a/test/helpers/meetingSessionLifecycle.test.js
+++ b/test/helpers/meetingSessionLifecycle.test.js
@@ -1,0 +1,143 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { MeetingSessionLifecycle } = require("../../src/helpers/meetingSessionLifecycle");
+const { resolveMeetingNoteIdentity } = require("../../src/helpers/meetingDiarizationPersistence");
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+test("a new meeting cannot replace session ownership while the previous stop is suspended", async () => {
+  const lifecycle = new MeetingSessionLifecycle();
+  const releaseStop = deferred();
+  const events = [];
+  let activeIdentity = null;
+  let stoppedIdentity = null;
+
+  await lifecycle.start(async () => {
+    activeIdentity = { noteId: 1, clientNoteId: "client-a" };
+    events.push("start-a");
+  });
+
+  const stopA = lifecycle.stop(async () => {
+    stoppedIdentity = { ...activeIdentity };
+    events.push("stop-a-begin");
+    await releaseStop.promise;
+    events.push(`stop-a-end:${stoppedIdentity.clientNoteId}`);
+  });
+
+  await Promise.resolve();
+  const startB = lifecycle.start(async () => {
+    activeIdentity = { noteId: 2, clientNoteId: "client-b" };
+    events.push("start-b");
+  });
+
+  await Promise.resolve();
+  assert.equal(lifecycle.isStopping, true);
+  assert.deepEqual(activeIdentity, { noteId: 1, clientNoteId: "client-a" });
+  assert.deepEqual(events, ["start-a", "stop-a-begin"]);
+
+  releaseStop.resolve();
+  await Promise.all([stopA, startB]);
+
+  assert.deepEqual(stoppedIdentity, { noteId: 1, clientNoteId: "client-a" });
+  assert.deepEqual(activeIdentity, { noteId: 2, clientNoteId: "client-b" });
+  assert.deepEqual(events, ["start-a", "stop-a-begin", "stop-a-end:client-a", "start-b"]);
+  assert.equal(lifecycle.isStopping, false);
+});
+
+test("a stop queued after the next start is not deduplicated with the previous session's stop", async () => {
+  const lifecycle = new MeetingSessionLifecycle();
+  const releaseStopA = deferred();
+  const events = [];
+
+  await lifecycle.start(() => events.push("start-a"));
+  const stopA = lifecycle.stop(async () => {
+    events.push("stop-a");
+    await releaseStopA.promise;
+  });
+  const startB = lifecycle.start(() => events.push("start-b"));
+  const stopB = lifecycle.stop(() => events.push("stop-b"));
+
+  assert.notEqual(stopA, stopB);
+  releaseStopA.resolve();
+  await Promise.all([stopA, startB, stopB]);
+
+  assert.deepEqual(events, ["start-a", "stop-a", "start-b", "stop-b"]);
+  assert.equal(lifecycle.isStopping, false);
+});
+
+test("a queued start fails closed if its numeric note id is reused before it runs", async () => {
+  const lifecycle = new MeetingSessionLifecycle();
+  const releaseStop = deferred();
+  const rows = new Map([
+    [1, { id: 1, client_note_id: "client-a", deleted_at: null }],
+    [2, { id: 2, client_note_id: "client-b", deleted_at: null }],
+  ]);
+  const databaseManager = { getNote: (id) => rows.get(id) ?? null };
+  let activeIdentity = null;
+
+  await lifecycle.start(() => {
+    activeIdentity = resolveMeetingNoteIdentity(databaseManager, 1, "client-a");
+  });
+  const stopA = lifecycle.stop(() => releaseStop.promise);
+  const startB = lifecycle.start(() => {
+    const identity = resolveMeetingNoteIdentity(databaseManager, 2, "client-b");
+    if (!identity) throw new Error("Meeting note changed before recording could start");
+    activeIdentity = identity;
+  });
+
+  rows.set(2, { id: 2, client_note_id: "replacement", deleted_at: null });
+  releaseStop.resolve();
+  await stopA;
+
+  await assert.rejects(startB, /Meeting note changed/);
+  assert.deepEqual(activeIdentity, { noteId: 1, clientNoteId: "client-a" });
+});
+
+test("pre-warming is serialized between stop and the next start", async () => {
+  const lifecycle = new MeetingSessionLifecycle();
+  const releaseStop = deferred();
+  const events = [];
+
+  await lifecycle.start(() => events.push("start-a"));
+  const stopA = lifecycle.stop(async () => {
+    events.push("stop-a");
+    await releaseStop.promise;
+  });
+  const prepareB = lifecycle.run(() => events.push("prepare-b"));
+  const startB = lifecycle.start(() => events.push("start-b"));
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["start-a", "stop-a"]);
+  releaseStop.resolve();
+  await Promise.all([stopA, prepareB, startB]);
+
+  assert.deepEqual(events, ["start-a", "stop-a", "prepare-b", "start-b"]);
+});
+
+test("pre-warming does not make a duplicate stop look like a new session stop", async () => {
+  const lifecycle = new MeetingSessionLifecycle();
+  const releaseStop = deferred();
+  let stopCount = 0;
+
+  await lifecycle.start(() => undefined);
+  const stopA = lifecycle.stop(async () => {
+    stopCount += 1;
+    await releaseStop.promise;
+  });
+  const prepare = lifecycle.run(() => undefined);
+  const duplicateStopA = lifecycle.stop(() => {
+    stopCount += 1;
+  });
+
+  assert.equal(duplicateStopA, stopA);
+  releaseStop.resolve();
+  await Promise.all([stopA, prepare, duplicateStopA]);
+  assert.equal(stopCount, 1);
+});

--- a/test/utils/meetingDiarizationTarget.test.js
+++ b/test/utils/meetingDiarizationTarget.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/meetingDiarizationTarget.ts");
+
+test("a delayed A result cannot update B's visible state", async () => {
+  const { matchesMeetingDiarizationTarget } = await load();
+  const result = { sessionId: "session-a", noteId: 1, clientNoteId: "client-a" };
+
+  assert.equal(
+    matchesMeetingDiarizationTarget(result, {
+      sessionId: "session-b",
+      noteId: 2,
+      clientNoteId: "client-b",
+    }),
+    false
+  );
+});
+
+test("all three identity fields must match before applying UI state", async () => {
+  const { matchesMeetingDiarizationTarget } = await load();
+  const target = { sessionId: "session-a", noteId: 1, clientNoteId: "client-a" };
+
+  assert.equal(matchesMeetingDiarizationTarget({ ...target }, target), true);
+  assert.equal(matchesMeetingDiarizationTarget({ ...target, sessionId: "old" }, target), false);
+  assert.equal(matchesMeetingDiarizationTarget({ ...target, noteId: 2 }, target), false);
+  assert.equal(
+    matchesMeetingDiarizationTarget({ ...target, clientNoteId: "replaced" }, target),
+    false
+  );
+  assert.equal(matchesMeetingDiarizationTarget(null, target), false);
+});


### PR DESCRIPTION
## Summary

Fixes #1495.

Background diarization now persists against the note identity established when the recording starts, rather than whichever note is rendered when processing completes. The main process owns this persistence; the renderer applies the resulting overlay only when the session ID, note ID, and client note ID all match.

Because diarization can outlive navigation or even the next recording, this establishes ownership across the meeting lifecycle rather than only guarding the final renderer callback.

## Implementation

- Serialize meeting prepare, start, and stop operations in both renderer and main.
- Fence queued starts and transcript, embedding, speaker-mapping, and auto-label writes with `(note.id, client_note_id)`.
- Preserve edits and speaker locks made during background processing by merging into the latest stored transcript.
- Share speaker-state normalization and merge behavior between main and renderer.

## Validation

- 15 lifecycle, persistence, and identity regression tests
- `npm run typecheck`
- `npm run lint`
- `npm run build:renderer`
- Scoped Prettier checks and `git diff --check`

`npm test` reported 1,163 passing and 6 skipped tests, then exited non-zero on one local `better-sqlite3` teardown failure in `spacesDatabase.test.js`.
