### PR TITLE
fix(streaming): wait for the realtime transcript tail instead of sleeping

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -260,10 +260,8 @@ const isValidApiKey = (key, provider = "openai") => {
   return key !== placeholder;
 };
 
-// Realtime providers deliver the tail of the transcript after the audio stops,
-// and unlike Deepgram/AssemblyAI/Corti they expose no finalize handshake. Wait
-// for the text to settle rather than sleeping a fixed window that dropped the
-// last words whenever the provider answered slower than it.
+// Realtime providers expose no finalize handshake (unlike Deepgram/AssemblyAI/
+// Corti), so the transcript tail lands whenever it lands — wait, don't sleep.
 const STREAMING_FINAL_QUIET_MS = 250;
 const STREAMING_FINAL_CEILING_MS = 2000;
 
@@ -4042,9 +4040,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
-  // Resolves once the transcript stops moving. An outstanding partial means its
+  // Resolves once the transcript stops moving. An outstanding partial proves its
   // final is still in flight, so only the ceiling ends the wait until it lands —
-  // a plain debounce would expire on the same slow tail this replaces.
+  // a plain debounce would expire on the very tail this exists to catch.
   awaitStreamingTextSettled() {
     return new Promise((resolve) => {
       const settle = () => {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -260,6 +260,13 @@ const isValidApiKey = (key, provider = "openai") => {
   return key !== placeholder;
 };
 
+// Realtime providers deliver the tail of the transcript after the audio stops,
+// and unlike Deepgram/AssemblyAI/Corti they expose no finalize handshake. Wait
+// for the text to settle rather than sleeping a fixed window that dropped the
+// last words whenever the provider answered slower than it.
+const STREAMING_FINAL_QUIET_MS = 250;
+const STREAMING_FINAL_CEILING_MS = 2000;
+
 const STREAMING_PROVIDERS = {
   deepgram: {
     warmup: (opts) => window.electronAPI.deepgramStreamingWarmup(opts),
@@ -286,6 +293,7 @@ const STREAMING_PROVIDERS = {
     onSessionEnd: (cb) => window.electronAPI.onAssemblyAiSessionEnd(cb),
   },
   "openai-realtime": {
+    awaitsFinalTranscript: true,
     warmup: (opts) => window.electronAPI.dictationRealtimeWarmup(opts),
     start: (opts) => window.electronAPI.dictationRealtimeStart(opts),
     send: (buf) => window.electronAPI.dictationRealtimeSend(buf),
@@ -308,6 +316,7 @@ const STREAMING_PROVIDERS = {
     onSessionEnd: (cb) => window.electronAPI.onCortiSessionEnd(cb),
   },
   "tinfoil-realtime": {
+    awaitsFinalTranscript: true,
     warmup: (opts) =>
       window.electronAPI.dictationRealtimeWarmup({
         ...opts,
@@ -453,7 +462,7 @@ class AudioManager {
     this.streamingCleanupFns = [];
     this.streamingFinalText = "";
     this.streamingPartialText = "";
-    this.streamingTextResolve = null;
+    this.streamingTextBump = null;
     this.streamingTextDebounce = null;
     this.cachedMicDeviceId = null;
     this.validatedSelectedMicDeviceId = null;
@@ -3832,11 +3841,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       //    events are lost during the connect handshake.
       this.streamingFinalText = "";
       this.streamingPartialText = "";
-      this.streamingTextResolve = null;
+      this.streamingTextBump = null;
       this.streamingTextDebounce = null;
 
       const partialCleanup = provider.onPartial((text) => {
         this.streamingPartialText = text;
+        this.streamingTextBump?.();
         this.onPartialTranscript?.(text);
       });
 
@@ -3846,6 +3856,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         const prevLen = this.streamingFinalText.length;
         this.streamingFinalText = text;
         this.streamingPartialText = "";
+        this.streamingTextBump?.();
         const newSegment = text.slice(prevLen);
         if (newSegment) {
           this.onStreamingCommit?.(newSegment);
@@ -4031,6 +4042,29 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     }
   }
 
+  // Resolves once the transcript stops moving. An outstanding partial means its
+  // final is still in flight, so only the ceiling ends the wait until it lands —
+  // a plain debounce would expire on the same slow tail this replaces.
+  awaitStreamingTextSettled() {
+    return new Promise((resolve) => {
+      const settle = () => {
+        clearTimeout(this.streamingTextDebounce);
+        clearTimeout(ceiling);
+        this.streamingTextBump = null;
+        this.streamingTextDebounce = null;
+        resolve();
+      };
+      const ceiling = setTimeout(settle, STREAMING_FINAL_CEILING_MS);
+      const arm = () => {
+        clearTimeout(this.streamingTextDebounce);
+        if (this.streamingPartialText) return;
+        this.streamingTextDebounce = setTimeout(settle, STREAMING_FINAL_QUIET_MS);
+      };
+      this.streamingTextBump = arm;
+      arm();
+    });
+  }
+
   async stopStreamingRecording() {
     if (this.streamingStartInProgress) {
       this.stopRequestedDuringStreamingStart = true;
@@ -4108,12 +4142,17 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     //    Then mark streaming done so no further audio is forwarded.
     await new Promise((resolve) => setTimeout(resolve, 120));
     this.isStreaming = false;
+    const tFlush = performance.now();
 
     // 4. Finalize tells the provider to process any buffered audio and send final results.
-    //    Wait briefly so the server sends back the finalized transcript before disconnect.
+    //    Wait for the transcript to settle before disconnecting.
     const provider = this.getStreamingProvider();
     provider.finalize?.();
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    if (provider.awaitsFinalTranscript) {
+      await this.awaitStreamingTextSettled();
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
     const tForceEndpoint = performance.now();
 
     const stopResult = await provider.stop().catch((e) => {
@@ -4146,6 +4185,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         durationSeconds,
         audioCleanupMs: Math.round(tAudioCleanup - t0),
         flushWaitMs: Math.round(tForceEndpoint - tAudioCleanup),
+        finalSettleMs: Math.round(tForceEndpoint - tFlush),
         terminateRoundTripMs: Math.round(tTerminate - tForceEndpoint),
         totalStopMs: Math.round(tTerminate - t0),
         textLength: finalText.length,
@@ -4526,7 +4566,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     this.streamingCleanupFns = [];
     this.streamingFinalText = "";
     this.streamingPartialText = "";
-    this.streamingTextResolve = null;
+    this.streamingTextBump = null;
     clearTimeout(this.streamingTextDebounce);
     this.streamingTextDebounce = null;
   }

--- a/test/helpers/audioManagerStreamingSettle.test.js
+++ b/test/helpers/audioManagerStreamingSettle.test.js
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+const QUIET_MS = 250;
+const CEILING_MS = 2000;
+
+async function loadManager(t) {
+  installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-settle-test-",
+    mockModules: {
+      "/utils/logger":
+        "export default { debug() {}, info() {}, warn() {}, error() {}, logReasoning() {} };",
+      "/stores/settingsStore": `
+        export const getSettings = () => ({});
+        export const getEffectiveCleanupModel = () => null;
+        export const isCloudCleanupMode = () => false;
+        export const isCloudDictationAgentMode = () => false;
+        export const isCloudTranslationMode = () => false;
+      `,
+      "/services/ReasoningService": "export default { processText: async (t) => t };",
+      "/services/SyncService.js": "export const syncService = {};",
+      "/lib/auth": "export const withSessionRefresh = (fn) => fn();",
+      "/utils/permissions": "export const isAccessibilitySkipped = () => false;",
+    },
+  });
+  const AudioManager = (await vite.ssrLoadModule("/helpers/audioManager.js")).default;
+  return Object.create(AudioManager.prototype);
+}
+
+async function elapsed(fn) {
+  const start = Date.now();
+  await fn();
+  return Date.now() - start;
+}
+
+test("settles on the quiet window when the transcript is already complete", async (t) => {
+  const manager = await loadManager(t);
+
+  const ms = await elapsed(() => manager.awaitStreamingTextSettled());
+
+  assert.ok(ms >= QUIET_MS, `settled too early: ${ms}ms`);
+  assert.ok(ms < QUIET_MS + 150, `settled too late: ${ms}ms`);
+});
+
+test("waits out a slow tail instead of expiring on it", async (t) => {
+  const manager = await loadManager(t);
+  const lateFinalAt = 600;
+  manager.streamingPartialText = "the last few words";
+  setTimeout(() => {
+    manager.streamingPartialText = "";
+    manager.streamingTextBump?.();
+  }, lateFinalAt);
+
+  const ms = await elapsed(() => manager.awaitStreamingTextSettled());
+
+  assert.ok(ms >= lateFinalAt + QUIET_MS, `dropped the late tail: ${ms}ms`);
+  assert.ok(ms < CEILING_MS, `should settle on quiet, not the ceiling: ${ms}ms`);
+});
+
+test("the ceiling bounds a final that never lands", async (t) => {
+  const manager = await loadManager(t);
+  manager.streamingPartialText = "never finalized";
+
+  const ms = await elapsed(() => manager.awaitStreamingTextSettled());
+
+  assert.ok(ms >= CEILING_MS, `gave up too early: ${ms}ms`);
+  assert.ok(ms < CEILING_MS + 300, `overran the ceiling: ${ms}ms`);
+});
+
+test("clears its timers so a settled wait leaves no handles behind", async (t) => {
+  const manager = await loadManager(t);
+
+  await manager.awaitStreamingTextSettled();
+
+  assert.equal(manager.streamingTextBump, null);
+  assert.equal(manager.streamingTextDebounce, null);
+});


### PR DESCRIPTION
## Problem

When you stop dictating, the app **never actually asks OpenAI Realtime for your final transcript** — it sleeps 300ms and takes whatever arrived.

```js
provider.finalize?.();
await new Promise((resolve) => setTimeout(resolve, 300));
finalText = this.streamingFinalText || "";
```

Deepgram, AssemblyAI and Corti all define a `finalize` method. **`openai-realtime` and `tinfoil-realtime` don't** — so for them `provider.finalize?.()` is a silent no-op and that 300ms is the only thing standing between the user and a truncated transcript. Any tail the provider delivers later is dropped.

`openai-realtime` is the **default dictation provider**, so this is the common path.

This is also why re-transcribing from History fixes a cut-off note: it decodes the full stored recording in one batch pass, with no flush deadline to miss.

## Fix

Wait for the transcript to settle rather than sleeping a fixed window:

- Resolve once no partial or final has arrived for **250ms**
- An **outstanding partial** means its final is still in flight, so only the ceiling ends the wait until it lands — a plain debounce would expire on the same slow tail this replaces
- **2s ceiling** bounds a provider that never answers

## Scoping

Gated behind an `awaitsFinalTranscript` capability flag, set only on `openai-realtime` and `tinfoil-realtime` (they share the `dictation-realtime-*` transport). **Deepgram, AssemblyAI and Corti run the existing fixed sleep byte-for-byte**, so they cannot regress — they already send a real finalize handshake and can be ported individually once this is proven.

## Latency

Faster, not slower. Today every realtime stop pays a flat 300ms; the settle path returns as soon as the text stops moving. The ceiling is a timeout, not a wait — it's only reached when a final never lands, which is exactly the case currently losing words.

`finalSettleMs` is now logged so the ceiling can be tuned from real data before porting the remaining providers.

## Testing

- 1,832 tests pass (4 new: quiet-window settle, slow-tail wait, ceiling bound, timer cleanup)
- No new lint warnings
- The slow-tail test caught a real flaw in the first implementation — a pure debounce settled at 250ms even when the tail hadn't arrived, reproducing the original bug with a shorter deadline. That's what the outstanding-partial check fixes.

## Note

Also renames the dead `streamingTextResolve` field (initialized and reset in three places, never assigned) to `streamingTextBump` and wires it to its actual purpose.