### PR TITLE
fix(stt): guard empty normalized text and prompt in dictionary echo filter

### DIFF
--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -11,6 +11,8 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   const normalizedText = normalize(text);
   const normalizedPrompt = normalize(dictionaryPrompt);
 
+  if (!normalizedText || !normalizedPrompt) return false;
+
   if (normalizedText === normalizedPrompt) return true;
 
   const dictWords = new Set(normalizedPrompt.split(" "));

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -116,3 +116,11 @@ test("does not flag completely unrelated text", async () => {
     false
   );
 });
+
+test("returns false when text or prompt normalizes to empty string (punctuation only)", async () => {
+  const { matchesDictionaryPrompt } = await import("../../src/utils/dictionaryEchoFilter.js");
+  assert.equal(matchesDictionaryPrompt("...", "..."), false);
+  assert.equal(matchesDictionaryPrompt("!!!", ",,,"), false);
+  assert.equal(matchesDictionaryPrompt("???", "OpenWhispr, Parakeet"), false);
+  assert.equal(matchesDictionaryPrompt("OpenWhispr, Parakeet", "!!!"), false);
+});


### PR DESCRIPTION
## Summary
Fixes an issue where `matchesDictionaryPrompt` returns `true` when the input transcript or dictionary prompt consists solely of punctuation or symbols (e.g. `text = "..."` and `dictionaryPrompt = "..."` or `text = "!!!"` and `dictionaryPrompt = ",,,"`), incorrectly treating punctuation-only text as an echo of the custom dictionary prompt and discarding the transcript.

Fixes #1542

## Problem
`matchesDictionaryPrompt(text, dictionaryPrompt)` normalizes both strings by converting to lowercase and stripping all non-alphanumeric characters (`.replace(/[^\p{L}\p{N}\s]/gu, "")`). When either string contains only punctuation/symbols, `normalize` returns an empty string `""`.
Because `normalizedText === normalizedPrompt` (`"" === ""`) evaluates to `true`, the function returns `true`, causing valid non-speech punctuation transcripts or prompts containing punctuation to trigger prompt echo filtering and discard transcript output.

## Root Cause
`matchesDictionaryPrompt` guarded against empty raw strings (`if (!text || !dictionaryPrompt) return false;`), but failed to check if `normalizedText` or `normalizedPrompt` became empty after stripping non-alphanumeric characters.

## Fix
Added a check after normalization:
```javascript
if (!normalizedText || !normalizedPrompt) return false;
```
If either string normalizes to an empty string (lacks letters or numbers), `matchesDictionaryPrompt` immediately returns `false`.

## Behavior Before and After
- **Before**: `matchesDictionaryPrompt("...", "...")` and `matchesDictionaryPrompt("!!!", ",,,")` returned `true` (incorrectly flagged as prompt echo).
- **After**: `matchesDictionaryPrompt("...", "...")` and `matchesDictionaryPrompt("!!!", ",,,")` return `false` (correctly allowed through). Standard word echo detection remains unchanged.

## Scope & Non-Goals
- Scope: `src/utils/dictionaryEchoFilter.js`.
- Non-Goals: Does not alter word-level echo threshold calculations (`textComposition >= 0.9 && dictionaryUsage >= 0.7`) for valid alphanumeric text.

## Tests Added
Added a deterministic unit test in `test/helpers/dictionaryEchoFilter.test.js`:
- Verifies `matchesDictionaryPrompt("...", "...")` returns `false`.
- Verifies `matchesDictionaryPrompt("!!!", ",,,")` returns `false`.
- Verifies `matchesDictionaryPrompt("???", "OpenWhispr, Parakeet")` returns `false`.
- Verifies `matchesDictionaryPrompt("OpenWhispr, Parakeet", "!!!")` returns `false`.

## Validation Commands and Results
1. `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/dictionaryEchoFilter.test.js` -> Passed (17 tests pass, 0 fail).
2. `ELECTRON_OVERRIDE_DIST_PATH=/tmp npm test` -> Passed (1103 tests pass).
3. `npm run typecheck` -> Passed (0 errors).
4. `npm run lint` -> Passed (0 errors).
5. `npm run format:check` -> Passed (All matched files use Prettier code style).
6. `npm run i18n:check` -> Passed (Locale keys consistent).
7. `node --check src/utils/dictionaryEchoFilter.js` -> Passed.
8. `git diff --check` -> Passed (0 formatting errors).

## Platform or Environment Limitations
None. Platform-independent JavaScript.
