### PR TITLE
fix(i18n): replace Spanish and untranslated strings in Chinese locales

### DIFF
--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -158,16 +158,16 @@
     "tap": "点按",
     "close": "关闭",
     "dismiss": "忽略",
-    "save": "Guardar",
-    "saving": "Guardando…",
-    "create": "Crear",
-    "delete": "Eliminar",
-    "actions": "Acciones",
-    "error": "Algo salió mal",
-    "unknownError": "Ocurrió un error desconocido",
-    "copy": "Copiar",
-    "copied": "Copiado",
-    "done": "Listo",
+    "save": "保存",
+    "saving": "保存中…",
+    "create": "创建",
+    "delete": "删除",
+    "actions": "操作",
+    "error": "出了点问题",
+    "unknownError": "发生未知错误",
+    "copy": "复制",
+    "copied": "已复制",
+    "done": "完成",
     "skip": "跳过"
   },
   "onboarding": {
@@ -1307,8 +1307,8 @@
           "accountCredit": "账户余额",
           "newPrice": "新价格",
           "nextBilling": "下次计费",
-          "mo": "mo",
-          "yr": "yr",
+          "mo": "月",
+          "yr": "年",
           "cancel": "取消",
           "confirm": "确认"
         }
@@ -1779,7 +1779,7 @@
       "description": "配置用于听写清理、笔记格式化和聊天的模型",
       "tabs": {
         "dictationCleanup": "听写清理",
-        "dictationAgent": "Voice Agent",
+        "dictationAgent": "语音助手",
         "noteFormatting": "笔记格式化",
         "chatIntelligence": "聊天",
         "dictationTranslation": "翻译"
@@ -2169,8 +2169,8 @@
         "bedrock_gpt_oss_120b": "OpenAI 开放权重模型。低成本下的强大推理能力。",
         "bedrock_deepseek_v3_2": "开放权重前沿模型。智能助手模式的高性价比之选。",
         "bedrock_qwen3_next_80b": "稀疏开放权重模型。快速且多语言。",
-        "vertex_gemini_2_5_flash": "Fast multimodal model via Vertex",
-        "vertex_gemini_2_5_pro": "Advanced reasoning via Vertex"
+        "vertex_gemini_2_5_flash": "通过 Vertex 提供的快速多模态模型",
+        "vertex_gemini_2_5_pro": "通过 Vertex 提供的高级推理模型"
       },
       "local": {
         "qwen_qwen3_5_9b_q4_k_m": "强大的混合模型",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1307,8 +1307,8 @@
           "accountCredit": "帳戶餘額",
           "newPrice": "新價格",
           "nextBilling": "下次計費",
-          "mo": "mo",
-          "yr": "yr",
+          "mo": "月",
+          "yr": "年",
           "cancel": "取消",
           "confirm": "確認"
         }
@@ -1646,7 +1646,7 @@
       },
       "updates": {
         "badges": {
-          "dev": "Dev",
+          "dev": "開發版",
           "latest": "最新",
           "update": "更新"
         },
@@ -1779,7 +1779,7 @@
       "description": "設定用於聽寫清理、筆記格式化和聊天的模型",
       "tabs": {
         "dictationCleanup": "聽寫清理",
-        "dictationAgent": "Voice Agent",
+        "dictationAgent": "語音助手",
         "noteFormatting": "筆記格式化",
         "chatIntelligence": "聊天",
         "dictationTranslation": "翻譯"
@@ -2169,8 +2169,8 @@
         "bedrock_gpt_oss_120b": "OpenAI 開放權重模型。低成本下的強大推理能力。",
         "bedrock_deepseek_v3_2": "開放權重前沿模型。智慧助手模式的高性價比之選。",
         "bedrock_qwen3_next_80b": "稀疏開放權重模型。快速且多語言。",
-        "vertex_gemini_2_5_flash": "Fast multimodal model via Vertex",
-        "vertex_gemini_2_5_pro": "Advanced reasoning via Vertex"
+        "vertex_gemini_2_5_flash": "透過 Vertex 提供的快速多模態模型",
+        "vertex_gemini_2_5_pro": "透過 Vertex 提供的進階推理模型"
       },
       "local": {
         "qwen_qwen3_5_9b_q4_k_m": "強大的混合模型",


### PR DESCRIPTION
## Description

An audit of the locale files found that 10 keys in the zh-CN common group contained Spanish instead of Simplified Chinese ("save": "Guardar", "error": "Algo salió mal", etc.), an issue that predates this branch and shipped to Chinese users on main. A scripted sweep of all 10 locales (flagging values with no CJK/kana/Cyrillic script, script mixing between Simplified and Traditional, and values identical to English) confirmed the Spanish leak was zh-CN-only, and surfaced a handful of genuinely untranslated English strings in both Chinese files. All were replaced using terminology already established in each file (e.g. 语音助手 for "Voice Agent", matching its 8 existing uses in zh-CN; error phrasing mirroring errorBoundary.title).