### PR TITLE
Update desktop Business pricing to $16 monthly and $160 annual

### DIFF
--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1556,11 +1556,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/Monat",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/Jahr",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Alle Pro-Funktionen +",
           "badge": "Beliebteste Wahl",
           "features": [

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1556,11 +1556,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/mo",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/yr",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "All Pro features +",
           "badge": "Most Popular",
           "features": [

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1318,11 +1318,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/mes",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/año",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Todas las funciones de Pro +",
           "badge": "Más popular",
           "features": [

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1556,11 +1556,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/mois",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/an",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Toutes les fonctionnalités Pro +",
           "badge": "Le plus populaire",
           "features": [

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -1290,11 +1290,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/mese",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/anno",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Tutte le funzionalità Pro +",
           "badge": "Più popolare",
           "features": [

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1270,11 +1270,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/月",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/年",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Pro の全機能 +",
           "badge": "一番人気",
           "features": [

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1269,11 +1269,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/mês",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/ano",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Todos os recursos do Pro +",
           "badge": "Mais popular",
           "features": [

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -1294,11 +1294,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/мес.",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/год",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "Все функции Pro +",
           "badge": "Самый популярный",
           "features": [

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -1290,11 +1290,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/月",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/年",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "所有 Pro 功能 +",
           "badge": "最受欢迎",
           "features": [

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -1290,11 +1290,11 @@
         },
         "business": {
           "name": "Business",
-          "monthlyPrice": "$20",
+          "monthlyPrice": "$16",
           "monthlyPeriod": "/月",
-          "annualPrice": "$200",
+          "annualPrice": "$160",
           "annualPeriod": "/年",
-          "annualEquivalent": "$16.67",
+          "annualEquivalent": "$13.33",
           "includesPrefix": "所有 Pro 功能 +",
           "badge": "最熱門",
           "features": [


### PR DESCRIPTION
## Summary

- lower the desktop Business monthly price display from $20 to $16
- lower the annual price display from $200 to $160
- update the annual monthly equivalent from $16.67 to $13.33 across all 10 locales

## Validation

- `npm run i18n:check`
- Prettier check for all changed locale files
- `npm run typecheck`
