### PR TITLE
fix(gpu): isolate GPU binary packs in per-pack directories with atomic installs

### DIFF
--- a/main.js
+++ b/main.js
@@ -278,6 +278,7 @@ const TextEditMonitor = require("./src/helpers/textEditMonitor");
 const SelectionManager = require("./src/helpers/selectionManager");
 const WhisperCudaManager = require("./src/helpers/whisperCudaManager");
 const WhisperVulkanManager = require("./src/helpers/whisperVulkanManager");
+const { migrateLegacyBinDir } = require("./src/helpers/gpuBinaryManager");
 const GoogleCalendarManager = require("./src/helpers/googleCalendarManager");
 const MicrosoftCalendarManager = require("./src/helpers/microsoftCalendarManager");
 const AppleCalendarManager = require("./src/helpers/appleCalendarManager");
@@ -425,6 +426,10 @@ function initializeCoreManagers() {
   if (process.platform !== "darwin") {
     whisperCudaManager = new WhisperCudaManager();
     whisperVulkanManager = new WhisperVulkanManager();
+    // Heal installs from before GPU packs got per-pack directories; must run
+    // before startup pre-warm resolves any GPU binary path.
+    const LlamaVulkanManager = require("./src/helpers/llamaVulkanManager");
+    migrateLegacyBinDir([whisperCudaManager, whisperVulkanManager, new LlamaVulkanManager()]);
   }
   parakeetManager = new ParakeetManager();
   diarizationManager = new DiarizationManager();

--- a/src/helpers/gpuBinaryManager.js
+++ b/src/helpers/gpuBinaryManager.js
@@ -38,23 +38,30 @@ function sha256File(filePath) {
 
 // Shared download/install pipeline for GPU server binaries fetched from GitHub
 // releases (whisper CUDA, whisper Vulkan, llama Vulkan). Subclasses configure
-// the release URL and per-`${platform}-${arch}` assets (exact assetName or
-// assetPattern regex; optional libPattern for companion libs). Archives are
-// sha256-verified against expectedDigests, falling back to the digest the
-// GitHub API reports.
+// the release URL, a dirName, and per-`${platform}-${arch}` assets (exact
+// assetName or assetPattern regex; optional libPattern for companion libs).
+// Archives are sha256-verified against expectedDigests, falling back to the
+// digest the GitHub API reports.
+//
+// Each pack installs into its own `userData/bin/<dirName>/` directory: the
+// packs ship identically-named ggml DLLs, so a shared directory lets one
+// pack's install silently overwrite another's runtime (and one pack's delete
+// remove another's libs). The directory is staged next to its final location
+// and swapped in with a single rename, so a crash or power loss mid-install
+// can never leave a truncated binary that isDownloaded() reports as installed.
 class GpuBinaryManager {
   constructor(config) {
     this.config = config;
-    this._binDir = null;
     this._downloadSignal = null;
     this._downloading = false;
   }
 
+  get binRoot() {
+    return path.join(app.getPath("userData"), "bin");
+  }
+
   get binDir() {
-    if (!this._binDir) {
-      this._binDir = path.join(app.getPath("userData"), "bin");
-    }
-    return this._binDir;
+    return path.join(this.binRoot, this.config.dirName);
   }
 
   _getAssetConfig() {
@@ -140,15 +147,16 @@ class GpuBinaryManager {
     const tempDir = getSafeTempDir();
     let archivePath = null;
     let extractDir = null;
+    let stagingDir = null;
 
     try {
-      await fsPromises.mkdir(this.binDir, { recursive: true });
-      await cleanupStaleDownloads(this.binDir);
+      await fsPromises.mkdir(this.binRoot, { recursive: true });
+      await cleanupStaleDownloads(this.binRoot);
 
       const { asset, version } = await this._resolveAsset(assetConfig);
 
       const requiredBytes = (asset.size || FALLBACK_ASSET_SIZE) * DISK_SPACE_MULTIPLIER;
-      const spaceCheck = await checkDiskSpace(this.binDir, requiredBytes);
+      const spaceCheck = await checkDiskSpace(this.binRoot, requiredBytes);
       if (!spaceCheck.ok) {
         throw new Error(
           `Not enough disk space. Need ~${Math.round(requiredBytes / 1_000_000)}MB, ` +
@@ -179,20 +187,31 @@ class GpuBinaryManager {
       const binaryPath = await findFile(extractDir, assetConfig.binaryName);
       if (!binaryPath) throw new Error(`${assetConfig.binaryName} not found in archive`);
 
-      const outputPath = path.join(this.binDir, assetConfig.outputName);
+      // Stage the complete pack beside its final directory (same volume), then
+      // swap it in with one rename. The prefix keeps cleanupStaleDownloads able
+      // to reap a staging dir orphaned by a crash.
+      stagingDir = path.join(this.binRoot, `temp-extract-stage-${this.config.dirName}`);
+      await fsPromises.rm(stagingDir, { recursive: true, force: true });
+      await fsPromises.mkdir(stagingDir, { recursive: true });
+
+      const outputPath = path.join(stagingDir, assetConfig.outputName);
       await fsPromises.copyFile(binaryPath, outputPath);
       if (process.platform !== "win32") await fsPromises.chmod(outputPath, 0o755);
 
       if (assetConfig.libPattern) {
         const libs = await findFiles(extractDir, assetConfig.libPattern);
         for (const lib of libs) {
-          const dest = path.join(this.binDir, path.basename(lib));
+          const dest = path.join(stagingDir, path.basename(lib));
           await fsPromises.copyFile(lib, dest);
           if (process.platform !== "win32") await fsPromises.chmod(dest, 0o755);
         }
       }
 
-      debugLogger.info(`${this.config.name} binary installed`, { version, path: outputPath });
+      await fsPromises.rm(this.binDir, { recursive: true, force: true });
+      await fsPromises.rename(stagingDir, this.binDir);
+      stagingDir = null;
+
+      debugLogger.info(`${this.config.name} binary installed`, { version, path: this.binDir });
       return { version };
     } finally {
       this._downloading = false;
@@ -200,6 +219,9 @@ class GpuBinaryManager {
       if (archivePath) await fsPromises.unlink(archivePath).catch(() => {});
       if (extractDir) {
         await fsPromises.rm(extractDir, { recursive: true, force: true }).catch(() => {});
+      }
+      if (stagingDir) {
+        await fsPromises.rm(stagingDir, { recursive: true, force: true }).catch(() => {});
       }
     }
   }
@@ -214,8 +236,7 @@ class GpuBinaryManager {
   }
 
   async delete() {
-    const assetConfig = this._getAssetConfig();
-    if (!assetConfig) return { deletedCount: 0, freedBytes: 0 };
+    if (!this._getAssetConfig()) return { deletedCount: 0, freedBytes: 0 };
 
     let deletedCount = 0;
     let freedBytes = 0;
@@ -223,19 +244,17 @@ class GpuBinaryManager {
     try {
       const entries = await fsPromises.readdir(this.binDir);
       for (const entry of entries) {
-        if (entry !== assetConfig.outputName && !assetConfig.libPattern?.test(entry)) continue;
-        const filePath = path.join(this.binDir, entry);
         try {
-          const stats = await fsPromises.stat(filePath);
-          await fsPromises.unlink(filePath);
+          const stats = await fsPromises.stat(path.join(this.binDir, entry));
           freedBytes += stats.size;
           deletedCount++;
         } catch {
-          // Continue with remaining files
+          // Still deleted with the directory below
         }
       }
+      await fsPromises.rm(this.binDir, { recursive: true, force: true });
     } catch {
-      // Directory may not exist
+      // Pack directory may not exist
     }
 
     debugLogger.info(`${this.config.name} binary deleted`, { deletedCount, freedBytes });
@@ -243,4 +262,53 @@ class GpuBinaryManager {
   }
 }
 
+// One-time healing of the pre-subdirectory layout, where every pack installed
+// directly into userData/bin and their identically-named ggml DLLs overwrote
+// each other. A pack without companion libs is just moved into its directory.
+// A pack with libs can't tell which of the surviving DLLs are its own (the
+// clobbering destroyed that), so its files are removed and the pack shows as
+// not installed until re-downloaded from Settings. Synchronous so it completes
+// before startup pre-warm reads any binary path.
+function migrateLegacyBinDir(managers) {
+  const packs = managers
+    .map((m) => ({ manager: m, assetConfig: m._getAssetConfig() }))
+    .filter((p) => p.assetConfig);
+  if (packs.length === 0) return;
+
+  const binRoot = packs[0].manager.binRoot;
+  if (!fs.existsSync(binRoot)) return;
+
+  for (const { manager, assetConfig } of packs) {
+    const legacyBinary = path.join(binRoot, assetConfig.outputName);
+    try {
+      if (!fs.existsSync(legacyBinary)) continue;
+      if (assetConfig.libPattern) {
+        fs.unlinkSync(legacyBinary);
+        debugLogger.info(`${manager.config.name} legacy install removed (needs re-download)`);
+      } else if (manager.isDownloaded()) {
+        fs.unlinkSync(legacyBinary);
+      } else {
+        fs.mkdirSync(manager.binDir, { recursive: true });
+        fs.renameSync(legacyBinary, path.join(manager.binDir, assetConfig.outputName));
+        debugLogger.info(`${manager.config.name} migrated`, { to: manager.binDir });
+      }
+    } catch (err) {
+      debugLogger.warn(`${manager.config.name} legacy migration failed`, { error: err.message });
+    }
+  }
+
+  // The lib-carrying packs' orphaned companion libs (ownership is unknowable)
+  const libPatterns = packs.map((p) => p.assetConfig.libPattern).filter(Boolean);
+  if (libPatterns.length === 0) return;
+  try {
+    for (const entry of fs.readdirSync(binRoot, { withFileTypes: true })) {
+      if (!entry.isFile() || !libPatterns.some((pattern) => pattern.test(entry.name))) continue;
+      try {
+        fs.unlinkSync(path.join(binRoot, entry.name));
+      } catch {}
+    }
+  } catch {}
+}
+
 module.exports = GpuBinaryManager;
+module.exports.migrateLegacyBinDir = migrateLegacyBinDir;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2697,6 +2697,9 @@ class IPCHandlers {
         return { success: false, error: "CUDA not supported on this platform" };
       }
       try {
+        // Stop the server first: swapping in a pack a running binary is loaded
+        // from EBUSYs on Windows (same rule as the Vulkan handler below)
+        await this.whisperManager.stopServer().catch(() => {});
         await this.whisperCudaManager.download((downloaded, total) => {
           if (!event.sender.isDestroyed()) {
             event.sender.send("cuda-download-progress", {
@@ -2707,8 +2710,6 @@ class IPCHandlers {
           }
         });
         this._syncStartupEnv({ WHISPER_CUDA_ENABLED: "true" });
-        // Restart whisper-server so it picks up the CUDA binary
-        await this.whisperManager.stopServer().catch(() => {});
         return { success: true };
       } catch (error) {
         debugLogger.error("CUDA binary download failed", {

--- a/src/helpers/llamaServer.js
+++ b/src/helpers/llamaServer.js
@@ -8,6 +8,7 @@ const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { app } = require("electron");
 const sidecarPidFile = require("./sidecarPidFile");
+const { BIN_SUBDIR: LLAMA_VULKAN_BIN_SUBDIR } = require("./llamaVulkanManager");
 
 // Range kept clear of cliBridge (8200-8219) to avoid port-bind collisions.
 const PORT_RANGE_START = 8221;
@@ -74,11 +75,16 @@ class LlamaServerManager {
         resolveBinary(`llama-server-${platformArch}`) || resolveBinary(`llama-server${ext}`);
       paths = defaultBin ? { default: defaultBin } : {};
     } else {
-      const userBinDir = path.join(app.getPath("userData"), "bin");
       const vulkanName = `llama-server-vulkan${ext}`;
       let vulkanBin = null;
       try {
-        const vulkanPath = path.join(userBinDir, vulkanName);
+        // Installed by LlamaVulkanManager into its own pack directory
+        const vulkanPath = path.join(
+          app.getPath("userData"),
+          "bin",
+          LLAMA_VULKAN_BIN_SUBDIR,
+          vulkanName
+        );
         if (fs.existsSync(vulkanPath)) vulkanBin = vulkanPath;
       } catch {}
 

--- a/src/helpers/llamaVulkanManager.js
+++ b/src/helpers/llamaVulkanManager.js
@@ -4,10 +4,13 @@ const GpuBinaryManager = require("./gpuBinaryManager");
 // Overridable via LLAMA_CPP_VERSION so GPU and CPU stay on one tested llama.cpp.
 const LLAMA_CPP_TAG = process.env.LLAMA_CPP_VERSION || "b9763";
 
+const BIN_SUBDIR = "llama-vulkan";
+
 class LlamaVulkanManager extends GpuBinaryManager {
   constructor() {
     super({
       name: "Vulkan llama",
+      dirName: BIN_SUBDIR,
       releaseUrl: `https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/${LLAMA_CPP_TAG}`,
       assets: {
         "win32-x64": {
@@ -43,3 +46,4 @@ class LlamaVulkanManager extends GpuBinaryManager {
 }
 
 module.exports = LlamaVulkanManager;
+module.exports.BIN_SUBDIR = BIN_SUBDIR;

--- a/src/helpers/whisperCudaManager.js
+++ b/src/helpers/whisperCudaManager.js
@@ -13,10 +13,13 @@ const EXPECTED_DIGESTS = {
   },
 };
 
+const BIN_SUBDIR = "whisper-cuda";
+
 class WhisperCudaManager extends GpuBinaryManager {
   constructor() {
     super({
       name: "CUDA whisper",
+      dirName: BIN_SUBDIR,
       releaseUrl: `https://api.github.com/repos/OpenWhispr/whisper.cpp/releases/tags/${WHISPER_CPP_TAG}`,
       expectedDigests: EXPECTED_DIGESTS[WHISPER_CPP_TAG],
       assets: {
@@ -71,3 +74,4 @@ class WhisperCudaManager extends GpuBinaryManager {
 }
 
 module.exports = WhisperCudaManager;
+module.exports.BIN_SUBDIR = BIN_SUBDIR;

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -11,6 +11,8 @@ const { isPortAvailable } = require("../utils/serverUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { convertToWav } = require("./ffmpegUtils");
 const sidecarPidFile = require("./sidecarPidFile");
+const { BIN_SUBDIR: CUDA_BIN_SUBDIR } = require("./whisperCudaManager");
+const { BIN_SUBDIR: VULKAN_BIN_SUBDIR } = require("./whisperVulkanManager");
 const { sanitizeWhisperVadConfig, DEFAULT_WHISPER_VAD_CONFIG } = require("./whisperVadConfig");
 const {
   computeTranscriptionTimeoutMs,
@@ -325,7 +327,8 @@ class WhisperServerManager extends EventEmitter {
     if (gpuBackend) {
       const ext = process.platform === "win32" ? ".exe" : "";
       const gpuBinary = `whisper-server-${process.platform}-${process.arch}-${gpuBackend}${ext}`;
-      const gpuPath = path.join(app.getPath("userData"), "bin", gpuBinary);
+      const subdir = gpuBackend === "cuda" ? CUDA_BIN_SUBDIR : VULKAN_BIN_SUBDIR;
+      const gpuPath = path.join(app.getPath("userData"), "bin", subdir, gpuBinary);
       if (fs.existsSync(gpuPath)) return gpuPath;
     }
 

--- a/src/helpers/whisperVulkanManager.js
+++ b/src/helpers/whisperVulkanManager.js
@@ -13,11 +13,14 @@ const EXPECTED_DIGESTS = {
   },
 };
 
-// Statically linked — no companion libs to copy, nothing to clobber in userData/bin
+const BIN_SUBDIR = "whisper-vulkan";
+
+// Statically linked — no companion libs to copy
 class WhisperVulkanManager extends GpuBinaryManager {
   constructor() {
     super({
       name: "Vulkan whisper",
+      dirName: BIN_SUBDIR,
       releaseUrl: `https://api.github.com/repos/OpenWhispr/whisper.cpp/releases/tags/${WHISPER_CPP_TAG}`,
       expectedDigests: EXPECTED_DIGESTS[WHISPER_CPP_TAG],
       assets: {
@@ -37,3 +40,4 @@ class WhisperVulkanManager extends GpuBinaryManager {
 }
 
 module.exports = WhisperVulkanManager;
+module.exports.BIN_SUBDIR = BIN_SUBDIR;

--- a/test/helpers/gpuBinaryManager.test.js
+++ b/test/helpers/gpuBinaryManager.test.js
@@ -136,7 +136,7 @@ test("CUDA: resolves its exact asset from the pinned tag and installs binary + c
   assert.match(state.fetchedUrls[0], /OpenWhispr\/whisper\.cpp\/releases\/tags\/0\.0\.8$/);
   assert.equal(state.downloads[0].url, "https://dl/whisper-server-linux-x64-cuda.zip");
 
-  const binDir = path.join(userDataDir, "bin");
+  const binDir = path.join(userDataDir, "bin", "whisper-cuda");
   const binaryPath = path.join(binDir, "whisper-server-linux-x64-cuda");
   assert.ok(fs.existsSync(binaryPath));
   assert.ok(fs.statSync(binaryPath).mode & 0o100, "binary is executable");
@@ -144,6 +144,11 @@ test("CUDA: resolves its exact asset from the pinned tag and installs binary + c
   assert.ok(!fs.existsSync(path.join(binDir, "README.md")), "unrelated files not copied");
   assert.equal(manager.getCudaBinaryPath(), binaryPath);
   assert.equal(manager.isDownloaded(), true);
+  assert.equal(
+    fs.readdirSync(path.join(userDataDir, "bin")).some((e) => e.startsWith("temp-extract-stage-")),
+    false,
+    "staging dir swapped away"
+  );
 });
 
 test("llama Vulkan: resolves asset by regex from the pinned tag", async () => {
@@ -155,8 +160,9 @@ test("llama Vulkan: resolves asset by regex from the pinned tag", async () => {
 
   assert.deepEqual(result, { success: true });
   assert.match(state.fetchedUrls[0], /ggml-org\/llama\.cpp\/releases\/tags\/b9763$/);
-  assert.ok(fs.existsSync(path.join(userDataDir, "bin", "llama-server-vulkan")), "renamed output");
-  assert.ok(fs.existsSync(path.join(userDataDir, "bin", "libvulkan.so.1")));
+  const packDir = path.join(userDataDir, "bin", "llama-vulkan");
+  assert.ok(fs.existsSync(path.join(packDir, "llama-server-vulkan")), "renamed output");
+  assert.ok(fs.existsSync(path.join(packDir, "libvulkan.so.1")));
 });
 
 test("CUDA: pinned digest rejects an asset that doesn't match (fail closed)", async () => {
@@ -183,6 +189,7 @@ test("whisper Vulkan: pinned asset, no companion libs, rejects a digest mismatch
 test("digest: pinned match installs; API-reported digest is the fallback and also fails closed", async () => {
   const config = (expectedDigests) => ({
     name: "test",
+    dirName: "test-pack",
     releaseUrl: "https://api.github.com/repos/x/y/releases/latest",
     expectedDigests,
     assets: {
@@ -194,7 +201,7 @@ test("digest: pinned match installs; API-reported digest is the fallback and als
 
   state.release = makeRelease("bin.zip");
   await new GpuBinaryManager(config({ "bin.zip": goodDigest })).download();
-  assert.ok(fs.existsSync(path.join(userDataDir, "bin", "server-out")));
+  assert.ok(fs.existsSync(path.join(userDataDir, "bin", "test-pack", "server-out")));
 
   state.release = makeRelease("bin.zip", { digest: `sha256:${goodDigest}` });
   await new GpuBinaryManager(config(undefined)).download();
@@ -313,28 +320,107 @@ test("disk space: failure surfaces the friendly error with the 2.5x requirement"
   });
 });
 
-test("delete: removes binary + matching libs only; whisper Vulkan leaves shared DLL-space alone", async () => {
-  const binDir = path.join(userDataDir, "bin");
-  fs.mkdirSync(binDir, { recursive: true });
-  const seed = (name) => fs.writeFileSync(path.join(binDir, name), "x");
-  seed("whisper-server-linux-x64-cuda");
-  seed("libggml-cuda.so");
-  seed("llama-server-vulkan");
-  seed("whisper-server-linux-x64-vulkan");
+function seedPack(dirName, files) {
+  const dir = path.join(userDataDir, "bin", dirName);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const name of files) fs.writeFileSync(path.join(dir, name), "x");
+  return dir;
+}
+
+test("delete: removes only the pack's own directory; other packs untouched", async () => {
+  const cudaDir = seedPack("whisper-cuda", ["whisper-server-linux-x64-cuda", "libggml-cuda.so"]);
+  const llamaDir = seedPack("llama-vulkan", ["llama-server-vulkan", "libggml-base.so"]);
+  const vulkanDir = seedPack("whisper-vulkan", ["whisper-server-linux-x64-vulkan"]);
 
   const cudaResult = await new WhisperCudaManager().delete();
   assert.equal(cudaResult.success, true);
   assert.equal(cudaResult.deleted_count, 2);
-  assert.ok(!fs.existsSync(path.join(binDir, "whisper-server-linux-x64-cuda")));
-  assert.ok(!fs.existsSync(path.join(binDir, "libggml-cuda.so")));
-  assert.ok(fs.existsSync(path.join(binDir, "llama-server-vulkan")), "other backends untouched");
+  assert.ok(!fs.existsSync(cudaDir), "own pack directory removed");
+  assert.ok(fs.existsSync(path.join(llamaDir, "libggml-base.so")), "other packs' libs untouched");
 
   const vulkanResult = await new WhisperVulkanManager().delete();
   assert.equal(vulkanResult.deletedCount, 1);
-  assert.ok(!fs.existsSync(path.join(binDir, "whisper-server-linux-x64-vulkan")));
+  assert.ok(!fs.existsSync(vulkanDir));
 
   const llamaResult = await new LlamaVulkanManager().deleteBinary();
-  assert.deepEqual(llamaResult, { success: true, deletedCount: 1 });
+  assert.deepEqual(llamaResult, { success: true, deletedCount: 2 });
+});
+
+test("install isolation: packs sharing lib names cannot clobber each other", async () => {
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "whisper-server-linux-x64-cuda": "bin", "libggml-base.so": "cuda-ggml" };
+  await cudaManagerWithoutDigestPin().download();
+
+  state.release = makeRelease("llama-b9763-bin-ubuntu-vulkan-x64.tar.gz");
+  state.extractedFiles = { "llama-server": "bin", "libggml-base.so": "llama-ggml" };
+  await new LlamaVulkanManager().download();
+
+  const read = (dir) =>
+    fs.readFileSync(path.join(userDataDir, "bin", dir, "libggml-base.so"), "utf8");
+  assert.equal(read("whisper-cuda"), "cuda-ggml");
+  assert.equal(read("llama-vulkan"), "llama-ggml");
+});
+
+test("atomic install: a failure after extraction leaves no half-installed pack", async () => {
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "not-the-binary": "x" };
+
+  const manager = cudaManagerWithoutDigestPin();
+  await assert.rejects(() => manager.download(), { message: /not found in archive/ });
+
+  assert.equal(manager.isDownloaded(), false);
+  assert.ok(!fs.existsSync(path.join(userDataDir, "bin", "whisper-cuda")));
+  assert.equal(
+    fs.readdirSync(path.join(userDataDir, "bin")).some((e) => e.startsWith("temp-extract-stage-")),
+    false,
+    "staging dir cleaned up"
+  );
+});
+
+test("re-download replaces the previous install, including stale libs", async () => {
+  seedPack("whisper-cuda", ["whisper-server-linux-x64-cuda", "libstale.so"]);
+
+  state.release = makeRelease("whisper-server-linux-x64-cuda.zip");
+  state.extractedFiles = { "whisper-server-linux-x64-cuda": "new", "libggml-cuda.so": "lib" };
+  await cudaManagerWithoutDigestPin().download();
+
+  const packDir = path.join(userDataDir, "bin", "whisper-cuda");
+  assert.deepEqual(fs.readdirSync(packDir).sort(), [
+    "libggml-cuda.so",
+    "whisper-server-linux-x64-cuda",
+  ]);
+});
+
+test("legacy migration: lib-free pack is moved, lib-carrying packs are cleared for re-download", () => {
+  const { migrateLegacyBinDir } = GpuBinaryManager;
+  const binRoot = path.join(userDataDir, "bin");
+  fs.mkdirSync(binRoot, { recursive: true });
+  const seed = (name) => fs.writeFileSync(path.join(binRoot, name), "x");
+  // Pre-subdirectory flat layout: both lib-carrying packs plus whisper Vulkan
+  seed("whisper-server-linux-x64-cuda");
+  seed("whisper-server-linux-x64-vulkan");
+  seed("llama-server-vulkan");
+  seed("libggml-base.so"); // clobbered shared lib — owner unknowable
+  seed("libvulkan.so.1");
+
+  const cuda = new WhisperCudaManager();
+  const vulkan = new WhisperVulkanManager();
+  const llama = new LlamaVulkanManager();
+  migrateLegacyBinDir([cuda, vulkan, llama]);
+
+  assert.equal(vulkan.isDownloaded(), true, "statically-linked pack migrated in place");
+  assert.ok(fs.existsSync(path.join(binRoot, "whisper-vulkan", "whisper-server-linux-x64-vulkan")));
+  assert.equal(cuda.isDownloaded(), false, "ambiguous pack needs re-download");
+  assert.equal(llama.isDownloaded(), false);
+  assert.deepEqual(
+    fs.readdirSync(binRoot).sort(),
+    ["whisper-vulkan"],
+    "legacy binaries and orphaned libs removed"
+  );
+
+  // Idempotent on the healed layout
+  migrateLegacyBinDir([cuda, vulkan, llama]);
+  assert.equal(vulkan.isDownloaded(), true);
 });
 
 test("getStatus reflects supported/downloaded/downloading", async () => {
@@ -345,8 +431,6 @@ test("getStatus reflects supported/downloaded/downloading", async () => {
     downloading: false,
   });
 
-  const binDir = path.join(userDataDir, "bin");
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(path.join(binDir, "whisper-server-linux-x64-vulkan"), "x");
+  seedPack("whisper-vulkan", ["whisper-server-linux-x64-vulkan"]);
   assert.equal(manager.getStatus().downloaded, true);
 });


### PR DESCRIPTION
## Problem
All three GPU packs (whisper CUDA, whisper Vulkan, llama Vulkan) installed into one flat `userData/bin`, causing three defects:
1. whisper CUDA and llama Vulkan both ship ggml DLLs under identical names and both matched `libPattern /\.dll$/i` — installing one silently overwrote the other's runtime, and **deleting one deleted the other's libs**.
2. The final install was a bare `copyFile` onto the live filename — a crash or power cut mid-copy left a truncated binary that `isDownloaded()` (bare `existsSync`) reported as installed forever (reproduced in the field as a 0-byte `llama-server-vulkan.exe` after a mains power loss).
3. The CUDA download handler stopped the whisper server only *after* downloading, so repairing a pack the server was running from EBUSYed on Windows.

## Fix
- Each pack owns `userData/bin/<dirName>/`. Installs stage next to the final directory and swap in with a **single rename**; `delete()` removes exactly its own directory.
- CUDA handler stops the server before touching files, matching the Vulkan handler.
- `migrateLegacyBinDir()` heals the old layout at startup: the statically-linked whisper Vulkan pack is moved in place (working setups keep working); the lib-carrying packs — whose surviving DLLs can't be attributed after the clobbering — are cleared and re-offered in Settings.
- `whisperServer`/`llamaServer` lookups follow the pack directories via `BIN_SUBDIR` exports.

## Tests
Characterization tests updated to the new layout, plus new coverage: install isolation (same-named libs in both packs), atomic-install failure leaving nothing behind, re-download replacing stale libs, migration (move vs clear vs idempotence). Full suite green (1872 pass), typecheck + lint + prettier clean.