### PR TITLE
feat(meeting): enable live speaker identification for Windows loopbac…

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6180,58 +6180,71 @@ class IPCHandlers {
       }
 
       meetingLiveSpeakerState = null;
-      meetingLiveSpeakerStartedAt = Date.now();
-      const started = await liveSpeakerIdentifier.start(
-        (identification) => {
-          if (!win || win.isDestroyed()) {
-            return;
-          }
-
-          bindOneOnOneAttendeeToSpeaker(identification.speakerId);
-
-          const displayName = meetingOneOnOneAttendee
-            ? meetingOneOnOneAttendee.displayName
-            : identification.displayName;
-
-          const startTime = Math.max(
-            meetingLiveSpeakerStartedAt || 0,
-            (meetingLiveSpeakerStartedAt || 0) + identification.startTime * 1000
-          );
-          const endTime = Math.max(
-            startTime,
-            (meetingLiveSpeakerStartedAt || 0) + identification.endTime * 1000
-          );
-          const enrichedIdentification = {
-            ...identification,
-            displayName,
-            startTime,
-            endTime,
-          };
-
-          win.webContents.send("meeting-speaker-identified", enrichedIdentification);
-
-          for (const seg of meetingDiarizationSegments) {
-            if (
-              seg.source === "system" &&
-              seg.timestamp != null &&
-              seg.timestamp >= startTime &&
-              seg.timestamp <= endTime &&
-              (!seg.speaker || seg.speakerIsPlaceholder)
-            ) {
-              applyConfirmedSpeaker(seg, {
-                speaker: identification.speakerId,
-                speakerName: displayName || seg.speakerName,
-                speakerIsPlaceholder: false,
-              });
+      // Anchored on the first system chunk instead, in sendMeetingAudio.
+      meetingLiveSpeakerStartedAt = null;
+      const started = await liveSpeakerIdentifier
+        .start(
+          (identification) => {
+            if (!win || win.isDestroyed() || meetingLiveSpeakerStartedAt == null) {
+              return;
             }
+
+            bindOneOnOneAttendeeToSpeaker(identification.speakerId);
+
+            const displayName = meetingOneOnOneAttendee
+              ? meetingOneOnOneAttendee.displayName
+              : identification.displayName;
+
+            const startTime = Math.max(
+              meetingLiveSpeakerStartedAt,
+              meetingLiveSpeakerStartedAt + identification.startTime * 1000
+            );
+            const endTime = Math.max(
+              startTime,
+              meetingLiveSpeakerStartedAt + identification.endTime * 1000
+            );
+            const enrichedIdentification = {
+              ...identification,
+              displayName,
+              startTime,
+              endTime,
+            };
+
+            win.webContents.send("meeting-speaker-identified", enrichedIdentification);
+
+            for (const seg of meetingDiarizationSegments) {
+              if (
+                seg.source === "system" &&
+                seg.timestamp != null &&
+                seg.timestamp >= startTime &&
+                seg.timestamp <= endTime &&
+                (!seg.speaker || seg.speakerIsPlaceholder)
+              ) {
+                applyConfirmedSpeaker(seg, {
+                  speaker: identification.speakerId,
+                  speakerName: displayName || seg.speakerName,
+                  speakerIsPlaceholder: false,
+                });
+              }
+            }
+          },
+          {
+            getSpeakerProfiles: getLiveSpeakerProfiles,
+            maxSpeakers: resolveSessionMaxSpeakers(),
+            enabled: true,
           }
-        },
-        {
-          getSpeakerProfiles: getLiveSpeakerProfiles,
-          maxSpeakers: resolveSessionMaxSpeakers(),
-          enabled: true,
-        }
-      );
+        )
+        .catch((error) => {
+          // isAvailable() only stats the model file, so a corrupt model or an
+          // onnxruntime binding that won't load still throws here. Speaker labels
+          // are an enhancement — never let them take the recording down with them.
+          debugLogger.warn(
+            "Live speaker identification start failed",
+            { error: error.message },
+            "speaker"
+          );
+          return false;
+        });
 
       if (started) {
         meetingLiveSpeakerActive = true;
@@ -6956,6 +6969,13 @@ class IPCHandlers {
         flushPendingMeetingMicChunks();
 
         if (meetingLiveSpeakerActive) {
+          // identification.startTime counts samples from the first chunk the
+          // identifier sees, so the wall-clock anchor has to be the arrival of
+          // that chunk. Stamping it when identification starts is only correct
+          // when capture is already running (the macOS tap); the Windows
+          // loopback helper can take seconds to hand over its first buffer, and
+          // a stale anchor shifts every label earlier by that gap.
+          meetingLiveSpeakerStartedAt ??= receivedAt;
           void liveSpeakerIdentifier.feedAudio(outboundBuffer);
         }
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -32,6 +32,7 @@ const { getTinfoilChatModels } = require("./tinfoilCatalog");
 const { transcribeWithTinfoil } = require("./tinfoilTranscription");
 const AudioStorageManager = require("./audioStorage");
 const liveSpeakerIdentifier = require("./liveSpeakerIdentifier");
+const { supportsLiveSpeakerIdentification } = require("./liveSpeakerIdPolicy");
 const MeetingEchoLeakDetector = require("./meetingEchoLeakDetector");
 const { partitionPendingMicFinals, isWithinRetractWindow } = require("./meetingMicHoldback");
 const { applySmartSpacing } = require("./smartSpacing");
@@ -6166,7 +6167,10 @@ class IPCHandlers {
     const startLiveSpeakerIdentification = async (win, systemAudioMode) => {
       await stopLiveSpeakerIdentification();
 
-      if (systemAudioMode !== "native" || !liveSpeakerIdentifier.isAvailable()) {
+      if (
+        !supportsLiveSpeakerIdentification(systemAudioMode) ||
+        !liveSpeakerIdentifier.isAvailable()
+      ) {
         return false;
       }
 

--- a/src/helpers/liveSpeakerIdPolicy.js
+++ b/src/helpers/liveSpeakerIdPolicy.js
@@ -1,0 +1,12 @@
+// Whether live speaker identification can run for the given meeting system
+// audio mode.
+//
+// "native" (macOS Core Audio tap) and Windows "loopback" (WASAPI helper or
+// renderer display-media fallback) all deliver 24 kHz mono s16le PCM through
+// the same sendMeetingAudio("system") path, so the identifier works unchanged.
+// Linux reports "loopback" too (PipeWire portal) but that capture path has not
+// been verified against the identifier yet, so it stays disabled.
+export function supportsLiveSpeakerIdentification(systemAudioMode, platform = process.platform) {
+  if (systemAudioMode === "native") return true;
+  return systemAudioMode === "loopback" && platform === "win32";
+}

--- a/test/helpers/liveSpeakerIdPolicy.test.js
+++ b/test/helpers/liveSpeakerIdPolicy.test.js
@@ -41,11 +41,32 @@ test("missing mode never identifies speakers", async () => {
   assert.equal(supportsLiveSpeakerIdentification(null, "darwin"), false);
 });
 
+// The sole production call site passes only the mode, so the defaulted platform
+// is the path that actually ships. Asserting it against process.platform would
+// compare the function to itself and pass on CI (Linux) even if the default were
+// deleted, so stub the platform instead.
 test("platform defaults to the current process platform", async () => {
   const { supportsLiveSpeakerIdentification } = await load();
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
-  assert.equal(
-    supportsLiveSpeakerIdentification("loopback"),
-    supportsLiveSpeakerIdentification("loopback", process.platform)
-  );
+  const onPlatform = (platform, run) => {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    try {
+      run();
+    } finally {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  };
+
+  onPlatform("win32", () => {
+    assert.equal(supportsLiveSpeakerIdentification("loopback"), true);
+    assert.equal(supportsLiveSpeakerIdentification("native"), true);
+  });
+  onPlatform("linux", () => {
+    assert.equal(supportsLiveSpeakerIdentification("loopback"), false);
+    assert.equal(supportsLiveSpeakerIdentification("native"), true);
+  });
+  onPlatform("darwin", () => {
+    assert.equal(supportsLiveSpeakerIdentification("loopback"), false);
+  });
 });

--- a/test/helpers/liveSpeakerIdPolicy.test.js
+++ b/test/helpers/liveSpeakerIdPolicy.test.js
@@ -1,0 +1,51 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/liveSpeakerIdPolicy.js");
+
+test("native system audio (macOS tap) supports live speaker identification", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  for (const platform of ["darwin", "win32", "linux"]) {
+    assert.equal(supportsLiveSpeakerIdentification("native", platform), true);
+  }
+});
+
+test("Windows loopback supports live speaker identification", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  // Both Windows strategies (WASAPI helper and renderer display-media
+  // fallback) report mode "loopback" and feed the same 24 kHz mono s16le
+  // sendMeetingAudio path as the macOS native tap.
+  assert.equal(supportsLiveSpeakerIdentification("loopback", "win32"), true);
+});
+
+test("Linux loopback (PipeWire portal) stays disabled until verified", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  assert.equal(supportsLiveSpeakerIdentification("loopback", "linux"), false);
+});
+
+test("unsupported mode never identifies speakers", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  for (const platform of ["darwin", "win32", "linux"]) {
+    assert.equal(supportsLiveSpeakerIdentification("unsupported", platform), false);
+  }
+});
+
+test("missing mode never identifies speakers", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  assert.equal(supportsLiveSpeakerIdentification(undefined, "win32"), false);
+  assert.equal(supportsLiveSpeakerIdentification(null, "darwin"), false);
+});
+
+test("platform defaults to the current process platform", async () => {
+  const { supportsLiveSpeakerIdentification } = await load();
+
+  assert.equal(
+    supportsLiveSpeakerIdentification("loopback"),
+    supportsLiveSpeakerIdentification("loopback", process.platform)
+  );
+});


### PR DESCRIPTION
## Description

Live speaker identification was gated on systemAudioMode === "native", which only macOS reports (Core Audio tap). Windows delivers meeting system audio as mode "loopback" — via the WASAPI process-loopback helper, or Chromium display-media capture as fallback — so the feature was silently disabled there, even though both Windows paths feed the exact same 24 kHz mono s16le PCM into sendMeetingAudio(chunk, "system") → liveSpeakerIdentifier.feedAudio() as the macOS tap.

This replaces the inline mode check with a small, unit-tested predicate. It deliberately takes the platform as a second input: Linux PipeWire capture also reports mode "loopback" (there is no separate "portal" mode), so a mode-only check would have enabled Linux as a side effect. Linux stays disabled until that path is verified.

Verified by code trace: the WASAPI helper is spawned with --sample-rate 24000; the renderer fallback captures through an AudioContext({ sampleRate: 24000 }) worklet emitting mono s16le — so the identifier keeps working across the mid-session wasapi-loopback → renderer-loopback downgrade. Windows builds bundle the required models (prebuild:win downloads silero_vad.onnx + the CAM++ embedding model), and liveSpeakerIdentifier.isAvailable() still guards at runtime if they're missing.

Follow-ups / known limitations
Not yet validated on real Windows hardware — the format/path verification is a careful code trace (as scoped for this change). A smoke test on a Windows machine before release is recommended: start a meeting recording, confirm meeting-speaker-identified events arrive, and check debug logs for identifier start.
Linux (PipeWire loopback) intentionally left disabled — the helper claims the same 24 kHz protocol, but needs separate verification before flipping the predicate.
Split out of the broader meeting speaker-identity work (fix/meeting-speaker-identity)
