### PR TITLE
fix(notes): let a reassigned segment outrank its diarization cluster

### DIFF
--- a/src/components/notes/MeetingTranscriptChat.tsx
+++ b/src/components/notes/MeetingTranscriptChat.tsx
@@ -8,6 +8,7 @@ import { MAX_SPEAKER_COUNT } from "../../constants/speakerDetection.json";
 import type { TranscriptSegment } from "../../stores/meetingRecordingStore";
 import {
   isTranscriptSpeakerLocked,
+  resolveSegmentSpeakerName,
   type TranscriptSpeakerStatus,
 } from "../../utils/transcriptSpeakerState";
 
@@ -50,15 +51,12 @@ const SPEAKER_BORDER_COLORS = [
 
 const STICKY_SCROLL_THRESHOLD_PX = 80;
 
-const getSpeakerKey = (segment: TranscriptSegment) => segment.speaker || segment.source;
-
 const getEffectiveSpeakerKey = (
   segment: TranscriptSegment,
   speakerMappings?: Record<string, string>
 ): string => {
-  const mapped = segment.speaker ? speakerMappings?.[segment.speaker] : undefined;
-  if (mapped) return `name:${mapped.toLowerCase()}`;
-  if (segment.speakerName) return `name:${segment.speakerName.toLowerCase()}`;
+  const name = resolveSegmentSpeakerName(segment, speakerMappings);
+  if (name) return `name:${name.toLowerCase()}`;
   if (segment.speaker) return `id:${segment.speaker}`;
   return `src:${segment.source}`;
 };
@@ -376,7 +374,7 @@ function SpeakerPicker({ speakerProfiles, participants, onSelectName, t }: Speak
 function SpeakerLabel({
   speakerId,
   segment,
-  mappedName,
+  resolvedName,
   speakerProfiles,
   participants,
   colorIdx,
@@ -388,7 +386,7 @@ function SpeakerLabel({
 }: {
   speakerId: string;
   segment: TranscriptSegment;
-  mappedName?: string;
+  resolvedName?: string;
   speakerProfiles?: SpeakerProfileLite[];
   participants?: Array<{ email: string; displayName: string | null }>;
   colorIdx: number;
@@ -403,15 +401,15 @@ function SpeakerLabel({
     segment.speakerLocked || isTranscriptSpeakerLocked(segment)
       ? "locked"
       : segment.speakerStatus ||
-        (segment.suggestedName && !mappedName
+        (segment.suggestedName && !resolvedName
           ? "suggested"
-          : segment.speakerName || mappedName
+          : segment.speakerName || resolvedName
             ? "confirmed"
             : segment.speakerIsPlaceholder
               ? "provisional"
               : undefined);
 
-  const hasSuggestion = !!segment.suggestedName && !mappedName;
+  const hasSuggestion = !!segment.suggestedName && !resolvedName;
 
   if (hasSuggestion) {
     return (
@@ -438,12 +436,12 @@ function SpeakerLabel({
   }
 
   const displayLabel =
-    mappedName ||
+    resolvedName ||
     segment.speakerName ||
     (isOriginallyYou
       ? t("notes.speaker.you")
       : t("notes.speaker.label", { n: getSpeakerNumber(speakerId) }));
-  const isUnmapped = !mappedName && !segment.speakerName;
+  const isUnmapped = !resolvedName && !segment.speakerName;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -757,7 +755,8 @@ export function MeetingTranscriptChat({
           const selfSide = isSelfSide(segment);
           const prevSegment = i > 0 ? segments[i - 1] : null;
           const sameSpeaker = prevSegment
-            ? getSpeakerKey(prevSegment) === getSpeakerKey(segment)
+            ? getEffectiveSpeakerKey(prevSegment, speakerMappings) ===
+              getEffectiveSpeakerKey(segment, speakerMappings)
             : false;
 
           const hasSpeaker = !!segment.speaker;
@@ -768,7 +767,7 @@ export function MeetingTranscriptChat({
           const isSelected = selectedSegmentIds?.has(segment.id) ?? false;
           const selectable = !!onToggleSelect;
 
-          const activeName = speakerMappings?.[segment.speaker!] || segment.speakerName;
+          const activeName = resolveSegmentSpeakerName(segment, speakerMappings);
           const matchedProfile =
             activeName && speakerProfiles
               ? speakerProfiles.find((p) => p.id != null && p.display_name === activeName)
@@ -784,7 +783,7 @@ export function MeetingTranscriptChat({
               <SpeakerLabel
                 speakerId={segment.speaker!}
                 segment={segment}
-                mappedName={speakerMappings?.[segment.speaker!]}
+                resolvedName={activeName}
                 speakerProfiles={speakerProfiles}
                 participants={participants}
                 colorIdx={colorIdx}

--- a/src/utils/transcriptSpeakerState.ts
+++ b/src/utils/transcriptSpeakerState.ts
@@ -206,3 +206,16 @@ export const serializeTranscriptSegments = (segments: TranscriptSegment[]) =>
       speakerLockSource: segment.speakerLockSource,
     }))
   );
+
+// A speaker mapping renames a whole diarization cluster; a locked segment is the
+// user correcting one stretch of it. The correction has to outrank the cluster,
+// or reassigning part of a mis-split block appears to do nothing (#1533). This
+// mirrors the precedence the exporter already applies in transcriptFormatter.js.
+export const resolveSegmentSpeakerName = (
+  segment: TranscriptSegment,
+  speakerMappings?: Record<string, string>
+): string | undefined => {
+  if (segment.speakerName && isTranscriptSpeakerLocked(segment)) return segment.speakerName;
+  const mapped = segment.speaker ? speakerMappings?.[segment.speaker] : undefined;
+  return mapped || segment.speakerName;
+};

--- a/test/utils/segmentSpeakerName.test.js
+++ b/test/utils/segmentSpeakerName.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/transcriptSpeakerState.ts");
+
+// The renderer groups consecutive segments into one bubble and only labels the
+// first of a run, so it must key on the resolved name — otherwise a stretch the
+// user reassigned stays merged into its old cluster and its label never shows.
+const groupKey = (segment, mappings, resolve) => {
+  const name = resolve(segment, mappings);
+  if (name) return `name:${name.toLowerCase()}`;
+  if (segment.speaker) return `id:${segment.speaker}`;
+  return `src:${segment.source}`;
+};
+
+const userAssigned = (speaker, speakerName) => ({
+  source: "system",
+  speaker,
+  speakerName,
+  speakerLocked: true,
+  speakerLockSource: "user",
+  speakerStatus: "locked",
+});
+
+const clusterOnly = (speaker) => ({ source: "system", speaker });
+
+test("a user-assigned segment name outranks the cluster mapping", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+  const segment = userAssigned("speaker_0", "Bob");
+
+  assert.equal(resolveSegmentSpeakerName(segment, { speaker_0: "Alice" }), "Bob");
+});
+
+test("the cluster mapping still names segments the user has not touched", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+
+  assert.equal(
+    resolveSegmentSpeakerName(clusterOnly("speaker_0"), { speaker_0: "Alice" }),
+    "Alice"
+  );
+});
+
+test("an auto-assigned name does not outrank the mapping", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+  // Diarization sets confirmed, not locked; only a user edit should win.
+  const segment = {
+    source: "system",
+    speaker: "speaker_0",
+    speakerName: "Speaker 1",
+    speakerStatus: "confirmed",
+  };
+
+  assert.equal(resolveSegmentSpeakerName(segment, { speaker_0: "Alice" }), "Alice");
+});
+
+test("falls back to the segment name, then to nothing", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+
+  assert.equal(resolveSegmentSpeakerName({ source: "system", speakerName: "Bob" }, {}), "Bob");
+  assert.equal(resolveSegmentSpeakerName(clusterOnly("speaker_0"), {}), undefined);
+  assert.equal(resolveSegmentSpeakerName({ source: "mic" }, undefined), undefined);
+});
+
+test("reassigning the middle of a mis-split block breaks it into three runs", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+  // The reported case: diarization gave one cluster A,A,A,A,A,A; the user
+  // reassigns the middle two to B. Before the fix every key was "id:speaker_0",
+  // so all six stayed one run under one label and the edit looked like a no-op.
+  const mappings = { speaker_0: "Alice" };
+  const segments = [
+    clusterOnly("speaker_0"),
+    clusterOnly("speaker_0"),
+    userAssigned("speaker_0", "Bob"),
+    userAssigned("speaker_0", "Bob"),
+    clusterOnly("speaker_0"),
+    clusterOnly("speaker_0"),
+  ];
+
+  const keys = segments.map((s) => groupKey(s, mappings, resolveSegmentSpeakerName));
+  const runs = keys.filter((key, i) => i === 0 || key !== keys[i - 1]);
+
+  assert.deepEqual(runs, ["name:alice", "name:bob", "name:alice"]);
+});
+
+test("own-voice segments are unaffected by a mapping on another cluster", async () => {
+  const { resolveSegmentSpeakerName } = await load();
+  const you = { source: "mic", speaker: "you" };
+
+  assert.equal(resolveSegmentSpeakerName(you, { speaker_0: "Alice" }), undefined);
+  assert.equal(groupKey(you, { speaker_0: "Alice" }, resolveSegmentSpeakerName), "id:you");
+});


### PR DESCRIPTION
Closes #1533.

## What I found

The feature the reporter wanted **already exists and already works**. `handleBulkAssignName` (`NoteEditor.tsx:655`) writes `speakerName` to exactly the selected segments and never touches `speakerMappings` or `segment.speaker`. The data was correct all along.

The renderer just never showed it, in two places that both put the cluster first:

1. **The label.** `speakerMappings[segment.speaker] || segment.speakerName` — a cluster-wide mapping shadowed the per-segment name, so the pill kept showing the old speaker.
2. **Bubble grouping.** Consecutive segments were grouped on the raw cluster id, and only the first segment of a run is labelled. A reassigned stretch stayed inside its old run, so even the correct label had nowhere to render.

Net effect is exactly the report: select lines, assign B, **nothing visibly changes**. And the export disagreed with the screen, because `transcriptFormatter.js:4-5` already preferred `speakerName`.

## The fix

Resolve the name once, in `transcriptSpeakerState.ts` next to the lock helpers, and group on that resolved identity.

The precedence rule is *a user-locked segment name beats the cluster mapping*. `isTranscriptSpeakerLocked` is the right discriminator because `lockTranscriptSpeaker` stamps `speakerLockSource: "user"` on a manual edit, while diarization's auto-assignment goes through `applyConfirmedSpeaker` and marks segments **confirmed, not locked** — so auto-assigned names can't hijack a mapping. The UI now matches the exporter.

No new UI, no data-model change, no change to what gets persisted.

## Deliberately unchanged

Mapping a whole cluster still overwrites per-segment edits inside it. That's arguable, but it's the existing semantic and it isn't what was reported — reassigning a *subset* was simply invisible. Worth a separate decision rather than a silent change here.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite **1825 pass / 0 fail** (+6).

`test/utils/segmentSpeakerName.test.js` pins the precedence and reproduces the reported case directly: a six-segment cluster with the middle two reassigned now yields three runs (`Alice`, `Bob`, `Alice`) where it previously yielded one.

I don't have a meeting recording with real diarization to click through, so this is verified at the unit level plus code reading, not end-to-end.

## Note on the issue thread

The linked "speaker-block-correction contract" comment is vendor self-promotion (UTM-tagged links to the poster's own product). I haven't used it and wouldn't recommend taking the offered fixture.