### PR TITLE
fix(utils): format sub-zero, non-finite, and nullish durations safely

### DIFF
--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,4 +1,7 @@
 export function formatMmSs(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) {
+    return "00:00";
+  }
   const whole = Math.floor(totalSeconds);
   const minutes = Math.floor(whole / 60);
   const seconds = whole % 60;

--- a/test/utils/formatDuration.test.js
+++ b/test/utils/formatDuration.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/formatDuration.ts");
+
+test("formatMmSs formats valid positive seconds", async () => {
+  const { formatMmSs } = await load();
+  assert.equal(formatMmSs(0), "00:00");
+  assert.equal(formatMmSs(5), "00:05");
+  assert.equal(formatMmSs(65), "01:05");
+  assert.equal(formatMmSs(3605), "60:05");
+});
+
+test("formatMmSs handles sub-zero, non-finite, NaN, and nullish inputs safely", async () => {
+  const { formatMmSs } = await load();
+  assert.equal(formatMmSs(-5), "00:00");
+  assert.equal(formatMmSs(NaN), "00:00");
+  assert.equal(formatMmSs(Infinity), "00:00");
+  assert.equal(formatMmSs(-Infinity), "00:00");
+  assert.equal(formatMmSs(null), "00:00");
+  assert.equal(formatMmSs(undefined), "00:00");
+});


### PR DESCRIPTION
### Summary
Safely handle sub-zero, non-finite (`NaN`, `Infinity`), and nullish/invalid inputs in `formatMmSs` (`src/utils/formatDuration.ts`).

### Problem
When audio duration values are uninitialized, corrupted, or calculated as negative (e.g. due to clock drift or unready media stream metadata), `formatMmSs` generates broken strings like `"NaN:NaN"`, `"-1:-5"`, or `"Infinity:NaN"`. These strings render directly in UI components such as `TranscriptionItem`, `NoteBottomBar`, and `DictationWidget`.

### Root Cause
`formatMmSs` previously performed `Math.floor` and modulo arithmetic without checking whether `totalSeconds` was a finite positive number.

### Fix
Add a guard at the beginning of `formatMmSs` returning `"00:00"` when `!Number.isFinite(totalSeconds)` or `totalSeconds <= 0`.

### Behavior Before & After
- **Before**:
  - `formatMmSs(-5)` → `"-1:-5"`
  - `formatMmSs(NaN)` → `"NaN:NaN"`
  - `formatMmSs(Infinity)` → `"Infinity:NaN"`
  - `formatMmSs(undefined)` → `"NaN:NaN"`
- **After**:
  - All invalid, negative, non-finite, or nullish inputs safely return `"00:00"`.
  - Valid positive seconds (e.g., `65` → `"01:05"`) format normally.

### Scope & Non-Goals
- Scope is strictly limited to input validation in `formatMmSs` and adding unit test coverage in `test/utils/formatDuration.test.js`.
- Non-goal: Modifying audio duration calculation call sites in renderer components.

### Tests Added
- `test/utils/formatDuration.test.js`: Validates formatting for normal positive durations as well as edge cases (`-5`, `NaN`, `Infinity`, `-Infinity`, `null`, `undefined`).

### Validation Commands & Results
- `node --test test/utils/formatDuration.test.js`: Passed (2 tests)
- `npm run typecheck`: Passed
- `npm run i18n:check`: Passed
- `git diff --check`: Passed

Fixes #1511
