### PR TITLE
fix(utils): guard non-positive, non-integer, and non-finite expected speaker counts

### DIFF
--- a/src/utils/participants.ts
+++ b/src/utils/participants.ts
@@ -6,7 +6,13 @@ export const resolveExpectedSpeakerCount = (note?: {
   expected_speaker_count?: number | null;
   participants?: string | null;
 }): number | null => {
-  if (note?.expected_speaker_count != null) return note.expected_speaker_count;
+  if (
+    typeof note?.expected_speaker_count === "number" &&
+    Number.isInteger(note.expected_speaker_count) &&
+    note.expected_speaker_count > 0
+  ) {
+    return note.expected_speaker_count;
+  }
   if (!note?.participants) return null;
 
   let attendees: CalendarAttendee[];

--- a/test/utils/participants.test.js
+++ b/test/utils/participants.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/participants.ts");
+
+test("returns positive integer expected_speaker_count verbatim", async () => {
+  const { resolveExpectedSpeakerCount } = await load();
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: 3 }), 3);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: 1 }), 1);
+});
+
+test("ignores non-positive expected_speaker_count and falls back to participants", async () => {
+  const { resolveExpectedSpeakerCount } = await load();
+  const note = {
+    expected_speaker_count: 0,
+    participants: JSON.stringify([{ name: "Alice" }, { name: "Bob", self: true }]),
+  };
+  assert.equal(resolveExpectedSpeakerCount(note), 2);
+
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: 0 }), null);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: -1 }), null);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: -10 }), null);
+});
+
+test("ignores non-integer and non-finite expected_speaker_count", async () => {
+  const { resolveExpectedSpeakerCount } = await load();
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: 1.5 }), null);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: NaN }), null);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: Infinity }), null);
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: -Infinity }), null);
+});
+
+test("derives speaker count from calendar participants when expected_speaker_count is nullish", async () => {
+  const { resolveExpectedSpeakerCount } = await load();
+  const participants = JSON.stringify([
+    { name: "Alice" },
+    { name: "Charlie" },
+    { name: "Bob", self: true },
+  ]);
+
+  assert.equal(resolveExpectedSpeakerCount({ expected_speaker_count: null, participants }), 3);
+  assert.equal(resolveExpectedSpeakerCount({ participants }), 3);
+});
+
+test("returns null when participants has no non-self attendees or is malformed", async () => {
+  const { resolveExpectedSpeakerCount } = await load();
+  assert.equal(
+    resolveExpectedSpeakerCount({ participants: JSON.stringify([{ name: "Bob", self: true }]) }),
+    null
+  );
+  assert.equal(resolveExpectedSpeakerCount({ participants: "invalid json" }), null);
+  assert.equal(resolveExpectedSpeakerCount({ participants: "" }), null);
+  assert.equal(resolveExpectedSpeakerCount({}), null);
+  assert.equal(resolveExpectedSpeakerCount(), null);
+});


### PR DESCRIPTION
## Summary
Fixes `resolveExpectedSpeakerCount` in `src/utils/participants.ts` to ensure `expected_speaker_count` is validated as a positive integer before returning it. Non-positive numbers (`0`, `-1`), non-integers (`1.5`), and non-finite values (`NaN`, `Infinity`) are ignored, allowing the function to properly fall back to calendar `participants` resolution or return `null`.

Fixes #1520

## Problem
`resolveExpectedSpeakerCount` calculates the expected total speaker count for a meeting note. Previously, it checked `if (note?.expected_speaker_count != null) return note.expected_speaker_count;`. Because this only guarded against `null` and `undefined`, non-positive numbers (`0`), non-integers (`1.5`), and non-finite values (`NaN`) passed through.

In particular, a value of `0` (a common default/uninitialized column value in database notes) caused `resolveExpectedSpeakerCount` to return `0` immediately, bypassing calendar `participants` parsing and returning a zero count to downstream diarization and speaker UI components.

## Root Cause
`note?.expected_speaker_count != null` did not verify that `expected_speaker_count` is a positive integer (`typeof count === "number" && Number.isInteger(count) && count > 0`).

## Fix
Updated `resolveExpectedSpeakerCount` in `src/utils/participants.ts` to require `typeof count === "number" && Number.isInteger(count) && count > 0`. If `expected_speaker_count` does not satisfy these conditions, the function proceeds to derive the count from calendar `participants` or returns `null`.

## Behavior Before and After
- **Before:**
  - `{ expected_speaker_count: 0, participants: '[{"name":"Alice"},{"name":"Bob","self":true}]' }` returned `0`.
  - `{ expected_speaker_count: -1 }` returned `-1`.
  - `{ expected_speaker_count: NaN }` returned `NaN`.
  - `{ expected_speaker_count: 1.5 }` returned `1.5`.

- **After:**
  - `{ expected_speaker_count: 0, participants: '[{"name":"Alice"},{"name":"Bob","self":true}]' }` returns `2` (derived from participants).
  - `{ expected_speaker_count: 0 }` (no participants) returns `null`.
  - `{ expected_speaker_count: -1 }` returns `null`.
  - `{ expected_speaker_count: NaN }` returns `null`.
  - `{ expected_speaker_count: 1.5 }` returns `null`.

## Scope and Non-Goals
- **In scope:** Validating `expected_speaker_count` in `resolveExpectedSpeakerCount` and adding unit test coverage.
- **Non-goals:** Changing database schema defaults or altering speaker diarization clustering algorithms.

## Tests Added
Created `test/utils/participants.test.js` covering:
- Positive integer `expected_speaker_count` returned verbatim.
- Non-positive (`0`, `-1`, `-10`) ignored, falling back to `participants` or returning `null`.
- Non-integer (`1.5`) and non-finite (`NaN`, `Infinity`, `-Infinity`) ignored.
- Calendar `participants` attendee parsing and filtering (`self: true`).
- Malformed and missing inputs handled safely.

## Validation Commands and Results
- `node --test test/utils/participants.test.js` — **PASS** (5 tests passed)
- `npm run typecheck` — **PASS** (0 errors)
- `npm run lint` — **PASS** (0 linter errors)
- `npx prettier --check src/utils/participants.ts test/utils/participants.test.js` — **PASS**
- `npm run i18n:check` — **PASS**
- `npm run build:renderer` — **PASS**
- `git diff --check` — **PASS** (no whitespace issues)

## Platform / Environment Limitations
Tested on macOS arm64 with Node.js v24.9.0 and npm 11.6.0. No platform-specific dependencies.
