### PR TITLE
fix(privacy): wait for the renderer sync before the first retention sweep

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -570,6 +570,7 @@ class IPCHandlers {
     this.audioStorageManager = new AudioStorageManager();
     this._retentionCleanupInterval = null;
     this._retentionSettings = { ...DEFAULT_RETENTION_SETTINGS }; // Synced from renderer
+    this._retentionSettingsSynced = false;
     this._noteFilesEnabled = false;
     this.speakerDiarizationEnabled = true;
     this.activeMeetingSpeakerConfig = null;
@@ -927,8 +928,13 @@ class IPCHandlers {
 
   _setupRetentionCleanup() {
     const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
-    this._runRetentionCleanup();
-    this._retentionCleanupInterval = setInterval(() => this._runRetentionCleanup(), SIX_HOURS_MS);
+    // No sweep at startup: _retentionSettings still holds the 30-day default
+    // until the renderer syncs, so sweeping here deletes audio a user set to
+    // keep for 60/90 days or forever (#1370). The first sync runs the first
+    // sweep instead.
+    this._retentionCleanupInterval = setInterval(() => {
+      if (this._retentionSettingsSynced) this._runRetentionCleanup();
+    }, SIX_HOURS_MS);
   }
 
   _runRetentionCleanup() {
@@ -1261,8 +1267,10 @@ class IPCHandlers {
       createRetentionSettingsHandler({
         getCurrentSettings: () => this._retentionSettings,
         getOwner: () => this.windowManager.mainWindow?.webContents,
+        hasSynced: () => this._retentionSettingsSynced,
         onSettingsChanged: (settings) => {
           this._retentionSettings = settings;
+          this._retentionSettingsSynced = true;
           this._runRetentionCleanup();
         },
       })

--- a/src/helpers/retentionSettings.js
+++ b/src/helpers/retentionSettings.js
@@ -25,13 +25,21 @@ function applyRetentionSettings(current, incoming) {
   return { changed, settings };
 }
 
-function createRetentionSettingsHandler({ getCurrentSettings, getOwner, onSettingsChanged }) {
+function createRetentionSettingsHandler({
+  getCurrentSettings,
+  getOwner,
+  hasSynced,
+  onSettingsChanged,
+}) {
   return (event, incoming) => {
     const owner = getOwner();
     if (!owner || event.sender !== owner) return;
 
     const { changed, settings } = applyRetentionSettings(getCurrentSettings(), incoming);
-    if (changed) onSettingsChanged(settings);
+    // Before the first sync the current values are defaults, not the user's, so
+    // "unchanged" only means they happen to match the default — the consumer
+    // still needs that first sync to know the settings are real (#1370).
+    if (changed || !hasSynced()) onSettingsChanged(settings);
   };
 }
 

--- a/test/helpers/retentionSettings.test.js
+++ b/test/helpers/retentionSettings.test.js
@@ -48,11 +48,14 @@ test("only the main renderer can replace process-global retention settings", () 
   const managedSettings = { audioRetentionDays: 7, transcriptRetentionDays: 30 };
   let current = { ...DEFAULT_RETENTION_SETTINGS };
   let cleanupRuns = 0;
+  let synced = false;
   const handleRetentionSettingsChanged = createRetentionSettingsHandler({
     getCurrentSettings: () => current,
     getOwner: () => mainRenderer,
+    hasSynced: () => synced,
     onSettingsChanged: (settings) => {
       current = settings;
+      synced = true;
       cleanupRuns += 1;
     },
   });
@@ -76,4 +79,67 @@ test("only the main renderer can replace process-global retention settings", () 
   );
   assert.deepEqual(current, { audioRetentionDays: 90, transcriptRetentionDays: 0 });
   assert.equal(cleanupRuns, 2);
+});
+
+test("no sweep runs before the renderer has synced the persisted settings", () => {
+  const IPCHandlers = require("../../src/helpers/ipcHandlers");
+  const sweeps = [];
+  const context = {
+    _retentionCleanupInterval: null,
+    _retentionSettingsSynced: false,
+    _retentionSettings: { ...DEFAULT_RETENTION_SETTINGS },
+    _runRetentionCleanup() {
+      sweeps.push({ ...this._retentionSettings });
+    },
+  };
+
+  IPCHandlers.prototype._setupRetentionCleanup.call(context);
+  clearInterval(context._retentionCleanupInterval);
+
+  // The 30-day default would have deleted audio a "Disabled" user asked to keep.
+  assert.deepEqual(sweeps, []);
+});
+
+test("the first sync sweeps even when the user's settings match the defaults", () => {
+  let current = { ...DEFAULT_RETENTION_SETTINGS };
+  let synced = false;
+  let cleanupRuns = 0;
+  const owner = {};
+  const handle = createRetentionSettingsHandler({
+    getCurrentSettings: () => current,
+    getOwner: () => owner,
+    hasSynced: () => synced,
+    onSettingsChanged: (settings) => {
+      current = settings;
+      synced = true;
+      cleanupRuns += 1;
+    },
+  });
+
+  handle({ sender: owner }, { ...DEFAULT_RETENTION_SETTINGS });
+  assert.equal(cleanupRuns, 1);
+
+  // A second window mounting must not sweep again.
+  handle({ sender: owner }, { ...DEFAULT_RETENTION_SETTINGS });
+  assert.equal(cleanupRuns, 1);
+});
+
+test("a disabled retention setting reaches the sweep before it can delete", () => {
+  let current = { ...DEFAULT_RETENTION_SETTINGS };
+  let synced = false;
+  const sweptWith = [];
+  const owner = {};
+  const handle = createRetentionSettingsHandler({
+    getCurrentSettings: () => current,
+    getOwner: () => owner,
+    hasSynced: () => synced,
+    onSettingsChanged: (settings) => {
+      current = settings;
+      synced = true;
+      sweptWith.push({ ...settings });
+    },
+  });
+
+  handle({ sender: owner }, { audioRetentionDays: 0, transcriptRetentionDays: 0 });
+  assert.deepEqual(sweptWith, [{ audioRetentionDays: 0, transcriptRetentionDays: 0 }]);
 });


### PR DESCRIPTION
Closes #1370. Supersedes #1371 — same design, rebuilt on current `main` (see below).

## The bug

`_setupRetentionCleanup()` is called from the `IPCHandlers` constructor (`ipcHandlers.js:585`) and ran `_runRetentionCleanup()` **synchronously** (`:930`), long before any window exists. At that point `_retentionSettings` is still `{ ...DEFAULT_RETENTION_SETTINGS }` — 30 days.

So on **every launch**, a user who chose **Disabled**, **60** or **90** days had their audio swept at 30 days. Silent and permanent. The UI offers all of those (`SettingsPage.tsx:164`).

## The fix

Drop the startup sweep; let the first renderer sync trigger it.

The sweep still runs on every launch — `SettingsProvider` mounts in every window (`src/main.jsx:19`) and its effect syncs unconditionally (`useSettings.ts:187-191`), and the dictation window is created unconditionally at startup (`main.js:951`). The 6-hour interval is unchanged, just gated on having synced.

`createRetentionSettingsHandler` gains a `hasSynced` callback because it previously fired `onSettingsChanged` **only when the value changed**. Without that, a user whose settings happen to equal the defaults would never trigger the first sweep and cleanup would never run at all — which is why the flag can't live purely in the handler.

## Why this isn't #1371 rebased

#1371's design is sound and this keeps it (`_retentionSettingsSynced`, no startup sweep, first-sync-runs-cleanup). But it was written before `main` replaced the inline IPC listener with the owner-scoped `createRetentionSettingsHandler`, so it conflicts and its `_syncRetentionSettings` method no longer has a place to live. Credit to @hsusul for the diagnosis and the approach.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1713 pass / 0 fail**.

Three new tests in `test/helpers/retentionSettings.test.js`: no sweep before sync, first sync sweeps even when settings match defaults (and a second window doesn't re-sweep), and a `Disabled` setting reaches the sweep before it can delete.