### PR TITLE
fix(linux): use xprop for window-class detection and prefer ydotool on X11

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1423,13 +1423,14 @@ class ClipboardManager {
     };
 
     const preDetectWindowClass = (windowId) => {
-      if (!xdotoolExists || (isWayland && !xwaylandAvailable)) return null;
+      if (!windowId) return null;
+      // xprop never crashes on windows without WM_CLASS (xdotool getwindowclassname
+      // aborts with a double free on such windows — see jordansissel/xdotool#517).
       try {
-        const args = windowId
-          ? ["getwindowclassname", windowId]
-          : ["getactivewindow", "getwindowclassname"];
-        const result = spawnSync("xdotool", args);
-        return result.status === 0 ? result.stdout.toString().toLowerCase().trim() || null : null;
+        const result = spawnSync("xprop", ["-id", windowId, "WM_CLASS"], { timeout: 1000 });
+        if (result.status !== 0) return null;
+        const match = result.stdout.toString().match(/"([^"]+)"/);
+        return match ? match[1].toLowerCase().trim() || null : null;
       } catch {
         return null;
       }
@@ -1793,8 +1794,10 @@ class ClipboardManager {
     // Compositor-aware priority ordering
     let candidates;
     if (!isWayland) {
-      // X11: xdotool is native and needs no daemon; ydotool as fallback
-      candidates = [...xdotoolEntry, ...ydotoolEntry];
+      // X11: prefer ydotool (uinput) when its daemon is running — xdotool's
+      // getwindowclassname aborts on windows without WM_CLASS (jordansissel/xdotool#517)
+      // and XTest injection is flaky on KDE. xdotool remains the fallback.
+      candidates = [...ydotoolEntry, ...xdotoolEntry];
     } else if (isWlroots) {
       // wlroots (Sway, Hyprland, etc.): wtype is native; then xdotool for XWayland; ydotool last
       candidates = [...wtypeEntry, ...xdotoolEntry, ...ydotoolEntry];


### PR DESCRIPTION
## Summary

Fixes two Linux paste issues on KDE/X11:

1. **`xdotool getwindowclassname` crashes (SIGABRT) on windows without `WM_CLASS`** — OpenWhispr calls it on every paste via `preDetectWindowClass`. On such windows xdotool aborts with `free(): invalid size` (double free, see [jordansissel/xdotool#517](https://github.com/jordansissel/xdotool/issues/517) — fixed upstream only in v4 releases; Fedora still ships the crashing v3.20211022.1). This spams crash-report dialogs and silently breaks window-class detection.
2. **X11 paste prefers xdotool over ydotool** — on KDE/X11, XTest injection is flaky and hits the crashing code path. ydotool (uinput) is the more reliable choice when its daemon is running.

## Changes

- `preDetectWindowClass`: query `WM_CLASS` via `xprop -id <win> WM_CLASS` instead of `xdotool getwindowclassname`. `xprop` exits cleanly (status 0, "not found") when the property is absent, so detection never crashes and still returns the class when present.
- X11 paste candidate ordering: `[ydotool, xdotool]` when the ydotool daemon is running; xdotool remains the fallback. Mirrors the existing GNOME Wayland preference (issue #202).

## Reproduction of the crash

```console
$ xdotool getwindowclassname 848   # window without WM_CLASS
free(): invalid size
$ echo $?
134
```

Stack trace (from coredump): `XFree` → `malloc_printerr` → `xdo_get_window_classname` → `cmd_getwindowclassname`.

## Testing

- `xprop -id <win> WM_CLASS` returns the class for windows that have it, and "not found" (exit 0) for those that don't — no crash in either case.
- `node --check` passes; eslint clean on the changed file.