### PR TITLE
fix(export): normalize meeting transcript timestamps and parse note dates as UTC

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2180,7 +2180,7 @@ class IPCHandlers {
         if (format === "txt") {
           exportContent = transcriptFormatter.formatTxt(note, segments, speakerMappings);
         } else if (format === "srt") {
-          exportContent = transcriptFormatter.formatSrt(segments, speakerMappings);
+          exportContent = transcriptFormatter.formatSrt(segments, speakerMappings, note);
         } else if (format === "md") {
           exportContent = transcriptFormatter.formatMd(note, segments, speakerMappings);
         } else {

--- a/src/helpers/transcriptFormatter.js
+++ b/src/helpers/transcriptFormatter.js
@@ -21,6 +21,54 @@ function speakerKey(seg) {
   return [seg.speaker || "", named, seg.speaker ? "" : seg.source || ""].join("\u0000");
 }
 
+function parseNoteDate(createdAt) {
+  if (createdAt == null || createdAt === "") {
+    return new Date(NaN);
+  }
+  if (typeof createdAt === "number") {
+    return new Date(createdAt);
+  }
+
+  const value = String(createdAt).trim();
+  if (/[zZ]|[+-]\d{2}:\d{2}$/.test(value)) {
+    return new Date(value);
+  }
+
+  // SQLite CURRENT_TIMESTAMP is UTC without a timezone suffix.
+  return new Date(value.includes("T") ? `${value}Z` : `${value.replace(" ", "T")}Z`);
+}
+
+function resolveRecordingStartMs(segments, note) {
+  const segmentTimestamps = segments
+    .map((seg) => seg.timestamp)
+    .filter((ts) => typeof ts === "number" && Number.isFinite(ts));
+
+  if (segmentTimestamps.length > 0) {
+    return Math.min(...segmentTimestamps);
+  }
+
+  const noteDate = parseNoteDate(note?.created_at);
+  return Number.isNaN(noteDate.getTime()) ? null : noteDate.getTime();
+}
+
+function normalizeSegmentTimestamps(segments, note) {
+  const startMs = resolveRecordingStartMs(segments, note);
+  if (startMs == null || startMs <= 1e9) {
+    return segments;
+  }
+
+  return segments.map((seg) => {
+    const normalized = { ...seg };
+    if (typeof seg.timestamp === "number" && Number.isFinite(seg.timestamp)) {
+      normalized.timestamp = (seg.timestamp - startMs) / 1000;
+    }
+    if (typeof seg.endTimestamp === "number" && Number.isFinite(seg.endTimestamp)) {
+      normalized.endTimestamp = (seg.endTimestamp - startMs) / 1000;
+    }
+    return normalized;
+  });
+}
+
 function mergeSegments(segments) {
   const merged = [];
   let lastTimestamp = null;
@@ -59,7 +107,7 @@ function formatSrtTimestamp(seconds) {
 
 function extractMetadata(note) {
   const title = note.title || "Untitled";
-  const noteDate = new Date(note.created_at);
+  const noteDate = parseNoteDate(note.created_at);
   const dateStr =
     noteDate.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" }) +
     " " +
@@ -75,7 +123,7 @@ function extractMetadata(note) {
 }
 
 function formatTxt(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr, participants } = extractMetadata(note);
 
   const lines = [title, dateStr];
@@ -90,8 +138,8 @@ function formatTxt(note, segments, speakerMappings) {
   return lines.join("\n");
 }
 
-function formatSrt(segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+function formatSrt(segments, speakerMappings, note = {}) {
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const entries = [];
   for (let i = 0; i < merged.length; i++) {
     const seg = merged[i];
@@ -105,7 +153,7 @@ function formatSrt(segments, speakerMappings) {
 }
 
 function formatJson(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr } = extractMetadata(note);
 
   const speakersSet = new Set();
@@ -134,7 +182,7 @@ function formatJson(note, segments, speakerMappings) {
 }
 
 function formatMd(note, segments, speakerMappings) {
-  const merged = mergeSegments(segments);
+  const merged = mergeSegments(normalizeSegmentTimestamps(segments, note));
   const { title, dateStr, participants } = extractMetadata(note);
 
   const lines = [`# ${title}`, "", `**Date:** ${dateStr}`];
@@ -148,4 +196,11 @@ function formatMd(note, segments, speakerMappings) {
   return lines.join("\n");
 }
 
-module.exports = { formatTxt, formatSrt, formatJson, formatMd };
+module.exports = {
+  formatTxt,
+  formatSrt,
+  formatJson,
+  formatMd,
+  parseNoteDate,
+  normalizeSegmentTimestamps,
+};

--- a/test/helpers/transcriptFormatter.test.js
+++ b/test/helpers/transcriptFormatter.test.js
@@ -253,3 +253,26 @@ test("an explicit speaker mapping still overrides the own-voice label", () => {
 
   assert.ok(txtOutput.includes("[00:00:00] Ada:\nMorning."));
 });
+
+test("epoch-millisecond segment timestamps export relative to the recording start", () => {
+  const recordingStartMs = 1_754_310_000_000;
+  const segments = [
+    { speaker: "speaker_0", timestamp: recordingStartMs, text: "Opening." },
+    { speaker: "speaker_1", timestamp: recordingStartMs + 477_000, text: "Closing." },
+  ];
+  const note = {
+    title: "Meeting",
+    created_at: "2026-08-04 13:02:00",
+  };
+
+  const mdOutput = formatMd(note, segments, {});
+  assert.match(mdOutput, /`00:00:00`/);
+  assert.match(mdOutput, /`00:07:57`/);
+});
+
+test("SQLite UTC note timestamps are parsed as UTC before local formatting", () => {
+  const { parseNoteDate } = require("../../src/helpers/transcriptFormatter");
+  const parsed = parseNoteDate("2026-08-04 13:02:00");
+
+  assert.equal(parsed.toISOString(), "2026-08-04T13:02:00.000Z");
+});


### PR DESCRIPTION
Closes #1472. This is @stantheman0128's #1473, rebased onto current `main` — see below for why it moved branches.

## The bugs

Two independent defects, both verified:

1. **Segment timestamps are epoch milliseconds rendered as seconds-since-start.** Meeting segments are stamped with `Date.now()` (`ipcHandlers.js:6549`), but `formatTimestamp` treats the value as elapsed seconds. `floor(1785848551200 / 3600) = 496069042` — which matches the hours field in the reporter's export digit for digit.

2. **The header time is UTC rendered as local.** SQLite's `created_at` has no timezone suffix (`database.js:200`), and `new Date("2026-08-04 13:02:00")` parses that as local time.

This corrupts **every** export format, not just markdown — `formatTxt`, `formatSrt`, `formatJson` and `formatMd` all share `mergeSegments`/`formatTimestamp` — plus the on-disk markdown mirror (`markdownMirror.js:110`).

## The fix

- `parseNoteDate()` appends `Z` to timezone-less values before parsing.
- `normalizeSegmentTimestamps()` rebases segment timestamps onto the recording start when they look like epoch values (`startMs > 1e9` — a recording is never 1e9 *seconds* long, so anything above that is unambiguously epoch), falling back to `note.created_at` when no segment carries a usable timestamp.

Applied to all four formatters, so the mirror is fixed too. `formatSrt` gains an optional `note` parameter; its only caller is updated (`ipcHandlers.js:2183`).

## Rebase notes

The only conflict was in `test/helpers/transcriptFormatter.test.js`, and it was purely additive — `main` gained i18n speaker-label tests (from #1426) while this PR added timestamp tests. Both sets are kept; nothing was dropped.

I pushed to this branch rather than updating #1473 because my token can't push to a fork branch whose rebase touches `.github/workflows/`. #1473 is closed pointing here. Full credit to @stantheman0128 — the diagnosis and the fix are theirs, unchanged.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1719 pass / 0 fail**.