### PR TITLE
fix(calendar): safely handle whitespace hangout_link and nullish candidates in meeting join URL helpers

### DIFF
--- a/src/helpers/meetingJoinUrl.js
+++ b/src/helpers/meetingJoinUrl.js
@@ -3,11 +3,15 @@ const MEETING_URL_PATTERN =
 
 export function getMeetingJoinUrl(event) {
   if (!event) return null;
-  if (event.hangout_link) return event.hangout_link;
+  const hangoutLink = event.hangout_link?.trim();
+  if (hangoutLink) return hangoutLink;
   if (!event.conference_data) return null;
   try {
     const data = JSON.parse(event.conference_data);
-    return data?.entryPoints?.find((ep) => ep.entryPointType === "video")?.uri ?? null;
+    const uri = data?.entryPoints
+      ?.find((ep) => ep.entryPointType === "video" && ep.uri?.trim())
+      ?.uri?.trim();
+    return uri || null;
   } catch {
     return null;
   }
@@ -16,6 +20,7 @@ export function getMeetingJoinUrl(event) {
 // Finds a meeting link in loose text (EventKit has no structured conference
 // data — Zoom/Meet/Teams/Webex links live in url, location, or notes).
 export function extractMeetingUrl(candidates) {
+  if (!Array.isArray(candidates)) return null;
   for (const candidate of candidates) {
     const match = candidate?.match?.(MEETING_URL_PATTERN);
     if (match) return match[0].replace(/[),.;:!?]+$/, "");

--- a/test/helpers/meetingJoinUrl.test.js
+++ b/test/helpers/meetingJoinUrl.test.js
@@ -92,6 +92,26 @@ test("extractMeetingUrl returns the first matching candidate", async () => {
 test("extractMeetingUrl returns null when nothing matches", async () => {
   const { extractMeetingUrl } = await load();
   assert.equal(extractMeetingUrl([]), null);
+  assert.equal(extractMeetingUrl(null), null);
+  assert.equal(extractMeetingUrl(undefined), null);
+  assert.equal(extractMeetingUrl("not an array"), null);
   assert.equal(extractMeetingUrl([null, undefined, ""]), null);
   assert.equal(extractMeetingUrl(["Conference Room 4B", "https://example.com/agenda"]), null);
+});
+
+test("getMeetingJoinUrl trims hangout_link and skips whitespace-only links", async () => {
+  const { getMeetingJoinUrl } = await load();
+
+  const eventWithSpace = {
+    hangout_link: "  https://meet.google.com/abc-defg-hij  ",
+  };
+  assert.equal(getMeetingJoinUrl(eventWithSpace), "https://meet.google.com/abc-defg-hij");
+
+  const eventWithWhitespaceOnly = {
+    hangout_link: "   ",
+    conference_data: JSON.stringify({
+      entryPoints: [{ entryPointType: "video", uri: " https://zoom.us/j/123 " }],
+    }),
+  };
+  assert.equal(getMeetingJoinUrl(eventWithWhitespaceOnly), "https://zoom.us/j/123");
 });


### PR DESCRIPTION
### Summary
This PR fixes two edge cases in `src/helpers/meetingJoinUrl.js` that cause meeting join URL resolution to fail or throw errors when handling dirty or non-standard input data.

### Problem
1. `getMeetingJoinUrl()` checks `if (event.hangout_link)` without trimming whitespace. When a calendar event object contains whitespace (e.g. `"   "`), it returns that whitespace string instead of falling back to valid video entry points in `event.conference_data`.
2. `extractMeetingUrl()` assumes `candidates` is always an array and loops using `for (const candidate of candidates)`. Passing `null` or `undefined` throws an unhandled `TypeError: candidates is not iterable`.

### Root Cause
- `getMeetingJoinUrl` lacked string trimming on `hangout_link` and `conference_data` entry point URIs.
- `extractMeetingUrl` lacked an `Array.isArray(candidates)` check.

### Fix
- Trim `hangout_link` in `getMeetingJoinUrl()` and ensure whitespace-only links fall through to `conference_data`.
- Trim extracted video URIs from `conference_data` entry points.
- Add an `Array.isArray(candidates)` guard at the beginning of `extractMeetingUrl()`.

### Behavior Before vs. After
- **Before:** `getMeetingJoinUrl({ hangout_link: "   ", conference_data: "..." })` returned `"   "`. `extractMeetingUrl(null)` threw `TypeError`.
- **After:** `getMeetingJoinUrl({ hangout_link: "   ", conference_data: "..." })` returns the video URI from `conference_data`. `extractMeetingUrl(null)` returns `null`.

### Scope and Non-Goals
- Scope limited strictly to helper robustness in `src/helpers/meetingJoinUrl.js` and its corresponding test file.
- No changes to meeting detection timing or IPC contracts.

### Tests Added
- Added unit tests in `test/helpers/meetingJoinUrl.test.js` verifying:
  - `extractMeetingUrl()` with `null`, `undefined`, and non-array inputs.
  - `getMeetingJoinUrl()` with whitespace-padded `hangout_link` and whitespace-only `hangout_link` falling back to `conference_data`.

### Validation Results
- `node --test test/helpers/meetingJoinUrl.test.js` -> 10 tests passed
- `npm run typecheck` -> Passed
- `npm run lint` -> Passed
- `npm run format:check` -> Passed
- `npm run i18n:check` -> Passed
- `npm run build:renderer` -> Passed
- `git diff --check` -> Clean

Fixes #1579
