### PR TITLE
fix(gpu): gate the cleanup GPU banner on local inference

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
 import { Button } from "./ui/button";
 import {
   Download,
@@ -32,8 +33,13 @@ import {
   updateTranscription as updateInStore,
   clearTranscriptions as clearStore,
 } from "../stores/transcriptionStore";
-import { getSettings, useSettingsStore } from "../stores/settingsStore";
+import {
+  getSettings,
+  selectPolicyEffectiveSettings,
+  useSettingsStore,
+} from "../stores/settingsStore";
 import { usePolicyStore } from "../stores/policyStore";
+import { usePolicySnapshot } from "../hooks/usePolicy";
 import {
   isAgentAllowed,
   isControlPanelViewAllowed,
@@ -53,7 +59,7 @@ import WindowControls from "./WindowControls";
 
 import { getCachedPlatform } from "../utils/platform";
 import { isAccessibilitySkipped } from "../utils/permissions";
-import { eligibleGpuOffers } from "../utils/gpuBannerPolicy";
+import { eligibleGpuOffers, type GpuOffers } from "../utils/gpuBannerPolicy";
 import {
   setActiveNoteId,
   setActiveFolderId,
@@ -146,12 +152,9 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
     folderId: number;
     event: any;
   } | null>(null);
-  const [gpuAccelAvailable, setGpuAccelAvailable] = useState<{
-    transcription: boolean;
-    intelligence: boolean;
-  }>({
+  const [gpuAccelAvailable, setGpuAccelAvailable] = useState<GpuOffers>({
     transcription: false,
-    intelligence: false,
+    intelligence: null,
   });
   const [gpuBannerDismissed, setGpuBannerDismissed] = useState(
     () => localStorage.getItem("gpuBannerDismissedUnified") === "true"
@@ -161,14 +164,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   const updateErrorToastShown = useRef<Error | null>(null);
   const { hotkey } = useHotkey();
   const { toast } = useToast();
-  const {
-    useLocalWhisper,
-    localTranscriptionProvider,
-    useCleanupModel,
-    cleanupMode,
-    setUseLocalWhisper,
-    setCloudTranscriptionMode,
-  } = useSettings();
+  const { useCleanupModel, setUseLocalWhisper, setCloudTranscriptionMode } = useSettings();
   const { isSignedIn, isLoaded: authLoaded, user } = useAuth();
   // Suppressed while a deep-linked invitation is open so the two never stack.
   const {
@@ -203,6 +199,23 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
   }, [activeView, agentAllowedByPolicy, policyActionsAllowed]);
   const updateRequiredByOrg = usePolicyStore(isUpdateRequiredByOrg);
   const policyMinAppVersion = usePolicyStore((s) => s.policy?.minAppVersion ?? null);
+
+  // Policy-effective, because the settings pane the GPU banner links to renders
+  // the clamped mode — see eligibleGpuOffers.
+  const policySnapshot = usePolicySnapshot();
+  const gpuBannerSettings = useSettingsStore(
+    useShallow((settings) => {
+      const effective = selectPolicyEffectiveSettings(settings, policySnapshot);
+      return {
+        useLocalWhisper: effective.useLocalWhisper,
+        localTranscriptionProvider: effective.localTranscriptionProvider,
+        useCleanupModel: effective.useCleanupModel,
+        cleanupMode: effective.cleanupMode,
+        useDictationAgent: effective.useDictationAgent,
+        dictationAgentMode: effective.dictationAgentMode,
+      };
+    })
+  );
 
   const {
     confirmDialog,
@@ -391,14 +404,13 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
 
   useEffect(() => {
     if (platform === "darwin" || gpuBannerDismissed) return;
-    const offers = eligibleGpuOffers({
-      useLocalWhisper,
-      localTranscriptionProvider,
-      useCleanupModel,
-      cleanupMode,
-    });
+    const offers = eligibleGpuOffers({ ...gpuBannerSettings, agentAllowedByPolicy });
+    // A run that loses its settings mid-probe must not publish: switching to a
+    // cloud mode resolves with no IPC at all, so an older local-mode run would
+    // otherwise land last and re-raise the banner for the rest of the session.
+    let cancelled = false;
     const detect = async () => {
-      const results = { transcription: false, intelligence: false };
+      const results: GpuOffers = { transcription: false, intelligence: null };
       if (offers.transcription) {
         try {
           const status = await window.electronAPI?.getCudaWhisperStatus?.();
@@ -416,13 +428,16 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
             window.electronAPI?.detectVulkanGpu?.(),
             window.electronAPI?.getLlamaVulkanStatus?.(),
           ]);
-          if (gpu?.available && !vulkan?.downloaded) results.intelligence = true;
+          if (gpu?.available && !vulkan?.downloaded) results.intelligence = offers.intelligence;
         } catch {}
       }
-      setGpuAccelAvailable(results);
+      if (!cancelled) setGpuAccelAvailable(results);
     };
     detect();
-  }, [useLocalWhisper, localTranscriptionProvider, useCleanupModel, cleanupMode, gpuBannerDismissed]);
+    return () => {
+      cancelled = true;
+    };
+  }, [gpuBannerSettings, agentAllowedByPolicy, gpuBannerDismissed]);
 
   useEffect(() => {
     const drain = async () => {
@@ -1135,7 +1150,11 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                             className="h-7 text-xs"
                             onClick={() => {
                               setSettingsSection(
-                                gpuAccelAvailable.transcription ? "transcription" : "intelligence"
+                                gpuAccelAvailable.transcription
+                                  ? "transcription"
+                                  : gpuAccelAvailable.intelligence === "dictationAgent"
+                                    ? "dictationAgent"
+                                    : "intelligence"
                               );
                               setShowSettings(true);
                             }}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -53,6 +53,7 @@ import WindowControls from "./WindowControls";
 
 import { getCachedPlatform } from "../utils/platform";
 import { isAccessibilitySkipped } from "../utils/permissions";
+import { eligibleGpuOffers } from "../utils/gpuBannerPolicy";
 import {
   setActiveNoteId,
   setActiveFolderId,
@@ -164,6 +165,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
     useLocalWhisper,
     localTranscriptionProvider,
     useCleanupModel,
+    cleanupMode,
     setUseLocalWhisper,
     setCloudTranscriptionMode,
   } = useSettings();
@@ -389,9 +391,15 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
 
   useEffect(() => {
     if (platform === "darwin" || gpuBannerDismissed) return;
+    const offers = eligibleGpuOffers({
+      useLocalWhisper,
+      localTranscriptionProvider,
+      useCleanupModel,
+      cleanupMode,
+    });
     const detect = async () => {
       const results = { transcription: false, intelligence: false };
-      if (useLocalWhisper && localTranscriptionProvider === "whisper") {
+      if (offers.transcription) {
         try {
           const status = await window.electronAPI?.getCudaWhisperStatus?.();
           if (status?.gpuInfo.hasNvidiaGpu && status.gpuInfo.cudaSupported) {
@@ -402,7 +410,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
           }
         } catch {}
       }
-      if (useCleanupModel) {
+      if (offers.intelligence) {
         try {
           const [gpu, vulkan] = await Promise.all([
             window.electronAPI?.detectVulkanGpu?.(),
@@ -414,7 +422,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
       setGpuAccelAvailable(results);
     };
     detect();
-  }, [useLocalWhisper, localTranscriptionProvider, useCleanupModel, gpuBannerDismissed]);
+  }, [useLocalWhisper, localTranscriptionProvider, useCleanupModel, cleanupMode, gpuBannerDismissed]);
 
   useEffect(() => {
     const drain = async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -21,10 +21,12 @@ export type { SettingsSectionType };
 // The old AI Models sidebar had four items (transcription, meetings,
 // intelligence, agentMode) — they now collapse into two: speechToText + llms.
 // Legacy deep-links land on the matching sub-tab via LEGACY_SUB_TAB.
+// "dictationAgent" is a live deep-link (the Home GPU banner), not a legacy alias.
 const SECTION_ALIASES: Record<string, SettingsSectionType> = {
   aiModels: "llms",
   agentConfig: "llms",
   agentMode: "llms",
+  dictationAgent: "llms",
   intelligence: "llms",
   meetings: "llms",
   prompts: "llms",
@@ -39,6 +41,7 @@ const SECTION_ALIASES: Record<string, SettingsSectionType> = {
 const LEGACY_SUB_TAB: Record<string, string> = {
   transcription: "dictation",
   uploadTranscription: "upload",
+  dictationAgent: "dictationAgent",
   meetings: "noteFormatting",
   intelligence: "dictationCleanup",
   agentMode: "chatIntelligence",

--- a/src/utils/gpuBannerPolicy.ts
+++ b/src/utils/gpuBannerPolicy.ts
@@ -1,24 +1,42 @@
-import type { InferenceMode } from "../types/electron";
+import type { InferenceMode, LocalTranscriptionProvider } from "../types/electron";
 
 export interface GpuOfferInputs {
   useLocalWhisper: boolean;
-  localTranscriptionProvider: string;
+  localTranscriptionProvider: LocalTranscriptionProvider;
   useCleanupModel: boolean;
   cleanupMode: InferenceMode;
+  useDictationAgent: boolean;
+  dictationAgentMode: InferenceMode;
+  agentAllowedByPolicy: boolean;
 }
+
+export type IntelligenceGpuTarget = "cleanup" | "dictationAgent";
 
 export interface GpuOffers {
   transcription: boolean;
-  intelligence: boolean;
+  intelligence: IntelligenceGpuTarget | null;
 }
 
 // The Home-screen GPU banner offers to install local acceleration binaries, so
-// each branch must require its engine to actually run locally — with cloud
-// cleanup there is nothing a local Vulkan build could accelerate, and the
-// Enable GPU button would land on a pane without the install control (#1509).
+// each branch must require an engine that actually runs locally — otherwise the
+// Enable GPU button would land on a settings pane without the install control
+// (#1509). Cleanup and the dictation agent share the local llama server (see
+// resolveLocalServerNeeds), so either one running locally makes the Vulkan
+// pack worth offering; the target names the settings tab that carries the
+// install control. A policy-blocked agent gets no offer — its tab is hidden.
+//
+// Modes must be policy-effective (selectPolicyEffectiveSettings), not raw: the
+// settings pane renders the clamped mode, so a managed profile that forbids
+// local inference leaves the raw mode at "local" pointing at a pane that shows
+// no install control — the same dead end #1509 reported.
 export function eligibleGpuOffers(inputs: GpuOfferInputs): GpuOffers {
+  const cleanupLocal = inputs.useCleanupModel && inputs.cleanupMode === "local";
+  const agentLocal =
+    inputs.useDictationAgent &&
+    inputs.agentAllowedByPolicy &&
+    inputs.dictationAgentMode === "local";
   return {
     transcription: inputs.useLocalWhisper && inputs.localTranscriptionProvider === "whisper",
-    intelligence: inputs.useCleanupModel && inputs.cleanupMode === "local",
+    intelligence: cleanupLocal ? "cleanup" : agentLocal ? "dictationAgent" : null,
   };
 }

--- a/src/utils/gpuBannerPolicy.ts
+++ b/src/utils/gpuBannerPolicy.ts
@@ -1,0 +1,24 @@
+import type { InferenceMode } from "../types/electron";
+
+export interface GpuOfferInputs {
+  useLocalWhisper: boolean;
+  localTranscriptionProvider: string;
+  useCleanupModel: boolean;
+  cleanupMode: InferenceMode;
+}
+
+export interface GpuOffers {
+  transcription: boolean;
+  intelligence: boolean;
+}
+
+// The Home-screen GPU banner offers to install local acceleration binaries, so
+// each branch must require its engine to actually run locally — with cloud
+// cleanup there is nothing a local Vulkan build could accelerate, and the
+// Enable GPU button would land on a pane without the install control (#1509).
+export function eligibleGpuOffers(inputs: GpuOfferInputs): GpuOffers {
+  return {
+    transcription: inputs.useLocalWhisper && inputs.localTranscriptionProvider === "whisper",
+    intelligence: inputs.useCleanupModel && inputs.cleanupMode === "local",
+  };
+}

--- a/test/utils/gpuBannerPolicy.test.js
+++ b/test/utils/gpuBannerPolicy.test.js
@@ -3,88 +3,100 @@ const assert = require("node:assert/strict");
 
 const load = () => import("../../src/utils/gpuBannerPolicy.ts");
 
-test("cloud cleanup (openwhispr default) is not eligible for the intelligence GPU offer", async () => {
+const offersWith = async (overrides) => {
   const { eligibleGpuOffers } = await load();
-
-  const offers = eligibleGpuOffers({
+  return eligibleGpuOffers({
     useLocalWhisper: false,
     localTranscriptionProvider: "whisper",
-    useCleanupModel: true,
+    useCleanupModel: false,
     cleanupMode: "openwhispr",
+    useDictationAgent: false,
+    dictationAgentMode: "openwhispr",
+    agentAllowedByPolicy: true,
+    ...overrides,
   });
+};
 
-  assert.equal(offers.intelligence, false);
+test("cloud cleanup (openwhispr default) is not eligible for the intelligence GPU offer", async () => {
+  const offers = await offersWith({ useCleanupModel: true, cleanupMode: "openwhispr" });
+
+  assert.equal(offers.intelligence, null);
 });
 
 test("cloud cleanup modes are never eligible even with cleanup enabled", async () => {
-  const { eligibleGpuOffers } = await load();
-
   for (const cleanupMode of ["openwhispr", "providers", "self-hosted", "enterprise"]) {
-    const offers = eligibleGpuOffers({
-      useLocalWhisper: false,
-      localTranscriptionProvider: "whisper",
-      useCleanupModel: true,
-      cleanupMode,
-    });
-    assert.equal(offers.intelligence, false, `cleanupMode=${cleanupMode}`);
+    const offers = await offersWith({ useCleanupModel: true, cleanupMode });
+    assert.equal(offers.intelligence, null, `cleanupMode=${cleanupMode}`);
   }
 });
 
-test("local cleanup with the model enabled is eligible for the intelligence GPU offer", async () => {
-  const { eligibleGpuOffers } = await load();
+test("local cleanup with the model enabled targets the cleanup tab", async () => {
+  const offers = await offersWith({ useCleanupModel: true, cleanupMode: "local" });
 
-  const offers = eligibleGpuOffers({
-    useLocalWhisper: false,
-    localTranscriptionProvider: "whisper",
-    useCleanupModel: true,
-    cleanupMode: "local",
-  });
-
-  assert.equal(offers.intelligence, true);
+  assert.equal(offers.intelligence, "cleanup");
 });
 
 test("local cleanup with the model disabled is not eligible", async () => {
-  const { eligibleGpuOffers } = await load();
+  const offers = await offersWith({ useCleanupModel: false, cleanupMode: "local" });
 
-  const offers = eligibleGpuOffers({
-    useLocalWhisper: false,
-    localTranscriptionProvider: "whisper",
-    useCleanupModel: false,
-    cleanupMode: "local",
+  assert.equal(offers.intelligence, null);
+});
+
+test("a local dictation agent with cloud cleanup targets the agent tab", async () => {
+  const offers = await offersWith({
+    useCleanupModel: true,
+    cleanupMode: "openwhispr",
+    useDictationAgent: true,
+    dictationAgentMode: "local",
   });
 
-  assert.equal(offers.intelligence, false);
+  assert.equal(offers.intelligence, "dictationAgent");
+});
+
+test("local cleanup wins the target when both scopes run locally", async () => {
+  const offers = await offersWith({
+    useCleanupModel: true,
+    cleanupMode: "local",
+    useDictationAgent: true,
+    dictationAgentMode: "local",
+  });
+
+  assert.equal(offers.intelligence, "cleanup");
+});
+
+test("a disabled or cloud-mode dictation agent is not eligible", async () => {
+  const disabled = await offersWith({ useDictationAgent: false, dictationAgentMode: "local" });
+  assert.equal(disabled.intelligence, null);
+
+  for (const dictationAgentMode of ["openwhispr", "providers", "self-hosted", "enterprise"]) {
+    const cloud = await offersWith({ useDictationAgent: true, dictationAgentMode });
+    assert.equal(cloud.intelligence, null, `dictationAgentMode=${dictationAgentMode}`);
+  }
+});
+
+test("a policy-blocked agent gets no offer — its settings tab is hidden", async () => {
+  const offers = await offersWith({
+    useDictationAgent: true,
+    dictationAgentMode: "local",
+    agentAllowedByPolicy: false,
+  });
+
+  assert.equal(offers.intelligence, null);
 });
 
 test("local whisper transcription is eligible for the transcription GPU offer", async () => {
-  const { eligibleGpuOffers } = await load();
-
-  const offers = eligibleGpuOffers({
-    useLocalWhisper: true,
-    localTranscriptionProvider: "whisper",
-    useCleanupModel: false,
-    cleanupMode: "openwhispr",
-  });
+  const offers = await offersWith({ useLocalWhisper: true });
 
   assert.equal(offers.transcription, true);
 });
 
 test("cloud transcription and non-whisper local providers are not eligible", async () => {
-  const { eligibleGpuOffers } = await load();
-
-  const cloud = eligibleGpuOffers({
-    useLocalWhisper: false,
-    localTranscriptionProvider: "whisper",
-    useCleanupModel: false,
-    cleanupMode: "openwhispr",
-  });
+  const cloud = await offersWith({ useLocalWhisper: false });
   assert.equal(cloud.transcription, false);
 
-  const parakeet = eligibleGpuOffers({
+  const parakeet = await offersWith({
     useLocalWhisper: true,
     localTranscriptionProvider: "nvidia",
-    useCleanupModel: false,
-    cleanupMode: "openwhispr",
   });
   assert.equal(parakeet.transcription, false);
 });

--- a/test/utils/gpuBannerPolicy.test.js
+++ b/test/utils/gpuBannerPolicy.test.js
@@ -1,0 +1,90 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/gpuBannerPolicy.ts");
+
+test("cloud cleanup (openwhispr default) is not eligible for the intelligence GPU offer", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  const offers = eligibleGpuOffers({
+    useLocalWhisper: false,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: true,
+    cleanupMode: "openwhispr",
+  });
+
+  assert.equal(offers.intelligence, false);
+});
+
+test("cloud cleanup modes are never eligible even with cleanup enabled", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  for (const cleanupMode of ["openwhispr", "providers", "self-hosted", "enterprise"]) {
+    const offers = eligibleGpuOffers({
+      useLocalWhisper: false,
+      localTranscriptionProvider: "whisper",
+      useCleanupModel: true,
+      cleanupMode,
+    });
+    assert.equal(offers.intelligence, false, `cleanupMode=${cleanupMode}`);
+  }
+});
+
+test("local cleanup with the model enabled is eligible for the intelligence GPU offer", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  const offers = eligibleGpuOffers({
+    useLocalWhisper: false,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: true,
+    cleanupMode: "local",
+  });
+
+  assert.equal(offers.intelligence, true);
+});
+
+test("local cleanup with the model disabled is not eligible", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  const offers = eligibleGpuOffers({
+    useLocalWhisper: false,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: false,
+    cleanupMode: "local",
+  });
+
+  assert.equal(offers.intelligence, false);
+});
+
+test("local whisper transcription is eligible for the transcription GPU offer", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  const offers = eligibleGpuOffers({
+    useLocalWhisper: true,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: false,
+    cleanupMode: "openwhispr",
+  });
+
+  assert.equal(offers.transcription, true);
+});
+
+test("cloud transcription and non-whisper local providers are not eligible", async () => {
+  const { eligibleGpuOffers } = await load();
+
+  const cloud = eligibleGpuOffers({
+    useLocalWhisper: false,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: false,
+    cleanupMode: "openwhispr",
+  });
+  assert.equal(cloud.transcription, false);
+
+  const parakeet = eligibleGpuOffers({
+    useLocalWhisper: true,
+    localTranscriptionProvider: "nvidia",
+    useCleanupModel: false,
+    cleanupMode: "openwhispr",
+  });
+  assert.equal(parakeet.transcription, false);
+});


### PR DESCRIPTION
## What & why

On Linux/Windows with cloud AI cleanup (the default), the Home screen showed the "GPU acceleration available" banner on every launch, forever. The eligibility check asked "is AI cleanup enabled?" (useCleanupModel, default true) instead of "does cleanup run locally?" (cleanupMode, default "openwhispr" = cloud). Since essentially every desktop GPU passes the Vulkan vendor allowlist and cloud users never download llama-server-vulkan, the banner's conditions were permanently satisfied. Worse, Enable GPU opened Settings → AI Models → Dictation Cleanup, which in cloud mode renders no GPU control at all — a dead-end button that could never clear the banner; the only exit was "Not now".

The fix gates the intelligence branch on cleanupMode === "local", mirroring the local-whisper guard the transcription branch already has. This also fixes the dead-end button structurally: the banner can now only appear when the pane it opens actually renders the GpuStatusBadge install control. The eligibility decision is extracted into a pure, unit-tested policy module, following the dockPolicy.js precedent.

## Verification
New tests written first and confirmed failing, then green after the fix.
Full suite under Node 24: 1948 tests, 1778 pass, 0 fail, 169 skipped (known local DB-ABI skips).
tsc --noEmit and eslint clean on touched files.

## Follow-ups / known limitations

The gate reads the raw cleanupMode setting, consistent with how the transcription branch reads raw settings. An enterprise-managed deployment that force-overrides a user whose stored mode is "local" could still see the banner — rare, and pre-existing behavior for the transcription branch; switching both branches to selectResolvedLLMConfig would be a separate cleanup.
Coverage is at the policy level; there's no component-render test infra for ControlPanel, so the effect wiring is verified by typecheck/lint and manual reading.
The one-time global "Not now" dismissal (gpuBannerDismissedUnified) is unchanged.

Fixes #1509 