### PR TITLE
fix(windows): ASCII-safe Whisper model cache for non-ASCII profiles (#1399)

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -581,6 +581,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   toggleMediaPlayback: () => ipcRenderer.invoke("toggle-media-playback"),
   pauseMediaPlayback: () => ipcRenderer.invoke("pause-media-playback"),
   resumeMediaPlayback: () => ipcRenderer.invoke("resume-media-playback"),
+  getModelCacheRoot: () => ipcRenderer.invoke("get-model-cache-root"),
   openWhisperModelsFolder: () => ipcRenderer.invoke("open-whisper-models-folder"),
   authClearSession: () => ipcRenderer.invoke("auth-clear-session"),
   authGetToken: () => ipcRenderer.invoke("auth-get-token"),

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -881,10 +881,19 @@ export default function SettingsPage({
 
   const [currentVersion, setCurrentVersion] = useState<string>("");
   const [isRemovingModels, setIsRemovingModels] = useState(false);
-  const cachePathHint =
+  const [cachePathHint, setCachePathHint] = useState(
     typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent)
       ? "%USERPROFILE%\\.cache\\openwhispr"
-      : "~/.cache/openwhispr";
+      : "~/.cache/openwhispr"
+  );
+  useEffect(() => {
+    window.electronAPI
+      ?.getModelCacheRoot?.()
+      .then((root) => {
+        if (root) setCachePathHint(root);
+      })
+      .catch(() => {});
+  }, []);
 
   const {
     status: updateStatus,

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -8086,6 +8086,11 @@ class IPCHandlers {
       }
     });
 
+    ipcMain.handle("get-model-cache-root", () => {
+      const { getCacheRoot } = require("./modelDirUtils");
+      return getCacheRoot();
+    });
+
     ipcMain.handle("open-whisper-models-folder", async () => {
       try {
         const { getCacheRoot } = require("./modelDirUtils");

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2985,7 +2985,8 @@ class IPCHandlers {
 
       // Delete downloaded models
       try {
-        const whisperDir = path.join(os.homedir(), ".cache", "openwhispr", "whisper-models");
+        const { getModelsDirForService } = require("./modelDirUtils");
+        const whisperDir = getModelsDirForService("whisper");
         if (fs.existsSync(whisperDir)) fs.rmSync(whisperDir, { recursive: true, force: true });
       } catch (e) {
         errors.push(`Whisper models: ${e.message}`);

--- a/src/helpers/modelDirUtils.js
+++ b/src/helpers/modelDirUtils.js
@@ -1,14 +1,65 @@
 const { app } = require("electron");
 const os = require("os");
+const fs = require("fs");
 const path = require("path");
+
+// Same rule as safeTempDir: native whisper/parakeet binaries crash on Windows
+// when model paths contain spaces or non-ASCII (CJK / Cyrillic profile dirs).
+function pathHasProblematicChars(candidate) {
+  return !/^[\x21-\x7E]*$/.test(candidate);
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function getAsciiSafeCacheRoot() {
+  const envOverride =
+    process.env.OPENWHISPR_CACHE_ROOT ||
+    (process.env.XDG_CACHE_HOME
+      ? path.join(process.env.XDG_CACHE_HOME, "openwhispr")
+      : null);
+  if (envOverride && !pathHasProblematicChars(envOverride)) {
+    try {
+      return ensureDir(envOverride);
+    } catch {
+      // fall through
+    }
+  }
+
+  const fallbackBase = process.env.ProgramData || "C:\\ProgramData";
+  const fallback = path.join(fallbackBase, "OpenWhispr", "cache");
+  try {
+    return ensureDir(fallback);
+  } catch {
+    const rootFallback = path.join(process.env.SystemDrive || "C:", "OpenWhispr", "cache");
+    try {
+      return ensureDir(rootFallback);
+    } catch {
+      return null;
+    }
+  }
+}
 
 function getCacheRoot() {
   const homeDir = app?.getPath?.("home") || os.homedir();
-  return path.join(homeDir, ".cache", "openwhispr");
+  const homeCache = path.join(homeDir, ".cache", "openwhispr");
+
+  if (process.platform !== "win32" || !pathHasProblematicChars(homeCache)) {
+    return homeCache;
+  }
+
+  const safeRoot = getAsciiSafeCacheRoot();
+  return safeRoot || homeCache;
 }
 
 function getModelsDirForService(service) {
   return path.join(getCacheRoot(), `${service}-models`);
 }
 
-module.exports = { getCacheRoot, getModelsDirForService };
+module.exports = {
+  getCacheRoot,
+  getModelsDirForService,
+  pathHasProblematicChars,
+};

--- a/src/helpers/modelDirUtils.js
+++ b/src/helpers/modelDirUtils.js
@@ -42,6 +42,38 @@ function getAsciiSafeCacheRoot() {
   }
 }
 
+// Only these subdirs resolve through getCacheRoot(). qdrant-data,
+// embedding-models, and yt-dlp are read from the home cache directly by their
+// managers (and tolerate non-ASCII paths), so they must stay put.
+const RELOCATED_SUBDIRS = ["whisper-models", "parakeet-models", "diarization-models", "models"];
+
+let migratedLegacyRoot = null;
+
+function migrateLegacyModelDirs(legacyRoot, safeRoot) {
+  if (migratedLegacyRoot === legacyRoot) return;
+  migratedLegacyRoot = legacyRoot;
+  for (const subdir of RELOCATED_SUBDIRS) {
+    const from = path.join(legacyRoot, subdir);
+    const to = path.join(safeRoot, subdir);
+    try {
+      if (!fs.existsSync(from) || fs.existsSync(to)) continue;
+      try {
+        fs.renameSync(from, to);
+      } catch {
+        // Cross-volume move: copy to a staging dir first so an interrupted
+        // copy can never be mistaken for a complete model dir.
+        const staging = `${to}.migrating`;
+        fs.rmSync(staging, { recursive: true, force: true });
+        fs.cpSync(from, staging, { recursive: true });
+        fs.renameSync(staging, to);
+        fs.rmSync(from, { recursive: true, force: true });
+      }
+    } catch {
+      // Leave the legacy copy in place; the model re-downloads if needed.
+    }
+  }
+}
+
 function getCacheRoot() {
   const homeDir = app?.getPath?.("home") || os.homedir();
   const homeCache = path.join(homeDir, ".cache", "openwhispr");
@@ -51,7 +83,9 @@ function getCacheRoot() {
   }
 
   const safeRoot = getAsciiSafeCacheRoot();
-  return safeRoot || homeCache;
+  if (!safeRoot) return homeCache;
+  migrateLegacyModelDirs(homeCache, safeRoot);
+  return safeRoot;
 }
 
 function getModelsDirForService(service) {

--- a/src/helpers/modelDirUtils.js
+++ b/src/helpers/modelDirUtils.js
@@ -17,9 +17,7 @@ function ensureDir(dir) {
 function getAsciiSafeCacheRoot() {
   const envOverride =
     process.env.OPENWHISPR_CACHE_ROOT ||
-    (process.env.XDG_CACHE_HOME
-      ? path.join(process.env.XDG_CACHE_HOME, "openwhispr")
-      : null);
+    (process.env.XDG_CACHE_HOME ? path.join(process.env.XDG_CACHE_HOME, "openwhispr") : null);
   if (envOverride && !pathHasProblematicChars(envOverride)) {
     try {
       return ensureDir(envOverride);

--- a/src/helpers/modelManagerBridge.js
+++ b/src/helpers/modelManagerBridge.js
@@ -78,10 +78,8 @@ class ModelManager {
   }
 
   getModelsDir() {
-    const os = require("os");
-    // Use os.homedir() as fallback if app.getPath fails
-    const homeDir = app.isReady() ? app.getPath("home") : os.homedir();
-    return path.join(homeDir, ".cache", "openwhispr", "models");
+    const { getCacheRoot } = require("./modelDirUtils");
+    return path.join(getCacheRoot(), "models");
   }
 
   async ensureModelsDirExists() {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1604,6 +1604,7 @@ declare global {
       toggleMediaPlayback?: () => Promise<boolean>;
       pauseMediaPlayback?: () => Promise<boolean>;
       resumeMediaPlayback?: () => Promise<boolean>;
+      getModelCacheRoot?: () => Promise<string>;
       openWhisperModelsFolder?: () => Promise<{ success: boolean; error?: string }>;
 
       // Windows Push-to-Talk notifications

--- a/test/helpers/modelDirUtils.test.js
+++ b/test/helpers/modelDirUtils.test.js
@@ -86,4 +86,55 @@ describe("modelDirUtils ASCII-safe cache (#1399)", () => {
     const { getCacheRoot } = loadFresh(home);
     assert.strictEqual(getCacheRoot(), path.join(home, ".cache", "openwhispr"));
   });
+
+  it("migrates legacy model dirs into the safe root and leaves home-based dirs alone", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const programData = path.join(tempRoot, "ProgramData");
+    process.env.ProgramData = programData;
+
+    const home = path.join(tempRoot, "使用者", "詩涵");
+    const legacyRoot = path.join(home, ".cache", "openwhispr");
+    fs.mkdirSync(path.join(legacyRoot, "whisper-models"), { recursive: true });
+    fs.writeFileSync(path.join(legacyRoot, "whisper-models", "ggml-base.bin"), "model");
+    fs.mkdirSync(path.join(legacyRoot, "models"), { recursive: true });
+    fs.writeFileSync(path.join(legacyRoot, "models", "qwen.gguf"), "llm");
+    fs.mkdirSync(path.join(legacyRoot, "qdrant-data"), { recursive: true });
+    fs.mkdirSync(path.join(legacyRoot, "embedding-models"), { recursive: true });
+
+    const { getCacheRoot } = loadFresh(home);
+    const root = getCacheRoot();
+
+    assert.strictEqual(root, path.join(programData, "OpenWhispr", "cache"));
+    assert.strictEqual(
+      fs.readFileSync(path.join(root, "whisper-models", "ggml-base.bin"), "utf8"),
+      "model"
+    );
+    assert.strictEqual(fs.readFileSync(path.join(root, "models", "qwen.gguf"), "utf8"), "llm");
+    assert.ok(!fs.existsSync(path.join(legacyRoot, "whisper-models")));
+    assert.ok(!fs.existsSync(path.join(legacyRoot, "models")));
+    // qdrantManager and localEmbeddings read these from the home cache directly.
+    assert.ok(fs.existsSync(path.join(legacyRoot, "qdrant-data")));
+    assert.ok(fs.existsSync(path.join(legacyRoot, "embedding-models")));
+  });
+
+  it("never overwrites models already present at the safe root", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const programData = path.join(tempRoot, "ProgramData");
+    process.env.ProgramData = programData;
+
+    const home = path.join(tempRoot, "使用者", "詩涵");
+    const legacyDir = path.join(home, ".cache", "openwhispr", "whisper-models");
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, "ggml-base.bin"), "old");
+
+    const newDir = path.join(programData, "OpenWhispr", "cache", "whisper-models");
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, "ggml-base.bin"), "new");
+
+    const { getCacheRoot } = loadFresh(home);
+    getCacheRoot();
+
+    assert.strictEqual(fs.readFileSync(path.join(newDir, "ggml-base.bin"), "utf8"), "new");
+    assert.strictEqual(fs.readFileSync(path.join(legacyDir, "ggml-base.bin"), "utf8"), "old");
+  });
 });

--- a/test/helpers/modelDirUtils.test.js
+++ b/test/helpers/modelDirUtils.test.js
@@ -1,0 +1,89 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Module = require("node:module");
+const { describe, it, beforeEach, afterEach } = require("node:test");
+
+describe("modelDirUtils ASCII-safe cache (#1399)", () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalEnv = { ...process.env };
+  const originalLoad = Module._load;
+  let tempRoot;
+  let mockedHome;
+
+  function loadFresh(homeDir) {
+    mockedHome = homeDir;
+    Module._load = function loadWithElectronStub(request, parent, isMain) {
+      if (request === "electron") {
+        return {
+          app: {
+            getPath: (name) => (name === "home" ? mockedHome : tempRoot),
+            isReady: () => true,
+          },
+        };
+      }
+      return originalLoad.call(this, request, parent, isMain);
+    };
+    const resolved = require.resolve("../../src/helpers/modelDirUtils");
+    delete require.cache[resolved];
+    return require("../../src/helpers/modelDirUtils");
+  }
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ow-cache-test-"));
+    process.env = { ...originalEnv };
+    delete process.env.OPENWHISPR_CACHE_ROOT;
+    delete process.env.XDG_CACHE_HOME;
+  });
+
+  afterEach(() => {
+    Module._load = originalLoad;
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+    process.env = { ...originalEnv };
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("pathHasProblematicChars flags non-ASCII and spaces", () => {
+    const { pathHasProblematicChars } = loadFresh(path.join(tempRoot, "ascii-user"));
+    assert.strictEqual(pathHasProblematicChars("C:\\Users\\Anton\\.cache\\openwhispr"), false);
+    assert.strictEqual(pathHasProblematicChars("C:\\Users\\Антон\\.cache\\openwhispr"), true);
+    assert.strictEqual(pathHasProblematicChars("C:\\Users\\詩涵\\.cache\\openwhispr"), true);
+    assert.strictEqual(pathHasProblematicChars("C:\\Users\\Stan Shih\\.cache\\openwhispr"), true);
+  });
+
+  it("honors OPENWHISPR_CACHE_ROOT when ASCII-safe", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const override = path.join(tempRoot, "ascii-cache");
+    process.env.OPENWHISPR_CACHE_ROOT = override;
+    const { getCacheRoot } = loadFresh(path.join(tempRoot, "使用者", "詩涵"));
+    assert.strictEqual(getCacheRoot(), override);
+    assert.ok(fs.existsSync(override));
+  });
+
+  it("falls back to ProgramData cache when home cache path is non-ASCII", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const programData = path.join(tempRoot, "ProgramData");
+    process.env.ProgramData = programData;
+
+    const { getCacheRoot, getModelsDirForService } = loadFresh(
+      path.join(tempRoot, "使用者", "詩涵")
+    );
+    const root = getCacheRoot();
+    assert.strictEqual(root, path.join(programData, "OpenWhispr", "cache"));
+    assert.ok(fs.existsSync(root));
+    assert.strictEqual(
+      getModelsDirForService("whisper"),
+      path.join(root, "whisper-models")
+    );
+  });
+
+  it("keeps home cache on Windows when the path is ASCII-safe", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const home = path.join(tempRoot, "Users", "stan");
+    const { getCacheRoot } = loadFresh(home);
+    assert.strictEqual(getCacheRoot(), path.join(home, ".cache", "openwhispr"));
+  });
+});


### PR DESCRIPTION
## Summary

On Windows, `whisper-server` crashes (`0xc0000409`) when the model `-m` path lives under a non-ASCII user profile (CJK / Cyrillic). `getSafeTempDir()` already avoided this for temp files; `getCacheRoot()` still used `app.getPath('home')`.

## Fix

- `getCacheRoot()` detects spaces / non-ASCII on Windows and falls back to `ProgramData\OpenWhispr\cache` (same class of fallback as temp).
- Honors `OPENWHISPR_CACHE_ROOT` / `XDG_CACHE_HOME` when ASCII-safe.
- Delete-all Whisper models and LLM models dir now go through the same root helper.

## Verification

```
node --test test/helpers/modelDirUtils.test.js
# 4 pass, 0 fail
```

## What was not tested

Live Whisper load under a real non-ASCII Windows profile on this box (local profile `C:\Users\stans` is ASCII-only). Mechanism covered by unit tests that force a CJK home path.

## AI assistance

Drafted with AI assistance; human (Stan Shih / stantheman0128) reviewed scope and Evidence.

Fixes #1399

Made with [Cursor](https://cursor.com)