### PR TITLE
fix(chat): guard non-positive and non-integer note IDs in assistant note card extraction

### DIFF
--- a/src/components/chat/noteCards.ts
+++ b/src/components/chat/noteCards.ts
@@ -19,9 +19,10 @@ function cardFromHit(
   // open. Non-numeric ids (cloud UUIDs) are equally unopenable locally.
   if (hit.id == null) return null;
   const noteId = Number(hit.id);
-  if (!Number.isFinite(noteId) || seen.has(noteId)) return null;
+  if (!Number.isSafeInteger(noteId) || noteId <= 0 || seen.has(noteId)) return null;
   seen.add(noteId);
-  return { noteId, title: typeof hit.title === "string" && hit.title ? hit.title : fallbackTitle };
+  const rawTitle = typeof hit.title === "string" ? hit.title.trim() : "";
+  return { noteId, title: rawTitle || fallbackTitle };
 }
 
 // Note cards rendered under an assistant message: one per note the turn
@@ -41,12 +42,12 @@ export function extractNoteCards(
     if (NOTE_TOOLS.has(tc.name) && tc.metadata && !Array.isArray(tc.metadata)) {
       if (!tc.metadata.id) continue;
       const noteId = Number(tc.metadata.id);
-      if (!Number.isFinite(noteId) || seen.has(noteId)) continue;
+      if (!Number.isSafeInteger(noteId) || noteId <= 0 || seen.has(noteId)) continue;
       seen.add(noteId);
-      const title =
-        (tc.metadata.title as string) ||
-        tc.result?.replace(/^(Created|Updated|Retrieved) note: "(.+)"$/, "$2") ||
-        fallbackTitle;
+      const metaTitle = typeof tc.metadata.title === "string" ? tc.metadata.title.trim() : "";
+      const resultTitle =
+        tc.result?.replace(/^(Created|Updated|Retrieved) note: "(.+)"$/, "$2")?.trim() || "";
+      const title = metaTitle || resultTitle || fallbackTitle;
       cards.push({ noteId, title });
     } else if (tc.name === "search_notes" && Array.isArray(tc.metadata)) {
       for (const hit of tc.metadata) {

--- a/test/helpers/noteCards.test.js
+++ b/test/helpers/noteCards.test.js
@@ -69,3 +69,31 @@ test("incomplete or unknown tools produce nothing", () => {
   ]);
   assert.deepEqual(cards, []);
 });
+
+test("skips non-positive, non-integer, and coerced falsy note ids", () => {
+  const cards = extractCards([
+    completed("create_note", { id: 0, title: "Zero ID" }),
+    completed("update_note", { id: -1, title: "Negative ID" }),
+    completed("get_note", { id: 2.5, title: "Float ID" }),
+    completed("search_notes", [
+      { id: 0, title: "Zero hit" },
+      { id: -3, title: "Negative hit" },
+      { id: 1.8, title: "Float hit" },
+      { id: false, title: "Boolean hit" },
+      { id: "", title: "Empty string hit" },
+      { id: 10, title: "Valid Note" },
+    ]),
+  ]);
+  assert.deepEqual(cards, [{ noteId: 10, title: "Valid Note" }]);
+});
+
+test("falls back to default title for whitespace-only titles in metadata or hits", () => {
+  const cards = extractCards([
+    completed("create_note", { id: 12, title: "   \n\t " }),
+    completed("search_notes", [{ id: 14, title: "   " }]),
+  ]);
+  assert.deepEqual(cards, [
+    { noteId: 12, title: "Note" },
+    { noteId: 14, title: "Note" },
+  ]);
+});


### PR DESCRIPTION
### Summary
Ensures assistant message note card extraction (`extractNoteCards` and `cardFromHit`) validates note IDs against positive safe integers (`Number.isSafeInteger(noteId) && noteId > 0`) and normalizes whitespace in titles to prevent rendering broken note cards.

### Problem
`extractNoteCards` and `cardFromHit` construct `NoteCardRef` objects rendered as clickable note card buttons under assistant messages. Previously, they validated note IDs using `Number.isFinite(noteId)`.

Because `Number.isFinite` accepts `0`, negative numbers (`-1`), non-integers (`1.5`), and falsy coerced types like `false` or `""` (which `Number(...)` turns into `0`), invalid note hits or tool call metadata generated broken note card action buttons pointing to invalid or non-existent note IDs. Whitespace-only titles were also passed through un-trimmed instead of falling back to default titles.

### Root Cause
1. `Number.isFinite(noteId)` permitted non-positive and fractional numeric values.
2. `hit.id == null` check passed for `false` and `""`, which `Number()` coerces to `0`.
3. Untrimmed title string check `typeof hit.title === "string" && hit.title` accepted whitespace-only strings like `"   "`.

### Fix
- Updated `cardFromHit` and `extractNoteCards` in `src/components/chat/noteCards.ts` to require `Number.isSafeInteger(noteId) && noteId > 0`.
- Trimmed titles before fallback selection so whitespace-only strings default to `fallbackTitle`.

### Tests Added
Added unit tests in `test/helpers/noteCards.test.js`:
- `skips non-positive, non-integer, and coerced falsy note ids`
- `falls back to default title for whitespace-only titles in metadata or hits`

### Validation Results
- `node --test test/helpers/noteCards.test.js` (PASSED 7/7)
- `npm run typecheck` (PASSED)
- `npm run lint` (PASSED)
- `npx prettier --check src/components/chat/noteCards.ts test/helpers/noteCards.test.js` (PASSED)
- `npm run i18n:check` (PASSED)
- `npm run build:renderer` (PASSED)

Fixes #1516
