### PR TITLE
fix(speaker-count): one definition of a usable expected speaker count

### DIFF
--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -23,7 +23,7 @@ import { cn } from "../lib/utils";
 import logger from "../../utils/logger";
 import { parseTranscriptSegments } from "../../utils/parseTranscriptSegments";
 import { serializeTranscriptSegments } from "../../utils/transcriptSpeakerState";
-import { resolveExpectedSpeakerCount } from "../../utils/participants";
+import { isExplicitSpeakerCount, resolveExpectedSpeakerCount } from "../../utils/participants";
 import {
   useNotes,
   useSpaces,
@@ -344,7 +344,7 @@ export default function PersonalNotesView({
       seedSegments,
       diarizationEnabled: note?.diarization_enabled == null ? null : note.diarization_enabled === 1,
       expectedCount: resolveExpectedSpeakerCount(note),
-      expectedCountIsExplicit: note?.expected_speaker_count != null,
+      expectedCountIsExplicit: isExplicitSpeakerCount(note?.expected_speaker_count),
     });
   }, [activeNote]);
 
@@ -639,7 +639,7 @@ export default function PersonalNotesView({
         diarizationEnabled:
           note?.diarization_enabled == null ? null : note.diarization_enabled === 1,
         expectedCount: resolveExpectedSpeakerCount(note),
-        expectedCountIsExplicit: note?.expected_speaker_count != null,
+        expectedCountIsExplicit: isExplicitSpeakerCount(note?.expected_speaker_count),
       },
       startRecording: storeStartRecording,
       restoreFromMeetingMode: async () => {

--- a/src/helpers/database.js
+++ b/src/helpers/database.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const { randomUUID } = require("crypto");
 const debugLogger = require("./debugLogger");
 const { buildNoteSearchQuery } = require("./noteSearch");
+const { normalizeStoredSpeakerCount } = require("./speakerCount");
 const { app } = require("electron");
 
 // Server-enforced trigger cap (openwhispr-api); enforced here so one oversized
@@ -4375,7 +4376,7 @@ class DatabaseManager {
         cloudNote.participants || null,
         cloudNote.calendar_event_id || null,
         cloudNote.diarization_enabled ?? null,
-        cloudNote.expected_speaker_count ?? null,
+        normalizeStoredSpeakerCount(cloudNote.expected_speaker_count),
         cloudNote.updated_by_user_id || null,
         cloudNote.user_id || null,
         cloudNote.created_at,

--- a/src/helpers/diarization.js
+++ b/src/helpers/diarization.js
@@ -496,9 +496,8 @@ class DiarizationManager {
           }
         }
 
-        // Overlap decides outright; the nearest cluster is only the fallback for
-        // a segment that lands between clusters. Tracking the two candidates
-        // separately keeps the fallback from freezing on the first cluster.
+        // Tracked separately so the between-clusters fallback compares every
+        // distance instead of latching onto the first cluster it sees.
         const bestSpeaker = overlapSpeaker ?? nearestSpeaker;
 
         if (bestSpeaker) {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -53,6 +53,7 @@ const {
   canAutoRelabelSpeaker,
   isSpeakerLocked,
 } = require("./speakerAssignmentPolicy");
+const { normalizeStoredSpeakerCount } = require("./speakerCount");
 const { downsample24kTo16k, pcm16ToWav } = require("../utils/audioUtils");
 const postMigrationDetector = require("./postMigrationDetector");
 const screenContextCapture = require("./screenContextCapture");
@@ -789,9 +790,9 @@ class IPCHandlers {
   }
 
   _noteExpectedSpeakerCountOrNull(note) {
-    const stored = Number(note?.expected_speaker_count);
-    if (Number.isFinite(stored) && stored > 0) {
-      return Math.min(stored, MAX_SPEAKER_COUNT);
+    const stored = normalizeStoredSpeakerCount(note?.expected_speaker_count);
+    if (stored != null) {
+      return stored;
     }
     const others = this._parseNonSelfParticipants(note?.participants).length;
     if (others > 0) {

--- a/src/helpers/speakerCount.js
+++ b/src/helpers/speakerCount.js
@@ -1,0 +1,12 @@
+const { MAX_SPEAKER_COUNT } = require("../constants/speakerDetection.json");
+
+// expected_speaker_count is a total that already includes you, so anything below
+// 1 is meaningless. Cloud sync persists whatever the server sends, so invalid
+// values arrive as data rather than as programmer error and must degrade to null.
+function normalizeStoredSpeakerCount(value) {
+  const count = Number(value);
+  if (!Number.isInteger(count) || count < 1) return null;
+  return Math.min(count, MAX_SPEAKER_COUNT);
+}
+
+module.exports = { normalizeStoredSpeakerCount };

--- a/src/utils/participants.ts
+++ b/src/utils/participants.ts
@@ -36,17 +36,18 @@ export const resolveInitialSpeakerCountOverride = (
   expectedCountIsExplicit?: boolean
 ): boolean => expectedCountIsExplicit ?? expectedCount != null;
 
+// A stored count only counts as the user's own choice when it is usable; the
+// cloud pull persists the server value unvalidated, so 0 and friends get here.
+export const isExplicitSpeakerCount = (value?: number | null): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+
 // Expected total speaker count for a meeting note: the stored value, else derived from
 // calendar participants (non-self attendees + you), else null so callers use their default.
 export const resolveExpectedSpeakerCount = (note?: {
   expected_speaker_count?: number | null;
   participants?: string | null;
 }): number | null => {
-  if (
-    typeof note?.expected_speaker_count === "number" &&
-    Number.isInteger(note.expected_speaker_count) &&
-    note.expected_speaker_count > 0
-  ) {
+  if (isExplicitSpeakerCount(note?.expected_speaker_count)) {
     return note.expected_speaker_count;
   }
   if (!note?.participants) return null;

--- a/test/helpers/parakeetWavNormalization.test.js
+++ b/test/helpers/parakeetWavNormalization.test.js
@@ -92,13 +92,7 @@ test("transcribes audible mono 16 kHz float32 WAV input", async () => {
   }
 
   try {
-    const modelDir = path.join(
-      tempHome,
-      ".cache",
-      "openwhispr",
-      "parakeet-models",
-      MODEL_NAME
-    );
+    const modelDir = path.join(tempHome, ".cache", "openwhispr", "parakeet-models", MODEL_NAME);
     fs.mkdirSync(modelDir, { recursive: true });
     for (const file of REQUIRED_MODEL_FILES) {
       fs.writeFileSync(path.join(modelDir, file), "");

--- a/test/helpers/speakerCount.test.js
+++ b/test/helpers/speakerCount.test.js
@@ -1,0 +1,25 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { normalizeStoredSpeakerCount } = require("../../src/helpers/speakerCount");
+const { MAX_SPEAKER_COUNT } = require("../../src/constants/speakerDetection.json");
+
+test("keeps a usable stored count", () => {
+  assert.equal(normalizeStoredSpeakerCount(1), 1);
+  assert.equal(normalizeStoredSpeakerCount(3), 3);
+  assert.equal(normalizeStoredSpeakerCount(MAX_SPEAKER_COUNT), MAX_SPEAKER_COUNT);
+});
+
+test("clamps above the supported maximum", () => {
+  assert.equal(normalizeStoredSpeakerCount(MAX_SPEAKER_COUNT + 5), MAX_SPEAKER_COUNT);
+});
+
+test("rejects values the cloud can persist but the app cannot use", () => {
+  for (const value of [0, -1, 1.5, NaN, Infinity, -Infinity, null, undefined, "", {}]) {
+    assert.equal(
+      normalizeStoredSpeakerCount(value),
+      null,
+      `expected ${JSON.stringify(value)} to normalize to null`
+    );
+  }
+});

--- a/test/utils/participants.test.js
+++ b/test/utils/participants.test.js
@@ -53,3 +53,15 @@ test("returns null when participants has no non-self attendees or is malformed",
   assert.equal(resolveExpectedSpeakerCount({}), null);
   assert.equal(resolveExpectedSpeakerCount(), null);
 });
+
+test("isExplicitSpeakerCount only accepts a usable stored count", async () => {
+  const { isExplicitSpeakerCount } = await load();
+  assert.equal(isExplicitSpeakerCount(3), true);
+  assert.equal(isExplicitSpeakerCount(1), true);
+
+  // The values that made expectedCountIsExplicit disagree with the resolved
+  // count, which pinned userTouchedStepper on and killed participant auto-sync.
+  for (const value of [0, -1, 1.5, NaN, Infinity, null, undefined]) {
+    assert.equal(isExplicitSpeakerCount(value), false, `expected ${value} to be rejected`);
+  }
+});


### PR DESCRIPTION
Follow-up to today's hardening-PR merge batch. Two related fixes, one root cause.

## 1. Renderer: the count and its "explicit" flag disagreed

#1522 tightened `resolveExpectedSpeakerCount` to require a positive integer, but the two callers in `PersonalNotesView.tsx` (`:347`, `:642`) still derived `expectedCountIsExplicit` from a bare `!= null`.

A stored `0` therefore resolved to `expectedCount: null` while still reporting itself explicit. `resolveInitialSpeakerCountOverride` then set `userTouchedStepper: true` (`meetingRecordingStore.ts:802-805`), and since `syncParticipantSpeakerCount` bails whenever that flag is set (`participants.ts:28`), the note lost calendar-participant auto-population permanently.

Extracted as `isExplicitSpeakerCount` (a type predicate, so the narrowing still works) and used at all three sites.

## 2. Sync: the bad value shouldn't have been stored at all

`upsertNoteFromCloud` bound `cloudNote.expected_speaker_count ?? null` straight through, so a `0`, negative or fractional count from the server overwrote a good local value.

Now normalized on the way in. An unusable value binds `null`, which the existing `COALESCE(excluded.expected_speaker_count, expected_speaker_count)` already treats as "keep what's there" — so a bad server value degrades to the local value instead of clobbering it.

## Why a new file

The rule ("a total including you, so `>= 1`, capped at `MAX_SPEAKER_COUNT`") already existed in two places and this would have been a third, so it moves to `src/helpers/speakerCount.js` and `ipcHandlers._noteExpectedSpeakerCountOrNull` now uses it too.

That also tightens the main-process check as a side effect: it used `Number.isFinite`, so it accepted `2.5`. It now requires an integer, matching the renderer and the stepper.

**Units note:** `expected_speaker_count` is a **total that already includes you** — `others + 1` (`participants.ts:16`). So `1` is legitimate (just you) and `>= 1` is the correct floor. It matches what the stepper (`Math.max(1, …)`, three sites) and the main process already enforced. There is no `-1` sentinel anywhere; negatives are only ever corruption.

## Also folded in

- `test/helpers/parakeetWavNormalization.test.js` (#1376) didn't match the repo Prettier config (`printWidth` 100, file wrapped at 80).

  Worth flagging separately: `npm run format:check` did **not** catch this. The script cds into `src/` before running Prettier, so `test/` is never checked — **16 of 215** files under `test/` currently fail a root-level `prettier --check`. I fixed only the one this batch introduced; happy to widen the glob and sweep the rest if you want.
- Tightened the three-line comment added in #1423 to two.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1710 pass / 0 fail** (+4). New coverage in `test/helpers/speakerCount.test.js` and `test/utils/participants.test.js`.