### PR TITLE
fix(meeting): stop meeting detection firing on our own dictation

### DIFF
--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -3,6 +3,7 @@ const { promisify } = require("util");
 const EventEmitter = require("events");
 const debugLogger = require("./debugLogger");
 const { resolveBundledBinary } = require("./binaryResolver");
+const { getOwnProcessPids } = require("./ownProcessPids");
 
 const execAsync = promisify(exec);
 
@@ -325,6 +326,10 @@ class AudioActivityDetector extends EventEmitter {
     const startMatch = line.match(/^MIC_START\s+(\d+)$/);
     if (startMatch) {
       const pid = parseInt(startMatch[1], 10);
+      // --exclude-pid only covers the main process, but dictation captures from
+      // Chromium's audio service, so our own mic reads arrive here as if they
+      // were another app's (#1392).
+      if (getOwnProcessPids().has(pid)) return;
       this._activeMicPids.add(pid);
       this._onMicStateChanged(true);
       return;

--- a/src/helpers/ownProcessPids.js
+++ b/src/helpers/ownProcessPids.js
@@ -1,0 +1,20 @@
+// Every PID OpenWhispr is currently running under, main process included.
+//
+// The Windows mic listener reports the PID that opened a capture session, and
+// dictation opens the mic from Chromium's audio service — a child process — so
+// the single --exclude-pid the helper is given can never match it. Without this
+// the app detects its own dictation as third-party mic activity (#1392).
+function getOwnProcessPids() {
+  const pids = new Set([process.pid]);
+  try {
+    const { app } = require("electron");
+    for (const metric of app.getAppMetrics()) {
+      if (typeof metric?.pid === "number") pids.add(metric.pid);
+    }
+  } catch {
+    // Outside Electron, or before the app is ready: the main PID is all we have.
+  }
+  return pids;
+}
+
+module.exports = { getOwnProcessPids };

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -17,7 +17,7 @@ function setPlatform(platform) {
 
 afterEach(() => setPlatform(originalPlatform));
 
-function loadDetector(platform, spawn) {
+function loadDetector(platform, spawn, ownPids) {
   delete require.cache[detectorModulePath];
   setPlatform(platform);
 
@@ -33,6 +33,11 @@ function loadDetector(platform, spawn) {
     // on the host rather than by setPlatform().
     if (request === "./binaryResolver") {
       return { resolveBundledBinary: (name) => `/fake/bin/${name}` };
+    }
+    // Outside Electron the real module can only see the main pid, so the
+    // child-process PIDs that matter for #1392 have to be injected.
+    if (request === "./ownProcessPids" && ownPids) {
+      return { getOwnProcessPids: () => new Set(ownPids) };
     }
     return originalLoad.call(this, request, parent, isMain);
   };
@@ -63,15 +68,19 @@ function createFakeChild(spawnError) {
   return child;
 }
 
-function createDetector(platform, { spawnError } = {}) {
+function createDetector(platform, { spawnError, ownPids } = {}) {
   const children = [];
   const calls = [];
-  const AudioActivityDetector = loadDetector(platform, (command, args, options) => {
-    calls.push({ command, args, options });
-    const child = createFakeChild(spawnError);
-    children.push(child);
-    return child;
-  });
+  const AudioActivityDetector = loadDetector(
+    platform,
+    (command, args, options) => {
+      calls.push({ command, args, options });
+      const child = createFakeChild(spawnError);
+      children.push(child);
+      return child;
+    },
+    ownPids
+  );
 
   const detector = new AudioActivityDetector();
   detector._isMicActive = async () => false;
@@ -368,5 +377,53 @@ test("win32: an unrelated app's mic session ending does not hide an ongoing dism
   t.mock.timers.tick(SUSTAINED_MS);
 
   assert.equal(emitted.length, 2, "the still-running call must re-prompt after the cooldown");
+  detector.stop();
+});
+
+// #1392: the helper is given a single --exclude-pid for the main process, but
+// dictation opens the mic from Chromium's audio service, so OpenWhispr's own
+// capture is reported back to us under a child PID and read as a meeting.
+test("win32: a mic session from one of our own child processes is ignored", async () => {
+  const AUDIO_SERVICE_PID = 4242;
+  const { detector, children } = createDetector("win32", {
+    ownPids: [process.pid, AUDIO_SERVICE_PID],
+  });
+
+  await detector.start();
+  children[0].stdout.emit("data", `MIC_START ${AUDIO_SERVICE_PID}\n`);
+
+  assert.equal(detector._activeMicPids.size, 0);
+  assert.equal(detector._sustainedTimer, null, "our own dictation must not arm detection");
+  assert.equal(detector._lastKnownMicState, false, "and must not leave stale state behind");
+  detector.stop();
+});
+
+test("win32: a mic session from another application is still detected", async () => {
+  const { detector, children } = createDetector("win32", {
+    ownPids: [process.pid, 4242],
+  });
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_START 9001\n");
+
+  assert.deepEqual([...detector._activeMicPids], [9001]);
+  assert.notEqual(detector._sustainedTimer, null);
+  detector.stop();
+});
+
+test("win32: our own capture cannot cancel a real meeting already in progress", async () => {
+  const AUDIO_SERVICE_PID = 4242;
+  const { detector, children } = createDetector("win32", {
+    ownPids: [process.pid, AUDIO_SERVICE_PID],
+  });
+
+  await detector.start();
+  children[0].stdout.emit("data", "MIC_START 9001\n");
+  children[0].stdout.emit("data", `MIC_START ${AUDIO_SERVICE_PID}\n`);
+  children[0].stdout.emit("data", `MIC_STOP ${AUDIO_SERVICE_PID}\n`);
+
+  // Dropping our own stop must not empty the set while the other app holds it.
+  assert.deepEqual([...detector._activeMicPids], [9001]);
+  assert.notEqual(detector._sustainedTimer, null);
   detector.stop();
 });


### PR DESCRIPTION
Closes #1392.

## Root cause

`audioActivityDetector.js:315` spawns the Windows mic listener with:

```js
args: ["--exclude-pid", String(process.pid)]
```

That's the **main process** PID. But the main process never opens the microphone — every `getUserMedia` call is renderer-side (`usePermissions.ts:199`, `micTrackHealth.js:72,102`), and Chromium performs the capture in its audio service. Both are separate PIDs.

`resources/windows-mic-listener.c:137,158,285` compares each WASAPI session's `GetProcessId` against that single value, so **the exclusion can never match**. Every dictation was reported back to us as third-party mic activity.

The timing corroborates it: `--exclude-pid` only started mattering on Windows in **1.7.6**, when the event-driven `windows-mic-listener.exe` first shipped — exactly the version @edernucci names, and consistent with @ksenia-anisimova seeing it on a fully local setup.

The `_userRecording` gate that already existed in 1.8.1 is why this is intermittent rather than constant: it suppresses evaluation *while* dictation is in flight, but it never stopped the app being its own detection source.

## The fix

Drop `MIC_START` for any PID in our own process tree, resolved from `app.getAppMetrics()` so restarted or newly spawned children are covered rather than a snapshot taken at spawn time.

`--exclude-pid` is kept as a cheap filter at the source. `MIC_STOP` needs no guard: an unknown PID is a no-op delete, and the set can only reach empty when nothing else holds the mic — the third test pins that.

Resolved in `ownProcessPids.js` rather than inline so the detector doesn't take an Electron dependency and the behaviour stays testable.

## Side benefit worth flagging for 1.8.3

`19c7d8c5` (unreleased) added `_reevaluateAfterGate()`, which re-fires evaluation from `setUserRecording(false)` using `_lastKnownMicState`. Since `setUserRecording(false)` runs the moment the stop IPC is *sent* — before the renderer releases the track — our own lingering session could re-trigger detection right after every dictation, turning #1392 from intermittent into near-constant.

This fix defuses that at the source: our own capture never sets `_lastKnownMicState` at all now. A test asserts it stays `false`.

## Verification

`typecheck`, `lint`, `format:check` clean; full suite **1822 pass / 0 fail** (+3). I confirmed the new tests fail without the fix.

**I can't test this on Windows.** The reasoning rests on Chromium's multi-process audio capture, which is well established, plus the 1.7.6 timing and two independent reports. Worth asking a reporter to confirm before the release notes claim it.