### PR TITLE
fix(gpu): stop offering the CUDA pack to cards its build cannot run on

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -394,7 +394,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
       if (useLocalWhisper && localTranscriptionProvider === "whisper") {
         try {
           const status = await window.electronAPI?.getCudaWhisperStatus?.();
-          if (status?.gpuInfo.hasNvidiaGpu) {
+          if (status?.gpuInfo.hasNvidiaGpu && status.gpuInfo.cudaSupported) {
             if (!status.downloaded) results.transcription = true;
           } else {
             const vulkan = await window.electronAPI?.getVulkanWhisperStatus?.();

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -591,8 +591,10 @@ export default function TranscriptionModelPicker({
     if (getCachedPlatform() === "darwin") return;
     const detect = async () => {
       try {
+        // Cards below the CUDA build's kernel floor (e.g. Pascal) crash at the
+        // first kernel launch, so they get the Vulkan pack like AMD/Intel GPUs.
         const cuda = await window.electronAPI?.getCudaWhisperStatus?.();
-        if (cuda?.gpuInfo.hasNvidiaGpu) {
+        if (cuda?.gpuInfo.hasNvidiaGpu && cuda.gpuInfo.cudaSupported) {
           setGpuBackend("cuda");
           setGpuDownloaded(cuda.downloaded);
           return;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -484,6 +484,9 @@ export interface GpuInfo {
   gpuName?: string;
   driverVersion?: string;
   vramMb?: number;
+  computeCap?: number;
+  /** Whether the card meets the shipped CUDA build's minimum compute capability. */
+  cudaSupported?: boolean;
 }
 
 export interface CudaWhisperStatus {

--- a/src/utils/gpuDetection.js
+++ b/src/utils/gpuDetection.js
@@ -1,47 +1,62 @@
 const { execFile } = require("child_process");
 
+// The shipped CUDA whisper build only carries kernels for Turing (compute
+// capability 7.5) and newer. On older cards (e.g. Pascal / GTX 10-series,
+// 6.1) the server starts, loads the model into VRAM, then aborts on the first
+// kernel launch with "no kernel image is available for execution on the
+// device" — so those cards must be offered Vulkan instead, which works on any
+// NVIDIA GPU.
+const MIN_CUDA_COMPUTE_CAP = 7.5;
+
 let cachedGpuInfo = null;
 
-function detectNvidiaGpu() {
-  if (cachedGpuInfo) return Promise.resolve(cachedGpuInfo);
-
-  if (process.platform === "darwin") {
-    cachedGpuInfo = { hasNvidiaGpu: false };
-    return Promise.resolve(cachedGpuInfo);
-  }
-
+function queryNvidiaSmi(fields) {
   return new Promise((resolve) => {
     execFile(
       "nvidia-smi",
-      ["--query-gpu=name,driver_version,memory.total", "--format=csv,noheader,nounits"],
+      ["--query-gpu=" + fields, "--format=csv,noheader,nounits"],
       { timeout: 5000, windowsHide: true },
-      (error, stdout) => {
-        if (error || !stdout) {
-          cachedGpuInfo = { hasNvidiaGpu: false };
-          resolve(cachedGpuInfo);
-          return;
-        }
-
-        const parts = stdout
-          .trim()
-          .split(",")
-          .map((s) => s.trim());
-        if (parts.length < 3) {
-          cachedGpuInfo = { hasNvidiaGpu: false };
-          resolve(cachedGpuInfo);
-          return;
-        }
-
-        cachedGpuInfo = {
-          hasNvidiaGpu: true,
-          gpuName: parts[0],
-          driverVersion: parts[1],
-          vramMb: parseInt(parts[2], 10) || undefined,
-        };
-        resolve(cachedGpuInfo);
-      }
+      (error, stdout) => resolve(error || !stdout ? null : stdout)
     );
   });
+}
+
+function parseNvidiaSmiGpuInfo(stdout) {
+  const parts = stdout
+    .trim()
+    .split("\n")[0]
+    .split(",")
+    .map((s) => s.trim());
+  if (parts.length < 3) return { hasNvidiaGpu: false };
+
+  const computeCap = parts.length >= 4 ? parseFloat(parts[3]) : NaN;
+  return {
+    hasNvidiaGpu: true,
+    gpuName: parts[0],
+    driverVersion: parts[1],
+    vramMb: parseInt(parts[2], 10) || undefined,
+    ...(Number.isFinite(computeCap) ? { computeCap } : {}),
+    cudaSupported: Number.isFinite(computeCap) && computeCap >= MIN_CUDA_COMPUTE_CAP,
+  };
+}
+
+async function detectNvidiaGpu() {
+  if (cachedGpuInfo) return cachedGpuInfo;
+
+  if (process.platform === "darwin") {
+    cachedGpuInfo = { hasNvidiaGpu: false };
+    return cachedGpuInfo;
+  }
+
+  let stdout = await queryNvidiaSmi("name,driver_version,memory.total,compute_cap");
+  if (stdout === null) {
+    // Drivers too old to answer the compute_cap query (pre-R470) also predate
+    // the CUDA 12 runtime the pack ships with, so cudaSupported stays false.
+    stdout = await queryNvidiaSmi("name,driver_version,memory.total");
+  }
+
+  cachedGpuInfo = stdout === null ? { hasNvidiaGpu: false } : parseNvidiaSmiGpuInfo(stdout);
+  return cachedGpuInfo;
 }
 
 let cachedGpuList = null;
@@ -87,4 +102,4 @@ function listNvidiaGpus() {
   });
 }
 
-module.exports = { detectNvidiaGpu, listNvidiaGpus };
+module.exports = { detectNvidiaGpu, listNvidiaGpus, parseNvidiaSmiGpuInfo, MIN_CUDA_COMPUTE_CAP };

--- a/test/helpers/gpuDetection.test.js
+++ b/test/helpers/gpuDetection.test.js
@@ -1,0 +1,57 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { parseNvidiaSmiGpuInfo, MIN_CUDA_COMPUTE_CAP } = require("../../src/utils/gpuDetection.js");
+
+// The CUDA pack must only be offered to cards its build actually carries
+// kernels for. A Pascal card passing this gate cost two days of debugging
+// ("GPU acceleration active" while every transcription crashed).
+
+test("Turing and newer report cudaSupported", () => {
+  const info = parseNvidiaSmiGpuInfo("NVIDIA GeForce RTX 4090, 582.66, 24564, 8.9");
+  assert.deepEqual(info, {
+    hasNvidiaGpu: true,
+    gpuName: "NVIDIA GeForce RTX 4090",
+    driverVersion: "582.66",
+    vramMb: 24564,
+    computeCap: 8.9,
+    cudaSupported: true,
+  });
+});
+
+test("Pascal is detected but not CUDA-supported (gets Vulkan instead)", () => {
+  const info = parseNvidiaSmiGpuInfo("NVIDIA GeForce GTX 1080 Ti, 582.66, 11264, 6.1");
+  assert.equal(info.hasNvidiaGpu, true);
+  assert.equal(info.computeCap, 6.1);
+  assert.equal(info.cudaSupported, false);
+});
+
+test("exactly the minimum compute capability is supported", () => {
+  const info = parseNvidiaSmiGpuInfo(`RTX 2060, 560.94, 6144, ${MIN_CUDA_COMPUTE_CAP}`);
+  assert.equal(info.cudaSupported, true);
+});
+
+test("a legacy query without compute_cap detects the GPU but stays conservative", () => {
+  const info = parseNvidiaSmiGpuInfo("NVIDIA GeForce GTX 970, 460.89, 4096");
+  assert.equal(info.hasNvidiaGpu, true);
+  assert.equal(info.computeCap, undefined);
+  assert.equal(info.cudaSupported, false);
+});
+
+test("an unparseable compute_cap ([N/A]) stays conservative", () => {
+  const info = parseNvidiaSmiGpuInfo("Some GPU, 582.66, 8192, [N/A]");
+  assert.equal(info.hasNvidiaGpu, true);
+  assert.equal(info.cudaSupported, false);
+});
+
+test("multi-GPU output uses the primary card", () => {
+  const info = parseNvidiaSmiGpuInfo(
+    "NVIDIA GeForce GTX 1080 Ti, 582.66, 11264, 6.1\nNVIDIA T400, 582.66, 2048, 7.5"
+  );
+  assert.equal(info.gpuName, "NVIDIA GeForce GTX 1080 Ti");
+  assert.equal(info.cudaSupported, false);
+});
+
+test("garbage output is not an NVIDIA GPU", () => {
+  assert.deepEqual(parseNvidiaSmiGpuInfo("command not found"), { hasNvidiaGpu: false });
+});


### PR DESCRIPTION
## Problem
The transcription picker offered the CUDA pack to every NVIDIA GPU, but the shipped CUDA whisper build only carries kernels for compute capability 7.5+ (Turing). On older cards (Pascal / GTX 10-series) the server starts, loads the whole model into VRAM, then aborts at the first kernel launch with `no kernel image is available for execution on the device` — while Vulkan works fine on the same hardware. Reported by a user who lost two days to this on a GTX 1080 Ti.

## Fix
- `detectNvidiaGpu` also queries `compute_cap` and reports `cudaSupported` against the build's 7.5 floor. Drivers too old to answer the query fall back to the legacy query (GPU still detected) and stay conservative — they also predate the CUDA 12 runtime the pack needs.
- The model picker and the ControlPanel GPU banner route unsupported NVIDIA cards to the **Vulkan** pack, same as AMD/Intel.
- Parsing extracted to a pure `parseNvidiaSmiGpuInfo` with unit tests (Turing, Pascal, boundary, legacy query, `[N/A]`, multi-GPU, garbage).

Full suite green (1875 pass), typecheck + lint + prettier clean.