### PR TITLE
fix(utils): guard formatAmount against invalid input

### DIFF
--- a/src/utils/formatAmount.ts
+++ b/src/utils/formatAmount.ts
@@ -1,3 +1,16 @@
-export function formatAmount(cents: number, currency: string): string {
-  return (cents / 100).toLocaleString(undefined, { style: "currency", currency });
+const FALLBACK_CURRENCY = "USD";
+
+export function formatAmount(
+  cents: number | null | undefined,
+  currency: string | null | undefined
+): string {
+  const amount = typeof cents === "number" && Number.isFinite(cents) ? cents / 100 : 0;
+  const trimmed = typeof currency === "string" ? currency.trim() : "";
+  const code = trimmed === "" ? FALLBACK_CURRENCY : trimmed.toUpperCase();
+  try {
+    return amount.toLocaleString(undefined, { style: "currency", currency: code });
+  } catch {
+    // Malformed currency codes make toLocaleString throw; fall back instead of crashing the render.
+    return amount.toLocaleString(undefined, { style: "currency", currency: FALLBACK_CURRENCY });
+  }
 }

--- a/test/utils/formatAmount.test.js
+++ b/test/utils/formatAmount.test.js
@@ -1,0 +1,86 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/formatAmount.ts");
+
+// Reference formatting through the same Intl path, so expectations
+// track the host locale instead of hardcoding "$1.00".
+const usd = (n) => n.toLocaleString(undefined, { style: "currency", currency: "USD" });
+
+test("formats a plain cents amount identically to direct toLocaleString", async () => {
+  const { formatAmount } = await load();
+  assert.equal(
+    formatAmount(12345, "USD"),
+    (12345 / 100).toLocaleString(undefined, { style: "currency", currency: "USD" })
+  );
+});
+
+test("falls back to USD when currency is null instead of throwing RangeError", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, null), usd(1));
+});
+
+test("falls back to USD when currency is undefined instead of throwing RangeError", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, undefined), usd(1));
+});
+
+test("falls back to USD when currency is an empty string instead of throwing RangeError", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, ""), usd(1));
+});
+
+test("falls back to USD when currency is only whitespace", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, "   "), usd(1));
+});
+
+test("trims untrimmed currency codes like ' USD ' instead of throwing RangeError", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, " USD "), usd(1));
+});
+
+test("accepts lowercase currency codes by uppercasing them", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, "usd"), usd(1));
+});
+
+test("falls back to USD on malformed currency codes that make Intl throw", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(100, "AB"), usd(1));
+  assert.equal(formatAmount(100, "TOOLONG"), usd(1));
+  assert.equal(formatAmount(100, "$$$"), usd(1));
+});
+
+test("keeps well-formed but unrecognized codes, which Intl formats without throwing", async () => {
+  const { formatAmount } = await load();
+  assert.equal(
+    formatAmount(100, "XYZ"),
+    (1).toLocaleString(undefined, { style: "currency", currency: "XYZ" })
+  );
+});
+
+test("treats NaN cents as zero instead of rendering '$NaN'", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(NaN, "USD"), usd(0));
+});
+
+test("treats Infinity and -Infinity cents as zero instead of rendering '$∞'", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(Infinity, "USD"), usd(0));
+  assert.equal(formatAmount(-Infinity, "USD"), usd(0));
+});
+
+test("treats nullish cents as zero", async () => {
+  const { formatAmount } = await load();
+  assert.equal(formatAmount(null, "USD"), usd(0));
+  assert.equal(formatAmount(undefined, "USD"), usd(0));
+});
+
+test("formats negative cents amounts", async () => {
+  const { formatAmount } = await load();
+  assert.equal(
+    formatAmount(-12345, "USD"),
+    (-123.45).toLocaleString(undefined, { style: "currency", currency: "USD" })
+  );
+});


### PR DESCRIPTION
## Summary
`formatAmount` passed `currency` straight into `toLocaleString` with `style: "currency"`, so nullish, empty, or untrimmed codes from billing payloads threw an uncaught `RangeError` that crashed the render in `WorkspaceBillingCard.tsx` and `SettingsPage.tsx`, and non-finite `cents` rendered `$NaN` or `$∞`. The formatter now trims and uppercases the code, falls back to USD when it is missing or malformed, treats non-finite or nullish cents as zero, and never throws.

Fixes #1512

## Changes
- `src/utils/formatAmount.ts`: normalize the currency code, fall back to USD on missing or malformed codes, guard non-finite cents to zero.
- `test/utils/formatAmount.test.js`: a named regression test per case from the issue, plus the happy path pinned to the previous output.
