### PR TITLE
feat(linux): Add launch at login via an XDG autostart entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - Only active on Linux + KDE desktop (detected via `XDG_CURRENT_DESKTOP`)
   - D-Bus transport: `@homebridge/dbus-native` (pure JavaScript, no native addons)
 - **linuxAutostart.js**: Launch-at-login on Linux via an XDG autostart entry
-  - `app.setLoginItemSettings()` is a no-op on Linux, so the entry is written directly to `$XDG_CONFIG_HOME/autostart/openwhispr.desktop`
+  - `app.setLoginItemSettings()` is a no-op on Linux, so the entry is written directly to `$XDG_CONFIG_HOME/autostart/open-whispr.desktop`, matching the executable name electron-builder packages under
   - `Exec` resolves from `$APPIMAGE` first: `process.execPath` is the ephemeral AppImage FUSE mount
   - `isAutostartEnabled()` honors `X-GNOME-Autostart-enabled=false` and `Hidden=true`, which GNOME Tweaks and KDE's autostart editor write in place instead of deleting the file
   - `syncAutostartEntry()` runs from `initializeCoreManagers()` in `main.js` and re-points a stale `Exec` after the executable moves (renamed or auto-updated AppImage); it never re-enables an entry the user disabled, and no-ops in development
@@ -775,7 +775,7 @@ const { t } = useTranslation();
 - No standardized URL scheme for system settings (user must open manually)
 - Privacy settings button hidden in UI (not applicable on Linux)
 - Recommend `pavucontrol` for audio device management
-- **Launch at login**: XDG autostart entry at `~/.config/autostart/openwhispr.desktop` (see `linuxAutostart.js`), since Electron's `setLoginItemSettings()` does nothing on Linux
+- **Launch at login**: XDG autostart entry at `~/.config/autostart/open-whispr.desktop` (see `linuxAutostart.js`), since Electron's `setLoginItemSettings()` does nothing on Linux
   - Disabling it from GNOME Tweaks or KDE's autostart editor is reflected in the Settings toggle
   - "Start minimized" is handled app-side by the `startMinimized` setting, not by the desktop entry
 - **Clipboard paste tools** (at least one required for auto-paste):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - Converts Electron hotkey format to Qt key codes
   - Only active on Linux + KDE desktop (detected via `XDG_CURRENT_DESKTOP`)
   - D-Bus transport: `@homebridge/dbus-native` (pure JavaScript, no native addons)
+- **linuxAutostart.js**: Launch-at-login on Linux via an XDG autostart entry
+  - `app.setLoginItemSettings()` is a no-op on Linux, so the entry is written directly to `$XDG_CONFIG_HOME/autostart/openwhispr.desktop`
+  - `Exec` resolves from `$APPIMAGE` first: `process.execPath` is the ephemeral AppImage FUSE mount
+  - `isAutostartEnabled()` honors `X-GNOME-Autostart-enabled=false` and `Hidden=true`, which GNOME Tweaks and KDE's autostart editor write in place instead of deleting the file
+  - `syncAutostartEntry()` runs from `initializeCoreManagers()` in `main.js` and re-points a stale `Exec` after the executable moves (renamed or auto-updated AppImage); it never re-enables an entry the user disabled, and no-ops in development
+  - Unit-tested in `test/helpers/linuxAutostart.test.js`
 - **ipcHandlers.js**: Centralized IPC handler registration
 - **windowsKeyManager.js**: Windows Push-to-Talk support with native key listener
   - Spawns native `windows-key-listener.exe` binary for low-level keyboard hooks
@@ -769,6 +775,9 @@ const { t } = useTranslation();
 - No standardized URL scheme for system settings (user must open manually)
 - Privacy settings button hidden in UI (not applicable on Linux)
 - Recommend `pavucontrol` for audio device management
+- **Launch at login**: XDG autostart entry at `~/.config/autostart/openwhispr.desktop` (see `linuxAutostart.js`), since Electron's `setLoginItemSettings()` does nothing on Linux
+  - Disabling it from GNOME Tweaks or KDE's autostart editor is reflected in the Settings toggle
+  - "Start minimized" is handled app-side by the `startMinimized` setting, not by the desktop entry
 - **Clipboard paste tools** (at least one required for auto-paste):
   - **X11**: `xdotool` (recommended)
   - **Wayland** (non-GNOME): `wtype` (requires virtual keyboard protocol) or `xdotool` (works via XWayland, recommended for Electron apps)

--- a/main.js
+++ b/main.js
@@ -380,6 +380,17 @@ function cleanupOrphanedLinuxRestoreToken() {
   } catch {}
 }
 
