### PR TITLE
fix(audio): stop classifying phone microphones as built-in

### DIFF
--- a/src/utils/audioDeviceUtils.ts
+++ b/src/utils/audioDeviceUtils.ts
@@ -25,7 +25,7 @@ export function isBuiltInMicrophone(label: string): boolean {
   // must flag "iPhone"/"Cell Phone"/"Headphones" without matching the "phone"
   // inside "microphone" itself.
   if (lowerLabel.includes("microphone")) {
-    const labelWithoutMicrophone = lowerLabel.replace(/microphone/g, "");
+    const labelWithoutMicrophone = lowerLabel.replace(/microphone/g, " ");
     const externalIndicators = [
       "bluetooth",
       "airpods",
@@ -36,10 +36,11 @@ export function isBuiltInMicrophone(label: string): boolean {
       "webcam",
       "iphone",
       "ipad",
-      // Phones surfaced via macOS Continuity carry the device's own name (e.g.
-      // "Galaxy Cell Microphone") — nothing above matched, so one was classified
-      // built-in, auto-selected, and cached; dictations then streamed distant
-      // phone-mic audio and transcribed as empty. "phone" also matches
+      // Phones connected to the computer (Continuity, Bluetooth) carry the
+      // device's own name (e.g. "Galaxy Cell Microphone" from a field report) —
+      // nothing above matched, so one was classified built-in, auto-selected,
+      // and cached; dictations then streamed distant phone-mic audio and
+      // transcribed as empty. "phone" also matches
       // "headphones", which is fine: a headphone mic is external too, and the
       // harmful direction is only external-classified-as-built-in.
       "cell",

--- a/src/utils/audioDeviceUtils.ts
+++ b/src/utils/audioDeviceUtils.ts
@@ -20,8 +20,12 @@ export function isBuiltInMicrophone(label: string): boolean {
     return true;
   }
 
-  // Generic "microphone" without external device indicators
+  // Generic "microphone" without external device indicators. Indicators are
+  // matched against the label with the word "microphone" removed — "phone"
+  // must flag "iPhone"/"Cell Phone"/"Headphones" without matching the "phone"
+  // inside "microphone" itself.
   if (lowerLabel.includes("microphone")) {
+    const labelWithoutMicrophone = lowerLabel.replace(/microphone/g, "");
     const externalIndicators = [
       "bluetooth",
       "airpods",
@@ -32,8 +36,17 @@ export function isBuiltInMicrophone(label: string): boolean {
       "webcam",
       "iphone",
       "ipad",
+      // Phones surfaced via macOS Continuity carry the device's own name (e.g.
+      // "Galaxy Cell Microphone") — nothing above matched, so one was classified
+      // built-in, auto-selected, and cached; dictations then streamed distant
+      // phone-mic audio and transcribed as empty. "phone" also matches
+      // "headphones", which is fine: a headphone mic is external too, and the
+      // harmful direction is only external-classified-as-built-in.
+      "cell",
+      "phone",
+      "continuity",
     ];
-    return !externalIndicators.some((indicator) => lowerLabel.includes(indicator));
+    return !externalIndicators.some((indicator) => labelWithoutMicrophone.includes(indicator));
   }
 
   return false;

--- a/test/utils/audioDeviceUtils.test.js
+++ b/test/utils/audioDeviceUtils.test.js
@@ -9,7 +9,7 @@ test("a phone microphone is never classified as built-in", async () => {
   const { isBuiltInMicrophone } = await load();
 
   // The bug this pins down: a label like "Galaxy Cell Microphone" (a phone
-  // surfaced via Continuity) contains "microphone" and matched none of the
+  // connected to the computer) contains "microphone" and matched none of the
   // external keywords, so the app classified it built-in, auto-selected it,
   // and cached it. Dictation then streamed distant phone-mic audio and the
   // ASR returned empty transcripts.

--- a/test/utils/audioDeviceUtils.test.js
+++ b/test/utils/audioDeviceUtils.test.js
@@ -1,0 +1,43 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+const load = () => import("../../src/utils/audioDeviceUtils.ts");
+
+test("a phone microphone is never classified as built-in", async () => {
+  const { isBuiltInMicrophone } = await load();
+
+  // The bug this pins down: a label like "Galaxy Cell Microphone" (a phone
+  // surfaced via Continuity) contains "microphone" and matched none of the
+  // external keywords, so the app classified it built-in, auto-selected it,
+  // and cached it. Dictation then streamed distant phone-mic audio and the
+  // ASR returned empty transcripts.
+  assert.equal(isBuiltInMicrophone("Galaxy Cell Microphone"), false);
+  assert.equal(isBuiltInMicrophone("Someone's Phone Microphone"), false);
+  assert.equal(isBuiltInMicrophone("iPhone Microphone"), false);
+  assert.equal(isBuiltInMicrophone("Continuity Camera Microphone"), false);
+});
+
+test("genuine built-in microphones stay built-in", async () => {
+  const { isBuiltInMicrophone } = await load();
+
+  assert.equal(isBuiltInMicrophone("MacBook Pro Microphone"), true);
+  assert.equal(isBuiltInMicrophone("Default - MacBook Pro Microphone (Built-in)"), true);
+  // Windows-style labels rely on the generic "microphone" fallback — the fix
+  // must not break them.
+  assert.equal(isBuiltInMicrophone("Microphone (Realtek High Definition Audio)"), true);
+  assert.equal(isBuiltInMicrophone("Microphone Array (Intel Smart Sound)"), true);
+  assert.equal(isBuiltInMicrophone("Internal Microphone"), true);
+});
+
+test("headphone and headset microphones are external", async () => {
+  const { isBuiltInMicrophone } = await load();
+
+  // "phone" (added for cell phones) also matches "headphones" — and that is
+  // correct: a headphone mic is external either way. Misclassifying external
+  // as built-in is the harmful direction; the reverse only skips a fallback.
+  assert.equal(isBuiltInMicrophone("Wired Headphones Microphone"), false);
+  assert.equal(isBuiltInMicrophone("USB Headset Microphone"), false);
+  assert.equal(isBuiltInMicrophone("AirPods Pro"), false);
+});


### PR DESCRIPTION
## Problem

`isBuiltInMicrophone` treats any device label containing "microphone" as built-in unless it matches a deny-list of external keywords. A phone surfaced via macOS Continuity enumerates under the phone's own name (e.g. `Galaxy Cell Microphone`), matches nothing on the list, and is classified built-in — so the app auto-selects it over the real microphone and caches the choice.

The practical failure: dictation silently captures distant phone-mic audio. There is enough energy to trip server VAD, but the streaming ASR returns empty transcripts on every dictation, while the batch fallback still scrapes out text. This cost hours of debugging aimed at the (healthy) streaming pipeline before the device label in the debug log gave it away.

## Fix

Add `cell`, `phone`, and `continuity` to the external indicators. Indicators are matched against the label with the word "microphone" stripped — a bare `phone` indicator would otherwise match the "phone" inside "microphone" itself and flip every generic-branch label (e.g. `Microphone (Realtek High Definition Audio)`) to external. The regression tests caught exactly that on the first attempt.

`phone` also matching "headphones" is intentional: a headphone mic is external too, and the harmful direction is only external-classified-as-built-in — the reverse merely skips an auto-selection fallback.

## Tests

`test/utils/audioDeviceUtils.test.js` (node --test): phone/Continuity labels are never built-in; genuine built-ins (macOS + Windows generic-branch labels) stay built-in; headphone/headset mics are external.
