### PR TITLE
fix(linux): link libgobject-2.0 for AT-SPI2 text monitor build

### DIFF
--- a/.github/workflows/build-linux-text-monitor.yml
+++ b/.github/workflows/build-linux-text-monitor.yml
@@ -30,12 +30,16 @@ jobs:
 
       - name: Compile Linux Text Monitor
         run: |
-          gcc -O2 resources/linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2)
+          gcc -O2 resources/linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs --static atspi-2)
 
       - name: Verify binary
         run: |
           file linux-text-monitor
-          test -f linux-text-monitor || { echo "Binary not found"; exit 1; }
+          test -x linux-text-monitor || { echo "Binary not found or not executable"; exit 1; }
+          ldd linux-text-monitor
+          ldd linux-text-monitor | grep -q "not found" && { echo "Unresolved shared library dependency"; exit 1; }
+          ldd linux-text-monitor | grep -q libgobject-2.0.so || { echo "libgobject-2.0 not linked - pkg-config --static flag may have regressed"; exit 1; }
+          exit 0
 
       - name: Create tar.gz archive
         run: |

--- a/.github/workflows/build-linux-text-monitor.yml
+++ b/.github/workflows/build-linux-text-monitor.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Compile Linux Text Monitor
         run: |
-          gcc -O2 resources/linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs --static atspi-2)
+          gcc -O2 resources/linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2) -lgobject-2.0
 
       - name: Verify binary
         run: |
@@ -38,7 +38,7 @@ jobs:
           test -x linux-text-monitor || { echo "Binary not found or not executable"; exit 1; }
           ldd linux-text-monitor
           ldd linux-text-monitor | grep -q "not found" && { echo "Unresolved shared library dependency"; exit 1; }
-          ldd linux-text-monitor | grep -q libgobject-2.0.so || { echo "libgobject-2.0 not linked - pkg-config --static flag may have regressed"; exit 1; }
+          ldd linux-text-monitor | grep -q libgobject-2.0.so || { echo "libgobject-2.0 not linked - explicit -lgobject-2.0 flag may have regressed"; exit 1; }
           exit 0
 
       - name: Create tar.gz archive

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -136,19 +136,6 @@ OpenWhispr tries clipboard methods in order: `wl-copy` (most reliable) → rende
 4. Restart OpenWhispr and start meeting transcription again
 5. No screen-share chooser is expected for Linux system audio; OpenWhispr captures the default sink monitor directly through PipeWire
 
-### Linux Auto-Learn Correction (AT-SPI2) Issues
-
-**Symptoms:** Auto-learn correction (Settings → Dictionary) never updates the custom dictionary after an edit, with no error shown, on Linux sessions other than GNOME.
-
-**Fix:**
-
-1. GTK/Gecko apps (Firefox, Claude Desktop, etc.) only register with AT-SPI2 when `org.gnome.desktop.interface toolkit-accessibility` is enabled — this is off by default on non-GNOME sessions (niri, Hyprland, sway, KDE). Enable it:
-   ```
-   gsettings set org.gnome.desktop.interface toolkit-accessibility true
-   ```
-2. Restart the target app (Firefox, etc.) after enabling — the flag is read once at startup, not watched live.
-3. This affects only apps that don't expose their accessibility tree; apps that do keep working as before, and unsupported apps simply skip correction learning silently rather than erroring.
-
 ### Meeting Transcription Issues
 
 **Symptoms:** Meeting detection not working, no transcription, audio not captured

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -136,6 +136,19 @@ OpenWhispr tries clipboard methods in order: `wl-copy` (most reliable) → rende
 4. Restart OpenWhispr and start meeting transcription again
 5. No screen-share chooser is expected for Linux system audio; OpenWhispr captures the default sink monitor directly through PipeWire
 
+### Linux Auto-Learn Correction (AT-SPI2) Issues
+
+**Symptoms:** Auto-learn correction (Settings → Dictionary) never updates the custom dictionary after an edit, with no error shown, on Linux sessions other than GNOME.
+
+**Fix:**
+
+1. GTK/Gecko apps (Firefox, Claude Desktop, etc.) only register with AT-SPI2 when `org.gnome.desktop.interface toolkit-accessibility` is enabled — this is off by default on non-GNOME sessions (niri, Hyprland, sway, KDE). Enable it:
+   ```
+   gsettings set org.gnome.desktop.interface toolkit-accessibility true
+   ```
+2. Restart the target app (Firefox, etc.) after enabling — the flag is read once at startup, not watched live.
+3. This affects only apps that don't expose their accessibility tree; apps that do keep working as before, and unsupported apps simply skip correction learning silently rather than erroring.
+
 ### Meeting Transcription Issues
 
 **Symptoms:** Meeting detection not working, no transcription, audio not captured

