### PR TITLE
fix(voice-agent): support extraction when completionMarker is empty or omitted

### DIFF
--- a/src/helpers/selectionEditing.js
+++ b/src/helpers/selectionEditing.js
@@ -43,11 +43,11 @@ export function getSelectionCaptureDisposition(capture, accessibilitySkipped = f
 }
 
 export function extractSelectionEditReplacement(result, completionMarker) {
-  if (typeof result !== "string" || !completionMarker || !result.endsWith(completionMarker)) {
+  if (typeof result !== "string" || (completionMarker && !result.endsWith(completionMarker))) {
     throw new Error("Model output was incomplete before the selection edit completed");
   }
 
-  const replacement = result.slice(0, -completionMarker.length);
+  const replacement = completionMarker ? result.slice(0, -completionMarker.length) : result;
   if (replacement.trim().length === 0) {
     throw new Error("Model returned an empty selection edit");
   }

--- a/test/helpers/selectionEditing.test.js
+++ b/test/helpers/selectionEditing.test.js
@@ -27,14 +27,8 @@ test("builds a structured prompt that keeps instruction and selection separate",
   assert.match(systemPrompt, /Output only the complete replacement text/);
   assert.match(systemPrompt, new RegExp(marker));
 
-  assert.equal(
-    extractSelectionEditReplacement(`Improved text${marker}`, marker),
-    "Improved text"
-  );
-  assert.throws(
-    () => extractSelectionEditReplacement("Truncated text", marker),
-    /incomplete/
-  );
+  assert.equal(extractSelectionEditReplacement(`Improved text${marker}`, marker), "Improved text");
+  assert.throws(() => extractSelectionEditReplacement("Truncated text", marker), /incomplete/);
 
   assert.equal(getSelectionCaptureDisposition({ status: "none" }), "standalone");
   assert.equal(
@@ -53,5 +47,28 @@ test("builds a structured prompt that keeps instruction and selection separate",
     "standalone"
   );
   assert.equal(getSelectionCaptureDisposition({ status: "target_changed" }), "changed");
-  assert.equal(getSelectionCaptureDisposition({ status: "unavailable", code: "copy_failed" }), "unavailable");
+  assert.equal(
+    getSelectionCaptureDisposition({ status: "unavailable", code: "copy_failed" }),
+    "unavailable"
+  );
+});
+
+test("extractSelectionEditReplacement supports empty or omitted completionMarker", async () => {
+  const { extractSelectionEditReplacement } = await load();
+
+  assert.equal(
+    extractSelectionEditReplacement("Direct replacement text", ""),
+    "Direct replacement text"
+  );
+  assert.equal(
+    extractSelectionEditReplacement("Direct replacement text", undefined),
+    "Direct replacement text"
+  );
+  assert.equal(
+    extractSelectionEditReplacement("Direct replacement text", null),
+    "Direct replacement text"
+  );
+
+  assert.throws(() => extractSelectionEditReplacement("   ", ""), /empty selection edit/);
+  assert.throws(() => extractSelectionEditReplacement(123, ""), /incomplete/);
 });


### PR DESCRIPTION
## Summary

This pull request fixes a bug in `extractSelectionEditReplacement` where selection edit extractions threw `Error: Model output was incomplete before the selection edit completed` whenever `completionMarker` was falsy (empty string, `null`, or `undefined`).

## Problem

`buildSelectionEditSystemPrompt(basePrompt, completionMarker = "")` explicitly supports omitting or passing an empty `completionMarker`, in which case no marker instruction is added to the system prompt. However, `extractSelectionEditReplacement(result, completionMarker)` evaluated `!completionMarker` in its validation guard as an incomplete output error, causing all marker-less selection edit extractions to fail even when the model produced a complete and valid replacement text.

## Root Cause

`extractSelectionEditReplacement` checked `!completionMarker` as part of its failure condition:
```javascript
if (typeof result !== "string" || !completionMarker || !result.endsWith(completionMarker))
```
This treated `completionMarker` as mandatory.

## Fix

Updated `extractSelectionEditReplacement` to evaluate `(completionMarker && !result.endsWith(completionMarker))` so that extractions without a completion marker succeed and return the non-empty `result` string as expected.

## Behavior Before and After

- **Before**: `extractSelectionEditReplacement("replacement text", "")` threw `Error: Model output was incomplete before the selection edit completed`.
- **After**: `extractSelectionEditReplacement("replacement text", "")` returns `"replacement text"`.

## Scope & Non-Goals

- Scope: `src/helpers/selectionEditing.js` and unit tests in `test/helpers/selectionEditing.test.js`.
- Non-goals: Does not alter system prompt generation or completion marker behavior when a marker is provided.

## Tests Added

- `test/helpers/selectionEditing.test.js`: Added unit tests verifying `extractSelectionEditReplacement` with empty string `""`, `undefined`, `null`, whitespace-only output, and invalid argument types.

## Validation Results

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --experimental-strip-types --test test/helpers/selectionEditing.test.js` (Passed 2/2 tests)
- `npm run typecheck` (Passed cleanly)
- `npm run lint` (Passed cleanly)
- `npm run format:check` (Passed cleanly)
- `npm run i18n:check` (Passed cleanly)
- `npm run build:renderer` (Passed cleanly)
- `git diff --check` (Passed cleanly)

Fixes #1586
