### PR TITLE
fix(transcription): stop reporting broken engine responses as "No Audio Detected"

### DIFF
--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -258,13 +258,19 @@ class ParakeetManager {
       textLength: output?.text?.length || 0,
     });
 
-    if (!output || !output.text) {
-      return { success: false, message: "No audio detected" };
+    // Missing output or a missing text field is a broken decode, not silence —
+    // only a present-but-empty transcript means the recording was actually blank.
+    if (!output || typeof output.text !== "string") {
+      return {
+        success: false,
+        error: "invalid_response",
+        message: "Transcription engine returned an unexpected response",
+      };
     }
 
     const text = output.text.trim();
 
-    if (!text || text.length === 0) {
+    if (!text) {
       return { success: false, message: "No audio detected" };
     }
 

--- a/src/helpers/whisper.js
+++ b/src/helpers/whisper.js
@@ -501,7 +501,17 @@ class WhisperManager {
       return { success: true, text };
     }
 
-    return { success: false, message: "No audio detected" };
+    // A response with neither shape is a broken backend, not silence. Reporting it
+    // as "No audio detected" sends users chasing their microphone when the engine
+    // is at fault, so surface it as the transcription failure it is.
+    const serverError = typeof result.error === "string" && result.error.trim();
+    return {
+      success: false,
+      error: "invalid_response",
+      message: serverError
+        ? `Transcription engine error: ${serverError}`
+        : "Transcription engine returned an unexpected response",
+    };
   }
 
   // Check if text is a whisper.cpp blank audio marker

--- a/test/helpers/transcriptionResultParsing.test.js
+++ b/test/helpers/transcriptionResultParsing.test.js
@@ -1,0 +1,74 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const WhisperManager = require("../../src/helpers/whisper.js");
+const ParakeetManager = require("../../src/helpers/parakeet.js");
+
+// "No audio detected" must mean exactly that: the engine decoded the recording
+// and found silence. A malformed or error response is an engine failure and has
+// to surface as one — reporting it as silence sends users debugging their mic.
+
+const whisper = new WhisperManager();
+const parakeet = new ParakeetManager();
+
+test("whisper: blank server text is genuine silence", () => {
+  assert.deepEqual(whisper.parseWhisperResult({ text: "" }), {
+    success: false,
+    message: "No audio detected",
+  });
+  assert.deepEqual(whisper.parseWhisperResult({ text: " [BLANK_AUDIO] " }), {
+    success: false,
+    message: "No audio detected",
+  });
+});
+
+test("whisper: blank CLI transcription is genuine silence", () => {
+  assert.deepEqual(whisper.parseWhisperResult({ transcription: [{ text: "" }] }), {
+    success: false,
+    message: "No audio detected",
+  });
+});
+
+test("whisper: real text passes through with normalized whitespace", () => {
+  assert.deepEqual(whisper.parseWhisperResult({ text: "hello\nworld " }), {
+    success: true,
+    text: "hello world",
+  });
+});
+
+test("whisper: a response with neither text nor transcription is an engine failure, not silence", () => {
+  const result = whisper.parseWhisperResult({ status: "loading" });
+  assert.equal(result.success, false);
+  assert.equal(result.error, "invalid_response");
+  assert.notEqual(result.message, "No audio detected");
+});
+
+test("whisper: a server-reported error is surfaced verbatim", () => {
+  const result = whisper.parseWhisperResult({ error: "failed to load model" });
+  assert.equal(result.error, "invalid_response");
+  assert.match(result.message, /failed to load model/);
+});
+
+test("parakeet: present-but-empty transcript is genuine silence", () => {
+  assert.deepEqual(parakeet.parseParakeetResult({ text: "  " }), {
+    success: false,
+    message: "No audio detected",
+  });
+});
+
+test("parakeet: missing output or text field is an engine failure, not silence", () => {
+  for (const output of [null, {}, { text: 42 }]) {
+    const result = parakeet.parseParakeetResult(output);
+    assert.equal(result.success, false);
+    assert.equal(result.error, "invalid_response");
+    assert.notEqual(result.message, "No audio detected");
+  }
+});
+
+test("parakeet: truncated decode keeps its warning", () => {
+  assert.deepEqual(parakeet.parseParakeetResult({ text: "hi", truncated: true }), {
+    success: true,
+    text: "hi",
+    warning: "truncated",
+  });
+});


### PR DESCRIPTION
## Problem
`parseWhisperResult`'s fallthrough treated any unrecognized whisper-server response shape as silence, and `parseParakeetResult` did the same for a missing decode result. Users saw **No Audio Detected** and spent time debugging their microphone when the transcription engine itself was broken (stacked no-audio toasts while the backend was down).

## Fix
- Blank text and `[BLANK_AUDIO]` still report no-audio — that contract is untouched, and every downstream `=== "No audio detected"` comparison (audioManager, ipcHandlers) now only ever matches genuine silence.
- Anything else returns an `invalid_response` failure carrying the server-reported error, which flows down the existing transcription-error path: honest toast, failed recording saved for retry, optional cloud fallback.
- Same split for Parakeet: missing output/text field is an engine failure; a present-but-empty transcript is silence.

## Tests
New `transcriptionResultParsing.test.js` covering both parsers (silence vs engine failure vs pass-through, server-error surfacing, truncation warning). Full suite green (1876 pass), lint + prettier clean.