--- a/resources/linux-text-monitor.c
+++ b/resources/linux-text-monitor.c
@@ -17,7 +17,12 @@
  *   First line: original pasted text (informational)
  *
  * Compile:
- *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2)
+ *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs --static atspi-2)
+ *
+ * Note: --static is required because atspi-2.pc lists gobject-2.0 under
+ * Requires.private rather than Requires, so a plain `pkg-config --libs`
+ * omits -lgobject-2.0 and fails to link with linkers defaulting to
+ * --as-needed (e.g. current Ubuntu/Arch toolchains).
  */
 
 #include <stdio.h>

--- a/resources/linux-text-monitor.c
+++ b/resources/linux-text-monitor.c
@@ -17,12 +17,12 @@
  *   First line: original pasted text (informational)
  *
  * Compile:
- *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs --static atspi-2)
+ *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2) -lgobject-2.0
  *
- * Note: --static is required because atspi-2.pc lists gobject-2.0 under
- * Requires.private rather than Requires, so a plain `pkg-config --libs`
- * omits -lgobject-2.0 and fails to link with linkers defaulting to
- * --as-needed (e.g. current Ubuntu/Arch toolchains).
+ * Note: -lgobject-2.0 must be added explicitly because atspi-2.pc lists
+ * gobject-2.0 under Requires.private rather than Requires, so a plain
+ * `pkg-config --libs` omits it and the link fails with linkers defaulting
+ * to --as-needed (e.g. current Ubuntu/Arch toolchains).
  */
 
 #include <stdio.h>

--- a/scripts/build-linux-text-monitor.js
+++ b/scripts/build-linux-text-monitor.js
@@ -113,13 +113,18 @@ function getPkgConfigFlags() {
     });
     if (check.status !== 0) return null;
 
-    const result = spawnSync("pkg-config", ["--cflags", "--libs", "--static", "atspi-2"], {
+    const result = spawnSync("pkg-config", ["--cflags", "--libs", "atspi-2"], {
       stdio: ["pipe", "pipe", "pipe"],
       env: process.env,
     });
     if (result.status !== 0) return null;
 
-    return result.stdout.toString().trim().split(/\s+/).filter(Boolean);
+    // atspi-2.pc lists gobject-2.0 under Requires.private, so plain --libs
+    // omits -lgobject-2.0; add it explicitly for --as-needed linkers.
+    return [
+      ...result.stdout.toString().trim().split(/\s+/).filter(Boolean),
+      "-lgobject-2.0",
+    ];
   } catch {
     return null;
   }

--- a/scripts/build-linux-text-monitor.js
+++ b/scripts/build-linux-text-monitor.js
@@ -113,7 +113,7 @@ function getPkgConfigFlags() {
     });
     if (check.status !== 0) return null;
 
-    const result = spawnSync("pkg-config", ["--cflags", "--libs", "atspi-2"], {
+    const result = spawnSync("pkg-config", ["--cflags", "--libs", "--static", "atspi-2"], {
       stdio: ["pipe", "pipe", "pipe"],
       env: process.env,
     });


### PR DESCRIPTION
## What this fixes

`pkg-config --libs atspi-2` leaves out `-lgobject-2.0` — it's listed under `Requires.private` in `atspi-2.pc`, not `Requires`. Linkers that default to `--as-needed` (current Ubuntu/Arch, including the GitHub Actions runner) fail with `undefined reference to symbol 'g_object_unref'`.

Fix: use `pkg-config --cflags --libs --static atspi-2`, which pulls in private deps too.

Also tightened the "Verify binary" CI step. It used to only check the file exists. Now it runs `ldd` and checks for unresolved libraries and for `libgobject-2.0.so` specifically, so this class of break gets caught in CI instead of failing silently again.

Tested locally: compiles clean, `ldd` shows no missing libraries.

## Takeaway

Even with the binary working, apps like Firefox won't expose their accessibility tree unless this is set — off by default outside GNOME (niri, Hyprland, Sway, KDE):

```
gsettings set org.gnome.desktop.interface toolkit-accessibility true
```

Restart the app after — it's read once at startup. Without it, auto-learn silently does nothing for that app.

Fixes #1531

## Summary
The ATSPI-2 feature on linux that we use for corrections for the voice models wasn't actually shipped since #327. This PR fixes it by including the c file and then fixing CI as well.