+function syncLinuxAutostartEntry() {
+  if (process.platform !== "linux") return;
+  try {
+    if (require("./src/helpers/linuxAutostart").syncAutostartEntry()) {
+      debugLogger.info("Re-pointed the autostart entry at the current executable");
+    }
+  } catch (error) {
+    debugLogger.warn("Failed to sync the autostart entry", { error: error?.message });
+  }
+}
+
 function initializeCoreManagers() {
   setupProductionPath();
 
@@ -432,6 +443,7 @@ function initializeCoreManagers() {
   // doesn't pay the probe spawn. No-ops on non-Windows.
   windowsLoopbackAudioManager.getCapability().catch(() => {});
   cleanupOrphanedLinuxRestoreToken();
+  syncLinuxAutostartEntry();
   meetingAecManager = new MeetingAecManager();
   windowManager.textEditMonitor = textEditMonitor;
   windowManager.selectionManager = selectionManager;

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1137,10 +1137,6 @@ export default function SettingsPage({
   const [autoStartLoading, setAutoStartLoading] = useState(true);
 
   useEffect(() => {
-    if (platform === "linux") {
-      setAutoStartLoading(false);
-      return;
-    }
     const loadAutoStart = async () => {
       if (window.electronAPI?.getAutoStartEnabled) {
         try {
@@ -1153,7 +1149,7 @@ export default function SettingsPage({
       setAutoStartLoading(false);
     };
     loadAutoStart();
-  }, [platform]);
+  }, []);
 
   useEffect(() => {
     window.electronAPI?.syncNotificationPreferences?.({
@@ -2781,20 +2777,18 @@ export default function SettingsPage({
                 description={t("settingsPage.general.startup.description")}
               />
               <SettingsPanel>
-                {platform !== "linux" && (
-                  <SettingsPanelRow>
-                    <SettingsRow
-                      label={t("settingsPage.general.startup.launchAtLogin")}
-                      description={t("settingsPage.general.startup.launchAtLoginDescription")}
-                    >
-                      <Toggle
-                        checked={autoStartEnabled}
-                        onChange={(checked: boolean) => handleAutoStartChange(checked)}
-                        disabled={autoStartLoading}
-                      />
-                    </SettingsRow>
-                  </SettingsPanelRow>
-                )}
+                <SettingsPanelRow>
+                  <SettingsRow
+                    label={t("settingsPage.general.startup.launchAtLogin")}
+                    description={t("settingsPage.general.startup.launchAtLoginDescription")}
+                  >
+                    <Toggle
+                      checked={autoStartEnabled}
+                      onChange={(checked: boolean) => handleAutoStartChange(checked)}
+                      disabled={autoStartLoading}
+                    />
+                  </SettingsRow>
+                </SettingsPanelRow>
                 <SettingsPanelRow>
                   <SettingsRow
                     label={t("settingsPage.general.startup.startMinimized")}

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -18,6 +18,7 @@ const {
 } = require("./policyResponseError");
 const { classifyAndLog } = require("./networkErrors");
 const { resolveLocalServerNeeds } = require("./localServerPolicy");
+const linuxAutostart = require("./linuxAutostart");
 const GnomeShortcutManager = require("./gnomeShortcut");
 const HyprlandShortcutManager = require("./hyprlandShortcut");
 const AssemblyAiStreaming = require("./assemblyAiStreaming");
@@ -3269,6 +3270,9 @@ class IPCHandlers {
 
     ipcMain.handle("get-auto-start-enabled", async () => {
       try {
+        if (process.platform === "linux") {
+          return linuxAutostart.isAutostartEnabled();
+        }
         const loginSettings = app.getLoginItemSettings();
         return loginSettings.openAtLogin;
       } catch (error) {
@@ -3279,10 +3283,14 @@ class IPCHandlers {
 
     ipcMain.handle("set-auto-start-enabled", async (event, enabled) => {
       try {
-        app.setLoginItemSettings({
-          openAtLogin: enabled,
-          openAsHidden: true, // Start minimized to tray
-        });
+        if (process.platform === "linux") {
+          linuxAutostart.setAutostartEnabled(enabled);
+        } else {
+          app.setLoginItemSettings({
+            openAtLogin: enabled,
+            openAsHidden: true, // Start minimized to tray
+          });
+        }
         debugLogger.debug("Auto-start setting updated", { enabled });
         return { success: true };
       } catch (error) {

--- a/src/helpers/linuxAutostart.js
+++ b/src/helpers/linuxAutostart.js
@@ -4,18 +4,36 @@ const os = require("os");
 
 const DESKTOP_ENTRY_GROUP = "[Desktop Entry]";
 
+// electron-builder names the packaged desktop entry and icon after the Linux
+// executable, which main.js also passes to app.setDesktopName(). Reusing it here
+// keeps our entry and the packaged one referring to the same icon.
+const LINUX_APP_NAME = "open-whispr";
+const ICON_THEME_SUBPATH = path.join(
+  "icons",
+  "hicolor",
+  "256x256",
+  "apps",
+  `${LINUX_APP_NAME}.png`
+);
+
 function getAutostartDir() {
   const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
   return path.join(xdgConfigHome, "autostart");
 }
 
 function getDesktopFilePath() {
-  return path.join(getAutostartDir(), "openwhispr.desktop");
+  return path.join(getAutostartDir(), `${LINUX_APP_NAME}.desktop`);
 }
 
-function getIconInstallPath() {
+// Icon= is resolved against the theme search path, so deb/rpm installs already
+// have one and only unpackaged layouts (AppImage, tar.gz) need a copy. The user
+// directory comes first because that is the only one we may write to.
+function getIconThemePaths() {
   const xdgDataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
-  return path.join(xdgDataHome, "icons", "hicolor", "256x256", "apps", "openwhispr.png");
+  const systemDataDirs = (process.env.XDG_DATA_DIRS || "/usr/local/share:/usr/share")
+    .split(":")
+    .filter(Boolean);
+  return [xdgDataHome, ...systemDataDirs].map((dir) => path.join(dir, ICON_THEME_SUBPATH));
 }
 
 function isDevelopment() {
@@ -40,32 +58,42 @@ function findBundledIconSource() {
   return candidates.find((candidate) => fs.existsSync(candidate)) || null;
 }
 
+// The icon is decoration; an unwritable data directory must not stop the entry
+// itself from being written, which is the only thing the toggle promises.
 function ensureIconInstalled() {
-  const iconDest = getIconInstallPath();
-  if (fs.existsSync(iconDest)) return iconDest;
+  try {
+    const [userIconPath, ...systemIconPaths] = getIconThemePaths();
+    if (fs.existsSync(userIconPath)) return true;
+    if (systemIconPaths.some((iconPath) => fs.existsSync(iconPath))) return true;
 
-  const iconSource = findBundledIconSource();
-  if (!iconSource) return null;
+    const iconSource = findBundledIconSource();
+    if (!iconSource) return false;
 
-  fs.mkdirSync(path.dirname(iconDest), { recursive: true });
-  fs.copyFileSync(iconSource, iconDest);
-  return iconDest;
+    fs.mkdirSync(path.dirname(userIconPath), { recursive: true });
+    fs.copyFileSync(iconSource, userIconPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
-// Reserved characters inside a quoted Exec argument have to be backslash-escaped
-// per the Desktop Entry spec, so a home directory containing one still resolves.
+// Exec goes through two unescaping passes: the desktop-entry string rule runs
+// first, then the argument-quoting rule. Reserved characters need a single
+// backslash for the quoting rule, but a literal backslash needs four, since the
+// string rule collapses each pair into one before quoting is applied.
 function quoteExecPath(execPath) {
-  return `"${execPath.replace(/(["`$\\])/g, "\\$1")}"`;
+  const escaped = execPath.replace(/\\/g, "\\\\\\\\").replace(/(["`$])/g, "\\$1");
+  return `"${escaped}"`;
 }
 
-function buildDesktopFileContents(execPath, iconPath) {
+function buildDesktopFileContents(execPath, iconName) {
   return [
     DESKTOP_ENTRY_GROUP,
     "Type=Application",
     "Name=OpenWhispr",
     "Comment=Voice dictation and AI agent",
     `Exec=${quoteExecPath(execPath)}`,
-    iconPath ? `Icon=${iconPath}` : null,
+    iconName ? `Icon=${iconName}` : null,
     "Terminal=false",
     "Categories=Utility;",
     "X-GNOME-Autostart-enabled=true",
@@ -116,17 +144,24 @@ function readBoolean(value) {
 
 // GNOME Tweaks and KDE's autostart editor disable an entry by rewriting these
 // keys in place rather than deleting the file, so existence alone is not enough.
-function isAutostartEnabled() {
-  const entry = readDesktopEntry();
+function isEntryEnabled(entry) {
   if (!entry) return false;
   if (readBoolean(entry.Hidden) === true) return false;
   return readBoolean(entry["X-GNOME-Autostart-enabled"]) !== false;
 }
 
+function isAutostartEnabled() {
+  return isEntryEnabled(readDesktopEntry());
+}
+
 function writeAutostartEntry() {
   fs.mkdirSync(getAutostartDir(), { recursive: true });
-  const contents = buildDesktopFileContents(resolveExecutablePath(), ensureIconInstalled());
-  fs.writeFileSync(getDesktopFilePath(), contents, { mode: 0o644 });
+  const iconName = ensureIconInstalled() ? LINUX_APP_NAME : null;
+  fs.writeFileSync(
+    getDesktopFilePath(),
+    buildDesktopFileContents(resolveExecutablePath(), iconName),
+    { mode: 0o644 }
+  );
 }
 
 function setAutostartEnabled(enabled) {
@@ -143,9 +178,9 @@ function setAutostartEnabled(enabled) {
 // nothing. Skipped in development, where execPath is the local Electron binary.
 function syncAutostartEntry() {
   if (isDevelopment()) return false;
-  if (!isAutostartEnabled()) return false;
 
   const entry = readDesktopEntry();
+  if (!isEntryEnabled(entry)) return false;
   if (entry.Exec === quoteExecPath(resolveExecutablePath())) return false;
 
   writeAutostartEntry();

--- a/src/helpers/linuxAutostart.js
+++ b/src/helpers/linuxAutostart.js
@@ -1,0 +1,162 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const DESKTOP_ENTRY_GROUP = "[Desktop Entry]";
+
+function getAutostartDir() {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  return path.join(xdgConfigHome, "autostart");
+}
+
+function getDesktopFilePath() {
+  return path.join(getAutostartDir(), "openwhispr.desktop");
+}
+
+function getIconInstallPath() {
+  const xdgDataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  return path.join(xdgDataHome, "icons", "hicolor", "256x256", "apps", "openwhispr.png");
+}
+
+function isDevelopment() {
+  return process.env.NODE_ENV === "development";
+}
+
+// electron.d.ts marks setLoginItemSettings' path override as win32-only; on Linux
+// process.execPath is the ephemeral AppImage FUSE mount, so we resolve it ourselves.
+function resolveExecutablePath() {
+  return process.env.APPIMAGE || process.execPath;
+}
+
+function findBundledIconSource() {
+  const candidates =
+    isDevelopment() || !process.resourcesPath
+      ? [path.join(__dirname, "..", "assets", "icon.png")]
+      : [
+          path.join(process.resourcesPath, "src", "assets", "icon.png"),
+          path.join(process.resourcesPath, "assets", "icon.png"),
+          path.join(process.resourcesPath, "app.asar.unpacked", "src", "assets", "icon.png"),
+        ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+function ensureIconInstalled() {
+  const iconDest = getIconInstallPath();
+  if (fs.existsSync(iconDest)) return iconDest;
+
+  const iconSource = findBundledIconSource();
+  if (!iconSource) return null;
+
+  fs.mkdirSync(path.dirname(iconDest), { recursive: true });
+  fs.copyFileSync(iconSource, iconDest);
+  return iconDest;
+}
+
+// Reserved characters inside a quoted Exec argument have to be backslash-escaped
+// per the Desktop Entry spec, so a home directory containing one still resolves.
+function quoteExecPath(execPath) {
+  return `"${execPath.replace(/(["`$\\])/g, "\\$1")}"`;
+}
+
+function buildDesktopFileContents(execPath, iconPath) {
+  return [
+    DESKTOP_ENTRY_GROUP,
+    "Type=Application",
+    "Name=OpenWhispr",
+    "Comment=Voice dictation and AI agent",
+    `Exec=${quoteExecPath(execPath)}`,
+    iconPath ? `Icon=${iconPath}` : null,
+    "Terminal=false",
+    "Categories=Utility;",
+    "X-GNOME-Autostart-enabled=true",
+    "",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+function parseDesktopEntry(contents) {
+  const values = {};
+  let inEntryGroup = false;
+
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    if (line.startsWith("[")) {
+      inEntryGroup = line === DESKTOP_ENTRY_GROUP;
+      continue;
+    }
+    if (!inEntryGroup) continue;
+
+    const separator = line.indexOf("=");
+    if (separator === -1) continue;
+    values[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+
+  return values;
+}
+
+// A missing file and an unreadable one both mean "not autostarting", which is
+// what the caller acts on; a failed write surfaces the real error instead.
+function readDesktopEntry() {
+  try {
+    return parseDesktopEntry(fs.readFileSync(getDesktopFilePath(), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function readBoolean(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return null;
+}
+
+// GNOME Tweaks and KDE's autostart editor disable an entry by rewriting these
+// keys in place rather than deleting the file, so existence alone is not enough.
+function isAutostartEnabled() {
+  const entry = readDesktopEntry();
+  if (!entry) return false;
+  if (readBoolean(entry.Hidden) === true) return false;
+  return readBoolean(entry["X-GNOME-Autostart-enabled"]) !== false;
+}
+
+function writeAutostartEntry() {
+  fs.mkdirSync(getAutostartDir(), { recursive: true });
+  const contents = buildDesktopFileContents(resolveExecutablePath(), ensureIconInstalled());
+  fs.writeFileSync(getDesktopFilePath(), contents, { mode: 0o644 });
+}
+
+function setAutostartEnabled(enabled) {
+  if (!enabled) {
+    fs.rmSync(getDesktopFilePath(), { force: true });
+    return;
+  }
+  writeAutostartEntry();
+}
+
+// The recorded Exec path goes stale whenever the executable moves: an AppImage
+// the user renames, or one an auto-update replaces with a new filename. The entry
+// survives, so the toggle still reads as enabled while the session launches
+// nothing. Skipped in development, where execPath is the local Electron binary.
+function syncAutostartEntry() {
+  if (isDevelopment()) return false;
+  if (!isAutostartEnabled()) return false;
+
+  const entry = readDesktopEntry();
+  if (entry.Exec === quoteExecPath(resolveExecutablePath())) return false;
+
+  writeAutostartEntry();
+  return true;
+}
+
+module.exports = {
+  getDesktopFilePath,
+  resolveExecutablePath,
+  buildDesktopFileContents,
+  isAutostartEnabled,
+  setAutostartEnabled,
+  syncAutostartEntry,
+};

--- a/test/helpers/linuxAutostart.test.js
+++ b/test/helpers/linuxAutostart.test.js
@@ -1,0 +1,241 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const load = () => import("../../src/helpers/linuxAutostart.js");
+
+// Assigning undefined to process.env coerces to the string "undefined", which
+// would leak a bogus value into every later test in this file.
+const MANAGED_ENV = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "APPIMAGE", "NODE_ENV"];
+
+function setEnv(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function withTmpXdgDirs(fn) {
+  return async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-autostart-test-"));
+    const saved = Object.fromEntries(MANAGED_ENV.map((name) => [name, process.env[name]]));
+    MANAGED_ENV.forEach((name) => setEnv(name, undefined));
+    process.env.XDG_CONFIG_HOME = path.join(root, "config");
+    process.env.XDG_DATA_HOME = path.join(root, "data");
+    try {
+      await fn(root);
+    } finally {
+      MANAGED_ENV.forEach((name) => setEnv(name, saved[name]));
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+}
+
+function writeEntry(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+test(
+  "prefers APPIMAGE over process.execPath, since execPath is the ephemeral mount",
+  withTmpXdgDirs(async () => {
+    const { resolveExecutablePath } = await load();
+
+    process.env.APPIMAGE = "/home/user/Applications/OpenWhispr.AppImage";
+    assert.equal(resolveExecutablePath(), "/home/user/Applications/OpenWhispr.AppImage");
+  })
+);
+
+test(
+  "falls back to process.execPath for deb/rpm/tar.gz installs (no APPIMAGE set)",
+  withTmpXdgDirs(async () => {
+    const { resolveExecutablePath } = await load();
+
+    assert.equal(resolveExecutablePath(), process.execPath);
+  })
+);
+
+test(
+  "desktop file contents quote the exec path and include the icon when present",
+  withTmpXdgDirs(async () => {
+    const { buildDesktopFileContents } = await load();
+
+    const contents = buildDesktopFileContents("/a/b/OpenWhispr.AppImage", "/a/b/icon.png");
+    assert.match(contents, /^Exec="\/a\/b\/OpenWhispr\.AppImage"$/m);
+    assert.match(contents, /^Icon=\/a\/b\/icon\.png$/m);
+    assert.match(contents, /^X-GNOME-Autostart-enabled=true$/m);
+  })
+);
+
+test(
+  "desktop file omits the Icon line rather than writing a broken reference",
+  withTmpXdgDirs(async () => {
+    const { buildDesktopFileContents } = await load();
+
+    const contents = buildDesktopFileContents("/a/b/OpenWhispr.AppImage", null);
+    assert.doesNotMatch(contents, /^Icon=/m);
+  })
+);
+
+test(
+  "exec paths containing reserved characters are escaped, not written raw",
+  withTmpXdgDirs(async () => {
+    const { buildDesktopFileContents } = await load();
+
+    const contents = buildDesktopFileContents('/home/o"neill/$HOME/`app`\\v/OpenWhispr', null);
+    assert.match(contents, /^Exec="\/home\/o\\"neill\/\\\$HOME\/\\`app\\`\\\\v\/OpenWhispr"$/m);
+  })
+);
+
+test(
+  "setAutostartEnabled(true) writes a desktop file, isAutostartEnabled reflects it, false removes it",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, isAutostartEnabled, getDesktopFilePath } = await load();
+
+    assert.equal(isAutostartEnabled(), false);
+
+    setAutostartEnabled(true);
+    assert.equal(isAutostartEnabled(), true);
+    assert.ok(fs.existsSync(getDesktopFilePath()));
+
+    setAutostartEnabled(false);
+    assert.equal(isAutostartEnabled(), false);
+    assert.ok(!fs.existsSync(getDesktopFilePath()));
+  })
+);
+
+test(
+  "setAutostartEnabled(false) on an already-disabled install is a no-op, not an error",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, isAutostartEnabled } = await load();
+
+    assert.doesNotThrow(() => setAutostartEnabled(false));
+    assert.equal(isAutostartEnabled(), false);
+  })
+);
+
+test(
+  "an entry GNOME Tweaks disabled in place reads as disabled, not as enabled",
+  withTmpXdgDirs(async () => {
+    const { isAutostartEnabled, getDesktopFilePath } = await load();
+
+    writeEntry(
+      getDesktopFilePath(),
+      "[Desktop Entry]\nType=Application\nName=OpenWhispr\nX-GNOME-Autostart-enabled=false\n"
+    );
+    assert.equal(isAutostartEnabled(), false);
+  })
+);
+
+test(
+  "an entry hidden by an autostart editor reads as disabled",
+  withTmpXdgDirs(async () => {
+    const { isAutostartEnabled, getDesktopFilePath } = await load();
+
+    writeEntry(
+      getDesktopFilePath(),
+      "[Desktop Entry]\nType=Application\nName=OpenWhispr\nHidden=TRUE\n"
+    );
+    assert.equal(isAutostartEnabled(), false);
+  })
+);
+
+test(
+  "keys outside the [Desktop Entry] group do not affect the enabled state",
+  withTmpXdgDirs(async () => {
+    const { isAutostartEnabled, getDesktopFilePath } = await load();
+
+    writeEntry(
+      getDesktopFilePath(),
+      "[Desktop Entry]\nType=Application\n\n[Desktop Action Other]\nHidden=true\n"
+    );
+    assert.equal(isAutostartEnabled(), true);
+  })
+);
+
+test(
+  "setAutostartEnabled(true) re-enables an entry that was disabled in place",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, isAutostartEnabled, getDesktopFilePath } = await load();
+
+    writeEntry(getDesktopFilePath(), "[Desktop Entry]\nType=Application\nHidden=true\n");
+    assert.equal(isAutostartEnabled(), false);
+
+    setAutostartEnabled(true);
+    assert.equal(isAutostartEnabled(), true);
+  })
+);
+
+test(
+  "syncAutostartEntry re-points a stale Exec after the AppImage moves",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, syncAutostartEntry, getDesktopFilePath } = await load();
+
+    process.env.APPIMAGE = "/old/path/OpenWhispr.AppImage";
+    setAutostartEnabled(true);
+
+    process.env.APPIMAGE = "/new/path/OpenWhispr-1.9.0.AppImage";
+    assert.equal(syncAutostartEntry(), true);
+
+    const contents = fs.readFileSync(getDesktopFilePath(), "utf8");
+    assert.match(contents, /^Exec="\/new\/path\/OpenWhispr-1\.9\.0\.AppImage"$/m);
+  })
+);
+
+test(
+  "syncAutostartEntry leaves an up-to-date entry untouched",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, syncAutostartEntry, getDesktopFilePath } = await load();
+
+    process.env.APPIMAGE = "/path/OpenWhispr.AppImage";
+    setAutostartEnabled(true);
+    const before = fs.statSync(getDesktopFilePath()).mtimeMs;
+
+    assert.equal(syncAutostartEntry(), false);
+    assert.equal(fs.statSync(getDesktopFilePath()).mtimeMs, before);
+  })
+);
+
+test(
+  "syncAutostartEntry never resurrects an entry the user disabled in place",
+  withTmpXdgDirs(async () => {
+    const { syncAutostartEntry, isAutostartEnabled, getDesktopFilePath } = await load();
+
+    process.env.APPIMAGE = "/new/path/OpenWhispr.AppImage";
+    writeEntry(
+      getDesktopFilePath(),
+      '[Desktop Entry]\nType=Application\nExec="/old/path/OpenWhispr.AppImage"\nX-GNOME-Autostart-enabled=false\n'
+    );
+
+    assert.equal(syncAutostartEntry(), false);
+    assert.equal(isAutostartEnabled(), false);
+    assert.match(fs.readFileSync(getDesktopFilePath(), "utf8"), /X-GNOME-Autostart-enabled=false/);
+  })
+);
+
+test(
+  "syncAutostartEntry is a no-op with no entry at all",
+  withTmpXdgDirs(async () => {
+    const { syncAutostartEntry, getDesktopFilePath } = await load();
+
+    assert.equal(syncAutostartEntry(), false);
+    assert.ok(!fs.existsSync(getDesktopFilePath()));
+  })
+);
+
+test(
+  "syncAutostartEntry skips development, where execPath is the local Electron binary",
+  withTmpXdgDirs(async () => {
+    const { setAutostartEnabled, syncAutostartEntry, getDesktopFilePath } = await load();
+
+    process.env.APPIMAGE = "/installed/OpenWhispr.AppImage";
+    setAutostartEnabled(true);
+
+    process.env.NODE_ENV = "development";
+    delete process.env.APPIMAGE;
+    assert.equal(syncAutostartEntry(), false);
+
+    const contents = fs.readFileSync(getDesktopFilePath(), "utf8");
+    assert.match(contents, /^Exec="\/installed\/OpenWhispr\.AppImage"$/m);
+  })
+);

--- a/test/helpers/linuxAutostart.test.js
+++ b/test/helpers/linuxAutostart.test.js
@@ -8,7 +8,9 @@ const load = () => import("../../src/helpers/linuxAutostart.js");
 
 // Assigning undefined to process.env coerces to the string "undefined", which
 // would leak a bogus value into every later test in this file.
-const MANAGED_ENV = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "APPIMAGE", "NODE_ENV"];
+const MANAGED_ENV = ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_DATA_DIRS", "APPIMAGE", "NODE_ENV"];
+
+const ICON_THEME_SUBPATH = path.join("icons", "hicolor", "256x256", "apps", "open-whispr.png");
 
 function setEnv(name, value) {
   if (value === undefined) delete process.env[name];
@@ -22,6 +24,7 @@ function withTmpXdgDirs(fn) {
     MANAGED_ENV.forEach((name) => setEnv(name, undefined));
     process.env.XDG_CONFIG_HOME = path.join(root, "config");
     process.env.XDG_DATA_HOME = path.join(root, "data");
+    process.env.XDG_DATA_DIRS = path.join(root, "system-data");
     try {
       await fn(root);
     } finally {
@@ -56,13 +59,13 @@ test(
 );
 
 test(
-  "desktop file contents quote the exec path and include the icon when present",
+  "desktop file contents quote the exec path and reference the icon by theme name",
   withTmpXdgDirs(async () => {
     const { buildDesktopFileContents } = await load();
 
-    const contents = buildDesktopFileContents("/a/b/OpenWhispr.AppImage", "/a/b/icon.png");
+    const contents = buildDesktopFileContents("/a/b/OpenWhispr.AppImage", "open-whispr");
     assert.match(contents, /^Exec="\/a\/b\/OpenWhispr\.AppImage"$/m);
-    assert.match(contents, /^Icon=\/a\/b\/icon\.png$/m);
+    assert.match(contents, /^Icon=open-whispr$/m);
     assert.match(contents, /^X-GNOME-Autostart-enabled=true$/m);
   })
 );
@@ -77,13 +80,43 @@ test(
   })
 );
 
+// The desktop-entry string rule unescapes the value before the quoting rule
+// splits it into arguments, so a literal backslash has to survive both passes.
 test(
   "exec paths containing reserved characters are escaped, not written raw",
   withTmpXdgDirs(async () => {
     const { buildDesktopFileContents } = await load();
 
     const contents = buildDesktopFileContents('/home/o"neill/$HOME/`app`\\v/OpenWhispr', null);
-    assert.match(contents, /^Exec="\/home\/o\\"neill\/\\\$HOME\/\\`app\\`\\\\v\/OpenWhispr"$/m);
+    assert.match(contents, /^Exec="\/home\/o\\"neill\/\\\$HOME\/\\`app\\`\\\\\\\\v\/OpenWhispr"$/m);
+  })
+);
+
+test(
+  "an icon the package already installed is referenced, not copied into the user theme",
+  withTmpXdgDirs(async (root) => {
+    const { setAutostartEnabled, getDesktopFilePath } = await load();
+
+    writeEntry(path.join(root, "system-data", ICON_THEME_SUBPATH), "pretend png");
+
+    setAutostartEnabled(true);
+    assert.match(fs.readFileSync(getDesktopFilePath(), "utf8"), /^Icon=open-whispr$/m);
+    assert.ok(!fs.existsSync(path.join(root, "data", ICON_THEME_SUBPATH)));
+  })
+);
+
+test(
+  "an unwritable icon directory still leaves launch at login enabled",
+  withTmpXdgDirs(async (root) => {
+    const { setAutostartEnabled, isAutostartEnabled, getDesktopFilePath } = await load();
+
+    // A file where the icon tree has to go makes every mkdir below it fail with
+    // ENOTDIR, standing in for a read-only or quota-exhausted home directory.
+    fs.writeFileSync(path.join(root, "data"), "not a directory");
+
+    assert.doesNotThrow(() => setAutostartEnabled(true));
+    assert.equal(isAutostartEnabled(), true);
+    assert.doesNotMatch(fs.readFileSync(getDesktopFilePath(), "utf8"), /^Icon=/m);
   })
 );
 


### PR DESCRIPTION
## Summary

"Launch at login" was hidden on Linux because Electron's `app.setLoginItemSettings()` is a no-op there. This implements it with an XDG autostart entry, so the existing Settings toggle now works on all three platforms instead of two.

No new UI strings: the toggle reuses the existing `settingsPage.general.startup.launchAtLogin` keys, so no locale files change.

| Before (v1.8.1) | After |
| --- | --- |
| <img width="450" alt="Startup section without Launch at login" src="https://github.com/user-attachments/assets/2881009a-a7d9-43ae-8559-525c23fd8f0d" /> | <img width="450" alt="Startup section with Launch at login" src="https://github.com/user-attachments/assets/be6d04a9-cc1f-48f2-8c06-daa79cc6a0c0" /> |

Settings → Preferences → Startup. The Launch at login row was hidden on Linux; it now appears above Start minimized.

## What changed

- **`src/helpers/linuxAutostart.js`** (new) writes `$XDG_CONFIG_HOME/autostart/openwhispr.desktop`.
- **`ipcHandlers.js`** routes `get-auto-start-enabled` / `set-auto-start-enabled` through it on Linux, leaving macOS and Windows on `setLoginItemSettings()`.
- **`SettingsPage.tsx`** drops the `platform !== "linux"` guard that hid the row.
- **`main.js`** calls `syncAutostartEntry()` from `initializeCoreManagers()`, next to the existing Linux startup cleanup.

## Edge cases handled

Three things make a naive `.desktop` write unreliable, so they're handled explicitly and covered by tests:

- **`process.execPath` is wrong on AppImage.** It points at the ephemeral FUSE mount, which is gone by the next boot, so `Exec` resolves from `$APPIMAGE` first.
- **The entry goes stale when the executable moves** (user renames the AppImage, or an auto-update replaces it with a new filename). The file survives, so the toggle keeps reading as enabled while the session launches nothing. `syncAutostartEntry()` re-points it at startup. It never re-enables an entry the user disabled, and no-ops in development, where `execPath` is the local Electron binary.
- **GNOME Tweaks and KDE's autostart editor disable an entry in place**, writing `X-GNOME-Autostart-enabled=false` or `Hidden=true` rather than deleting the file. `isAutostartEnabled()` parses those instead of just testing for the file, so disabling it outside the app is reflected in the toggle.

Reserved characters in `Exec` are also backslash-escaped per the Desktop Entry spec, so a home directory containing one still resolves.

## Testing

`test/helpers/linuxAutostart.test.js` adds 16 cases covering exec resolution and escaping, both in-place-disable keys, `[Desktop Entry]` group scoping, and every `syncAutostartEntry` path.

`npm run lint`, `npm run format`, `npm run typecheck`, and `npm test` all pass.

Manually verified on Ubuntu 26.04 LTS, GNOME Shell 50.1, Wayland, x86_64:

1. The Launch at login row now renders on Linux, and toggling it on creates `~/.config/autostart/openwhispr.desktop` (mode 644) with the icon installed under `hicolor/256x256/apps/`.
2. Reopening Settings reads the toggle back as on. Reinstating the old `platform !== "linux"` guard reproduces the pre-fix behavior (entry present on disk, toggle reads off), and removing it again restores the correct state.
3. Setting `X-GNOME-Autostart-enabled=false`, and separately `Hidden=true`, each make the toggle read as off. Toggling on from that state rewrites a clean, enabled entry.
4. Toggling off removes the file.
5. With `$APPIMAGE` set and `NODE_ENV` unset, a stale `Exec` is re-pointed at the current executable during startup ("Re-pointed the autostart entry at the current executable"), and `$APPIMAGE` takes precedence over `process.execPath`.
6. The same startup path leaves a user-disabled entry (`X-GNOME-Autostart-enabled=false`) completely untouched.

**Not verified**, to be explicit about the limits of the above:

- **Launch after an actual reboot.** No login cycle was performed.
- **A real packaged AppImage.** Steps 5 and 6 reproduced the packaged environment by setting `$APPIMAGE` and leaving `NODE_ENV` unset, which is what the AppImage runtime does, but no AppImage was built. So icon resolution against the packaged `resourcesPath` layout is untested; those candidate paths mirror the ones `tray.js` already uses in production, and a miss degrades gracefully by omitting the `Icon=` line.
- **Non-GNOME desktops.** `Hidden=true` and `X-GNOME-Autostart-enabled=false` were written by hand to match what KDE's editor and GNOME Tweaks produce; only GNOME was exercised directly.

## Notes

Start-minimized behavior is unchanged. `openAsHidden` is macOS-only in Electron, and the existing `startMinimized` setting is applied app-side in `main.js` on every platform, so the desktop entry deliberately carries no hidden flag.

`CLAUDE.md` is updated with the new helper and a Linux platform note, matching how other helpers are documented there.