### PR TITLE
fix(linux): prefer portal paste on GNOME once a restore token exists

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -112,6 +112,7 @@ class ClipboardManager {
     this.linuxFastPastePath = null;
     this.linuxFastPasteChecked = false;
     this.portalDenied = false;
+    this.portalTokenPasteFailed = false;
     this._kwinScriptPath = null;
     this.pasteQueue = Promise.resolve();
 
@@ -1653,16 +1654,16 @@ class ClipboardManager {
           }
         } else if (isGnome && linuxFastPaste) {
           // GNOME: uinput first for the first-ever paste — the portal shows a
-          // permission dialog and can stall for 10s+ (issue #494). But once a
-          // restore token exists the portal is dialog-free and instant, so
-          // prefer it: uinput creates and destroys a virtual keyboard on every
-          // paste, forcing mutter to hotplug an input device each time, which
-          // has driven gnome-shell into unrecoverable hangs under sustained
-          // dictation.
-          const havePortalToken = !this.portalDenied && !!this._readPortalToken();
-          if (havePortalToken) {
+          // permission dialog and can stall for 10s+ (issue #494). A valid
+          // restore token resumes without the dialog, so prefer it until a
+          // tokened attempt fails. This avoids the virtual keyboard hotplug
+          // churn that can hang gnome-shell under sustained dictation.
+          const shouldPreferPortal =
+            !this.portalDenied && !this.portalTokenPasteFailed && !!this._readPortalToken();
+          if (shouldPreferPortal) {
             const portalPaste = await tryPortalPaste();
             if (portalPaste) return { method: "portal", ...portalPaste };
+            this.portalTokenPasteFailed = true;
           }
           try {
             const uinputPaste = await tryUinputPaste();
@@ -1674,7 +1675,7 @@ class ClipboardManager {
               "clipboard"
             );
           }
-          if (!havePortalToken && !this.portalDenied) {
+          if (!shouldPreferPortal && !this.portalDenied) {
             const portalPaste = await tryPortalPaste();
             if (portalPaste) return { method: "portal", ...portalPaste };
           }

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1652,6 +1652,18 @@ class ClipboardManager {
             debugLogger.warn("uinput paste failed", { error: uinputError?.message }, "clipboard");
           }
         } else if (isGnome && linuxFastPaste) {
+          // GNOME: uinput first for the first-ever paste — the portal shows a
+          // permission dialog and can stall for 10s+ (issue #494). But once a
+          // restore token exists the portal is dialog-free and instant, so
+          // prefer it: uinput creates and destroys a virtual keyboard on every
+          // paste, forcing mutter to hotplug an input device each time, which
+          // has driven gnome-shell into unrecoverable hangs under sustained
+          // dictation.
+          const havePortalToken = !this.portalDenied && !!this._readPortalToken();
+          if (havePortalToken) {
+            const portalPaste = await tryPortalPaste();
+            if (portalPaste) return { method: "portal", ...portalPaste };
+          }
           try {
             const uinputPaste = await tryUinputPaste();
             return { method: "uinput", ...uinputPaste };
@@ -1662,7 +1674,7 @@ class ClipboardManager {
               "clipboard"
             );
           }
-          if (!this.portalDenied) {
+          if (!havePortalToken && !this.portalDenied) {
             const portalPaste = await tryPortalPaste();
             if (portalPaste) return { method: "portal", ...portalPaste };
           }

--- a/test/helpers/linuxPasteOrder.test.js
+++ b/test/helpers/linuxPasteOrder.test.js
@@ -134,7 +134,7 @@ test("GNOME paste keeps uinput first when no restore token exists", async () => 
   );
 });
 
-test("GNOME paste falls back to uinput when the tokened portal paste fails", async () => {
+test("GNOME paste keeps uinput first after a tokened portal paste fails", async () => {
   const calls = [];
   const failPortalSpawn = (command, args = []) => {
     calls.push({ command, args });
@@ -149,13 +149,14 @@ test("GNOME paste falls back to uinput when the tokened portal paste fails", asy
 
   await withEnv(GNOME_WAYLAND_ENV, async () => {
     const manager = createGnomeManager(ClipboardManager, { portalToken: "token-123" });
-    const result = await manager.pasteLinux(null, {});
-    assert.equal(result.method, "uinput");
+    const firstResult = await manager.pasteLinux(null, {});
+    const secondResult = await manager.pasteLinux(null, {});
+    assert.equal(firstResult.method, "uinput");
+    assert.equal(secondResult.method, "uinput");
   });
 
-  assert.ok(calls[0].args.includes("--portal"), "expected portal to be tried first");
-  assert.ok(
-    calls.some((call) => call.args.includes("--uinput")),
-    "expected uinput fallback after portal failure"
+  assert.deepEqual(
+    calls.map((call) => (call.args.includes("--portal") ? "portal" : "uinput")),
+    ["portal", "uinput", "uinput"]
   );
 });

--- a/test/helpers/linuxPasteOrder.test.js
+++ b/test/helpers/linuxPasteOrder.test.js
@@ -1,0 +1,161 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+const childProcess = require("node:child_process");
+
+const fakeClipboard = {
+  text: "",
+  availableFormats: () => ["text/plain"],
+  readText() {
+    return this.text;
+  },
+  writeText(text) {
+    this.text = text;
+  },
+  readHTML: () => "",
+  readRTF: () => "",
+  readImage: () => ({ isEmpty: () => true }),
+  write() {},
+  writeImage() {},
+};
+
+const clipboardModulePath = require.resolve("../../src/helpers/clipboard");
+
+const originalLoad = Module._load;
+
+function loadClipboardManager({ spawn } = {}) {
+  delete require.cache[clipboardModulePath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        clipboard: fakeClipboard,
+        systemPreferences: {
+          isTrustedAccessibilityClient: () => true,
+        },
+      };
+    }
+    if (request === "child_process" && spawn) {
+      return { ...childProcess, spawn };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../../src/helpers/clipboard");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createRecordingSpawn(calls) {
+  return function recordingSpawn(command, args = []) {
+    calls.push({ command, args });
+    const proc = new EventEmitter();
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = () => {};
+    process.nextTick(() => proc.emit("close", 0));
+    return proc;
+  };
+}
+
+const GNOME_WAYLAND_ENV = {
+  XDG_SESSION_TYPE: "wayland",
+  WAYLAND_DISPLAY: "wayland-0",
+  XDG_CURRENT_DESKTOP: "GNOME",
+  DISPLAY: "",
+};
+
+function withEnv(overrides, fn) {
+  const saved = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    saved[key] = process.env[key];
+    if (value === "") delete process.env[key];
+    else process.env[key] = value;
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    });
+}
+
+function createGnomeManager(ClipboardManager, { portalToken }) {
+  const manager = new ClipboardManager();
+  manager.commandExists = () => false;
+  manager.resolveLinuxFastPasteBinary = () => "/fake/linux-fast-paste";
+  manager._canAccessUinput = () => true;
+  manager._isYdotoolDaemonRunning = () => false;
+  manager._readPortalToken = () => portalToken;
+  manager._savePortalToken = () => {};
+  return manager;
+}
+
+test("GNOME paste prefers the portal when a restore token exists", async () => {
+  const calls = [];
+  const ClipboardManager = loadClipboardManager({ spawn: createRecordingSpawn(calls) });
+
+  await withEnv(GNOME_WAYLAND_ENV, async () => {
+    const manager = createGnomeManager(ClipboardManager, { portalToken: "token-123" });
+    const result = await manager.pasteLinux(null, {});
+    assert.equal(result.method, "portal");
+  });
+
+  assert.ok(calls.length > 0, "expected the fast-paste binary to be spawned");
+  assert.ok(
+    calls[0].args.includes("--portal"),
+    `expected first spawn to use --portal, got: ${calls[0].args.join(" ")}`
+  );
+  assert.ok(
+    calls[0].args.includes("--restore-token"),
+    "expected the saved restore token to be passed"
+  );
+});
+
+test("GNOME paste keeps uinput first when no restore token exists", async () => {
+  const calls = [];
+  const ClipboardManager = loadClipboardManager({ spawn: createRecordingSpawn(calls) });
+
+  await withEnv(GNOME_WAYLAND_ENV, async () => {
+    const manager = createGnomeManager(ClipboardManager, { portalToken: null });
+    const result = await manager.pasteLinux(null, {});
+    assert.equal(result.method, "uinput");
+  });
+
+  assert.ok(calls.length > 0, "expected the fast-paste binary to be spawned");
+  assert.ok(
+    calls[0].args.includes("--uinput"),
+    `expected first spawn to use --uinput, got: ${calls[0].args.join(" ")}`
+  );
+});
+
+test("GNOME paste falls back to uinput when the tokened portal paste fails", async () => {
+  const calls = [];
+  const failPortalSpawn = (command, args = []) => {
+    calls.push({ command, args });
+    const proc = new EventEmitter();
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = () => {};
+    process.nextTick(() => proc.emit("close", args.includes("--portal") ? 1 : 0));
+    return proc;
+  };
+  const ClipboardManager = loadClipboardManager({ spawn: failPortalSpawn });
+
+  await withEnv(GNOME_WAYLAND_ENV, async () => {
+    const manager = createGnomeManager(ClipboardManager, { portalToken: "token-123" });
+    const result = await manager.pasteLinux(null, {});
+    assert.equal(result.method, "uinput");
+  });
+
+  assert.ok(calls[0].args.includes("--portal"), "expected portal to be tried first");
+  assert.ok(
+    calls.some((call) => call.args.includes("--uinput")),
+    "expected uinput fallback after portal failure"
+  );
+});


### PR DESCRIPTION
## Problem

On GNOME Wayland, `pasteLinux` tries uinput before the RemoteDesktop portal. That order exists for a good reason (#494: the portal's first use shows a permission dialog and can stall pastes 10s+), but the uinput path creates and destroys the `openwhispr-paste` virtual keyboard on **every paste**, forcing mutter to hotplug an input device each time.

Under sustained dictation this destabilized the compositor on my machine (Fedora 44, GNOME/mutter 50.4, Wayland) two days in a row: minutes after a dictation burst, at-spi2 flags gnome-shell as unresponsive, libinput logs `event processing lagging behind`, and the session freezes hard enough to require a power cycle. Kernel logs show one new `input: openwhispr-paste as /devices/virtual/input/inputNN` per paste leading up to each hang; after switching pastes to the portal, the device churn and the hangs are gone.

## Fix

Keep uinput first for the first-ever paste (preserving the #494 behavior — no new dialog, no stall for fresh installs). But once a portal **restore token** has been saved, prefer the portal: with a token it is dialog-free and instant, injects keys compositor-side, and creates no devices. If the tokened portal paste fails, fall back to uinput as before.

The change is confined to the GNOME branch of the Wayland paste ordering in `src/helpers/clipboard.js`; KDE and wlroots ordering are untouched.

## Testing

- New `test/helpers/linuxPasteOrder.test.js` (same `Module._load` mocking pattern as `clipboardRestore.test.js`) covering: portal-first when a token exists, uinput-first when none exists, and uinput fallback when the tokened portal paste fails.
- Full suite: identical pass/fail tally to `main` on my machine, plus the 3 new tests passing.
- Live-verified on GNOME 50.4/Wayland: with a saved token, dictation pastes go through the portal (RemoteDesktop session visible in the journal, no permission dialog, no new kernel input devices); with the token file removed, behavior matches current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)