### PR TITLE
fix(linux): raise push-to-talk watchdog to 5 minutes

### DIFF
--- a/src/helpers/linuxKeyManager.js
+++ b/src/helpers/linuxKeyManager.js
@@ -5,8 +5,8 @@ const fs = require("fs");
 const debugLogger = require("./debugLogger");
 
 // Force a key-up if the native listener never reports one (e.g. a missed release
-// while another window had focus), so a held key can't get stuck recording.
-const WATCHDOG_MS = 30000;
+// while another window had focus); 5 min matches macOS MAX_PUSH_DURATION_MS.
+const WATCHDOG_MS = 300000;
 
 class LinuxKeyManager extends EventEmitter {
   constructor() {
@@ -135,9 +135,10 @@ class LinuxKeyManager extends EventEmitter {
       if (entry) {
         if (entry.watchdog) clearTimeout(entry.watchdog);
         entry.watchdog = setTimeout(() => {
-          debugLogger.warn("[LinuxKeyManager] Watchdog: no KEY_UP within 30s, forcing release", {
-            key,
-          });
+          debugLogger.warn(
+            `[LinuxKeyManager] Watchdog: no KEY_UP within ${WATCHDOG_MS / 1000}s, forcing release`,
+            { key }
+          );
           entry.watchdog = null;
           this.emit("key-up", key);
         }, WATCHDOG_MS);
@@ -230,5 +231,7 @@ class LinuxKeyManager extends EventEmitter {
     return null;
   }
 }
+
+LinuxKeyManager.WATCHDOG_MS = WATCHDOG_MS;
 
 module.exports = LinuxKeyManager;

--- a/test/helpers/linuxKeyManager.test.js
+++ b/test/helpers/linuxKeyManager.test.js
@@ -1,0 +1,136 @@
+const test = require("node:test");
+const { afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+const childProcess = require("node:child_process");
+
+const managerModulePath = require.resolve("../../src/helpers/linuxKeyManager");
+const originalLoad = Module._load;
+const originalPlatform = process.platform;
+
+function setPlatform(platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+function makeChild() {
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.stdout = Object.assign(new EventEmitter(), { setEncoding() {} });
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding() {} });
+  child.kill = () => {
+    child.killed = true;
+  };
+  return child;
+}
+
+// Returns the manager class plus the spawn calls it made, with the listener
+// binary lookup stubbed so tests don't depend on the binary being built.
+function loadManager() {
+  delete require.cache[managerModulePath];
+  setPlatform("linux");
+
+  const spawnCalls = [];
+  const spawn = (command, args) => {
+    const child = makeChild();
+    spawnCalls.push({ command, args, child });
+    return child;
+  };
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "./debugLogger") {
+      return { info() {}, warn() {}, debug() {}, error() {} };
+    }
+    if (request === "child_process") {
+      return { ...childProcess, spawn };
+    }
+    if (request === "fs") {
+      return { statSync: () => ({ isFile: () => true }) };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    const LinuxKeyManager = require(managerModulePath);
+    return { LinuxKeyManager, spawnCalls };
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+// Starts a manager watching one key and returns the fake child driving it plus
+// the key-up events observed so far.
+function startWatchedKey(LinuxKeyManager, spawnCalls, key = "F8") {
+  const manager = new LinuxKeyManager();
+  const keyUps = [];
+  manager.on("key-up", (releasedKey) => keyUps.push(releasedKey));
+  manager.setKeys([key]);
+  assert.equal(spawnCalls.length, 1);
+  return { manager, child: spawnCalls[0].child, keyUps };
+}
+
+afterEach(() => {
+  Module._load = originalLoad;
+  setPlatform(originalPlatform);
+});
+
+test("watchdog budget matches the macOS push-to-talk headroom of 5 minutes", () => {
+  const { LinuxKeyManager } = loadManager();
+  assert.equal(LinuxKeyManager.WATCHDOG_MS, 300000);
+});
+
+test("synthesizes key-up only when the full watchdog budget elapses without KEY_UP", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { LinuxKeyManager, spawnCalls } = loadManager();
+  const { child, keyUps } = startWatchedKey(LinuxKeyManager, spawnCalls);
+
+  child.stdout.emit("data", "KEY_DOWN\n");
+  t.mock.timers.tick(LinuxKeyManager.WATCHDOG_MS - 1);
+  assert.deepEqual(keyUps, []);
+
+  t.mock.timers.tick(1);
+  assert.deepEqual(keyUps, ["F8"]);
+});
+
+test("a real KEY_UP disarms the watchdog so no second key-up is synthesized", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { LinuxKeyManager, spawnCalls } = loadManager();
+  const { child, keyUps } = startWatchedKey(LinuxKeyManager, spawnCalls);
+
+  child.stdout.emit("data", "KEY_DOWN\n");
+  t.mock.timers.tick(1000);
+  child.stdout.emit("data", "KEY_UP\n");
+  assert.deepEqual(keyUps, ["F8"]);
+
+  t.mock.timers.tick(LinuxKeyManager.WATCHDOG_MS);
+  assert.deepEqual(keyUps, ["F8"]);
+});
+
+test("a repeated KEY_DOWN re-arms the watchdog from the latest press", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { LinuxKeyManager, spawnCalls } = loadManager();
+  const { child, keyUps } = startWatchedKey(LinuxKeyManager, spawnCalls);
+
+  child.stdout.emit("data", "KEY_DOWN\n");
+  t.mock.timers.tick(LinuxKeyManager.WATCHDOG_MS - 1000);
+  child.stdout.emit("data", "KEY_DOWN\n");
+
+  t.mock.timers.tick(LinuxKeyManager.WATCHDOG_MS - 1);
+  assert.deepEqual(keyUps, []);
+
+  t.mock.timers.tick(1);
+  assert.deepEqual(keyUps, ["F8"]);
+});
+
+test("stopping the listener clears a pending watchdog", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const { LinuxKeyManager, spawnCalls } = loadManager();
+  const { manager, child, keyUps } = startWatchedKey(LinuxKeyManager, spawnCalls);
+
+  child.stdout.emit("data", "KEY_DOWN\n");
+  manager.setKeys([]);
+  assert.equal(child.killed, true);
+
+  t.mock.timers.tick(LinuxKeyManager.WATCHDOG_MS);
+  assert.deepEqual(keyUps, []);
+});


### PR DESCRIPTION
## Problem

On Linux, hold (push-to-talk) dictation is silently force-stopped after ~30 seconds even while the key is still physically held. The watchdog in `src/helpers/linuxKeyManager.js` synthesizes a `key-up` 30s after `KEY_DOWN`, and in push mode that synthesized release is the only thing ending the recording, so the transcript just stops mid-sentence. macOS runs the same safety net for compound push-to-talk (`MAX_PUSH_DURATION_MS` in `windowManager.js`) with a 5 minute budget.

## Solution

Raise `WATCHDOG_MS` to 300000 so Linux hold mode gets the same 5 minute headroom as macOS. The protective semantics are unchanged: armed on `KEY_DOWN`, re-armed on key repeat, disarmed on `KEY_UP`, synthesized `key-up` at the deadline. New tests in `test/helpers/linuxKeyManager.test.js` pin the budget and the boundary behavior with mock timers.

Fixes #1594