### PR TITLE
feat(gpu): offer the CUDA pack to Pascal cards (0.0.9 kernel floor)

### DIFF
--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -597,17 +597,21 @@ export default function TranscriptionModelPicker({
     if (getCachedPlatform() === "darwin") return;
     const detect = async () => {
       try {
-        // Cards below the CUDA build's kernel floor (e.g. Pascal) crash at the
+        const [cuda, vulkan] = await Promise.all([
+          window.electronAPI?.getCudaWhisperStatus?.(),
+          window.electronAPI?.getVulkanWhisperStatus?.(),
+        ]);
+        // Cards below the CUDA build's kernel floor (e.g. Maxwell) crash at the
         // first kernel launch, so they get the Vulkan pack like AMD/Intel GPUs.
-        const cuda = await window.electronAPI?.getCudaWhisperStatus?.();
-        if (cuda?.gpuInfo.hasNvidiaGpu && cuda.gpuInfo.cudaSupported) {
+        const cudaEligible = !!cuda?.gpuInfo.hasNvidiaGpu && !!cuda.gpuInfo.cudaSupported;
+        // Prefer the pack that's already installed: a working Vulkan setup must
+        // not be re-prompted to download the CUDA pack (matches the resolver,
+        // which only prefers CUDA when it is actually downloaded).
+        if (cudaEligible && (cuda.downloaded || !vulkan?.downloaded)) {
           setGpuBackend("cuda");
           setGpuDownloaded(cuda.downloaded);
           setGpuFailed(!!cuda.gpuFailed);
-          return;
-        }
-        const vulkan = await window.electronAPI?.getVulkanWhisperStatus?.();
-        if (vulkan?.vulkan.available) {
+        } else if (vulkan?.vulkan.available) {
           setGpuBackend("vulkan");
           setGpuDownloaded(vulkan.downloaded);
           setGpuFailed(!!vulkan.gpuFailed);

--- a/src/utils/gpuDetection.js
+++ b/src/utils/gpuDetection.js
@@ -1,12 +1,13 @@
 const { execFile } = require("child_process");
 
-// The shipped CUDA whisper build only carries kernels for Turing (compute
-// capability 7.5) and newer. On older cards (e.g. Pascal / GTX 10-series,
-// 6.1) the server starts, loads the model into VRAM, then aborts on the first
-// kernel launch with "no kernel image is available for execution on the
-// device" — so those cards must be offered Vulkan instead, which works on any
-// NVIDIA GPU.
-const MIN_CUDA_COMPUTE_CAP = 7.5;
+// The shipped CUDA whisper build (release 0.0.9) carries kernels for Pascal
+// (compute capability 6.1) and newer; 6.1's embedded PTX also covers Volta via
+// driver JIT. On cards below the floor the server starts, loads the model into
+// VRAM, then aborts on the first kernel launch with "no kernel image is
+// available for execution on the device" — so those cards must be offered
+// Vulkan instead, which works on any NVIDIA GPU. Keep this floor in lockstep
+// with CUDA_ARCHITECTURES in OpenWhispr/whisper.cpp's build-binaries.yml.
+const MIN_CUDA_COMPUTE_CAP = 6.1;
 
 let cachedGpuInfo = null;
 

--- a/test/helpers/gpuDetection.test.js
+++ b/test/helpers/gpuDetection.test.js
@@ -19,15 +19,22 @@ test("Turing and newer report cudaSupported", () => {
   });
 });
 
-test("Pascal is detected but not CUDA-supported (gets Vulkan instead)", () => {
+test("Pascal is CUDA-supported since the 0.0.9 build ships sm_61 kernels", () => {
   const info = parseNvidiaSmiGpuInfo("NVIDIA GeForce GTX 1080 Ti, 582.66, 11264, 6.1");
   assert.equal(info.hasNvidiaGpu, true);
   assert.equal(info.computeCap, 6.1);
+  assert.equal(info.cudaSupported, true);
+});
+
+test("Maxwell is detected but not CUDA-supported (gets Vulkan instead)", () => {
+  const info = parseNvidiaSmiGpuInfo("NVIDIA GeForce GTX 970, 560.94, 4096, 5.2");
+  assert.equal(info.hasNvidiaGpu, true);
+  assert.equal(info.computeCap, 5.2);
   assert.equal(info.cudaSupported, false);
 });
 
 test("exactly the minimum compute capability is supported", () => {
-  const info = parseNvidiaSmiGpuInfo(`RTX 2060, 560.94, 6144, ${MIN_CUDA_COMPUTE_CAP}`);
+  const info = parseNvidiaSmiGpuInfo(`Some GPU, 560.94, 6144, ${MIN_CUDA_COMPUTE_CAP}`);
   assert.equal(info.cudaSupported, true);
 });
 
@@ -46,9 +53,9 @@ test("an unparseable compute_cap ([N/A]) stays conservative", () => {
 
 test("multi-GPU output uses the primary card", () => {
   const info = parseNvidiaSmiGpuInfo(
-    "NVIDIA GeForce GTX 1080 Ti, 582.66, 11264, 6.1\nNVIDIA T400, 582.66, 2048, 7.5"
+    "NVIDIA GeForce GTX 970, 560.94, 4096, 5.2\nNVIDIA T400, 582.66, 2048, 7.5"
   );
-  assert.equal(info.gpuName, "NVIDIA GeForce GTX 1080 Ti");
+  assert.equal(info.gpuName, "NVIDIA GeForce GTX 970");
   assert.equal(info.cudaSupported, false);
 });
 


### PR DESCRIPTION
**⏸ HOLD — do not merge until the Pascal smoke test below passes on real hardware.**

With #1584 pinning the packs to whisper.cpp 0.0.9 (which ships sm_61 kernels), this lowers `MIN_CUDA_COMPUTE_CAP` from 7.5 to 6.1 so GTX 10-series cards are offered the CUDA pack.

## Exactly who this affects
- **Cards ≥ 7.5, AMD/Intel, macOS, cloud users:** no change — they already passed the gate or never consult it.
- **Cards < 6.1 (Maxwell/Kepler):** no change — still routed to Vulkan (new below-floor test added).
- **Pascal/Volta (6.1–7.4):** newly offered the CUDA pack. Volta runs via the embedded compute_61 PTX (driver JIT).

## Prefer-installed-backend fix included
Without it, a Pascal user already running the **Vulkan** pack would see the "Enable GPU" CUDA banner reappear over a working setup the moment this gate opens. The picker now prefers whichever pack is installed — mirroring the runtime resolver, which only prefers CUDA once it's actually downloaded. Their dictation never changes out from under them either way.

## Bounded worst case (already shipped)
If a Pascal kernel still fails on some card: the dictation completes via the CPU fallback retry, the failure is persisted (`WHISPER_GPU_FAILED`) so it's never re-attempted silently, and the chip shows "GPU could not be activated — Retry". Nobody loses words; the cost is one wasted download.

## Go / no-go: Pascal smoke test
On a GTX 10-series machine running this build:
1. Settings → Speech-to-Text → Local → Whisper → **Enable GPU** (should offer CUDA, ~772 MB).
2. Wait for the chip to reach **"GPU acceleration active"** (poll reflects the live server, not the download).
3. Dictate a long sentence; confirm it pastes, no "using CPU instead" toast appears, and `whisper-server-status` reports `gpuBackend: "cuda"`.
4. Compare latency against the Vulkan pack on the same box (both should beat CPU; CUDA should beat or match Vulkan).

Full suite: 1923 pass / 0 fail, typecheck + prettier clean.