### PR TITLE
fix(meetings): always persist delayed diarization to its owning note (#1495)

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -72,7 +72,6 @@ import { parseTranscriptSegments } from "../../utils/parseTranscriptSegments";
 import {
   applyTranscriptSpeakerPatch,
   lockTranscriptSpeaker,
-  mergeTranscriptSegments,
   serializeTranscriptSegments,
 } from "../../utils/transcriptSpeakerState";
 import NoteParticipants from "./NoteParticipants";
@@ -365,7 +364,6 @@ export default function NoteEditor({
     Array<{ id: number; display_name: string; email: string | null }>
   >([]);
   const editorRef = useRef<Editor | null>(null);
-  const displaySegmentsRef = useRef<TranscriptSegment[]>([]);
 
   const embeddedChat = useEmbeddedChat({
     noteId: note.id,
@@ -399,10 +397,6 @@ export default function NoteEditor({
     if (diarizedSegments && diarizedSegments.length > 0) return diarizedSegments;
     return parseTranscriptSegments(note.transcript || "");
   }, [diarizedSegments, note.transcript]);
-
-  useEffect(() => {
-    displaySegmentsRef.current = displaySegments;
-  }, [displaySegments]);
 
   const hasChatSegments = displaySegments.length > 0;
 
@@ -527,49 +521,28 @@ export default function NoteEditor({
     prevRecordingForDiarizationRef.current = isRecording;
   }, [diarizationSessionId, isRecording, scheduleUiUpdate]);
 
+  // Persistence happens in meetingRecordingStore's module-level listener
+  // (#1495); this only mirrors a published result into the rendered note's UI.
+  const completedDiarization = useMeetingRecordingStore((s) => s.completedDiarization);
   useEffect(() => {
-    const expectedSession = diarizationSessionId;
-    const cleanup = window.electronAPI?.onMeetingDiarizationComplete?.(async (data) => {
-      if (!expectedSession || data?.sessionId !== expectedSession) return;
+    if (!completedDiarization || completedDiarization.noteId !== note.id) return;
+    // Consume so a later remount doesn't reapply a stale overlay on top of
+    // newer edits; the transcript itself is already persisted.
+    useMeetingRecordingStore.setState({ completedDiarization: null });
+    setIsDiarizing(false);
 
-      setIsDiarizing(false);
+    const enriched = completedDiarization.segments;
+    if (enriched.length === 0) return;
+    setDiarizedSegments(enriched);
 
-      if (!data?.segments?.length) return;
-
-      // Store segments outlive their recording — only use them for the note they belong to.
-      const { recordingNoteId, segments: liveSegments } = useMeetingRecordingStore.getState();
-      const persisted = await window.electronAPI?.getNote?.(note.id);
-      const existing = persisted?.transcript
-        ? parseTranscriptSegments(persisted.transcript)
-        : recordingNoteId === note.id && liveSegments.length > 0
-          ? liveSegments
-          : displaySegmentsRef.current;
-
-      const enriched = mergeTranscriptSegments(
-        existing,
-        data.segments.map((s: any, i: number) => ({
-          ...s,
-          id: s.id || `diarized-${i}`,
-        }))
-      );
-      setDiarizedSegments(enriched);
-
-      window.electronAPI.updateNote(note.id, { transcript: serializeTranscriptSegments(enriched) });
-
-      if (data.speakerEmbeddings) {
-        window.electronAPI?.saveNoteSpeakerEmbeddings?.(note.id, data.speakerEmbeddings);
-      }
-
-      const autoMappings: Record<string, string> = {};
-      for (const s of enriched) {
-        if (s.speakerName && s.speaker) autoMappings[s.speaker] = s.speakerName;
-      }
-      if (Object.keys(autoMappings).length > 0) {
-        setSpeakerMappings((prev) => ({ ...autoMappings, ...prev }));
-      }
-    });
-    return () => cleanup?.();
-  }, [note.id, diarizationSessionId]);
+    const autoMappings: Record<string, string> = {};
+    for (const s of enriched) {
+      if (s.speakerName && s.speaker) autoMappings[s.speaker] = s.speakerName;
+    }
+    if (Object.keys(autoMappings).length > 0) {
+      setSpeakerMappings((prev) => ({ ...autoMappings, ...prev }));
+    }
+  }, [completedDiarization, note.id]);
 
   const persistDisplaySegments = useCallback(
     async (nextSegments: TranscriptSegment[], updateOverlay = true) => {

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -526,8 +526,8 @@ export default function NoteEditor({
   const completedDiarization = useMeetingRecordingStore((s) => s.completedDiarization);
   useEffect(() => {
     if (!completedDiarization || completedDiarization.noteId !== note.id) return;
-    // Consume so a later remount doesn't reapply a stale overlay on top of
-    // newer edits; the transcript itself is already persisted.
+    // Consume so a remount can't repaint this overlay over newer edits; the
+    // transcript itself is already persisted.
     useMeetingRecordingStore.setState({ completedDiarization: null });
     setIsDiarizing(false);
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -9874,7 +9874,7 @@ class IPCHandlers {
   ) {
     const send = (payload) => {
       if (win && !win.isDestroyed()) {
-        win.webContents.send("meeting-diarization-complete", { sessionId, ...payload });
+        win.webContents.send("meeting-diarization-complete", { sessionId, noteId, ...payload });
       }
     };
 

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -1448,14 +1448,24 @@ if (typeof window !== "undefined") {
         }))
       );
 
-      window.electronAPI?.updateNote?.(targetNoteId, {
-        transcript: serializeTranscriptSegments(enriched),
-      });
-      if (data.speakerEmbeddings) {
-        window.electronAPI?.saveNoteSpeakerEmbeddings?.(targetNoteId, data.speakerEmbeddings);
+      try {
+        // Awaited so the next queued completion's getNote is guaranteed to
+        // read this write — without it the ordering depends on db-update-note
+        // staying synchronous ahead of its first await.
+        await window.electronAPI?.updateNote?.(targetNoteId, {
+          transcript: serializeTranscriptSegments(enriched),
+        });
+      } catch (error) {
+        // Clear a waiting spinner without an overlay the database never
+        // accepted; the outer catch logs the failure.
+        publish([]);
+        throw error;
       }
-
       publish(enriched);
+
+      if (data.speakerEmbeddings) {
+        await window.electronAPI?.saveNoteSpeakerEmbeddings?.(targetNoteId, data.speakerEmbeddings);
+      }
     }).catch((error) => {
       logger.error(
         "Diarization completion handling failed",

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -31,10 +31,14 @@ import { isTranscriptionContextAllowed } from "./policyRules";
 import { usePolicyStore } from "./policyStore";
 import {
   lockTranscriptSpeaker,
+  mergeTranscriptSegments,
   normalizeTranscriptSegment,
+  serializeTranscriptSegments,
   type TranscriptSpeakerLockSource,
   type TranscriptSpeakerStatus,
 } from "../utils/transcriptSpeakerState";
+import { parseTranscriptSegments } from "../utils/parseTranscriptSegments";
+import { resolveDiarizationTarget, selectBaseSegments } from "../utils/diarizationCompletion";
 
 export interface TranscriptSegment {
   id: string;
@@ -80,6 +84,8 @@ interface MeetingRecordingState {
   systemPartialSpeakerId: string | null;
   systemPartialSpeakerName: string | null;
   diarizationSessionId: string | null;
+  /** Latest diarization result published for UI mirroring; consumed (nulled) by the editor that applies it. */
+  completedDiarization: { noteId: number; segments: TranscriptSegment[] } | null;
   sessionDiarizationEnabled: boolean;
   sessionExpectedCount: number;
   userTouchedStepper: boolean;
@@ -434,6 +440,7 @@ export const useMeetingRecordingStore = create<MeetingRecordingState>()(() => ({
   systemPartialSpeakerId: null,
   systemPartialSpeakerName: null,
   diarizationSessionId: null,
+  completedDiarization: null,
   sessionDiarizationEnabled:
     (getSettings() as { speakerDiarizationEnabled?: boolean }).speakerDiarizationEnabled ?? true,
   sessionExpectedCount: DEFAULT_EXPECTED_SPEAKER_COUNT,
@@ -802,6 +809,7 @@ export async function startRecording(args: StartRecordingArgs): Promise<boolean>
     systemPartialSpeakerId: null,
     systemPartialSpeakerName: null,
     diarizationSessionId: null,
+    completedDiarization: null,
     error: null,
     micCaptureStatus: "inactive",
   });
@@ -1370,6 +1378,71 @@ export function lockSpeaker(speakerId: string, displayName: string): void {
 
 export function cancelPreparedTranscription(): void {
   window.electronAPI?.meetingTranscriptionCancel?.();
+}
+
+// Persists delayed diarization results to the note that owns the recording
+// session (#1495). Registered once at module load so results survive the
+// notes view unmounting; NoteEditor only mirrors `completedDiarization`.
+if (typeof window !== "undefined") {
+  window.electronAPI?.onMeetingDiarizationComplete?.(async (data) => {
+    const {
+      diarizationSessionId,
+      recordingNoteId,
+      segments: liveSegments,
+    } = useMeetingRecordingStore.getState();
+    const { targetNoteId, isCurrentSession } = resolveDiarizationTarget({
+      payloadNoteId: data?.noteId,
+      payloadSessionId: data?.sessionId,
+      currentSessionId: diarizationSessionId,
+      recordingNoteId,
+    });
+    if (targetNoteId == null) return;
+
+    const publish = (segments: TranscriptSegment[]) => {
+      if (isCurrentSession) {
+        useMeetingRecordingStore.setState({
+          completedDiarization: { noteId: targetNoteId, segments },
+        });
+      }
+    };
+
+    if (!data?.segments?.length) {
+      // Diarization failed or was skipped — publish so a waiting editor can
+      // clear its spinner, but there is nothing to persist.
+      publish([]);
+      return;
+    }
+
+    const persisted = await window.electronAPI?.getNote?.(targetNoteId);
+    // Writing to a deleted note would resurrect its tombstone in the
+    // sidebar, cloud mirror, and vector index.
+    if (!persisted || persisted.deleted_at) return;
+
+    const existing = selectBaseSegments({
+      persistedSegments: persisted.transcript
+        ? parseTranscriptSegments(persisted.transcript)
+        : null,
+      liveSegments,
+      recordingNoteId,
+      targetNoteId,
+    });
+    const enriched = mergeTranscriptSegments(
+      existing,
+      data.segments.map((segment, index) => ({
+        ...segment,
+        id: segment.id || `diarized-${index}`,
+      }))
+    );
+
+    window.electronAPI?.updateNote?.(targetNoteId, {
+      transcript: serializeTranscriptSegments(enriched),
+    });
+    if (data.speakerEmbeddings) {
+      window.electronAPI?.saveNoteSpeakerEmbeddings?.(targetNoteId, data.speakerEmbeddings);
+    }
+
+    publish(enriched);
+  });
 }
 
 // Throttled resize listener — keeps layout reflows during drag from thrashing

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -1413,7 +1413,15 @@ if (typeof window !== "undefined") {
       return;
     }
 
-    const persisted = await window.electronAPI?.getNote?.(targetNoteId);
+    let persisted;
+    try {
+      persisted = await window.electronAPI?.getNote?.(targetNoteId);
+    } catch {
+      // Without the persisted note there is no safe base to merge into —
+      // publish the empty result so a waiting editor still clears its spinner.
+      publish([]);
+      return;
+    }
     // Writing to a deleted note would resurrect its tombstone in the
     // sidebar, cloud mirror, and vector index.
     if (!persisted || persisted.deleted_at) return;

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -39,6 +39,7 @@ import {
 } from "../utils/transcriptSpeakerState";
 import { parseTranscriptSegments } from "../utils/parseTranscriptSegments";
 import { resolveDiarizationTarget, selectBaseSegments } from "../utils/diarizationCompletion";
+import { createSerialQueue } from "../utils/serialQueue";
 
 export interface TranscriptSegment {
   id: string;
@@ -1384,72 +1385,84 @@ export function cancelPreparedTranscription(): void {
 // session (#1495). Registered once at module load so results survive the
 // notes view unmounting; NoteEditor only mirrors `completedDiarization`.
 if (typeof window !== "undefined") {
-  window.electronAPI?.onMeetingDiarizationComplete?.(async (data) => {
-    const {
-      diarizationSessionId,
-      recordingNoteId,
-      segments: liveSegments,
-    } = useMeetingRecordingStore.getState();
-    const { targetNoteId, isCurrentSession } = resolveDiarizationTarget({
-      payloadNoteId: data?.noteId,
-      payloadSessionId: data?.sessionId,
-      currentSessionId: diarizationSessionId,
-      recordingNoteId,
-    });
-    if (targetNoteId == null) return;
+  // Serialized so rapid re-record completions can't interleave around the
+  // getNote await and overwrite each other's speaker labels — the later
+  // result merges on top of the earlier one's persisted transcript.
+  const enqueueDiarizationCompletion = createSerialQueue();
+  window.electronAPI?.onMeetingDiarizationComplete?.((data) => {
+    enqueueDiarizationCompletion(async () => {
+      const {
+        diarizationSessionId,
+        recordingNoteId,
+        segments: liveSegments,
+      } = useMeetingRecordingStore.getState();
+      const { targetNoteId, isCurrentSession } = resolveDiarizationTarget({
+        payloadNoteId: data?.noteId,
+        payloadSessionId: data?.sessionId,
+        currentSessionId: diarizationSessionId,
+        recordingNoteId,
+      });
+      if (targetNoteId == null) return;
 
-    const publish = (segments: TranscriptSegment[]) => {
-      if (isCurrentSession) {
-        useMeetingRecordingStore.setState({
-          completedDiarization: { noteId: targetNoteId, segments },
-        });
+      const publish = (segments: TranscriptSegment[]) => {
+        if (isCurrentSession) {
+          useMeetingRecordingStore.setState({
+            completedDiarization: { noteId: targetNoteId, segments },
+          });
+        }
+      };
+
+      if (!data?.segments?.length) {
+        // Diarization failed or was skipped — publish so a waiting editor can
+        // clear its spinner, but there is nothing to persist.
+        publish([]);
+        return;
       }
-    };
 
-    if (!data?.segments?.length) {
-      // Diarization failed or was skipped — publish so a waiting editor can
-      // clear its spinner, but there is nothing to persist.
-      publish([]);
-      return;
-    }
+      let persisted;
+      try {
+        persisted = await window.electronAPI?.getNote?.(targetNoteId);
+      } catch {
+        // Without the persisted note there is no safe base to merge into —
+        // publish the empty result so a waiting editor still clears its spinner.
+        publish([]);
+        return;
+      }
+      // Writing to a deleted note would resurrect its tombstone in the
+      // sidebar, cloud mirror, and vector index.
+      if (!persisted || persisted.deleted_at) return;
 
-    let persisted;
-    try {
-      persisted = await window.electronAPI?.getNote?.(targetNoteId);
-    } catch {
-      // Without the persisted note there is no safe base to merge into —
-      // publish the empty result so a waiting editor still clears its spinner.
-      publish([]);
-      return;
-    }
-    // Writing to a deleted note would resurrect its tombstone in the
-    // sidebar, cloud mirror, and vector index.
-    if (!persisted || persisted.deleted_at) return;
+      const existing = selectBaseSegments({
+        persistedSegments: persisted.transcript
+          ? parseTranscriptSegments(persisted.transcript)
+          : null,
+        liveSegments,
+        recordingNoteId,
+        targetNoteId,
+      });
+      const enriched = mergeTranscriptSegments(
+        existing,
+        data.segments.map((segment, index) => ({
+          ...segment,
+          id: segment.id || `diarized-${index}`,
+        }))
+      );
 
-    const existing = selectBaseSegments({
-      persistedSegments: persisted.transcript
-        ? parseTranscriptSegments(persisted.transcript)
-        : null,
-      liveSegments,
-      recordingNoteId,
-      targetNoteId,
+      window.electronAPI?.updateNote?.(targetNoteId, {
+        transcript: serializeTranscriptSegments(enriched),
+      });
+      if (data.speakerEmbeddings) {
+        window.electronAPI?.saveNoteSpeakerEmbeddings?.(targetNoteId, data.speakerEmbeddings);
+      }
+
+      publish(enriched);
+    }).catch((error) => {
+      logger.error(
+        "Diarization completion handling failed",
+        { error: (error as Error).message },
+        "meeting"
+      );
     });
-    const enriched = mergeTranscriptSegments(
-      existing,
-      data.segments.map((segment, index) => ({
-        ...segment,
-        id: segment.id || `diarized-${index}`,
-      }))
-    );
-
-    window.electronAPI?.updateNote?.(targetNoteId, {
-      transcript: serializeTranscriptSegments(enriched),
-    });
-    if (data.speakerEmbeddings) {
-      window.electronAPI?.saveNoteSpeakerEmbeddings?.(targetNoteId, data.speakerEmbeddings);
-    }
-
-    publish(enriched);
   });
 }
 

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -14,7 +14,7 @@ import {
   resolveInitialSpeakerCountOverride,
   resolveParticipantSpeakerCountSync,
 } from "../utils/participants";
-import type { SystemAudioAccessResult, SystemAudioStrategy } from "../types/electron";
+import type { NoteItem, SystemAudioAccessResult, SystemAudioStrategy } from "../types/electron";
 import type { CalendarAttendee } from "../types/calendar";
 import {
   DEFAULT_SYSTEM_AUDIO_ACCESS,
@@ -1400,10 +1400,11 @@ if (typeof window !== "undefined") {
         payloadNoteId: data?.noteId,
         payloadSessionId: data?.sessionId,
         currentSessionId: diarizationSessionId,
-        recordingNoteId,
       });
       if (targetNoteId == null) return;
 
+      // Publishing an empty result clears a waiting editor's spinner without
+      // painting an overlay; anything non-empty is already persisted.
       const publish = (segments: TranscriptSegment[]) => {
         if (isCurrentSession) {
           useMeetingRecordingStore.setState({
@@ -1413,24 +1414,27 @@ if (typeof window !== "undefined") {
       };
 
       if (!data?.segments?.length) {
-        // Diarization failed or was skipped — publish so a waiting editor can
-        // clear its spinner, but there is nothing to persist.
         publish([]);
         return;
       }
 
-      let persisted;
+      let persisted: NoteItem | null | undefined;
       try {
         persisted = await window.electronAPI?.getNote?.(targetNoteId);
-      } catch {
-        // Without the persisted note there is no safe base to merge into —
-        // publish the empty result so a waiting editor still clears its spinner.
+      } catch (error) {
+        logger.error(
+          "Diarization completion could not read its note",
+          { noteId: targetNoteId, error: (error as Error).message },
+          "meeting"
+        );
+      }
+      // No note means no safe base to merge into, and writing to a deleted one
+      // would resurrect its tombstone in the sidebar, cloud mirror, and vector
+      // index.
+      if (!persisted || persisted.deleted_at) {
         publish([]);
         return;
       }
-      // Writing to a deleted note would resurrect its tombstone in the
-      // sidebar, cloud mirror, and vector index.
-      if (!persisted || persisted.deleted_at) return;
 
       const existing = selectBaseSegments({
         persistedSegments: persisted.transcript
@@ -1456,8 +1460,6 @@ if (typeof window !== "undefined") {
           transcript: serializeTranscriptSegments(enriched),
         });
       } catch (error) {
-        // Clear a waiting spinner without an overlay the database never
-        // accepted; the outer catch logs the failure.
         publish([]);
         throw error;
       }

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -2248,6 +2248,7 @@ declare global {
       onMeetingDiarizationComplete?: (
         callback: (data: {
           sessionId?: string;
+          noteId?: number | null;
           segments: Array<{
             id: string;
             text: string;

--- a/src/utils/diarizationCompletion.ts
+++ b/src/utils/diarizationCompletion.ts
@@ -1,9 +1,9 @@
-// Routing rules for meeting-diarization-complete events (issue #1495):
-// results must be persisted to the note that owns the recording session,
-// never to whichever note happens to be rendered when the event arrives.
-// Persistence runs at store level (meetingRecordingStore), so results
-// survive the notes view unmounting; `isCurrentSession` gates only whether
-// the result is published to the UI.
+// Routing rules for meeting-diarization-complete events (issue #1495): a result
+// must be persisted to the note that owns the recording session, never to
+// whichever note happens to be rendered when the event arrives.
+//
+// Persistence runs at store level (meetingRecordingStore) so results survive the
+// notes view unmounting; `isCurrentSession` gates only the publish to the UI.
 
 export interface DiarizationCompletionPlan {
   targetNoteId: number | null;
@@ -14,25 +14,15 @@ export function resolveDiarizationTarget(params: {
   payloadNoteId?: number | null;
   payloadSessionId?: string | null;
   currentSessionId: string | null;
-  recordingNoteId: number | null;
 }): DiarizationCompletionPlan {
-  const { payloadNoteId, payloadSessionId, currentSessionId, recordingNoteId } = params;
+  const { payloadNoteId, payloadSessionId, currentSessionId } = params;
 
-  // A null current session means nothing newer is pending, so publishing is
-  // safe and clearing a waiting spinner prevents it from getting stuck.
-  const isCurrentSession = currentSessionId == null || payloadSessionId === currentSessionId;
-
-  if (payloadNoteId != null) {
-    return { targetNoteId: payloadNoteId, isCurrentSession };
-  }
-
-  // Legacy payloads without a noteId can only be attributed via the session
-  // check; recordingNoteId still names the owner (it is not cleared on stop).
-  if (currentSessionId != null && payloadSessionId === currentSessionId) {
-    return { targetNoteId: recordingNoteId, isCurrentSession };
-  }
-
-  return { targetNoteId: null, isCurrentSession };
+  return {
+    targetNoteId: payloadNoteId ?? null,
+    // A null current session means nothing newer is pending, so publishing is
+    // safe and clearing a waiting spinner prevents it from getting stuck.
+    isCurrentSession: currentSessionId == null || payloadSessionId === currentSessionId,
+  };
 }
 
 export function selectBaseSegments<Segment>(params: {
@@ -43,13 +33,9 @@ export function selectBaseSegments<Segment>(params: {
 }): Segment[] {
   const { persistedSegments, liveSegments, recordingNoteId, targetNoteId } = params;
 
-  if (persistedSegments) {
-    return persistedSegments;
-  }
+  if (persistedSegments) return persistedSegments;
   // Live segments belong to the recording note; merging them into any other
   // note would cross-contaminate transcripts.
-  if (recordingNoteId === targetNoteId && liveSegments.length > 0) {
-    return liveSegments;
-  }
+  if (recordingNoteId === targetNoteId && liveSegments.length > 0) return liveSegments;
   return [];
 }

--- a/src/utils/diarizationCompletion.ts
+++ b/src/utils/diarizationCompletion.ts
@@ -1,0 +1,55 @@
+// Routing rules for meeting-diarization-complete events (issue #1495):
+// results must be persisted to the note that owns the recording session,
+// never to whichever note happens to be rendered when the event arrives.
+// Persistence runs at store level (meetingRecordingStore), so results
+// survive the notes view unmounting; `isCurrentSession` gates only whether
+// the result is published to the UI.
+
+export interface DiarizationCompletionPlan {
+  targetNoteId: number | null;
+  isCurrentSession: boolean;
+}
+
+export function resolveDiarizationTarget(params: {
+  payloadNoteId?: number | null;
+  payloadSessionId?: string | null;
+  currentSessionId: string | null;
+  recordingNoteId: number | null;
+}): DiarizationCompletionPlan {
+  const { payloadNoteId, payloadSessionId, currentSessionId, recordingNoteId } = params;
+
+  // A null current session means nothing newer is pending, so publishing is
+  // safe and clearing a waiting spinner prevents it from getting stuck.
+  const isCurrentSession = currentSessionId == null || payloadSessionId === currentSessionId;
+
+  if (payloadNoteId != null) {
+    return { targetNoteId: payloadNoteId, isCurrentSession };
+  }
+
+  // Legacy payloads without a noteId can only be attributed via the session
+  // check; recordingNoteId still names the owner (it is not cleared on stop).
+  if (currentSessionId != null && payloadSessionId === currentSessionId) {
+    return { targetNoteId: recordingNoteId, isCurrentSession };
+  }
+
+  return { targetNoteId: null, isCurrentSession };
+}
+
+export function selectBaseSegments<Segment>(params: {
+  persistedSegments: Segment[] | null;
+  liveSegments: Segment[];
+  recordingNoteId: number | null;
+  targetNoteId: number;
+}): Segment[] {
+  const { persistedSegments, liveSegments, recordingNoteId, targetNoteId } = params;
+
+  if (persistedSegments) {
+    return persistedSegments;
+  }
+  // Live segments belong to the recording note; merging them into any other
+  // note would cross-contaminate transcripts.
+  if (recordingNoteId === targetNoteId && liveSegments.length > 0) {
+    return liveSegments;
+  }
+  return [];
+}

--- a/src/utils/serialQueue.ts
+++ b/src/utils/serialQueue.ts
@@ -1,0 +1,10 @@
+// Runs enqueued async tasks strictly one at a time, in enqueue order. A
+// rejected task rejects its own returned promise but never stalls the queue.
+export function createSerialQueue(): <Result>(task: () => Promise<Result>) => Promise<Result> {
+  let tail: Promise<unknown> = Promise.resolve();
+  return (task) => {
+    const run = tail.then(() => task());
+    tail = run.catch(() => undefined);
+    return run;
+  };
+}

--- a/test/utils/diarizationCompletion.test.js
+++ b/test/utils/diarizationCompletion.test.js
@@ -16,7 +16,6 @@ test("payload noteId targets the owning note", () => {
     payloadNoteId: 1,
     payloadSessionId: "diar-100",
     currentSessionId: "diar-100",
-    recordingNoteId: 1,
   });
   assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: true });
 });
@@ -29,7 +28,6 @@ test("payload noteId still targets the owning note after a new session started",
     payloadNoteId: 1,
     payloadSessionId: "diar-100",
     currentSessionId: "diar-200",
-    recordingNoteId: 2,
   });
   assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: false });
 });
@@ -41,47 +39,18 @@ test("payload noteId with no pending session is current", () => {
     payloadNoteId: 1,
     payloadSessionId: "diar-100",
     currentSessionId: null,
-    recordingNoteId: null,
   });
   assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: true });
 });
 
-test("without payload noteId, a matching session attributes to the recording note", () => {
+test("a payload without a noteId is dropped", () => {
+  // Main snapshots the same noteId the renderer passed to
+  // meetingTranscriptionStart, so a missing one means the recording was never
+  // tied to a note and there is nothing to persist to.
   const result = resolveDiarizationTarget({
     payloadNoteId: null,
     payloadSessionId: "diar-100",
     currentSessionId: "diar-100",
-    recordingNoteId: 2,
-  });
-  assert.deepEqual(result, { targetNoteId: 2, isCurrentSession: true });
-});
-
-test("without payload noteId and no recording note, the result is dropped", () => {
-  const result = resolveDiarizationTarget({
-    payloadNoteId: null,
-    payloadSessionId: "diar-100",
-    currentSessionId: "diar-100",
-    recordingNoteId: null,
-  });
-  assert.deepEqual(result, { targetNoteId: null, isCurrentSession: true });
-});
-
-test("without payload noteId, a session mismatch produces no target", () => {
-  const result = resolveDiarizationTarget({
-    payloadNoteId: null,
-    payloadSessionId: "diar-100",
-    currentSessionId: "diar-200",
-    recordingNoteId: 2,
-  });
-  assert.deepEqual(result, { targetNoteId: null, isCurrentSession: false });
-});
-
-test("without payload noteId and no current session, the result is dropped", () => {
-  const result = resolveDiarizationTarget({
-    payloadNoteId: null,
-    payloadSessionId: "diar-100",
-    currentSessionId: null,
-    recordingNoteId: 2,
   });
   assert.deepEqual(result, { targetNoteId: null, isCurrentSession: true });
 });

--- a/test/utils/diarizationCompletion.test.js
+++ b/test/utils/diarizationCompletion.test.js
@@ -1,0 +1,146 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  resolveDiarizationTarget,
+  selectBaseSegments,
+} = require("../../src/utils/diarizationCompletion.ts");
+
+// Issue #1495: a delayed diarization result must be saved to the note that
+// owns the recording session, never to whichever note happens to be rendered.
+// Persistence runs at store level; `isCurrentSession` gates only whether the
+// result is published to the UI.
+
+test("payload noteId targets the owning note", () => {
+  const result = resolveDiarizationTarget({
+    payloadNoteId: 1,
+    payloadSessionId: "diar-100",
+    currentSessionId: "diar-100",
+    recordingNoteId: 1,
+  });
+  assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: true });
+});
+
+test("payload noteId still targets the owning note after a new session started", () => {
+  // Data-loss mode of #1495: Meeting B already started, so the store's
+  // session no longer matches A's — A's result must still land on A, but
+  // must not be published to a UI that is waiting on the newer session.
+  const result = resolveDiarizationTarget({
+    payloadNoteId: 1,
+    payloadSessionId: "diar-100",
+    currentSessionId: "diar-200",
+    recordingNoteId: 2,
+  });
+  assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: false });
+});
+
+test("payload noteId with no pending session is current", () => {
+  // Nothing newer is pending, so publishing is safe and clearing a waiting
+  // spinner prevents it from getting stuck.
+  const result = resolveDiarizationTarget({
+    payloadNoteId: 1,
+    payloadSessionId: "diar-100",
+    currentSessionId: null,
+    recordingNoteId: null,
+  });
+  assert.deepEqual(result, { targetNoteId: 1, isCurrentSession: true });
+});
+
+test("without payload noteId, a matching session attributes to the recording note", () => {
+  const result = resolveDiarizationTarget({
+    payloadNoteId: null,
+    payloadSessionId: "diar-100",
+    currentSessionId: "diar-100",
+    recordingNoteId: 2,
+  });
+  assert.deepEqual(result, { targetNoteId: 2, isCurrentSession: true });
+});
+
+test("without payload noteId and no recording note, the result is dropped", () => {
+  const result = resolveDiarizationTarget({
+    payloadNoteId: null,
+    payloadSessionId: "diar-100",
+    currentSessionId: "diar-100",
+    recordingNoteId: null,
+  });
+  assert.deepEqual(result, { targetNoteId: null, isCurrentSession: true });
+});
+
+test("without payload noteId, a session mismatch produces no target", () => {
+  const result = resolveDiarizationTarget({
+    payloadNoteId: null,
+    payloadSessionId: "diar-100",
+    currentSessionId: "diar-200",
+    recordingNoteId: 2,
+  });
+  assert.deepEqual(result, { targetNoteId: null, isCurrentSession: false });
+});
+
+test("without payload noteId and no current session, the result is dropped", () => {
+  const result = resolveDiarizationTarget({
+    payloadNoteId: null,
+    payloadSessionId: "diar-100",
+    currentSessionId: null,
+    recordingNoteId: 2,
+  });
+  assert.deepEqual(result, { targetNoteId: null, isCurrentSession: true });
+});
+
+const seg = (id) => ({ id, text: id, source: "mic" });
+
+test("persisted segments of the target note win over live segments", () => {
+  const persisted = [seg("p1")];
+  const result = selectBaseSegments({
+    persistedSegments: persisted,
+    liveSegments: [seg("l1")],
+    recordingNoteId: 1,
+    targetNoteId: 1,
+  });
+  assert.equal(result, persisted);
+});
+
+test("an empty persisted transcript still wins over the fallbacks", () => {
+  // A transcript that parses to zero segments is authoritative for the note;
+  // falling back to live segments would reintroduce stale data.
+  const persisted = [];
+  const result = selectBaseSegments({
+    persistedSegments: persisted,
+    liveSegments: [seg("l1")],
+    recordingNoteId: 1,
+    targetNoteId: 1,
+  });
+  assert.equal(result, persisted);
+});
+
+test("live segments are used only when the recording belongs to the target note", () => {
+  const live = [seg("l1")];
+  const result = selectBaseSegments({
+    persistedSegments: null,
+    liveSegments: live,
+    recordingNoteId: 1,
+    targetNoteId: 1,
+  });
+  assert.equal(result, live);
+});
+
+test("another note's live segments are never merged into the target note", () => {
+  // The cross-contamination guard: the store's live segments belong to the
+  // recording note — they must not become part of any other note's transcript.
+  const result = selectBaseSegments({
+    persistedSegments: null,
+    liveSegments: [seg("l1")],
+    recordingNoteId: 2,
+    targetNoteId: 1,
+  });
+  assert.deepEqual(result, []);
+});
+
+test("no persisted transcript and empty live segments merge into nothing", () => {
+  const result = selectBaseSegments({
+    persistedSegments: null,
+    liveSegments: [],
+    recordingNoteId: 1,
+    targetNoteId: 1,
+  });
+  assert.deepEqual(result, []);
+});

--- a/test/utils/serialQueue.test.js
+++ b/test/utils/serialQueue.test.js
@@ -1,0 +1,51 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createSerialQueue } = require("../../src/utils/serialQueue.ts");
+
+test("runs tasks one at a time in enqueue order", async () => {
+  const run = createSerialQueue();
+  const events = [];
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  run(async () => {
+    events.push("start1");
+    await firstGate;
+    events.push("end1");
+  });
+  const second = run(async () => {
+    events.push("start2");
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["start1"], "second task must not start while the first is pending");
+
+  releaseFirst();
+  await second;
+  assert.deepEqual(events, ["start1", "end1", "start2"]);
+});
+
+test("resolves each task with its own result", async () => {
+  const run = createSerialQueue();
+  assert.equal(await run(async () => "a"), "a");
+  assert.equal(await run(async () => "b"), "b");
+});
+
+test("a rejected task does not stall the queue", async () => {
+  const run = createSerialQueue();
+  const events = [];
+
+  const failing = run(async () => {
+    throw new Error("boom");
+  });
+  const following = run(async () => {
+    events.push("ran");
+  });
+
+  await assert.rejects(failing, /boom/);
+  await following;
+  assert.deepEqual(events, ["ran"]);
+});


### PR DESCRIPTION
## Description
Fixes [#1495](https://github.com/OpenWhispr/openwhispr/issues/1495). When two meetings were recorded back-to-back, a delayed diarization result could be saved to whichever note was open instead of the note that owned the recording session — cross-contaminating transcripts and speaker embeddings, and then syncing the corruption to the cloud via the note mirror. A second mode of the same defect silently discarded the result if the next recording started before the callback arrived.

Root cause: the meeting-diarization-complete payload carried only a sessionId, and the renderer's handler — which lived inside the NoteEditor React component — validated that session against mutable global store state but persisted using the rendered note.id prop.

The fix makes completion events self-describing and moves persistence out of the component tree entirely:

The main process now includes the owning noteId in the completion payload (it was already snapshotted at recording stop, just never sent).
Persistence runs in a module-scope listener in meetingRecordingStore, which is guaranteed to be registered before any completion can fire and survives the notes view unmounting — closing the third loss mode where no editor was mounted at all.
NoteEditor only mirrors a published result into its UI (spinner, overlay, speaker mappings) when the rendered note matches, so stale results for a re-recorded note persist without repainting the wrong session's UI.
The routing rules live in a new pure module with node-test coverage, following the repo's dictationRouting/dockPolicy pattern. Guards were added so the write can never resurrect a soft-deleted note's tombstone, and a failed getNote publishes an empty result so a waiting spinner still clears.

## Follow-ups / known limitations
- If the app quits while diarization is still running, the result is lost — the only remaining loss window. Closing it would require main-process-side persistence; worth a separate issue if it shows up in practice.
- updateNote/saveNoteSpeakerEmbeddings remain fire-and-forget without .catch, matching the file's existing style — a logging pass over these IPC writes would make failed persists observable.
- Dev-only: Vite HMR re-evaluating the store module stacks a second listener; matches the pre-existing module-scope listener precedent in the same file.