### PR TITLE
fix(renderer): identify the control panel by query, not install path

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from "./components/ui/card.tsx";
 import { useAuth } from "./hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
 import { usePolicyStore } from "./stores/policyStore";
+import { isControlPanelWindow } from "./utils/windowContext.ts";
 
 const ControlPanel = React.lazy(() => import("./components/ControlPanel.tsx"));
 const OnboardingFlow = React.lazy(() => import("./components/OnboardingFlow.tsx"));
@@ -51,9 +52,7 @@ function MainApp() {
   const [postOnboardingSettingsSection, setPostOnboardingSettingsSection] = useState(undefined);
 
   const isAgentPanel = window.location.search.includes("agent=true");
-  const isControlPanel =
-    !isAgentPanel &&
-    (window.location.pathname.includes("control") || window.location.search.includes("panel=true"));
+  const isControlPanel = !isAgentPanel && isControlPanelWindow();
   const isDictationPanel = !isControlPanel && !isAgentPanel;
 
   useEffect(() => {

--- a/src/utils/windowContext.ts
+++ b/src/utils/windowContext.ts
@@ -1,9 +1,8 @@
-// The control panel loads with "control" in the path (packaged) or ?panel=true
-// (dev server); the dictation panel is the plain URL.
+// Window creation tags the control panel with ?panel=true in both development
+// and packaged builds; the dictation panel is the plain URL.
 export const isControlPanelWindow = (): boolean => {
   if (typeof window === "undefined") return false;
-  const { search, pathname } = window.location;
-  return pathname.includes("control") || search.includes("panel=true");
+  return new URLSearchParams(window.location.search).get("panel") === "true";
 };
 
 export const isDictationPanelWindow = (): boolean =>

--- a/test/helpers/windowContext.test.js
+++ b/test/helpers/windowContext.test.js
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/windowContext.ts");
+
+test("a packaged dictation window ignores control in its install path", async (t) => {
+  const originalWindow = globalThis.window;
+  t.after(() => {
+    globalThis.window = originalWindow;
+  });
+  globalThis.window = {
+    location: {
+      pathname:
+        "/Users/controller/Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html",
+      search: "",
+    },
+  };
+
+  const { isControlPanelWindow, isDictationPanelWindow } = await load();
+
+  assert.equal(isControlPanelWindow(), false);
+  assert.equal(isDictationPanelWindow(), true);
+});
+
+test("only the explicit panel=true query selects the control panel", async (t) => {
+  const originalWindow = globalThis.window;
+  t.after(() => {
+    globalThis.window = originalWindow;
+  });
+  globalThis.window = {
+    location: {
+      pathname: "/Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html",
+      search: "?panel=true",
+    },
+  };
+
+  const { isControlPanelWindow } = await load();
+
+  assert.equal(isControlPanelWindow(), true);
+
+  globalThis.window.location.search = "?notpanel=true";
+  assert.equal(isControlPanelWindow(), false);
+
+  globalThis.window.location.search = "?panel=trueish";
+  assert.equal(isControlPanelWindow(), false);
+});


### PR DESCRIPTION
Closes #1410. This is @hsusul's #1411, rebased onto current `main` — see below.

## The bug

Window role was decided partly by the URL *path*:

```js
pathname.includes("control") || search.includes("panel=true")
```

In a packaged build the path is the install location, so anyone whose app lives under a directory containing `control` — `C:\Users\control\...`, `/home/controller/Apps/`, `~/Projects/control-room/` — gets the **full control panel rendered inside the small always-on-top dictation overlay**.

The path clause is also simply vestigial: the packaged control panel loads as `index.html?panel=true`, same as dev. I confirmed no `control*.html` exists anywhere outside `node_modules`, and nothing loads a path containing `control`.

## The fix

Key on the query alone, and parse it properly — `new URLSearchParams(search).get("panel") === "true"` rather than a substring match, so `?notpanel=true` can't match either.

Checked before merging: the agent, notification and preview windows are matched earlier by their own query checks, and `?panel=true` survives both reload and the in-window sign-in callback (`src/lib/auth.ts:219,243`), so the panel can't lose its identity mid-session.

## Rebase note

One conflict, in `src/AppRouter.jsx`, and it was purely an import collision — `main` added `usePolicyStore`, this PR added `isControlPanelWindow`. Both kept; no logic touched.

Moved to this branch because my token can't push to a fork branch when the rebase carries `.github/workflows/` changes. #1411 is closed pointing here — credit to @hsusul.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite under CI env (`REQUIRE_DB_TESTS=1`) **1742 pass / 0 fail** (+2, new `test/helpers/windowContext.test.js`).