### PR TITLE
fix(cli): respond with HTTP 400 validation_error on route validation errors

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -212,6 +212,10 @@ class CliBridge {
       sendV1Error(res, 404, "not_found", err.message);
       return;
     }
+    if (err.code === "VALIDATION") {
+      sendV1Error(res, 400, "validation_error", err.message);
+      return;
+    }
     debugLogger.error("CLI bridge route error", { error: err.message }, "cli-bridge");
     sendV1Error(res, 500, "internal_error", err.message || "Internal server error");
   }

--- a/test/helpers/cliBridgeDictionary.test.js
+++ b/test/helpers/cliBridgeDictionary.test.js
@@ -37,7 +37,8 @@ const CliBridge = require("../../src/helpers/cliBridge.js");
 function isNativeBindingUnavailable(error) {
   const message = String(error?.message || error);
   return (
-    message.includes("NODE_MODULE_VERSION") || message.includes("Could not locate the bindings file")
+    message.includes("NODE_MODULE_VERSION") ||
+    message.includes("Could not locate the bindings file")
   );
 }
 
@@ -158,4 +159,88 @@ test("POST /v1/dictionary/update rejects an empty request", (t) => {
   assert.throws(() => call(ctx.bridge, "POST", "/v1/dictionary/update", {}), {
     code: "VALIDATION",
   });
+});
+
+test("route validation errors respond with HTTP 400 validation_error", async (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.bridge.token = "test-token";
+  ctx.bridge.port = 8200;
+
+  class MockResponse {
+    constructor() {
+      this.statusCode = null;
+      this.headers = {};
+      this.body = "";
+    }
+    writeHead(code, headers) {
+      this.statusCode = code;
+      this.headers = headers;
+    }
+    end(chunk) {
+      if (chunk) this.body += chunk;
+    }
+  }
+
+  const req = {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: { authorization: "Bearer test-token" },
+    method: "GET",
+    url: "/v1/notes/search",
+  };
+  const res = new MockResponse();
+
+  await ctx.bridge._handleRequest(req, res);
+
+  assert.equal(res.statusCode, 400);
+  const parsed = JSON.parse(res.body);
+  assert.equal(parsed.error.code, "validation_error");
+  assert.equal(parsed.error.message, "Search query is required");
+});
+
+test("POST /v1/dictionary/update responds with HTTP 400 validation_error for invalid payload", async (t) => {
+  const ctx = createBridge(t);
+  if (!ctx) return;
+
+  ctx.bridge.token = "test-token";
+  ctx.bridge.port = 8200;
+
+  class MockResponse {
+    constructor() {
+      this.statusCode = null;
+      this.headers = {};
+      this.body = "";
+    }
+    writeHead(code, headers) {
+      this.statusCode = code;
+      this.headers = headers;
+    }
+    end(chunk) {
+      if (chunk) this.body += chunk;
+    }
+  }
+
+  const req = {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: { authorization: "Bearer test-token" },
+    method: "POST",
+    url: "/v1/dictionary/update",
+    on(event, handler) {
+      if (event === "data") {
+        handler(JSON.stringify({ add: "not-an-array" }));
+      }
+      if (event === "end") {
+        handler();
+      }
+    },
+  };
+  const res = new MockResponse();
+
+  await ctx.bridge._handleRequest(req, res);
+
+  assert.equal(res.statusCode, 400);
+  const parsed = JSON.parse(res.body);
+  assert.equal(parsed.error.code, "validation_error");
+  assert.equal(parsed.error.message, "'add' must be an array of strings");
 });


### PR DESCRIPTION
## Summary
Fixes an issue where CLI bridge routes that throw a validation error (with `err.code === "VALIDATION"`) trigger a generic 500 `internal_error` response instead of an HTTP 400 `validation_error` response.

## Problem & Root Cause
In `src/helpers/cliBridge.js`, helper validation functions (such as `requireWordList`, search query validation in `/v1/notes/search`, and `/v1/dictionary/update`) throw errors annotated with `err.code = "VALIDATION"`.

However, `CliBridge._sendError(res, err)` only checked `if (err.code === "NOT_FOUND")`. Unhandled validation errors were passed to the default 500 handler (`sendV1Error(res, 500, "internal_error", ...)`), causing client-side input validation errors to be reported as HTTP 500 internal server errors.

## Behavior Before & After
- **Before:** A request to `GET /v1/notes/search` without a `q` parameter or `POST /v1/dictionary/update` with invalid parameters returned HTTP status 500 with `{"error":{"code":"internal_error","message":"..."}}`.
- **After:** Returns HTTP status 400 with `{"error":{"code":"validation_error","message":"..."}}`.

## Scope & Non-Goals
- **Scope:** Correct error mapping in `_sendError` for `VALIDATION` error code to return HTTP status 400 and code `"validation_error"`.
- **Non-Goals:** Does not alter route logic, database operations, or existing 404/500 error paths.

## Tests Added
- Added unit tests in `test/helpers/cliBridgeDictionary.test.js` verifying that `_handleRequest` returns HTTP 400 and `validation_error` when route validation fails (e.g. missing search query or invalid payload array).

## Validation Commands & Results
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/cliBridgeDictionary.test.js` (PASSED 9/9)
- `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` (PASSED 1103/1103)
- `npm run typecheck` (PASSED)
- `npm run lint` (PASSED)
- `npm run format:check` (PASSED)
- `npm run i18n:check` (PASSED)
- `npm run build:renderer` (PASSED)
- `git diff --check` (PASSED clean)

Fixes #1519
