### PR TITLE
fix(billing): show the covering workspace plan instead of "Free"

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -95,7 +95,6 @@ import type {
   GpuDevice,
   LocalTranscriptionProvider,
   InferenceMode,
-  Workspace,
 } from "../types/electron";
 import logger from "../utils/logger";
 import { SettingsRow, InferenceModeSelector } from "./ui/SettingsSection";
@@ -1009,24 +1008,23 @@ export default function SettingsPage({
   const { theme, setTheme } = useTheme();
   const usage = useUsage();
   const billingWorkspaces = useWorkspaceStore((s) => s.workspaces);
-  const coveringWorkspaces = (usage?.entitledWorkspaceIds ?? [])
-    .map((id) => billingWorkspaces.find((workspace) => workspace.id === id))
-    .filter((workspace): workspace is Workspace => Boolean(workspace));
+  const coveringWorkspaces = billingWorkspaces.filter((workspace) =>
+    usage?.entitledWorkspaceIds?.includes(workspace.id)
+  );
   const coveringWorkspaceNames = coveringWorkspaces.map((workspace) => workspace.name);
-  // Gated on the usage payload rather than the resolved workspaces: the workspace
-  // store loads separately, and the upgrade affordances must stay hidden while it
-  // does, or a covered member is invited to buy a plan their seat already grants.
+  // Reads the usage payload, not the workspace store, so the upgrade affordances
+  // stay hidden across the window where the store is still loading.
   const isWorkspaceCovered =
     !usage?.isPersonallySubscribed && (usage?.entitledWorkspaceIds?.length ?? 0) > 0;
-  // Names the tier the seat actually grants. Null until the store resolves, which
-  // leaves the personal-plan label untouched rather than guessing at a tier.
-  const coveringPlanLabel = coveringWorkspaces.length
-    ? t(
-        `settingsPage.workspace.billing.planLabel.${highestPlan(
-          coveringWorkspaces.map((workspace) => workspace.plan)
-        )}`
-      )
-    : null;
+  // Null until the store resolves, so the label waits rather than guessing a tier.
+  const coveringPlanLabel =
+    isWorkspaceCovered && coveringWorkspaces.length
+      ? t(
+          `settingsPage.workspace.billing.planLabel.${highestPlan(
+            coveringWorkspaces.map((workspace) => workspace.plan)
+          )}`
+        )
+      : null;
   const hasShownApproachingToast = useRef(false);
   useEffect(() => {
     if (usage?.isApproachingLimit && !hasShownApproachingToast.current) {
@@ -1943,9 +1941,8 @@ export default function SettingsPage({
                                       ? t("settingsPage.unifiedBilling.providedBy", {
                                           workspaces: coveringWorkspaceNames.join(", "),
                                         })
-                                      : // Covered, but the workspace store hasn't resolved a
-                                        // name yet. The free-usage copy would print the
-                                        // subscribed sentinel limit as "-1 words".
+                                      : // usage.limit is -1 once subscribed, which the
+                                        // free-usage copy would print as "-1 words".
                                         isWorkspaceCovered
                                         ? t("settingsPage.account.planDescriptions.unlimited")
                                         : t("settingsPage.account.planDescriptions.freeUsage", {

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -95,6 +95,7 @@ import type {
   GpuDevice,
   LocalTranscriptionProvider,
   InferenceMode,
+  Workspace,
 } from "../types/electron";
 import logger from "../utils/logger";
 import { SettingsRow, InferenceModeSelector } from "./ui/SettingsSection";
@@ -112,6 +113,7 @@ import {
   useSettingsStore,
 } from "../stores/settingsStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { highestPlan } from "../lib/usageStore";
 import {
   canChangeCloudBackupPreference,
   effectiveAudioRetentionDays,
@@ -1007,9 +1009,24 @@ export default function SettingsPage({
   const { theme, setTheme } = useTheme();
   const usage = useUsage();
   const billingWorkspaces = useWorkspaceStore((s) => s.workspaces);
-  const coveringWorkspaceNames = (usage?.entitledWorkspaceIds ?? [])
-    .map((id) => billingWorkspaces.find((workspace) => workspace.id === id)?.name)
-    .filter((name): name is string => Boolean(name));
+  const coveringWorkspaces = (usage?.entitledWorkspaceIds ?? [])
+    .map((id) => billingWorkspaces.find((workspace) => workspace.id === id))
+    .filter((workspace): workspace is Workspace => Boolean(workspace));
+  const coveringWorkspaceNames = coveringWorkspaces.map((workspace) => workspace.name);
+  // Gated on the usage payload rather than the resolved workspaces: the workspace
+  // store loads separately, and the upgrade affordances must stay hidden while it
+  // does, or a covered member is invited to buy a plan their seat already grants.
+  const isWorkspaceCovered =
+    !usage?.isPersonallySubscribed && (usage?.entitledWorkspaceIds?.length ?? 0) > 0;
+  // Names the tier the seat actually grants. Null until the store resolves, which
+  // leaves the personal-plan label untouched rather than guessing at a tier.
+  const coveringPlanLabel = coveringWorkspaces.length
+    ? t(
+        `settingsPage.workspace.billing.planLabel.${highestPlan(
+          coveringWorkspaces.map((workspace) => workspace.plan)
+        )}`
+      )
+    : null;
   const hasShownApproachingToast = useRef(false);
   useEffect(() => {
     if (usage?.isApproachingLimit && !hasShownApproachingToast.current) {
@@ -1900,7 +1917,8 @@ export default function SettingsPage({
                                     ? usage.plan === "business"
                                       ? t("settingsPage.account.planLabels.business")
                                       : t("settingsPage.account.planLabels.pro")
-                                    : t("settingsPage.account.planLabels.free")
+                                    : (coveringPlanLabel ??
+                                      t("settingsPage.account.planLabels.free"))
                             }
                             description={
                               usage.isTrial
@@ -1925,10 +1943,15 @@ export default function SettingsPage({
                                       ? t("settingsPage.unifiedBilling.providedBy", {
                                           workspaces: coveringWorkspaceNames.join(", "),
                                         })
-                                      : t("settingsPage.account.planDescriptions.freeUsage", {
-                                          used: usage.wordsUsed.toLocaleString(i18n.language),
-                                          limit: usage.limit.toLocaleString(i18n.language),
-                                        })
+                                      : // Covered, but the workspace store hasn't resolved a
+                                        // name yet. The free-usage copy would print the
+                                        // subscribed sentinel limit as "-1 words".
+                                        isWorkspaceCovered
+                                        ? t("settingsPage.account.planDescriptions.unlimited")
+                                        : t("settingsPage.account.planDescriptions.freeUsage", {
+                                            used: usage.wordsUsed.toLocaleString(i18n.language),
+                                            limit: usage.limit.toLocaleString(i18n.language),
+                                          })
                             }
                           >
                             {usage.isTrial ? (
@@ -1943,6 +1966,8 @@ export default function SettingsPage({
                                   ? t("settingsPage.account.badges.business")
                                   : t("settingsPage.account.badges.pro")}
                               </Badge>
+                            ) : coveringPlanLabel ? (
+                              <Badge variant="success">{coveringPlanLabel}</Badge>
                             ) : usage.isOverLimit ? (
                               <Badge variant="warning">
                                 {t("settingsPage.account.badges.limitReached")}
@@ -2022,7 +2047,7 @@ export default function SettingsPage({
                                 ? t("settingsPage.account.billing.opening")
                                 : t("settingsPage.account.billing.manageBilling")}
                             </Button>
-                          ) : (
+                          ) : isWorkspaceCovered ? null : (
                             <Button
                               onClick={async () => {
                                 setCheckoutTier("plan-upgrade");
@@ -2062,7 +2087,10 @@ export default function SettingsPage({
                     <div
                       className={cn(
                         "rounded-md p-2.5 flex flex-col",
-                        planStateKnown && !usage?.isPersonallySubscribed && !usage?.isTrial
+                        planStateKnown &&
+                          !usage?.isPersonallySubscribed &&
+                          !usage?.isTrial &&
+                          !isWorkspaceCovered
                           ? "border-2 border-primary/30 bg-primary/3 dark:border-primary/20 dark:bg-primary/5"
                           : "border border-border/50 dark:border-border-subtle/60 bg-card/30 dark:bg-surface-2/30"
                       )}
@@ -2123,7 +2151,7 @@ export default function SettingsPage({
                             ? t("settingsPage.account.billing.opening")
                             : t("settingsPage.account.pricing.downgrade")}
                         </Button>
-                      ) : planStateKnown ? (
+                      ) : planStateKnown && !isWorkspaceCovered ? (
                         <div className="mt-2 text-center">
                           <span className="text-[9px] font-medium text-primary/70">
                             {t("settingsPage.account.pricing.currentPlan")}

--- a/src/lib/usageStore.ts
+++ b/src/lib/usageStore.ts
@@ -6,8 +6,7 @@ const USAGE_CACHE_TTL = CACHE_CONFIG.API_KEY_TTL;
 const RETRY_DELAYS_MS = [2000, 4000, 8000];
 const PAID_PLANS = new Set(["pro", "business", "enterprise"]);
 
-// Ascending tier ladder. Unknown plans rank as free so a tier this build has
-// never heard of can never out-rank a known paid one.
+// Unknown tiers rank as free so a plan this build predates can't out-rank a paid one.
 const PLAN_ORDER: Record<string, number> = { free: 0, pro: 1, business: 2, enterprise: 3 };
 
 export function highestPlan(plans: string[]): string {

--- a/src/lib/usageStore.ts
+++ b/src/lib/usageStore.ts
@@ -6,6 +6,17 @@ const USAGE_CACHE_TTL = CACHE_CONFIG.API_KEY_TTL;
 const RETRY_DELAYS_MS = [2000, 4000, 8000];
 const PAID_PLANS = new Set(["pro", "business", "enterprise"]);
 
+// Ascending tier ladder. Unknown plans rank as free so a tier this build has
+// never heard of can never out-rank a known paid one.
+const PLAN_ORDER: Record<string, number> = { free: 0, pro: 1, business: 2, enterprise: 3 };
+
+export function highestPlan(plans: string[]): string {
+  return plans.reduce(
+    (best, plan) => ((PLAN_ORDER[plan] ?? 0) > (PLAN_ORDER[best] ?? 0) ? plan : best),
+    "free"
+  );
+}
+
 export interface UsageData {
   wordsUsed: number;
   wordsRemaining: number;

--- a/test/lib/highestPlan.test.js
+++ b/test/lib/highestPlan.test.js
@@ -1,0 +1,20 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { highestPlan } = require("../../src/lib/usageStore.ts");
+
+test("the best tier a covering workspace grants wins", () => {
+  assert.equal(highestPlan(["free", "business"]), "business");
+  assert.equal(highestPlan(["pro", "enterprise", "business"]), "enterprise");
+  assert.equal(highestPlan(["pro", "pro"]), "pro");
+});
+
+test("nothing to rank falls back to free", () => {
+  assert.equal(highestPlan([]), "free");
+  assert.equal(highestPlan(["free"]), "free");
+});
+
+test("an unrecognized tier never out-ranks a known paid one", () => {
+  assert.equal(highestPlan(["mystery"]), "free");
+  assert.equal(highestPlan(["mystery", "pro"]), "pro");
+});


### PR DESCRIPTION
## Problem

A billable member of a paid workspace gets unlimited words and full paid access — `/api/usage` returns `isSubscribed: true` with `entitlementSources.workspaceIds` populated. But the plans screen keys its affordances off `isPersonallySubscribed`, which is `false` for them, so they see:

- the plan row labelled **"Free"** with an outline **"Free"** badge
- the **Free card highlighted and marked "Current plan"**
- a live **"Upgrade to Pro"** checkout button as the primary action

`fix/billing-entitlements` already added the "Paid access provided by {workspace}" description and the `planStateKnown` loading guard, so the screen explains the coverage in the fine print while the headline still says Free and invites a purchase.

The people most likely to act on that prompt are the ones who already paid. A customer hit exactly this: they bought an individual Business plan and a 2-seat workspace **66 seconds apart**, then had to be refunded manually. After the refund they're workspace-covered — i.e. back on the same screen that caused it.

## Fix

When a member is workspace-covered and not personally subscribed:

| | Before | After |
|---|---|---|
| Plan row label | Free | the covering workspace's tier |
| Badge | outline "Free" | success badge, same tier |
| Free pricing card | highlighted, "Current plan" | neither |
| Primary CTA | "Upgrade to Pro" checkout | withheld |

Unchanged: the workspace billing card, the "provided by" description, past-due and trial handling, and everything a personally-subscribed or genuinely free user sees.

### No new strings

Reuses `settingsPage.workspace.billing.planLabel`, which is already translated across all ten locales **and already includes `enterprise`** — unlike `account.planLabels`, which only has free/pro/business. Nothing falls back to English.

### Two load-order details

The upgrade affordances gate on `isWorkspaceCovered`, derived from the usage payload rather than the resolved workspace objects. The workspace store loads separately from `/api/usage`, and the CTA has to stay hidden across that window — gating it on resolved objects would flash a purchase button at a covered member on first paint.

The label does the opposite and waits for a resolved workspace rather than guessing a tier. That intermediate state previously fell through to the free-usage copy, which renders `usage.limit` — set to `-1` for subscribed users — as **"0 / -1 words this week"**. It now shows the existing `planDescriptions.unlimited` copy instead.

## Deliberately out of scope

The small secondary checkout buttons on the Pro and Business pricing cards still appear for covered members. Suppressing those would leave empty card footers and need new copy; the prominent primary CTA and the false "current plan" marker were the actual trap. Happy to take it further if you'd rather.

## Testing

- `npm run typecheck`, `npm run lint`, `prettier --check` — all clean
- `npm test` — 1398 pass, 0 fail, including 3 new cases for the `highestPlan` helper (best-of, empty, unknown tiers)