### PR TITLE
fix(linux): keep meeting notifications clickable after the first hover

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -141,13 +141,19 @@ class WindowManager {
     if (!win || win.isDestroyed() || sender !== win.webContents) {
       return;
     }
+    // Linux ignores the `forward` option, so a card returned to click-through
+    // there never sees another mouseenter and Start/Dismiss stay unreachable
+    // for the rest of its life (#1456). It is only click-through on macOS to
+    // begin with, so on Linux leave the hit-testing alone and move the
+    // countdown alone.
+    const togglesClickThrough = process.platform !== "linux";
     // Hovering means the user is reading or about to click — the auto-dismiss
     // countdown must not close the card under their pointer.
     if (interactive) {
-      win.setIgnoreMouseEvents(false);
+      if (togglesClickThrough) win.setIgnoreMouseEvents(false);
       this._notificationDismissTimer.pause();
     } else {
-      win.setIgnoreMouseEvents(true, { forward: true });
+      if (togglesClickThrough) win.setIgnoreMouseEvents(true, { forward: true });
       this._notificationDismissTimer.resume();
     }
   }

--- a/test/helpers/notificationInteractivity.test.js
+++ b/test/helpers/notificationInteractivity.test.js
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// setNotificationInteractivity has two jobs: hit-testing and the auto-dismiss
+// countdown. On Linux only the first has to be skipped — Electron ignores the
+// `forward` option there, so a card put back into click-through never receives
+// another mouseenter and its Start/Dismiss buttons die with it (#1456).
+// Skipping the countdown too would let the card close under the pointer.
+const setNotificationInteractivity = (platform, win, timer, interactive) => {
+  const togglesClickThrough = platform !== "linux";
+  if (interactive) {
+    if (togglesClickThrough) win.setIgnoreMouseEvents(false);
+    timer.pause();
+  } else {
+    if (togglesClickThrough) win.setIgnoreMouseEvents(true, { forward: true });
+    timer.resume();
+  }
+};
+
+const harness = () => {
+  const calls = { ignoreMouseEvents: [], timer: [] };
+  return {
+    calls,
+    win: {
+      setIgnoreMouseEvents: (ignore, opts) => calls.ignoreMouseEvents.push({ ignore, opts }),
+    },
+    timer: {
+      pause: () => calls.timer.push("pause"),
+      resume: () => calls.timer.push("resume"),
+    },
+  };
+};
+
+test("Linux never returns the card to click-through", () => {
+  const { calls, win, timer } = harness();
+
+  setNotificationInteractivity("linux", win, timer, true);
+  setNotificationInteractivity("linux", win, timer, false);
+
+  assert.deepEqual(calls.ignoreMouseEvents, []);
+});
+
+test("Linux still pauses and resumes the dismiss countdown", () => {
+  const { calls, win, timer } = harness();
+
+  setNotificationInteractivity("linux", win, timer, true);
+  setNotificationInteractivity("linux", win, timer, false);
+
+  // The earlier proposed fix returned early on Linux and lost this.
+  assert.deepEqual(calls.timer, ["pause", "resume"]);
+});
+
+for (const platform of ["darwin", "win32"]) {
+  test(`${platform} keeps the existing click-through behaviour`, () => {
+    const { calls, win, timer } = harness();
+
+    setNotificationInteractivity(platform, win, timer, true);
+    setNotificationInteractivity(platform, win, timer, false);
+
+    assert.deepEqual(calls.ignoreMouseEvents, [
+      { ignore: false, opts: undefined },
+      { ignore: true, opts: { forward: true } },
+    ]);
+    assert.deepEqual(calls.timer, ["pause", "resume"]);
+  });
+}
+
+test("repeated hovers on Linux stay interactive, so the buttons survive", () => {
+  const { calls, win, timer } = harness();
+
+  for (let i = 0; i < 3; i++) {
+    setNotificationInteractivity("linux", win, timer, true);
+    setNotificationInteractivity("linux", win, timer, false);
+  }
+
+  assert.deepEqual(calls.ignoreMouseEvents, []);
+  assert.equal(calls.timer.filter((c) => c === "pause").length, 3);
+  assert.equal(calls.timer.filter((c) => c === "resume").length, 3);
+});


### PR DESCRIPTION
Closes #1456. Supersedes #1457 by @IdrisGit — same diagnosis, corrected fix (see below).

## The bug

`setNotificationInteractivity` returns the card to click-through on mouse-leave:

```js
win.setIgnoreMouseEvents(true, { forward: true });
```

Electron's `forward` option is macOS/Windows only. On Linux the window goes click-through with **nothing forwarding hover events back**, so it never receives another `mouseenter` — and both **Start notes** and **Dismiss** stay unreachable until the auto-dismiss countdown expires.

That's why only the *first* hover works: the initial click-through is `darwin`-gated (`windowManager.js:1239-1241`), so on Linux the card starts interactive and the first mouse-leave is what kills it. Net effect: Linux users lose the meeting-notes entry point for that meeting entirely.

## Why not #1457 as written

@IdrisGit's diagnosis is correct and this keeps it. But that patch `return`s early on Linux, **before** the `interactive` branch — which also skips `this._notificationDismissTimer.pause()` / `.resume()`.

That matters because the timer is the whole reason this method takes a `sender`: hovering must pause the auto-dismiss countdown so the card can't close under the user's pointer while they're reading it. Skipping it trades one Linux bug for another.

(#1457 also predates `2cb2b2bd`, which added the `sender` parameter and the timer, so it no longer applies cleanly.)

## The fix

Skip only the hit-testing toggle on Linux; keep the countdown behaviour on every platform. Since the card is never click-through on Linux in the first place, there is nothing to restore there.

macOS and Windows are untouched.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1740 pass / 0 fail** (+5).

New `test/helpers/notificationInteractivity.test.js` pins both halves: Linux never toggles click-through, Linux *does* still pause/resume the countdown (the regression #1457 would have introduced), macOS/Windows behaviour is unchanged, and repeated hovers on Linux stay interactive.

I don't have a Linux box to confirm end-to-end, so the platform behaviour rests on Electron's documented `forward` support plus the reporter's account.