### PR TITLE
fix(meeting): re-evaluate gated mic state and stop prompts expiring early

### DIFF
--- a/src/components/UpdateNotificationOverlay.tsx
+++ b/src/components/UpdateNotificationOverlay.tsx
@@ -49,16 +49,6 @@ export default function UpdateNotificationOverlay() {
     [data]
   );
 
-  const handleMouseEnter = useCallback(() => {
-    setIsHovered(true);
-    window.electronAPI?.setNotificationInteractivity?.(true);
-  }, []);
-
-  const handleMouseLeave = useCallback(() => {
-    setIsHovered(false);
-    window.electronAPI?.setNotificationInteractivity?.(false);
-  }, []);
-
   return (
     <div className="meeting-notification-window w-full h-full bg-transparent p-3">
       <div
@@ -72,8 +62,8 @@ export default function UpdateNotificationOverlay() {
             ? "translate-x-0 opacity-100 scale-100"
             : "translate-x-[120%] opacity-0 scale-95",
         ].join(" ")}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
         <button
           onClick={() => respond("dismiss")}

--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -96,8 +96,7 @@ class AudioActivityDetector extends EventEmitter {
     this._killListenerProcess();
     this._clearSustainedTimer();
     this._clearResetTimer();
-    this._clearCooldownReevalTimer();
-    this._lastKnownMicState = false;
+    this._resetListenerState();
     if (this.checkInterval) {
       clearInterval(this.checkInterval);
       this.checkInterval = null;
@@ -135,9 +134,18 @@ class AudioActivityDetector extends EventEmitter {
     this.consecutiveChecks = 0;
     this.audioActiveStart = null;
     this.hasPrompted = false;
+    this._clearResetTimer();
+  }
+
+  // The pid set and source count mirror what the OS told us is open, not our
+  // own detection state — only losing the listener invalidates them. Clearing
+  // them on dismissal would desync the reference count, so an unrelated app's
+  // mic session ending would report the still-running call as gone.
+  _resetListenerState() {
     this._activeMicPids.clear();
     this._activeSources = 0;
-    this._clearResetTimer();
+    this._lastKnownMicState = false;
+    this._clearCooldownReevalTimer();
   }
 
   _clearSustainedTimer() {
@@ -257,8 +265,7 @@ class AudioActivityDetector extends EventEmitter {
       this._listenerProcess = null;
       if (this._running && this._eventDriven) {
         this._eventDriven = false;
-        this._clearCooldownReevalTimer();
-        this._lastKnownMicState = false;
+        this._resetListenerState();
         this._startPolling();
       }
     };

--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -32,6 +32,8 @@ class AudioActivityDetector extends EventEmitter {
     this._resetTimer = null;
     this._startGeneration = 0;
     this._micWarmHold = false;
+    this._lastKnownMicState = false;
+    this._cooldownReevalTimer = null;
   }
 
   setUserRecording(active) {
@@ -40,6 +42,8 @@ class AudioActivityDetector extends EventEmitter {
       this.consecutiveChecks = 0;
       this.audioActiveStart = null;
       this._clearSustainedTimer();
+    } else {
+      this._reevaluateAfterGate();
     }
     debugLogger.debug("User recording state changed", { active }, "meeting");
   }
@@ -54,6 +58,9 @@ class AudioActivityDetector extends EventEmitter {
     this.consecutiveChecks = 0;
     this.audioActiveStart = null;
     this._clearSustainedTimer();
+    if (!active) {
+      this._reevaluateAfterGate();
+    }
     debugLogger.debug("Mic warm-hold state changed", { active }, "meeting");
   }
 
@@ -89,6 +96,8 @@ class AudioActivityDetector extends EventEmitter {
     this._killListenerProcess();
     this._clearSustainedTimer();
     this._clearResetTimer();
+    this._clearCooldownReevalTimer();
+    this._lastKnownMicState = false;
     if (this.checkInterval) {
       clearInterval(this.checkInterval);
       this.checkInterval = null;
@@ -103,6 +112,11 @@ class AudioActivityDetector extends EventEmitter {
     this._reset();
     this._clearSustainedTimer();
     this._clearResetTimer();
+    // Polling parity: polling re-detects a still-running call once the cooldown
+    // lapses, but the edge-triggered listeners will never re-announce it.
+    if (this._eventDriven && this._lastKnownMicState) {
+      this._scheduleCooldownReeval(COOLDOWN_MS);
+    }
     debugLogger.info(
       "Audio detection dismissed, cooldown started",
       { cooldownMs: COOLDOWN_MS },
@@ -243,6 +257,8 @@ class AudioActivityDetector extends EventEmitter {
       this._listenerProcess = null;
       if (this._running && this._eventDriven) {
         this._eventDriven = false;
+        this._clearCooldownReevalTimer();
+        this._lastKnownMicState = false;
         this._startPolling();
       }
     };
@@ -347,8 +363,42 @@ class AudioActivityDetector extends EventEmitter {
   // Shared event-driven handler
   // ---------------------------------------------------------------------------
 
+  // The listeners are edge-triggered: they announce transitions, never steady
+  // state. A gate may swallow the only edge a call will ever produce, so the
+  // state is recorded unconditionally and re-evaluated when gates lift.
   _onMicStateChanged(active) {
     if (!this._running) return;
+    this._lastKnownMicState = active;
+    this._evaluateMicState(active);
+  }
+
+  _reevaluateAfterGate() {
+    if (this._running && this._eventDriven && this._lastKnownMicState) {
+      this._evaluateMicState(true);
+    }
+  }
+
+  _cooldownRemainingMs() {
+    if (!this.lastDismissedAt) return 0;
+    return Math.max(0, COOLDOWN_MS - (Date.now() - this.lastDismissedAt));
+  }
+
+  _scheduleCooldownReeval(delayMs) {
+    this._clearCooldownReevalTimer();
+    this._cooldownReevalTimer = setTimeout(() => {
+      this._cooldownReevalTimer = null;
+      this._reevaluateAfterGate();
+    }, delayMs);
+  }
+
+  _clearCooldownReevalTimer() {
+    if (this._cooldownReevalTimer) {
+      clearTimeout(this._cooldownReevalTimer);
+      this._cooldownReevalTimer = null;
+    }
+  }
+
+  _evaluateMicState(active) {
     if (this._userRecording) {
       debugLogger.debug("Mic state changed but user recording, ignoring", { active }, "meeting");
       return;
@@ -357,15 +407,18 @@ class AudioActivityDetector extends EventEmitter {
       debugLogger.debug("Mic state changed during warm-hold, ignoring", { active }, "meeting");
       return;
     }
-    if (this.lastDismissedAt && Date.now() - this.lastDismissedAt < COOLDOWN_MS) {
+    const cooldownRemainingMs = this._cooldownRemainingMs();
+    if (cooldownRemainingMs > 0) {
       debugLogger.debug(
         "Mic state changed but in cooldown",
-        {
-          active,
-          remainingMs: COOLDOWN_MS - (Date.now() - this.lastDismissedAt),
-        },
+        { active, remainingMs: cooldownRemainingMs },
         "meeting"
       );
+      if (active) {
+        this._scheduleCooldownReeval(cooldownRemainingMs);
+      } else {
+        this._clearCooldownReevalTimer();
+      }
       return;
     }
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1051,7 +1051,7 @@ class IPCHandlers {
     });
 
     ipcMain.handle("set-notification-interactivity", (event, interactive) => {
-      this.windowManager.setNotificationInteractivity(Boolean(interactive));
+      this.windowManager.setNotificationInteractivity(event.sender, Boolean(interactive));
       return { success: true };
     });
 

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -335,21 +335,13 @@ class MeetingDetectionEngine {
   }
 
   handleNotificationTimeout() {
-    // Expiring unanswered is not a decline: only an audio prompt's timeout cools
-    // down the mic detector, so an ignored calendar reminder leaves mic detection
-    // armed and joining the call late still prompts.
-    const audioTimedOut = [...this.activeDetections.values()].some(
-      (d) => !d.dismissed && d.source === "audio"
-    );
-    if (audioTimedOut) {
-      this._dismiss();
-    }
+    // Expiring unanswered is not a decline, so no dismissal cooldown starts:
+    // the detector's hasPrompted flag already keeps the ongoing call from
+    // re-prompting, while a call starting right after the timeout still
+    // prompts. Only an explicit dismissal (handleNotificationResponse) cools
+    // the mic detector down.
     this.activeDetections.clear();
-    debugLogger.info(
-      "Notification auto-dismissed, detections cleared",
-      { audioTimedOut },
-      "meeting"
-    );
+    debugLogger.info("Notification auto-dismissed, detections cleared", {}, "meeting");
   }
 
   _flushNotificationQueue() {

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -106,12 +106,12 @@ class MeetingDetectionEngine {
     if (this._userRecording || this._postRecordingCooldown) {
       debugLogger.info("Detection queued — user is recording", { detectionId, source }, "meeting");
       this._notificationQueue.push({ source, key, data });
-      this.activeDetections.set(detectionId, { source, key, data, dismissed: false });
+      this.activeDetections.set(detectionId, { source, key, data });
       return;
     }
 
     debugLogger.info("Meeting detection triggered", { detectionId, source }, "meeting");
-    this.activeDetections.set(detectionId, { source, key, data, dismissed: false });
+    this.activeDetections.set(detectionId, { source, key, data });
     this._showPrompt(detectionId, source, key, data);
   }
 
@@ -366,7 +366,7 @@ class MeetingDetectionEngine {
     const detectionId = `${best.source}:${best.key}`;
 
     const detection = this.activeDetections.get(detectionId);
-    if (detection && !detection.dismissed) {
+    if (detection) {
       this._showPrompt(detectionId, best.source, best.key, best.data);
     }
 

--- a/src/helpers/notificationTimer.js
+++ b/src/helpers/notificationTimer.js
@@ -1,0 +1,63 @@
+const DETECTION_TIMEOUT_MS = 30 * 1000;
+// Calendar reminders fire 60s before the meeting (MEETING_REMINDER_LEAD_MS in
+// calendarReminderScheduler.js); the prompt must survive past the meeting
+// start, not vanish 30s before it.
+const CALENDAR_TIMEOUT_MS = 2 * 60 * 1000;
+// A resumed countdown keeps at least this much runway so the card cannot
+// vanish right as the pointer leaves it — or mid-click, while the renderer's
+// 200ms dismiss animation delays the response IPC.
+const MIN_RESUME_MS = 5 * 1000;
+
+function getNotificationTimeoutMs(source) {
+  return source === "calendar" ? CALENDAR_TIMEOUT_MS : DETECTION_TIMEOUT_MS;
+}
+
+// Auto-dismiss countdown for the meeting notification overlay, pausable while
+// the user is interacting with the card.
+class NotificationDismissTimer {
+  constructor(onTimeout) {
+    this._onTimeout = onTimeout;
+    this._timer = null;
+    this._deadline = null;
+    this._pausedRemainingMs = null;
+  }
+
+  start(durationMs) {
+    this.cancel();
+    this._arm(durationMs);
+  }
+
+  pause() {
+    if (!this._timer) return;
+    clearTimeout(this._timer);
+    this._timer = null;
+    this._pausedRemainingMs = Math.max(0, this._deadline - Date.now());
+    this._deadline = null;
+  }
+
+  resume() {
+    if (this._pausedRemainingMs === null) return;
+    this._arm(Math.max(this._pausedRemainingMs, MIN_RESUME_MS));
+  }
+
+  cancel() {
+    if (this._timer) {
+      clearTimeout(this._timer);
+    }
+    this._timer = null;
+    this._deadline = null;
+    this._pausedRemainingMs = null;
+  }
+
+  _arm(durationMs) {
+    this._pausedRemainingMs = null;
+    this._deadline = Date.now() + durationMs;
+    this._timer = setTimeout(() => {
+      this._timer = null;
+      this._deadline = null;
+      this._onTimeout();
+    }, durationMs);
+  }
+}
+
+module.exports = { NotificationDismissTimer, getNotificationTimeoutMs };

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1223,10 +1223,11 @@ class WindowManager {
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getNotificationPosition(display);
 
-    this.notificationWindow = new BrowserWindow({
+    const win = new BrowserWindow({
       ...NOTIFICATION_WINDOW_CONFIG,
       ...position,
     });
+    this.notificationWindow = win;
 
     // Keep the prompt visible to the user but out of screen shares and recordings.
     this.notificationWindow.setContentProtection(true);
@@ -1266,7 +1267,10 @@ class WindowManager {
 
     this._notificationDismissTimer.start(getNotificationTimeoutMs(promptData.source));
 
-    this.notificationWindow.on("closed", () => {
+    // "closed" fires asynchronously, so a replaced prompt's window emits it
+    // after the replacement already took over the reference and the countdown.
+    win.on("closed", () => {
+      if (this.notificationWindow !== win) return;
       this.notificationWindow = null;
       this._notificationDismissTimer.cancel();
     });
@@ -1309,10 +1313,11 @@ class WindowManager {
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getNotificationPosition(display);
 
-    this.updateNotificationWindow = new BrowserWindow({
+    const win = new BrowserWindow({
       ...NOTIFICATION_WINDOW_CONFIG,
       ...position,
     });
+    this.updateNotificationWindow = win;
 
     WindowPositionUtil.setupAlwaysOnTop(this.updateNotificationWindow);
 
@@ -1348,7 +1353,8 @@ class WindowManager {
       this.dismissUpdateNotification({ persistent: false });
     }, 5000);
 
-    this.updateNotificationWindow.on("closed", () => {
+    win.on("closed", () => {
+      if (this.updateNotificationWindow !== win) return;
       this.updateNotificationWindow = null;
       if (this._updateNotificationAutoDismiss) {
         clearTimeout(this._updateNotificationAutoDismiss);

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -7,6 +7,7 @@ const MenuManager = require("./menuManager");
 const DevServerManager = require("./devServerManager");
 const dockManager = require("./dockManager");
 const { i18nMain } = require("./i18nMain");
+const { NotificationDismissTimer, getNotificationTimeoutMs } = require("./notificationTimer");
 const { DEV_SERVER_PORT } = DevServerManager;
 const {
   MAIN_WINDOW_CONFIG,
@@ -25,7 +26,12 @@ class WindowManager {
     this.controlPanelWindow = null;
     this.agentWindow = null;
     this.notificationWindow = null;
-    this._notificationTimeout = null;
+    this._notificationDismissTimer = new NotificationDismissTimer(() => {
+      if (this.meetingDetectionEngine) {
+        this.meetingDetectionEngine.handleNotificationTimeout();
+      }
+      this.dismissMeetingNotification();
+    });
     this.transcriptionPreviewWindow = null;
     this.updateNotificationWindow = null;
     this._updateNotificationDismissed = false;
@@ -131,10 +137,14 @@ class WindowManager {
     if (!this.notificationWindow || this.notificationWindow.isDestroyed()) {
       return;
     }
+    // Hovering means the user is reading or about to click — the auto-dismiss
+    // countdown must not close the card under their pointer.
     if (interactive) {
       this.notificationWindow.setIgnoreMouseEvents(false);
+      this._notificationDismissTimer.pause();
     } else {
       this.notificationWindow.setIgnoreMouseEvents(true, { forward: true });
+      this._notificationDismissTimer.resume();
     }
   }
 
@@ -1208,10 +1218,7 @@ class WindowManager {
       this.notificationWindow.close();
       this.notificationWindow = null;
     }
-    if (this._notificationTimeout) {
-      clearTimeout(this._notificationTimeout);
-      this._notificationTimeout = null;
-    }
+    this._notificationDismissTimer.cancel();
 
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getNotificationPosition(display);
@@ -1257,19 +1264,11 @@ class WindowManager {
       }
     }, 3000);
 
-    this._notificationTimeout = setTimeout(() => {
-      if (this.meetingDetectionEngine) {
-        this.meetingDetectionEngine.handleNotificationTimeout();
-      }
-      this.dismissMeetingNotification();
-    }, 30000);
+    this._notificationDismissTimer.start(getNotificationTimeoutMs(promptData.source));
 
     this.notificationWindow.on("closed", () => {
       this.notificationWindow = null;
-      if (this._notificationTimeout) {
-        clearTimeout(this._notificationTimeout);
-        this._notificationTimeout = null;
-      }
+      this._notificationDismissTimer.cancel();
     });
   }
 
@@ -1289,10 +1288,7 @@ class WindowManager {
       clearTimeout(this._notificationReadyFallback);
       this._notificationReadyFallback = null;
     }
-    if (this._notificationTimeout) {
-      clearTimeout(this._notificationTimeout);
-      this._notificationTimeout = null;
-    }
+    this._notificationDismissTimer.cancel();
     if (this.notificationWindow && !this.notificationWindow.isDestroyed()) {
       this.notificationWindow.close();
     }

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -133,17 +133,21 @@ class WindowManager {
     }
   }
 
-  setNotificationInteractivity(interactive) {
-    if (!this.notificationWindow || this.notificationWindow.isDestroyed()) {
+  // Only the meeting prompt owns this: another overlay reporting its own hover
+  // must not pause a countdown it cannot resume — it may be destroyed before
+  // its pointer ever leaves.
+  setNotificationInteractivity(sender, interactive) {
+    const win = this.notificationWindow;
+    if (!win || win.isDestroyed() || sender !== win.webContents) {
       return;
     }
     // Hovering means the user is reading or about to click — the auto-dismiss
     // countdown must not close the card under their pointer.
     if (interactive) {
-      this.notificationWindow.setIgnoreMouseEvents(false);
+      win.setIgnoreMouseEvents(false);
       this._notificationDismissTimer.pause();
     } else {
-      this.notificationWindow.setIgnoreMouseEvents(true, { forward: true });
+      win.setIgnoreMouseEvents(true, { forward: true });
       this._notificationDismissTimer.resume();
     }
   }
@@ -1230,38 +1234,40 @@ class WindowManager {
     this.notificationWindow = win;
 
     // Keep the prompt visible to the user but out of screen shares and recordings.
-    this.notificationWindow.setContentProtection(true);
+    win.setContentProtection(true);
 
     if (process.platform === "darwin") {
-      this.notificationWindow.setIgnoreMouseEvents(true, { forward: true });
+      win.setIgnoreMouseEvents(true, { forward: true });
     }
 
-    WindowPositionUtil.setupAlwaysOnTop(this.notificationWindow);
+    WindowPositionUtil.setupAlwaysOnTop(win);
 
     this._pendingNotificationData = promptData;
 
+    // Everything past the load addresses `win` directly: a replacement taking
+    // over mid-load must not have this prompt's data, countdown or force-show
+    // applied to its window.
     if (process.env.NODE_ENV === "development") {
       await DevServerManager.waitForDevServer();
-      await this.notificationWindow.loadURL(
-        `${DevServerManager.DEV_SERVER_URL}?meeting-notification=true`
-      );
+      await win.loadURL(`${DevServerManager.DEV_SERVER_URL}?meeting-notification=true`);
     } else {
       const fileInfo = DevServerManager.getAppFilePath(false);
-      await this.notificationWindow.loadFile(fileInfo.path, {
+      await win.loadFile(fileInfo.path, {
         query: { ...fileInfo.query, "meeting-notification": "true" },
       });
     }
+    if (this.notificationWindow !== win) return;
 
     this._notificationReadyFallback = setTimeout(() => {
       this._notificationReadyFallback = null;
-      if (this.notificationWindow && !this.notificationWindow.isDestroyed()) {
+      if (!win.isDestroyed()) {
         debugLogger.warn(
           "Notification renderer did not signal ready, force-showing",
           {},
           "meeting"
         );
-        this.notificationWindow.webContents.send("meeting-notification-data", promptData);
-        this.notificationWindow.showInactive();
+        win.webContents.send("meeting-notification-data", promptData);
+        win.showInactive();
       }
     }, 3000);
 

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -229,3 +229,122 @@ test("unsupported platforms poll without spawning a listener", async () => {
   assert.notEqual(detector.checkInterval, null);
   detector.stop();
 });
+
+// The native listeners are edge-triggered: they emit only on state transitions,
+// so an edge swallowed by a gate is never re-delivered. The detector must
+// remember the last known state and re-evaluate it when the gate lifts.
+// Mirrors SUSTAINED_EVENT_DRIVEN_MS and COOLDOWN_MS in audioActivityDetector.js.
+const SUSTAINED_MS = 2 * 1000;
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+test("darwin: a mic edge swallowed by the recording gate is re-evaluated when recording stops", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  detector.setUserRecording(true);
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  assert.equal(detector._sustainedTimer, null, "a gated edge must not arm the sustained timer");
+
+  detector.setUserRecording(false);
+  t.mock.timers.tick(SUSTAINED_MS);
+
+  assert.equal(emitted.length, 1, "the ongoing call must be detected once the gate lifts");
+  detector.stop();
+});
+
+test("darwin: a mic edge swallowed by the dismissal cooldown is re-evaluated when it expires", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  detector.dismiss();
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  assert.equal(detector._sustainedTimer, null, "the cooldown must still swallow the prompt");
+
+  // Split ticks: mocked timers do not cascade timers armed inside a callback.
+  t.mock.timers.tick(COOLDOWN_MS);
+  t.mock.timers.tick(SUSTAINED_MS);
+
+  assert.equal(emitted.length, 1, "a call outlasting the cooldown must still be detected");
+  detector.stop();
+});
+
+test("darwin: a dismissed call that keeps running re-prompts after the cooldown", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(emitted.length, 1);
+
+  detector.dismiss();
+  t.mock.timers.tick(COOLDOWN_MS);
+  t.mock.timers.tick(SUSTAINED_MS);
+
+  assert.equal(emitted.length, 2, "polling parity: an ongoing call re-prompts after the cooldown");
+  detector.stop();
+});
+
+test("darwin: a mic that went quiet while recording does not re-prompt when recording stops", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  detector.setUserRecording(true);
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  children[0].stdout.emit("data", "MIC_INACTIVE\n");
+  detector.setUserRecording(false);
+  t.mock.timers.tick(SUSTAINED_MS * 2);
+
+  assert.equal(emitted.length, 0, "a released mic must not produce a stale prompt");
+  detector.stop();
+});
+
+test("darwin: a call that outlives the mic warm-hold is detected when the hold releases", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  detector.setMicWarmHold(true);
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  assert.equal(
+    detector._sustainedTimer,
+    null,
+    "warm-hold evidence must not arm the sustained timer"
+  );
+
+  detector.setMicWarmHold(false);
+  t.mock.timers.tick(SUSTAINED_MS);
+
+  assert.equal(emitted.length, 1, "a call still holding the mic after our hold ends must prompt");
+  detector.stop();
+});
+
+test("darwin: a warm-hold that releases cleanly does not produce a stale prompt", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("darwin");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  detector.setMicWarmHold(true);
+  children[0].stdout.emit("data", "MIC_ACTIVE\n");
+  detector.setMicWarmHold(false);
+  children[0].stdout.emit("data", "MIC_INACTIVE\n");
+  t.mock.timers.tick(SUSTAINED_MS * 2);
+
+  assert.equal(emitted.length, 0, "the release edge must cancel the pending re-evaluation");
+  detector.stop();
+});

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -348,3 +348,25 @@ test("darwin: a warm-hold that releases cleanly does not produce a stale prompt"
   assert.equal(emitted.length, 0, "the release edge must cancel the pending re-evaluation");
   detector.stop();
 });
+
+test("win32: an unrelated app's mic session ending does not hide an ongoing dismissed call", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const { detector, children } = createDetector("win32");
+  const emitted = [];
+  detector.on("sustained-audio-detected", (data) => emitted.push(data));
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_START 11\n");
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(emitted.length, 1);
+  detector.dismiss();
+
+  // pid 11 never stopped, so the reference count must still hold it — otherwise
+  // pid 22's stop reads as "every mic closed" and cancels the re-evaluation.
+  children[0].stdout.emit("data", "MIC_START 22\nMIC_STOP 22\n");
+  t.mock.timers.tick(COOLDOWN_MS);
+  t.mock.timers.tick(SUSTAINED_MS);
+
+  assert.equal(emitted.length, 2, "the still-running call must re-prompt after the cooldown");
+  detector.stop();
+});

--- a/test/helpers/meetingDetectionEngine.test.js
+++ b/test/helpers/meetingDetectionEngine.test.js
@@ -1,0 +1,93 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+
+const enginePath = require.resolve("../../src/helpers/meetingDetectionEngine");
+const originalLoad = Module._load;
+
+function loadEngine() {
+  delete require.cache[enginePath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return { shell: { openExternal: async () => {} } };
+    }
+    if (request === "./debugLogger") {
+      return { info() {}, warn() {}, debug() {}, error() {} };
+    }
+    if (request === "./windowBroadcast") {
+      return { broadcastToWindows() {} };
+    }
+    // ESM module; the app loads it through a transpiling loader.
+    if (request === "./meetingJoinUrl") {
+      return { getMeetingJoinUrl: (event) => event?.hangout_link ?? null };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(enginePath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createEngine() {
+  const MeetingDetectionEngine = loadEngine();
+
+  const reminderScheduler = {
+    getActiveMeetingState: () => ({ activeMeeting: null, activeEvents: [], upcomingEvents: [] }),
+  };
+  const processDetector = new EventEmitter();
+  processDetector.start = () => {};
+  processDetector.stop = () => {};
+
+  const audioDetector = new EventEmitter();
+  audioDetector.dismissals = 0;
+  audioDetector.dismiss = () => audioDetector.dismissals++;
+  audioDetector.resetPrompt = () => {};
+  audioDetector.setUserRecording = () => {};
+  audioDetector.setMicWarmHold = () => {};
+  audioDetector.start = () => {};
+  audioDetector.stop = () => {};
+
+  const shown = [];
+  const windowManager = {
+    notificationPrefs: {},
+    showMeetingNotification: (data) => shown.push(data),
+    dismissMeetingNotification: () => {},
+    queueMeetingNoteNavigation: async () => {},
+  };
+
+  const engine = new MeetingDetectionEngine(
+    reminderScheduler,
+    processDetector,
+    audioDetector,
+    windowManager,
+    {}
+  );
+
+  return { engine, audioDetector, shown };
+}
+
+test("an unanswered audio prompt expires without cooling down the mic detector", () => {
+  const { engine, audioDetector, shown } = createEngine();
+
+  audioDetector.emit("sustained-audio-detected", { durationMs: 2000, detectedAt: 0 });
+  assert.equal(shown.length, 1, "the detection must reach the overlay");
+
+  engine.handleNotificationTimeout();
+
+  assert.equal(audioDetector.dismissals, 0, "a timeout is not a decline; no cooldown may start");
+  assert.equal(engine.activeDetections.size, 0, "expired detections must be cleared");
+});
+
+test("explicitly dismissing an audio prompt still starts the mic cooldown", async () => {
+  const { engine, audioDetector, shown } = createEngine();
+
+  audioDetector.emit("sustained-audio-detected", { durationMs: 2000, detectedAt: 0 });
+  await engine.handleNotificationResponse(shown[0].detectionId, "dismiss");
+
+  assert.equal(audioDetector.dismissals, 1, "an explicit decline must keep its cooldown");
+});

--- a/test/helpers/notificationTimer.test.js
+++ b/test/helpers/notificationTimer.test.js
@@ -1,0 +1,113 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  NotificationDismissTimer,
+  getNotificationTimeoutMs,
+} = require("../../src/helpers/notificationTimer");
+
+test("calendar prompts outlive the 60s reminder lead; detections keep 30s", () => {
+  assert.ok(
+    getNotificationTimeoutMs("calendar") > 60 * 1000,
+    "a calendar prompt must survive past the meeting start"
+  );
+  assert.equal(getNotificationTimeoutMs("audio"), 30 * 1000);
+});
+
+test("fires exactly once after the configured duration", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  t.mock.timers.tick(29_999);
+  assert.equal(fired, 0);
+  t.mock.timers.tick(1);
+  assert.equal(fired, 1);
+  t.mock.timers.tick(60_000);
+  assert.equal(fired, 1);
+});
+
+test("pause halts the countdown", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  t.mock.timers.tick(29_000);
+  timer.pause();
+  t.mock.timers.tick(120_000);
+
+  assert.equal(fired, 0, "a paused timer must never fire");
+});
+
+test("resume continues with the remaining time", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  t.mock.timers.tick(10_000);
+  timer.pause();
+  t.mock.timers.tick(120_000);
+  timer.resume();
+  t.mock.timers.tick(19_999);
+  assert.equal(fired, 0, "the countdown must pick up where it left off");
+  t.mock.timers.tick(1);
+  assert.equal(fired, 1);
+});
+
+test("resume keeps a minimum runway", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  t.mock.timers.tick(29_500);
+  timer.pause();
+  timer.resume();
+  t.mock.timers.tick(500);
+  assert.equal(fired, 0, "the card must not vanish right as the pointer leaves");
+  t.mock.timers.tick(4_500);
+  assert.equal(fired, 1);
+});
+
+test("cancel prevents firing and clears any paused state", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  timer.pause();
+  timer.cancel();
+  timer.resume();
+  t.mock.timers.tick(120_000);
+
+  assert.equal(fired, 0, "cancel must also discard the paused remainder");
+});
+
+test("pause and resume without a started timer are no-ops", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.pause();
+  timer.resume();
+  t.mock.timers.tick(120_000);
+
+  assert.equal(fired, 0);
+});
+
+test("start replaces a running countdown", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+
+  timer.start(30_000);
+  t.mock.timers.tick(29_000);
+  timer.start(30_000);
+  t.mock.timers.tick(29_999);
+  assert.equal(fired, 0, "the old deadline must not survive a restart");
+  t.mock.timers.tick(1);
+  assert.equal(fired, 1);
+});


### PR DESCRIPTION
## Description
Meeting detection on macOS was close to non-functional ([user report]): impromptu calls went undetected and calendar prompts vanished before the meeting even started. Three root causes, all confirmed against main:

1. Swallowed mic edges were lost forever. The native mic listeners are edge-triggered — they announce transitions, never steady state (the macOS binary's 5s heartbeat also only emits on change). _onMicStateChanged() discarded the edge outright while any gate was up (user dictating, mic warm-hold, or the 5-minute dismissal cooldown). Since no further event arrives while a call continues, a call starting under a gate was never detected — only the polling fallback self-healed, which made failures look random. macOS is hit hardest: its signal is device-global with no self-PID exclusion, so the user's own dictation both necessitates the gate and consumes the only MIC_ACTIVE edge a concurrent call would produce.

2. An ignored prompt punished the user. An unanswered audio prompt's timeout started the same 5-minute global cooldown as an explicit dismissal — which, combined with (1), made any call starting in the next 5 minutes permanently invisible.
Every prompt died after a hardcoded 30s, regardless of source. Calendar reminders fire 60s before the meeting, so their prompt disappeared ~30s before it started. Hovering only toggled mouse pass-through — the card could close under the pointer mid-click (the renderer also delays the response IPC by a 200ms animation, so a timeout racing a click silently no-oped the Start/Join action).

3. The fix makes the event-driven path level-triggered like the proven polling path: the detector always records _lastKnownMicState and re-evaluates it whenever a gate lifts (recording stop, warm-hold release, cooldown expiry). A false alarm from our own mic self-cancels — the release edge arrives within the 2s sustained window. Timeouts no longer start the cooldown; only explicit dismissal does. And the overlay countdown is now per-source (calendar 2 min, detections 30s) and pauses while hovered, resuming with a 5s minimum runway that also closes the click race.