### PR TITLE
chore(gpu): pin whisper.cpp GPU packs to release 0.0.9

### DIFF
--- a/src/helpers/whisperCudaManager.js
+++ b/src/helpers/whisperCudaManager.js
@@ -1,10 +1,17 @@
 const GpuBinaryManager = require("./gpuBinaryManager");
 
 // Pinned so untested future binaries never auto-ship; bump together with the digests below
-const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.8";
+const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.9";
 
 // sha256 per release tag; tags without an entry fall back to the API-reported digest
 const EXPECTED_DIGESTS = {
+  // Same source as 0.0.8; adds Pascal (sm_61) CUDA kernels
+  "0.0.9": {
+    "whisper-server-win32-x64-cuda.zip":
+      "f5fdc42696c2de6ae323c59b5589b7d6b234ecdd4dd99ca18360824b529ad2d9",
+    "whisper-server-linux-x64-cuda.zip":
+      "11f4c6403b91e751375aac8cdef19582a9f383e0b96c5500ae81daeedb3be3f7",
+  },
   "0.0.8": {
     "whisper-server-win32-x64-cuda.zip":
       "ef6df3492b6e512ccfb04ce69e01ac26b2e12f3c90a665cdb35e7f1f471ed203",

--- a/src/helpers/whisperVulkanManager.js
+++ b/src/helpers/whisperVulkanManager.js
@@ -1,10 +1,17 @@
 const GpuBinaryManager = require("./gpuBinaryManager");
 
 // Pinned so untested future binaries never auto-ship; bump together with the digests below
-const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.8";
+const WHISPER_CPP_TAG = process.env.WHISPER_CPP_VERSION || "0.0.9";
 
 // sha256 per release tag; tags without an entry fall back to the API-reported digest
 const EXPECTED_DIGESTS = {
+  // Same source as 0.0.8, rebuilt alongside the Pascal CUDA kernels
+  "0.0.9": {
+    "whisper-server-win32-x64-vulkan.zip":
+      "6f33424d111036c18a9c5d2c0c09c67f458f48fa3c86553f875bca23ae11014d",
+    "whisper-server-linux-x64-vulkan.zip":
+      "02ddc850715421ff92940d5b4589cce95e3dec1906a134d3d0c809065f47fb5d",
+  },
   "0.0.8": {
     "whisper-server-win32-x64-vulkan.zip":
       "d5f6188bb6561e66a9b7886ca0448d5927cb9713a02d311b87a20e33eb038222",

--- a/test/helpers/gpuBinaryManager.test.js
+++ b/test/helpers/gpuBinaryManager.test.js
@@ -133,7 +133,7 @@ test("CUDA: resolves its exact asset from the pinned tag and installs binary + c
   const manager = cudaManagerWithoutDigestPin();
   await manager.download();
 
-  assert.match(state.fetchedUrls[0], /OpenWhispr\/whisper\.cpp\/releases\/tags\/0\.0\.8$/);
+  assert.match(state.fetchedUrls[0], /OpenWhispr\/whisper\.cpp\/releases\/tags\/0\.0\.9$/);
   assert.equal(state.downloads[0].url, "https://dl/whisper-server-linux-x64-cuda.zip");
 
   const binDir = path.join(userDataDir, "bin", "whisper-cuda");


### PR DESCRIPTION
Bumps the GPU pack pin from `0.0.8` to `0.0.9` in both `whisperCudaManager` and `whisperVulkanManager` (they share `WHISPER_CPP_TAG`), with fresh sha256 pins for all four assets — verified independently by downloading and hashing, not just trusting the API digest.

**What 0.0.9 is:** the exact same whisper.cpp source as 0.0.8 (`compare 0.0.8...0.0.9` = 1 commit, 1 file: the build workflow), rebuilt with Pascal (sm_61) added to `CMAKE_CUDA_ARCHITECTURES` (OpenWhispr/whisper.cpp#5). CUDA zips: +17.5 MB (Win 755→772.5 MB, Linux 201→218.7 MB); Vulkan zips unchanged in size.

**Zero behavior change for users:**
- Installed packs are never version-checked, so existing installs keep their working binaries untouched.
- New downloads get 0.0.9, whose kernels are identical for every card the compute-cap gate currently admits (7.5+) — GPU binaries select their own arch's code at runtime.
- The bundled CPU/macOS binaries pin in `scripts/download-whisper-cpp.js` is deliberately untouched.
- The 0.0.8 digest set stays in the map so a `WHISPER_CPP_VERSION=0.0.8` rollback remains integrity-pinned.

Offering CUDA to Pascal cards (lowering `MIN_CUDA_COMPUTE_CAP` 7.5 → 6.1) is a separate follow-up PR, held until a real Pascal card smoke-tests the new kernels.

Full suite: 1922 pass / 0 fail.