### PR TITLE
Fix realtime streaming stop errors and calendar API error reporting

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -4054,7 +4054,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       const provider = this.getStreamingProvider();
 
       this.streamingProcessor.port.onmessage = (event) => {
-        if (!this.isStreaming) return;
+        // The worklet posts its remaining PCM followed by a "flushed" sentinel
+        // on stop; the sentinel must not be sent as audio (realtime backends
+        // reject the odd-length non-PCM bytes with "Invalid audio data").
+        if (!this.isStreaming || event.data === "flushed") return;
         provider.send(event.data);
       };
 

--- a/src/helpers/googleCalendarManager.js
+++ b/src/helpers/googleCalendarManager.js
@@ -325,16 +325,20 @@ class GoogleCalendarManager {
       useSessionCookies: false,
     });
     const text = await response.text();
-    let parsed;
+    let parsed = null;
     try {
       parsed = JSON.parse(text);
     } catch {
-      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+      // Error statuses can arrive with empty or non-JSON bodies; surface the
+      // status below instead of masking it as a parse failure.
     }
     if (response.status >= 400) {
-      const err = new Error(parsed.error?.message || `API error ${response.status}`);
+      const err = new Error(parsed?.error?.message || `API error ${response.status}`);
       err.statusCode = response.status;
       throw err;
+    }
+    if (parsed === null) {
+      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
     }
     return parsed;
   }

--- a/src/helpers/microsoftCalendarManager.js
+++ b/src/helpers/microsoftCalendarManager.js
@@ -332,16 +332,20 @@ class MicrosoftCalendarManager {
       useSessionCookies: false,
     });
     const text = await response.text();
-    let parsed;
+    let parsed = null;
     try {
       parsed = JSON.parse(text);
     } catch {
-      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
+      // Error statuses can arrive with empty or non-JSON bodies; surface the
+      // status below instead of masking it as a parse failure.
     }
     if (response.status >= 400) {
-      const err = new Error(parsed.error?.message || `API error ${response.status}`);
+      const err = new Error(parsed?.error?.message || `API error ${response.status}`);
       err.statusCode = response.status;
       throw err;
+    }
+    if (parsed === null) {
+      throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`);
     }
     return parsed;
   }


### PR DESCRIPTION
## Summary

Two production-log fixes from debugging a 1.8.2 install:

### 1. `Invalid audio data` on every realtime streaming stop
The PCM capture worklet posts its remaining audio followed by a `"flushed"` string sentinel when a recording stops. The streaming port handler forwarded every message to the provider, so the sentinel was appended to the realtime session as 7 bytes of non-PCM "audio". The Tinfoil realtime backend rejects the odd-length buffer with `backend_error: Invalid audio data` on **every** dictation stop, which also triggered the connection-lost auto-stop path and raced the user-initiated stop (duplicate disconnects in logs). Evidence: `audioBytesSent` was odd in every failing session — valid PCM16 totals are always even.

Fix: guard the handler with the same sentinel check the preview path already uses. The sentinel was also being sent as junk bytes to Deepgram/AssemblyAI/Corti (tolerated, but wrong).

### 2. Calendar API errors masked as `Invalid JSON response:`
`_apiGet` in the Microsoft and Google calendar managers parsed the response body **before** checking the HTTP status, so an error response with an empty or non-JSON body was logged as `Invalid JSON response: ` (empty) and the real status code was lost. Seen as a recurring Microsoft Graph failure at startup. Fix: check status first; keep the parse error only for 2xx responses with malformed bodies. `err.statusCode` behavior is unchanged for JSON error bodies.

## Testing
- 61 tests pass: tinfoil/openai realtime streaming, streaming connection lifecycle, audio manager fallback policy, microsoft calendar manager, calendar sync interval
- `npm run lint`, `prettier --check`, and `npm run typecheck` all clean