### PR TITLE
fix(stt): surface and keep recordings discarded as a dictionary echo

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -85,7 +85,11 @@ import { resolvePrompt, appendScreenContextSuffix } from "../config/prompts";
 import { syncService } from "../services/SyncService.js";
 import { evaluateFinishedRecording, withSalvageWarning } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
-import { matchesDictionaryPrompt } from "../utils/dictionaryEchoFilter.js";
+import {
+  DICTIONARY_ECHO_CODE,
+  dictionaryEchoError,
+  matchesDictionaryPrompt,
+} from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
 import {
   buildSelectionEditSystemPrompt,
@@ -556,6 +560,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   setCallbacks({
     onStateChange,
     onError,
+    // Optional: the agent overlay has no dictation toast surface.
+    onNoAudio = undefined,
     onTranscriptionComplete,
     onPartialTranscript,
     onStreamingCommit,
@@ -563,6 +569,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   }) {
     this.onStateChange = onStateChange;
     this.onError = onError;
+    this.onNoAudio = onNoAudio;
     this.onTranscriptionComplete = onTranscriptionComplete;
     this.onPartialTranscript = onPartialTranscript;
     this.onStreamingCommit = onStreamingCommit;
@@ -1710,7 +1717,16 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         "performance"
       );
 
-      if (error.message !== "No audio detected") {
+      if (error.code === DICTIONARY_ECHO_CODE) {
+        // The transcript was discarded as an echo of the dictionary prompt. Only
+        // the local engine's genuine-silence path gets a toast from main, so
+        // surface the same one here and keep the audio for a manual retry —
+        // otherwise the whole utterance disappears with no feedback (#1547).
+        this.onNoAudio?.();
+        if (this.lastAudioBlob) {
+          this.saveFailedTranscription(error.message, error.code, metadata);
+        }
+      } else if (error.message !== "No audio detected") {
         this.onError?.({
           title: error.selectionEditFatal ? "Selection Edit Failed" : "Transcription Error",
           description: error.selectionEditFatal
@@ -1788,7 +1804,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             skipVad: true,
           });
           if (!retry?.success || !retry.text?.trim() || this.isDictionaryEcho(retry.text)) {
-            throw new Error("No audio detected");
+            throw dictionaryEchoError();
           }
           logger.info(
             "Recovered transcript after dictionary-echo detection",
@@ -2736,7 +2752,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     const rawText = result.text;
     if (this.isDictionaryEcho(rawText)) {
-      throw new Error("No audio detected");
+      throw dictionaryEchoError();
     }
     let processedText = result.text;
     if (processedText && !this.skipReasoning) {
@@ -2926,7 +2942,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           throw new Error("No text transcribed - Tinfoil response was empty");
         }
         if (this.isDictionaryEcho(proxyText)) {
-          throw new Error("No audio detected");
+          throw dictionaryEchoError();
         }
         timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
         const reasoningStart = performance.now();
@@ -3031,7 +3047,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
         if (proxyText && proxyText.trim().length > 0) {
           if (this.isDictionaryEcho(proxyText)) {
-            throw new Error("No audio detected");
+            throw dictionaryEchoError();
           }
           timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
           const rawText = proxyText;
@@ -3064,7 +3080,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
         if (proxyText && proxyText.trim().length > 0) {
           if (this.isDictionaryEcho(proxyText)) {
-            throw new Error("No audio detected");
+            throw dictionaryEchoError();
           }
           timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
           const rawText = proxyText;
@@ -3095,7 +3111,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
         if (proxyText && proxyText.trim().length > 0) {
           if (this.isDictionaryEcho(proxyText)) {
-            throw new Error("No audio detected");
+            throw dictionaryEchoError();
           }
           timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
           const rawText = proxyText;
@@ -3245,7 +3261,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // Check for text - handle both empty string and missing field
       if (result.text && result.text.trim().length > 0) {
         if (this.isDictionaryEcho(result.text)) {
-          throw new Error("No audio detected");
+          throw dictionaryEchoError();
         }
         timings.transcriptionProcessingDurationMs = Math.round(performance.now() - apiCallStart);
         const rawText = result.text;

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -206,6 +206,17 @@ export const useAudioRecording = (toast, options = {}) => {
           window.electronAPI?.resumeMediaPlayback?.();
         }
       },
+      onNoAudio: () => {
+        window.electronAPI?.hideDictationPreview?.();
+        if (getSettings().pauseMediaOnDictation) {
+          window.electronAPI?.resumeMediaPlayback?.();
+        }
+        toast({
+          title: t("hooks.audioRecording.noAudio.title"),
+          description: t("hooks.audioRecording.noAudio.description"),
+          variant: "default",
+        });
+      },
       onPartialTranscript: (text) => {
         setPartialTranscript(text);
       },

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -28,3 +28,14 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
 
   return textComposition >= 0.9 && dictionaryUsage >= 0.7;
 }
+
+export const DICTIONARY_ECHO_CODE = "DICTIONARY_ECHO";
+
+// Keeps the "No audio detected" message so the existing message comparisons and
+// the main-process no-audio contract still match, while letting the pipeline
+// tell a discarded dictionary echo apart from genuine silence (#1547).
+export function dictionaryEchoError() {
+  const error = new Error("No audio detected");
+  error.code = DICTIONARY_ECHO_CODE;
+  return error;
+}

--- a/test/helpers/dictionaryEchoRecovery.test.js
+++ b/test/helpers/dictionaryEchoRecovery.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// The pipeline's catch block decides what a discarded dictionary echo costs the
+// user. Before #1547 it shared the genuine-silence branch, which suppressed both
+// the toast and saveFailedTranscription, so a whole utterance vanished with no
+// feedback and no way to retry it.
+const runCatch = (error, manager) => {
+  if (error.code === "DICTIONARY_ECHO") {
+    manager.onNoAudio?.();
+    if (manager.lastAudioBlob) {
+      manager.saveFailedTranscription(error.message, error.code, {});
+    }
+  } else if (error.message !== "No audio detected") {
+    manager.onError?.({ description: error.message });
+    if (manager.lastAudioBlob) {
+      manager.saveFailedTranscription(error.message, error.code || null, {});
+    }
+  }
+};
+
+const makeManager = () => {
+  const calls = { noAudio: 0, errors: [], saved: [] };
+  return {
+    calls,
+    lastAudioBlob: {},
+    onNoAudio: () => calls.noAudio++,
+    onError: (payload) => calls.errors.push(payload),
+    saveFailedTranscription: (message, code) => calls.saved.push({ message, code }),
+  };
+};
+
+test("a discarded dictionary echo toasts and keeps the recording", async () => {
+  const { DICTIONARY_ECHO_CODE } = await import("../../src/utils/dictionaryEchoFilter.js");
+  const manager = makeManager();
+  const error = new Error("No audio detected");
+  error.code = DICTIONARY_ECHO_CODE;
+
+  runCatch(error, manager);
+
+  assert.equal(manager.calls.noAudio, 1);
+  assert.deepEqual(manager.calls.saved, [
+    { message: "No audio detected", code: DICTIONARY_ECHO_CODE },
+  ]);
+  // Not the destructive "Transcription Error" toast — this is a soft outcome.
+  assert.deepEqual(manager.calls.errors, []);
+});
+
+test("genuine silence stays silent — main already toasts that path", () => {
+  const manager = makeManager();
+
+  runCatch(new Error("No audio detected"), manager);
+
+  assert.equal(manager.calls.noAudio, 0);
+  assert.deepEqual(manager.calls.saved, []);
+  assert.deepEqual(manager.calls.errors, []);
+});
+
+test("a real failure still reports an error and saves for retry", () => {
+  const manager = makeManager();
+
+  runCatch(new Error("Groq returned 500"), manager);
+
+  assert.equal(manager.calls.noAudio, 0);
+  assert.equal(manager.calls.errors.length, 1);
+  assert.deepEqual(manager.calls.saved, [{ message: "Groq returned 500", code: null }]);
+});
+
+test("every dictionary-echo discard is tagged, on local and remote paths alike", async () => {
+  const fs = require("fs");
+  const source = fs.readFileSync("src/helpers/audioManager.js", "utf-8");
+
+  // Each isDictionaryEcho guard must throw the tagged error; a plain
+  // `new Error("No audio detected")` there would be swallowed again.
+  const guards = source.match(/isDictionaryEcho\([\s\S]{0,400}?throw [^;]+;/g) ?? [];
+  assert.ok(guards.length >= 7, `expected the known echo guards, found ${guards.length}`);
+  for (const guard of guards) {
+    assert.match(guard, /throw dictionaryEchoError\(\);/);
+  }
+});


### PR DESCRIPTION
Closes #1547. Thanks @xlurie — the report was precise and the code matched it exactly.

## The bug

The dictionary-echo guard threw a bare `new Error("No audio detected")`. The pipeline's catch matched that against the genuine-silence branch and suppressed **both** arms:

```js
if (error.message !== "No audio detected") {
  this.onError?.({ ... });
  if (this.lastAudioBlob) this.saveFailedTranscription(...);
}
```

So no toast **and** no saved recording — the utterance was gone with no feedback and no retry path.

The reason genuine silence gets away with that is a detail worth naming: its toast doesn't come from this catch at all, it comes from a main-process IPC event (`ipcHandlers.js:2489`, `:2831`). A throw raised in the renderer can never reach it.

That hits **seven** sites, one more than the report counted:

- six remote providers (`audioManager.js` — OpenAI, Groq, Deepgram/proxy ×3, BYOK)
- **the local rescue path** (`:1802`): when #1461's prompt-free re-decode also comes back as an echo, that throw is renderer-side too and was equally silent

## The fix

Tag the discard with a `DICTIONARY_ECHO` code and branch on it — fire the existing no-audio toast, and keep the recording as a failed transcription so it's retryable.

The message stays `"No audio detected"` deliberately, so the existing `error.message === "No audio detected"` comparisons and the main-process no-audio contract keep matching. Only the discrimination is new.

`DICTIONARY_ECHO_CODE` and `dictionaryEchoError()` live in `src/utils/dictionaryEchoFilter.js` next to `matchesDictionaryPrompt` — better cohesion, and `audioManager.js` can't be imported in tests (it pulls the whole app graph).

**No new UI.** This reuses the `hooks.audioRecording.noAudio.*` strings already shown for genuine silence, so no new copy and no locale work.

## Deliberately not in scope

The report also asked for a retry-without-prompt on remote, and making the check opt-in for billed backends. Both are bigger than this: the first means rebuilding the shared `formData` request, the second needs a setting. Also still open, and worth deciding separately — Corti, xAI and Mistral run the echo check against a prompt they never sent.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1717 pass / 0 fail** (+4).

New `test/helpers/dictionaryEchoRecovery.test.js` pins the three catch outcomes (echo toasts + saves, genuine silence stays quiet, real failures still error), plus a guard test asserting every `isDictionaryEcho` site throws the tagged error so a future one can't silently regress.

Typecheck also caught that `AgentOverlay.tsx` is a second `setCallbacks` consumer, so `onNoAudio` is optional.