### PR TITLE
fix(linux): deliver notifications through the desktop notification daemon

### DIFF
--- a/main.js
+++ b/main.js
@@ -259,6 +259,7 @@ process.on("unhandledRejection", (reason, promise) => {
 // Import helper module classes (but don't instantiate yet - wait for app.whenReady())
 const EnvironmentManager = require("./src/helpers/environment");
 const WindowManager = require("./src/helpers/windowManager");
+const { linuxNotifier } = require("./src/helpers/linuxNotifier");
 const DatabaseManager = require("./src/helpers/database");
 const ClipboardManager = require("./src/helpers/clipboard");
 const WhisperManager = require("./src/helpers/whisper");
@@ -1895,4 +1896,5 @@ function performSyncTeardown() {
   if (ipcHandlers) ipcHandlers._cleanupTextEditMonitor();
   if (textEditMonitor) textEditMonitor.stopMonitoring();
   if (updateManager) updateManager.cleanup();
+  linuxNotifier.stop();
 }

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -9824,11 +9824,7 @@ class IPCHandlers {
     ipcMain.handle("update-notification-respond", async (_event, action) => {
       this.windowManager?.dismissUpdateNotification();
       if (action === "update") {
-        try {
-          await this.updateManager?.downloadUpdate();
-        } catch (error) {
-          console.error("Failed to start update download from notification:", error);
-        }
+        await this.updateManager?.downloadUpdateFromNotification();
       }
       return { success: true };
     });

--- a/src/helpers/linuxAutostart.js
+++ b/src/helpers/linuxAutostart.js
@@ -207,6 +207,7 @@ function syncAutostartEntry() {
 }
 
 module.exports = {
+  LINUX_APP_NAME,
   getDesktopFilePath,
   resolveExecutablePath,
   buildDesktopFileContents,

--- a/src/helpers/linuxNotifier.js
+++ b/src/helpers/linuxNotifier.js
@@ -1,0 +1,292 @@
+const debugLogger = require("./debugLogger");
+
+let dbus = null;
+try {
+  dbus = require("@homebridge/dbus-native");
+} catch (err) {
+  debugLogger.warn("Failed to load dbus-native, native notifications unavailable", {
+    error: err.message,
+  });
+}
+
+const APP_NAME = "OpenWhispr";
+// Icon and desktop-entry match the executable name electron-builder packages
+// under (see linuxAutostart.js), so daemons resolve the installed icon and
+// apply the user's per-app notification settings.
+const LINUX_APP_ID = "open-whispr";
+const NOTIFICATIONS_SERVICE = "org.freedesktop.Notifications";
+const NOTIFICATIONS_PATH = "/org/freedesktop/Notifications";
+const DBUS_CALL_TIMEOUT_MS = 3000;
+const MAX_TEXT_LENGTH = 512;
+
+const CLOSE_REASON_EXPIRED = 1;
+const CLOSE_REASON_DISMISSED = 2;
+
+const PROMPT_VARIANTS = new Set(["detected", "starting", "underway"]);
+
+function truncate(value) {
+  const text = typeof value === "string" ? value : "";
+  return text.length > MAX_TEXT_LENGTH ? text.slice(0, MAX_TEXT_LENGTH) : text;
+}
+
+// Servers advertising body-markup parse the body as XML-ish markup, so literal
+// &, <, > must be entity-escaped to display as typed.
+function escapeBodyMarkup(text) {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function buildMeetingPromptContent(promptData, t) {
+  const variant = PROMPT_VARIANTS.has(promptData?.variant) ? promptData.variant : "detected";
+  const eventSummary =
+    typeof promptData?.event?.summary === "string" ? promptData.event.summary.trim() : "";
+  // Mirrors MeetingNotificationOverlay: calendar-backed prompts lead with the
+  // event name, mic-only detections with the generic title.
+  const title = truncate(
+    (variant !== "detected" && eventSummary) || t("meetingNotification.title")
+  );
+  const body = truncate(t(`meetingNotification.body.${variant}`));
+  const actionKey = promptData?.joinUrl ? "join" : "start";
+  const actionLabel = truncate(
+    t(promptData?.joinUrl ? "meetingNotification.join" : "meetingNotification.start")
+  );
+  return { title, body, actionKey, actionLabel };
+}
+
+function buildUpdatePromptContent(info, t) {
+  return {
+    title: truncate(t("updateNotification.title")),
+    body: truncate(t("updateNotification.body", { version: info?.version ?? "" })),
+    actionKey: "update",
+    actionLabel: truncate(t("updateNotification.cta")),
+  };
+}
+
+// Native Linux notifications over the org.freedesktop.Notifications D-Bus
+// interface (the protocol behind notify-send/libnotify). See #1599.
+class LinuxNotifier {
+  constructor({
+    platform = process.platform,
+    dbusModule = dbus,
+    callTimeoutMs = DBUS_CALL_TIMEOUT_MS,
+  } = {}) {
+    this._platform = platform;
+    this._dbus = dbusModule;
+    this._callTimeoutMs = callTimeoutMs;
+    this._broken = false;
+    this._bus = null;
+    this._connectPromise = null;
+    this._capabilities = null;
+    this._active = new Map();
+  }
+
+  isSupported() {
+    return this._platform === "linux" && !!this._dbus && !this._broken;
+  }
+
+  // Wraps a callback-style D-Bus call with a deadline: a hung daemon must fail
+  // the native path so the caller can fall back to the overlay.
+  _call(fn, ...args) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        reject(new Error("D-Bus call timed out"));
+      }, this._callTimeoutMs);
+      try {
+        fn(...args, (err, result) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (err) reject(err instanceof Error ? err : new Error(String(err)));
+          else resolve(result);
+        });
+      } catch (err) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        }
+      }
+    });
+  }
+
+  _connect() {
+    if (this._connectPromise) return this._connectPromise;
+
+    this._connectPromise = new Promise((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        reject(new Error("D-Bus connection timed out"));
+      }, this._callTimeoutMs);
+
+      try {
+        const bus = this._dbus.sessionBus();
+        if (!bus) throw new Error("No session bus available");
+        this._bus = bus;
+
+        // Without this handler a dropped connection raises an uncaught
+        // EventEmitter error and takes the whole main process down.
+        bus.connection.on("error", (err) => {
+          debugLogger.warn("Notification D-Bus connection error", { error: err.message });
+          this._markBroken();
+          if (!settled) {
+            settled = true;
+            clearTimeout(timer);
+            reject(err);
+          }
+        });
+
+        bus
+          .getService(NOTIFICATIONS_SERVICE)
+          .getInterface(NOTIFICATIONS_PATH, NOTIFICATIONS_SERVICE, (err, iface) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            if (err) {
+              reject(err instanceof Error ? err : new Error(String(err)));
+              return;
+            }
+            iface.on("ActionInvoked", (id, actionKey) => this._onActionInvoked(id, actionKey));
+            iface.on("NotificationClosed", (id, reason) => this._onClosed(id, reason));
+            resolve(iface);
+          });
+      } catch (err) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        }
+      }
+    });
+
+    return this._connectPromise;
+  }
+
+  _onActionInvoked(id, actionKey) {
+    const entry = this._active.get(id);
+    if (!entry) return;
+    const action = actionKey === "default" ? entry.actionKey : actionKey;
+    if (action !== entry.actionKey) return;
+    // Settle before invoking: the daemon follows up with NotificationClosed,
+    // which must not also fire the dismiss path.
+    this._active.delete(id);
+    try {
+      entry.onAction(action);
+    } catch (err) {
+      debugLogger.error("Notification action handler failed", { error: err.message });
+    }
+  }
+
+  _onClosed(id, reason) {
+    const entry = this._active.get(id);
+    if (!entry) return;
+    this._active.delete(id);
+    if (reason !== CLOSE_REASON_EXPIRED && reason !== CLOSE_REASON_DISMISSED) return;
+    try {
+      entry.onClose(reason);
+    } catch (err) {
+      debugLogger.error("Notification close handler failed", { error: err.message });
+    }
+  }
+
+  _markBroken() {
+    this._broken = true;
+    this._active.clear();
+  }
+
+  // Shows a native notification with one primary action (also bound to the
+  // notification's default click). Returns { id, close } or null on any
+  // failure, after which the notifier stays unavailable for the session.
+  async show({
+    title,
+    body,
+    actionKey,
+    actionLabel,
+    timeoutMs,
+    replacesId = 0,
+    onAction,
+    onClose,
+  }) {
+    if (!this.isSupported()) return null;
+
+    try {
+      const iface = await this._connect();
+
+      if (!this._capabilities) {
+        this._capabilities = await this._call(iface.GetCapabilities.bind(iface));
+      }
+      const caps = Array.isArray(this._capabilities) ? this._capabilities : [];
+      if (!caps.includes("actions")) {
+        throw new Error("Notification server does not support actions");
+      }
+
+      const safeBody = caps.includes("body-markup") ? escapeBodyMarkup(body) : body;
+
+      const id = await this._call(
+        iface.Notify.bind(iface),
+        APP_NAME,
+        replacesId >>> 0,
+        LINUX_APP_ID,
+        title,
+        safeBody,
+        ["default", actionLabel, actionKey, actionLabel],
+        [
+          ["urgency", ["y", 1]],
+          ["desktop-entry", ["s", LINUX_APP_ID]],
+        ],
+        Math.max(0, Math.trunc(timeoutMs))
+      );
+
+      const entry = { actionKey, onAction, onClose };
+      this._active.set(id, entry);
+
+      return {
+        id,
+        close: () => {
+          // Drop callbacks first so the reason-3 NotificationClosed that
+          // follows our CloseNotification is ignored.
+          this._active.delete(id);
+          try {
+            iface.CloseNotification(id, () => {});
+          } catch (err) {
+            debugLogger.warn("CloseNotification failed", { error: err.message });
+          }
+        },
+      };
+    } catch (err) {
+      debugLogger.warn("Native notification failed, falling back to overlay", {
+        error: err.message,
+      });
+      this._markBroken();
+      return null;
+    }
+  }
+
+  stop() {
+    this._active.clear();
+    this._capabilities = null;
+    this._connectPromise = null;
+    if (this._bus) {
+      try {
+        this._bus.connection.end();
+      } catch {
+        // Connection may already be gone.
+      }
+      this._bus = null;
+    }
+  }
+}
+
+const linuxNotifier = new LinuxNotifier();
+
+module.exports = {
+  linuxNotifier,
+  LinuxNotifier,
+  buildMeetingPromptContent,
+  buildUpdatePromptContent,
+  CLOSE_REASON_EXPIRED,
+  CLOSE_REASON_DISMISSED,
+};

--- a/src/helpers/linuxNotifier.js
+++ b/src/helpers/linuxNotifier.js
@@ -1,4 +1,5 @@
 const debugLogger = require("./debugLogger");
+const { LINUX_APP_NAME } = require("./linuxAutostart");
 
 let dbus = null;
 try {
@@ -10,14 +11,13 @@ try {
 }
 
 const APP_NAME = "OpenWhispr";
-// Icon and desktop-entry match the executable name electron-builder packages
-// under (see linuxAutostart.js), so daemons resolve the installed icon and
-// apply the user's per-app notification settings.
-const LINUX_APP_ID = "open-whispr";
 const NOTIFICATIONS_SERVICE = "org.freedesktop.Notifications";
 const NOTIFICATIONS_PATH = "/org/freedesktop/Notifications";
 const DBUS_CALL_TIMEOUT_MS = 3000;
 const MAX_TEXT_LENGTH = 512;
+// Failure backoff, so a daemon that is slow at login gets retried later.
+const RETRY_BASE_MS = 30 * 1000;
+const RETRY_MAX_MS = 30 * 60 * 1000;
 
 const CLOSE_REASON_EXPIRED = 1;
 const CLOSE_REASON_DISMISSED = 2;
@@ -26,11 +26,14 @@ const PROMPT_VARIANTS = new Set(["detected", "starting", "underway"]);
 
 function truncate(value) {
   const text = typeof value === "string" ? value : "";
-  return text.length > MAX_TEXT_LENGTH ? text.slice(0, MAX_TEXT_LENGTH) : text;
+  if (text.length <= MAX_TEXT_LENGTH) return text;
+  const cut = text.slice(0, MAX_TEXT_LENGTH);
+  // Never end on a dangling high surrogate.
+  const last = cut.charCodeAt(cut.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? cut.slice(0, -1) : cut;
 }
 
-// Servers advertising body-markup parse the body as XML-ish markup, so literal
-// &, <, > must be entity-escaped to display as typed.
+// Escape &, <, > for servers that parse the notification body as markup.
 function escapeBodyMarkup(text) {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
@@ -39,8 +42,7 @@ function buildMeetingPromptContent(promptData, t) {
   const variant = PROMPT_VARIANTS.has(promptData?.variant) ? promptData.variant : "detected";
   const eventSummary =
     typeof promptData?.event?.summary === "string" ? promptData.event.summary.trim() : "";
-  // Mirrors MeetingNotificationOverlay: calendar-backed prompts lead with the
-  // event name, mic-only detections with the generic title.
+  // Same rule as MeetingNotificationOverlay: event name only for calendar-backed variants.
   const title = truncate(
     (variant !== "detected" && eventSummary) || t("meetingNotification.title")
   );
@@ -61,38 +63,55 @@ function buildUpdatePromptContent(info, t) {
   };
 }
 
-// Native Linux notifications over the org.freedesktop.Notifications D-Bus
-// interface (the protocol behind notify-send/libnotify). See #1599.
+// Native Linux notifications over the org.freedesktop.Notifications session bus.
 class LinuxNotifier {
   constructor({
     platform = process.platform,
     dbusModule = dbus,
     callTimeoutMs = DBUS_CALL_TIMEOUT_MS,
+    now = Date.now,
   } = {}) {
     this._platform = platform;
     this._dbus = dbusModule;
     this._callTimeoutMs = callTimeoutMs;
-    this._broken = false;
+    this._now = now;
+    this._failureCount = 0;
+    this._retryAt = 0;
     this._bus = null;
+    this._iface = null;
     this._connectPromise = null;
     this._capabilities = null;
     this._active = new Map();
   }
 
   isSupported() {
-    return this._platform === "linux" && !!this._dbus && !this._broken;
+    return this._platform === "linux" && !!this._dbus && this._now() >= this._retryAt;
   }
 
-  // Wraps a callback-style D-Bus call with a deadline: a hung daemon must fail
-  // the native path so the caller can fall back to the overlay.
-  _call(fn, ...args) {
+  _withTimeout(promise, timeoutMs, label) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
+      promise.then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (err) => {
+          clearTimeout(timer);
+          reject(err);
+        }
+      );
+    });
+  }
+
+  _call(fn, args, timeoutMs) {
     return new Promise((resolve, reject) => {
       let settled = false;
       const timer = setTimeout(() => {
         if (settled) return;
         settled = true;
         reject(new Error("D-Bus call timed out"));
-      }, this._callTimeoutMs);
+      }, timeoutMs);
       try {
         fn(...args, (err, result) => {
           if (settled) return;
@@ -127,9 +146,9 @@ class LinuxNotifier {
         if (!bus) throw new Error("No session bus available");
         this._bus = bus;
 
-        // Without this handler a dropped connection raises an uncaught
-        // EventEmitter error and takes the whole main process down.
+        // A connection error with no handler is an uncaught EventEmitter error.
         bus.connection.on("error", (err) => {
+          if (this._bus !== bus) return;
           debugLogger.warn("Notification D-Bus connection error", { error: err.message });
           this._markBroken();
           if (!settled) {
@@ -151,6 +170,7 @@ class LinuxNotifier {
             }
             iface.on("ActionInvoked", (id, actionKey) => this._onActionInvoked(id, actionKey));
             iface.on("NotificationClosed", (id, reason) => this._onClosed(id, reason));
+            this._iface = iface;
             resolve(iface);
           });
       } catch (err) {
@@ -161,6 +181,8 @@ class LinuxNotifier {
         }
       }
     });
+    // A rejection may be observed only through _withTimeout races.
+    this._connectPromise.catch(() => {});
 
     return this._connectPromise;
   }
@@ -170,8 +192,7 @@ class LinuxNotifier {
     if (!entry) return;
     const action = actionKey === "default" ? entry.actionKey : actionKey;
     if (action !== entry.actionKey) return;
-    // Settle before invoking: the daemon follows up with NotificationClosed,
-    // which must not also fire the dismiss path.
+    // Settle before invoking, so the daemon's follow-up NotificationClosed is a no-op.
     this._active.delete(id);
     try {
       entry.onAction(action);
@@ -193,13 +214,36 @@ class LinuxNotifier {
   }
 
   _markBroken() {
-    this._broken = true;
+    const backoff = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** this._failureCount);
+    this._failureCount = Math.min(this._failureCount + 1, 16);
+    this._retryAt = this._now() + backoff;
+
+    // Owners of live notifications must not keep waiting on a dead connection.
+    const orphans = [...this._active.values()];
     this._active.clear();
+    for (const entry of orphans) {
+      try {
+        entry.onClose(CLOSE_REASON_EXPIRED);
+      } catch (err) {
+        debugLogger.error("Notification close handler failed", { error: err.message });
+      }
+    }
+
+    this._capabilities = null;
+    this._connectPromise = null;
+    this._iface = null;
+    if (this._bus) {
+      try {
+        this._bus.connection.end();
+      } catch {
+        // Connection may already be gone.
+      }
+      this._bus = null;
+    }
   }
 
-  // Shows a native notification with one primary action (also bound to the
-  // notification's default click). Returns { id, close } or null on any
-  // failure, after which the notifier stays unavailable for the session.
+  // Shows a notification with one primary action, also bound to the default click.
+  // Returns { id, close } or null; failures back off and retry later.
   async show({
     title,
     body,
@@ -212,11 +256,14 @@ class LinuxNotifier {
   }) {
     if (!this.isSupported()) return null;
 
+    const deadline = this._now() + this._callTimeoutMs;
+    const remaining = () => Math.max(1, deadline - this._now());
+
     try {
-      const iface = await this._connect();
+      const iface = await this._withTimeout(this._connect(), remaining(), "D-Bus connection");
 
       if (!this._capabilities) {
-        this._capabilities = await this._call(iface.GetCapabilities.bind(iface));
+        this._capabilities = await this._call(iface.GetCapabilities.bind(iface), [], remaining());
       }
       const caps = Array.isArray(this._capabilities) ? this._capabilities : [];
       if (!caps.includes("actions")) {
@@ -227,27 +274,30 @@ class LinuxNotifier {
 
       const id = await this._call(
         iface.Notify.bind(iface),
-        APP_NAME,
-        replacesId >>> 0,
-        LINUX_APP_ID,
-        title,
-        safeBody,
-        ["default", actionLabel, actionKey, actionLabel],
         [
-          ["urgency", ["y", 1]],
-          ["desktop-entry", ["s", LINUX_APP_ID]],
+          APP_NAME,
+          replacesId >>> 0,
+          LINUX_APP_NAME,
+          title,
+          safeBody,
+          ["default", actionLabel, actionKey, actionLabel],
+          [
+            ["urgency", ["y", 1]],
+            ["desktop-entry", ["s", LINUX_APP_NAME]],
+          ],
+          Math.max(0, Math.trunc(timeoutMs)),
         ],
-        Math.max(0, Math.trunc(timeoutMs))
+        remaining()
       );
 
-      const entry = { actionKey, onAction, onClose };
-      this._active.set(id, entry);
+      this._failureCount = 0;
+      this._retryAt = 0;
+      this._active.set(id, { actionKey, onAction, onClose });
 
       return {
         id,
         close: () => {
-          // Drop callbacks first so the reason-3 NotificationClosed that
-          // follows our CloseNotification is ignored.
+          // Drop callbacks first, so the reason-3 NotificationClosed that follows is ignored.
           this._active.delete(id);
           try {
             iface.CloseNotification(id, () => {});
@@ -266,9 +316,19 @@ class LinuxNotifier {
   }
 
   stop() {
+    if (this._iface) {
+      for (const id of this._active.keys()) {
+        try {
+          this._iface.CloseNotification(id, () => {});
+        } catch {
+          // Best effort during teardown.
+        }
+      }
+    }
     this._active.clear();
     this._capabilities = null;
     this._connectPromise = null;
+    this._iface = null;
     if (this._bus) {
       try {
         this._bus.connection.end();

--- a/src/helpers/linuxNotifier.js
+++ b/src/helpers/linuxNotifier.js
@@ -77,6 +77,8 @@ class LinuxNotifier {
     this._now = now;
     this._failureCount = 0;
     this._retryAt = 0;
+    this._connectionGeneration = 0;
+    this._lastBrokenGeneration = -1;
     this._bus = null;
     this._iface = null;
     this._connectPromise = null;
@@ -133,6 +135,7 @@ class LinuxNotifier {
   _connect() {
     if (this._connectPromise) return this._connectPromise;
 
+    const generation = (this._connectionGeneration = this._connectionGeneration + 1);
     this._connectPromise = new Promise((resolve, reject) => {
       let settled = false;
       const timer = setTimeout(() => {
@@ -150,7 +153,7 @@ class LinuxNotifier {
         bus.connection.on("error", (err) => {
           if (this._bus !== bus) return;
           debugLogger.warn("Notification D-Bus connection error", { error: err.message });
-          this._markBroken();
+          this._markBroken(generation);
           if (!settled) {
             settled = true;
             clearTimeout(timer);
@@ -213,10 +216,15 @@ class LinuxNotifier {
     }
   }
 
-  _markBroken() {
-    const backoff = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** this._failureCount);
-    this._failureCount = Math.min(this._failureCount + 1, 16);
-    this._retryAt = this._now() + backoff;
+  _markBroken(generation = this._connectionGeneration) {
+    // A connection event and every caller awaiting that connection can all
+    // observe the same failure. Advance the backoff once for that transport.
+    if (this._lastBrokenGeneration !== generation) {
+      const backoff = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** this._failureCount);
+      this._failureCount = Math.min(this._failureCount + 1, 16);
+      this._retryAt = this._now() + backoff;
+      this._lastBrokenGeneration = generation;
+    }
 
     // Owners of live notifications must not keep waiting on a dead connection.
     const orphans = [...this._active.values()];
@@ -259,8 +267,11 @@ class LinuxNotifier {
     const deadline = this._now() + this._callTimeoutMs;
     const remaining = () => Math.max(1, deadline - this._now());
 
+    let connectionGeneration = this._connectionGeneration;
     try {
-      const iface = await this._withTimeout(this._connect(), remaining(), "D-Bus connection");
+      const connectionPromise = this._connect();
+      connectionGeneration = this._connectionGeneration;
+      const iface = await this._withTimeout(connectionPromise, remaining(), "D-Bus connection");
 
       if (!this._capabilities) {
         this._capabilities = await this._call(iface.GetCapabilities.bind(iface), [], remaining());
@@ -310,7 +321,7 @@ class LinuxNotifier {
       debugLogger.warn("Native notification failed, falling back to overlay", {
         error: err.message,
       });
-      this._markBroken();
+      this._markBroken(connectionGeneration);
       return null;
     }
   }

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -16,11 +16,7 @@ function resolveOverlayWindowType({ role, platform, linuxSession }) {
 
   // Sway asks wlroots whether an unmanaged XWayland surface wants focus.
   // "toolbar" opts in; "notification" keeps the existing text field focused.
-  if (
-    linuxSession.isSway &&
-    linuxSession.xwaylandAvailable &&
-    FOCUSLESS_OVERLAY_ROLES.has(role)
-  ) {
+  if (linuxSession.isSway && linuxSession.xwaylandAvailable && FOCUSLESS_OVERLAY_ROLES.has(role)) {
     return "notification";
   }
 

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1259,12 +1259,17 @@ class WindowManager {
     }
   }
 
+  // Checked before awaiting so the overlay path keeps creating its window in
+  // the same tick as the caller. Only actionable prompts reach the daemon.
+  _canUseNativeMeetingNotification(promptData) {
+    return linuxNotifier.isSupported() && Boolean(promptData?.detectionId);
+  }
+
   // Deliver the prompt through the desktop notification daemon, falling back
   // to the overlay when the caller gets false back.
   async _tryNativeMeetingNotification(promptData, { autoDismiss = true } = {}) {
-    if (!linuxNotifier.isSupported()) return false;
-    const detectionId = promptData?.detectionId;
-    if (!detectionId) return false;
+    if (!this._canUseNativeMeetingNotification(promptData)) return false;
+    const detectionId = promptData.detectionId;
 
     const previous = this._nativeMeetingNotification;
     this._nativeMeetingNotification = null;
@@ -1323,7 +1328,12 @@ class WindowManager {
       this._notificationReadyFallback = null;
     }
 
-    if (await this._tryNativeMeetingNotification(promptData, { autoDismiss })) return;
+    if (
+      this._canUseNativeMeetingNotification(promptData) &&
+      (await this._tryNativeMeetingNotification(promptData, { autoDismiss }))
+    ) {
+      return;
+    }
 
     const display = screen.getPrimaryDisplay();
     const notificationSize = getMeetingNotificationWindowSize(promptData);
@@ -1538,7 +1548,9 @@ class WindowManager {
       this._updateNotificationAutoDismiss = null;
     }
 
-    if (await this._tryNativeUpdateNotification(info, onUpdate)) return;
+    if (linuxNotifier.isSupported() && (await this._tryNativeUpdateNotification(info, onUpdate))) {
+      return;
+    }
 
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getNotificationPosition(display);

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1452,6 +1452,8 @@ class WindowManager {
   }
 
   dismissMeetingNotification() {
+    // Invalidate a native show that may still be waiting on D-Bus.
+    this._nativeMeetingShowSeq = this._nativeMeetingShowSeq + 1;
     this._pendingNotificationData = null;
     if (this._nativeMeetingNotification) {
       this._nativeMeetingNotification.close();
@@ -1602,6 +1604,8 @@ class WindowManager {
   }
 
   dismissUpdateNotification({ persistent = true } = {}) {
+    // Invalidate a native show that may still be waiting on D-Bus.
+    this._nativeUpdateShowSeq = this._nativeUpdateShowSeq + 1;
     this._pendingUpdateNotificationData = null;
     if (persistent) this._updateNotificationDismissed = true;
     if (this._nativeUpdateNotification) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -8,6 +8,13 @@ const DevServerManager = require("./devServerManager");
 const dockManager = require("./dockManager");
 const { i18nMain } = require("./i18nMain");
 const { NotificationDismissTimer, getNotificationTimeoutMs } = require("./notificationTimer");
+const {
+  linuxNotifier,
+  buildMeetingPromptContent,
+  buildUpdatePromptContent,
+  CLOSE_REASON_EXPIRED,
+  CLOSE_REASON_DISMISSED,
+} = require("./linuxNotifier");
 const { DEV_SERVER_PORT } = DevServerManager;
 const AUTO_END_NOTIFICATION_LOAD_TIMEOUT_MS = 10_000;
 const {
@@ -37,6 +44,8 @@ class WindowManager {
     });
     this.transcriptionPreviewWindow = null;
     this.updateNotificationWindow = null;
+    this._nativeMeetingNotification = null;
+    this._nativeUpdateNotification = null;
     this._updateNotificationDismissed = false;
     this.notificationPrefs = {
       notificationsEnabled: true,
@@ -1248,6 +1257,44 @@ class WindowManager {
     }
   }
 
+  // Delivers the prompt through the desktop's notification daemon instead of
+  // the overlay window, which Wayland compositors center and focus. See #1599.
+  async _tryNativeMeetingNotification(promptData, { autoDismiss = true } = {}) {
+    if (!linuxNotifier.isSupported()) return false;
+    const detectionId = promptData?.detectionId;
+    if (!detectionId) return false;
+
+    const previous = this._nativeMeetingNotification;
+    this._nativeMeetingNotification = null;
+    const timeoutMs = getNotificationTimeoutMs(promptData.source);
+
+    const handle = await linuxNotifier.show({
+      ...buildMeetingPromptContent(promptData, (key, opts) => i18nMain.t(key, opts)),
+      timeoutMs,
+      replacesId: previous?.id ?? 0,
+      onAction: (action) => {
+        this.meetingDetectionEngine?.handleNotificationResponse(detectionId, action);
+      },
+      onClose: (reason) => {
+        if (this._nativeMeetingNotification?.id !== handle?.id) return;
+        if (reason === CLOSE_REASON_DISMISSED) {
+          this.meetingDetectionEngine?.handleNotificationResponse(detectionId, "dismiss");
+        } else if (reason === CLOSE_REASON_EXPIRED) {
+          this._nativeMeetingNotification = null;
+          this._notificationDismissTimer.cancel();
+          this.meetingDetectionEngine?.handleNotificationTimeout();
+        }
+      },
+    });
+    if (!handle) return false;
+
+    this._nativeMeetingNotification = handle;
+    // Backstop for daemons that ignore expire_timeout (GNOME): keeps the
+    // active-detection lifecycle on the same clock as the overlay.
+    if (autoDismiss) this._notificationDismissTimer.start(timeoutMs);
+    return true;
+  }
+
   async showMeetingNotification(promptData, { autoDismiss = true } = {}) {
     if (this.notificationWindow && !this.notificationWindow.isDestroyed()) {
       const previousWindow = this.notificationWindow;
@@ -1264,6 +1311,8 @@ class WindowManager {
       clearTimeout(this._notificationReadyFallback);
       this._notificationReadyFallback = null;
     }
+
+    if (await this._tryNativeMeetingNotification(promptData, { autoDismiss })) return;
 
     const display = screen.getPrimaryDisplay();
     const notificationSize = getMeetingNotificationWindowSize(promptData);
@@ -1393,6 +1442,10 @@ class WindowManager {
 
   dismissMeetingNotification() {
     this._pendingNotificationData = null;
+    if (this._nativeMeetingNotification) {
+      this._nativeMeetingNotification.close();
+      this._nativeMeetingNotification = null;
+    }
     if (this._notificationReadyFallback) {
       clearTimeout(this._notificationReadyFallback);
       this._notificationReadyFallback = null;
@@ -1424,7 +1477,37 @@ class WindowManager {
     this.dismissMeetingNotification();
   }
 
-  async showUpdateNotification(info) {
+  async _tryNativeUpdateNotification(info, onUpdate) {
+    if (!linuxNotifier.isSupported()) return false;
+
+    const previous = this._nativeUpdateNotification;
+    this._nativeUpdateNotification = null;
+
+    const handle = await linuxNotifier.show({
+      ...buildUpdatePromptContent(info, (key, opts) => i18nMain.t(key, opts)),
+      timeoutMs: 5000,
+      replacesId: previous?.id ?? 0,
+      onAction: () => {
+        this.dismissUpdateNotification();
+        if (typeof onUpdate === "function") onUpdate();
+      },
+      onClose: (reason) => {
+        if (this._nativeUpdateNotification?.id !== handle?.id) return;
+        // A user close is a decline for the session; expiry keeps the
+        // notification eligible for the next update check, like the overlay.
+        this.dismissUpdateNotification({ persistent: reason === CLOSE_REASON_DISMISSED });
+      },
+    });
+    if (!handle) return false;
+
+    this._nativeUpdateNotification = handle;
+    this._updateNotificationAutoDismiss = setTimeout(() => {
+      this.dismissUpdateNotification({ persistent: false });
+    }, 5000);
+    return true;
+  }
+
+  async showUpdateNotification(info, { onUpdate } = {}) {
     if (this._updateNotificationDismissed) return;
     if (this.updateNotificationWindow && !this.updateNotificationWindow.isDestroyed()) {
       this.updateNotificationWindow.close();
@@ -1434,6 +1517,8 @@ class WindowManager {
       clearTimeout(this._updateNotificationAutoDismiss);
       this._updateNotificationAutoDismiss = null;
     }
+
+    if (await this._tryNativeUpdateNotification(info, onUpdate)) return;
 
     const display = screen.getPrimaryDisplay();
     const position = WindowPositionUtil.getNotificationPosition(display);
@@ -1501,6 +1586,10 @@ class WindowManager {
   dismissUpdateNotification({ persistent = true } = {}) {
     this._pendingUpdateNotificationData = null;
     if (persistent) this._updateNotificationDismissed = true;
+    if (this._nativeUpdateNotification) {
+      this._nativeUpdateNotification.close();
+      this._nativeUpdateNotification = null;
+    }
     if (this._updateNotificationReadyFallback) {
       clearTimeout(this._updateNotificationReadyFallback);
       this._updateNotificationReadyFallback = null;

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -46,6 +46,8 @@ class WindowManager {
     this.updateNotificationWindow = null;
     this._nativeMeetingNotification = null;
     this._nativeUpdateNotification = null;
+    this._nativeMeetingShowSeq = 0;
+    this._nativeUpdateShowSeq = 0;
     this._updateNotificationDismissed = false;
     this.notificationPrefs = {
       notificationsEnabled: true,
@@ -1257,8 +1259,8 @@ class WindowManager {
     }
   }
 
-  // Delivers the prompt through the desktop's notification daemon instead of
-  // the overlay window, which Wayland compositors center and focus. See #1599.
+  // Deliver the prompt through the desktop notification daemon, falling back
+  // to the overlay when the caller gets false back.
   async _tryNativeMeetingNotification(promptData, { autoDismiss = true } = {}) {
     if (!linuxNotifier.isSupported()) return false;
     const detectionId = promptData?.detectionId;
@@ -1266,6 +1268,8 @@ class WindowManager {
 
     const previous = this._nativeMeetingNotification;
     this._nativeMeetingNotification = null;
+    // Staleness guard across the await, like the overlay's window identity check.
+    const seq = (this._nativeMeetingShowSeq = this._nativeMeetingShowSeq + 1);
     const timeoutMs = getNotificationTimeoutMs(promptData.source);
 
     const handle = await linuxNotifier.show({
@@ -1286,11 +1290,18 @@ class WindowManager {
         }
       },
     });
-    if (!handle) return false;
+    if (this._nativeMeetingShowSeq !== seq) {
+      // A newer prompt superseded this one mid-flight; it owns the surface now.
+      handle?.close();
+      return true;
+    }
+    if (!handle) {
+      previous?.close();
+      return false;
+    }
 
     this._nativeMeetingNotification = handle;
-    // Backstop for daemons that ignore expire_timeout (GNOME): keeps the
-    // active-detection lifecycle on the same clock as the overlay.
+    // Backstop expiry for daemons that ignore expire_timeout.
     if (autoDismiss) this._notificationDismissTimer.start(timeoutMs);
     return true;
   }
@@ -1482,6 +1493,7 @@ class WindowManager {
 
     const previous = this._nativeUpdateNotification;
     this._nativeUpdateNotification = null;
+    const seq = (this._nativeUpdateShowSeq = this._nativeUpdateShowSeq + 1);
 
     const handle = await linuxNotifier.show({
       ...buildUpdatePromptContent(info, (key, opts) => i18nMain.t(key, opts)),
@@ -1493,12 +1505,18 @@ class WindowManager {
       },
       onClose: (reason) => {
         if (this._nativeUpdateNotification?.id !== handle?.id) return;
-        // A user close is a decline for the session; expiry keeps the
-        // notification eligible for the next update check, like the overlay.
+        // User close declines for the session; expiry stays eligible, like the overlay.
         this.dismissUpdateNotification({ persistent: reason === CLOSE_REASON_DISMISSED });
       },
     });
-    if (!handle) return false;
+    if (this._nativeUpdateShowSeq !== seq) {
+      handle?.close();
+      return true;
+    }
+    if (!handle) {
+      previous?.close();
+      return false;
+    }
 
     this._nativeUpdateNotification = handle;
     this._updateNotificationAutoDismiss = setTimeout(() => {

--- a/src/updater.js
+++ b/src/updater.js
@@ -89,9 +89,19 @@ class UpdateManager {
         this.notifyRenderers("update-available", info);
         const notifAllowed = appUpdatesEnabled(this.windowManager?.notificationPrefs);
         if (this.windowManager && info && !this._suppressNotification && notifAllowed) {
-          this.windowManager.showUpdateNotification(info).catch((err) => {
-            console.error("Failed to show update notification:", err);
-          });
+          this.windowManager
+            .showUpdateNotification(info, {
+              // Native Linux notifications act in the main process; the overlay
+              // routes the same action through update-notification-respond.
+              onUpdate: () => {
+                this.downloadUpdate().catch((err) => {
+                  console.error("Failed to start update download from notification:", err);
+                });
+              },
+            })
+            .catch((err) => {
+              console.error("Failed to show update notification:", err);
+            });
         }
         this._suppressNotification = false;
       },

--- a/src/updater.js
+++ b/src/updater.js
@@ -91,13 +91,7 @@ class UpdateManager {
         if (this.windowManager && info && !this._suppressNotification && notifAllowed) {
           this.windowManager
             .showUpdateNotification(info, {
-              // Native Linux notifications act in the main process; the overlay
-              // routes the same action through update-notification-respond.
-              onUpdate: () => {
-                this.downloadUpdate().catch((err) => {
-                  console.error("Failed to start update download from notification:", err);
-                });
-              },
+              onUpdate: () => this.downloadUpdateFromNotification(),
             })
             .catch((err) => {
               console.error("Failed to show update notification:", err);
@@ -203,6 +197,14 @@ class UpdateManager {
       console.error("❌ Update check error:", error);
       throw error;
     }
+  }
+
+  // Single entry point for the notification Update action, shared by the
+  // overlay's IPC respond handler and the native Linux notification.
+  downloadUpdateFromNotification() {
+    return this.downloadUpdate().catch((error) => {
+      console.error("Failed to start update download from notification:", error);
+    });
   }
 
   async downloadUpdate() {

--- a/test/helpers/linuxNotifier.test.js
+++ b/test/helpers/linuxNotifier.test.js
@@ -30,11 +30,14 @@ function createFakeDbus({
   capabilities = ["actions", "body"],
   notifyId = 42,
   interfaceError = null,
+  failFirstInterface = false,
   hangNotify = false,
 } = {}) {
   const iface = new EventEmitter();
   const notifyCalls = [];
   const closeCalls = [];
+  const connections = [];
+  let interfaceRequests = 0;
 
   iface.GetCapabilities = (cb) => process.nextTick(cb, null, capabilities);
   iface.Notify = (...args) => {
@@ -47,17 +50,27 @@ function createFakeDbus({
     if (cb) process.nextTick(cb, null);
   };
 
-  const connection = new EventEmitter();
-  connection.end = () => {};
-  const bus = {
-    connection,
-    getService: () => ({
-      getInterface: (path, name, cb) =>
-        process.nextTick(() => (interfaceError ? cb(interfaceError) : cb(null, iface))),
-    }),
+  const module = {
+    sessionBus: () => {
+      const connection = new EventEmitter();
+      connection.end = () => {};
+      connections.push(connection);
+      return {
+        connection,
+        getService: () => ({
+          getInterface: (path, name, cb) => {
+            interfaceRequests += 1;
+            const failThis = interfaceError || (failFirstInterface && interfaceRequests === 1);
+            process.nextTick(() =>
+              failThis ? cb(interfaceError || new Error("first connect fails")) : cb(null, iface)
+            );
+          },
+        }),
+      };
+    },
   };
 
-  return { module: { sessionBus: () => bus }, iface, notifyCalls, closeCalls, connection };
+  return { module, iface, notifyCalls, closeCalls, connections };
 }
 
 function baseShowArgs(overrides = {}) {
@@ -95,20 +108,20 @@ test("a missing dbus module means unsupported instead of a crash", async () => {
   assert.equal(await notifier.show(baseShowArgs()), null);
 });
 
-test("a server without the actions capability falls back for the whole session", async () => {
+test("a server without the actions capability backs off to the overlay", async () => {
   const { LinuxNotifier } = loadModule();
   const fake = createFakeDbus({ capabilities: ["body"] });
-  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module, now: () => 0 });
 
   assert.equal(await notifier.show(baseShowArgs()), null);
   assert.equal(fake.notifyCalls.length, 0);
   assert.equal(notifier.isSupported(), false);
 });
 
-test("a connection failure falls back for the whole session", async () => {
+test("a connection failure backs off to the overlay", async () => {
   const { LinuxNotifier } = loadModule();
   const fake = createFakeDbus({ interfaceError: new Error("no notification service") });
-  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module, now: () => 0 });
 
   assert.equal(await notifier.show(baseShowArgs()), null);
   assert.equal(notifier.isSupported(), false);
@@ -117,14 +130,68 @@ test("a connection failure falls back for the whole session", async () => {
 test("a daemon that never answers Notify times out into fallback", async () => {
   const { LinuxNotifier } = loadModule();
   const fake = createFakeDbus({ hangNotify: true });
+  let clock = 0;
   const notifier = new LinuxNotifier({
     platform: "linux",
     dbusModule: fake.module,
     callTimeoutMs: 20,
+    now: () => clock,
   });
 
   assert.equal(await notifier.show(baseShowArgs()), null);
   assert.equal(notifier.isSupported(), false);
+});
+
+test("native delivery retries with a fresh connection after the backoff window", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ failFirstInterface: true });
+  let clock = 0;
+  const notifier = new LinuxNotifier({
+    platform: "linux",
+    dbusModule: fake.module,
+    now: () => clock,
+  });
+
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  assert.equal(notifier.isSupported(), false);
+
+  clock = 31 * 1000;
+  assert.equal(notifier.isSupported(), true);
+  const handle = await notifier.show(baseShowArgs());
+  assert.equal(handle.id, 42);
+  assert.equal(fake.connections.length, 2);
+});
+
+test("a successful show resets the failure backoff", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ failFirstInterface: true });
+  let clock = 0;
+  const notifier = new LinuxNotifier({
+    platform: "linux",
+    dbusModule: fake.module,
+    now: () => clock,
+  });
+
+  await notifier.show(baseShowArgs());
+  clock = 31 * 1000;
+  await notifier.show(baseShowArgs());
+  assert.equal(notifier._failureCount, 0);
+  assert.equal(notifier.isSupported(), true);
+});
+
+test("the whole native attempt shares one deadline instead of stacking per-call timeouts", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ hangNotify: true });
+  const notifier = new LinuxNotifier({
+    platform: "linux",
+    dbusModule: fake.module,
+    callTimeoutMs: 60,
+  });
+
+  const started = Date.now();
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 150, `expected a single ~60ms deadline, took ${elapsed}ms`);
 });
 
 test("Notify carries paired actions, byte urgency and the desktop-entry hint", async () => {
@@ -148,6 +215,12 @@ test("Notify carries paired actions, byte urgency and the desktop-entry hint", a
     ["desktop-entry", ["s", "open-whispr"]],
   ]);
   assert.equal(expireTimeout, 30000);
+});
+
+test("the app identifier is shared with linuxAutostart", async () => {
+  loadModule();
+  const { LINUX_APP_NAME } = require("../../src/helpers/linuxAutostart");
+  assert.equal(LINUX_APP_NAME, "open-whispr");
 });
 
 test("replacing a prompt forwards the previous notification id", async () => {
@@ -252,6 +325,29 @@ test("an invoked action settles the prompt before the daemon's close signal", as
   assert.deepEqual(closes, []);
 });
 
+test("a dead connection expires live prompts so their owners can recover", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module, now: () => 0 });
+
+  const closes = [];
+  await notifier.show(baseShowArgs({ onClose: (r) => closes.push(r) }));
+  fake.connections[0].emit("error", new Error("daemon went away"));
+  assert.deepEqual(closes, [1]);
+  assert.equal(notifier._active.size, 0);
+  assert.equal(notifier.isSupported(), false);
+});
+
+test("stop() closes notifications still on screen", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  await notifier.show(baseShowArgs());
+  notifier.stop();
+  assert.deepEqual(fake.closeCalls, [42]);
+});
+
 test("meeting prompt content mirrors the overlay copy", async () => {
   const { buildMeetingPromptContent } = loadModule();
   const { i18nMain } = require("../../src/helpers/i18nMain");
@@ -313,4 +409,15 @@ test("oversized calendar summaries are truncated before hitting the daemon", asy
     (key) => key
   );
   assert.equal(content.title.length, 512);
+});
+
+test("truncation never leaves a dangling surrogate at the cut point", async () => {
+  const { buildMeetingPromptContent } = loadModule();
+
+  const content = buildMeetingPromptContent(
+    { variant: "starting", event: { summary: "x".repeat(511) + "\u{1F600}".repeat(10) } },
+    (key) => key
+  );
+  assert.equal(content.title.length, 511);
+  assert.equal(content.title.at(-1), "x");
 });

--- a/test/helpers/linuxNotifier.test.js
+++ b/test/helpers/linuxNotifier.test.js
@@ -29,6 +29,7 @@ function loadModule() {
 function createFakeDbus({
   capabilities = ["actions", "body"],
   notifyId = 42,
+  connectionError = null,
   interfaceError = null,
   failFirstInterface = false,
   hangNotify = false,
@@ -55,11 +56,15 @@ function createFakeDbus({
       const connection = new EventEmitter();
       connection.end = () => {};
       connections.push(connection);
+      if (connectionError) {
+        process.nextTick(() => connection.emit("error", connectionError));
+      }
       return {
         connection,
         getService: () => ({
           getInterface: (path, name, cb) => {
             interfaceRequests += 1;
+            if (connectionError) return;
             const failThis = interfaceError || (failFirstInterface && interfaceRequests === 1);
             process.nextTick(() =>
               failThis ? cb(interfaceError || new Error("first connect fails")) : cb(null, iface)
@@ -125,6 +130,29 @@ test("a connection failure backs off to the overlay", async () => {
 
   assert.equal(await notifier.show(baseShowArgs()), null);
   assert.equal(notifier.isSupported(), false);
+});
+
+test("one D-Bus connection error advances the failure backoff once", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ connectionError: new Error("connection lost") });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module, now: () => 0 });
+
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  assert.equal(notifier._failureCount, 1);
+  assert.equal(notifier._retryAt, 30 * 1000);
+});
+
+test("callers sharing one failed connection advance the backoff once", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ connectionError: new Error("connection lost") });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module, now: () => 0 });
+
+  assert.deepEqual(
+    await Promise.all([notifier.show(baseShowArgs()), notifier.show(baseShowArgs())]),
+    [null, null]
+  );
+  assert.equal(notifier._failureCount, 1);
+  assert.equal(notifier._retryAt, 30 * 1000);
 });
 
 test("a daemon that never answers Notify times out into fallback", async () => {

--- a/test/helpers/linuxNotifier.test.js
+++ b/test/helpers/linuxNotifier.test.js
@@ -1,0 +1,316 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+
+const notifierPath = require.resolve("../../src/helpers/linuxNotifier");
+const originalLoad = Module._load;
+
+function loadModule() {
+  delete require.cache[notifierPath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "./debugLogger") {
+      return { info() {}, warn() {}, debug() {}, error() {}, log() {} };
+    }
+    if (request === "@homebridge/dbus-native") {
+      return { sessionBus: () => null };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(notifierPath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createFakeDbus({
+  capabilities = ["actions", "body"],
+  notifyId = 42,
+  interfaceError = null,
+  hangNotify = false,
+} = {}) {
+  const iface = new EventEmitter();
+  const notifyCalls = [];
+  const closeCalls = [];
+
+  iface.GetCapabilities = (cb) => process.nextTick(cb, null, capabilities);
+  iface.Notify = (...args) => {
+    const cb = args.pop();
+    notifyCalls.push(args);
+    if (!hangNotify) process.nextTick(cb, null, notifyId);
+  };
+  iface.CloseNotification = (id, cb) => {
+    closeCalls.push(id);
+    if (cb) process.nextTick(cb, null);
+  };
+
+  const connection = new EventEmitter();
+  connection.end = () => {};
+  const bus = {
+    connection,
+    getService: () => ({
+      getInterface: (path, name, cb) =>
+        process.nextTick(() => (interfaceError ? cb(interfaceError) : cb(null, iface))),
+    }),
+  };
+
+  return { module: { sessionBus: () => bus }, iface, notifyCalls, closeCalls, connection };
+}
+
+function baseShowArgs(overrides = {}) {
+  return {
+    title: "Meeting detected",
+    body: "Want to take notes?",
+    actionKey: "start",
+    actionLabel: "Take notes",
+    timeoutMs: 30000,
+    onAction: () => {},
+    onClose: () => {},
+    ...overrides,
+  };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+test("native delivery is gated to Linux", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+
+  for (const platform of ["darwin", "win32"]) {
+    const notifier = new LinuxNotifier({ platform, dbusModule: fake.module });
+    assert.equal(notifier.isSupported(), false);
+    assert.equal(await notifier.show(baseShowArgs()), null);
+  }
+  assert.equal(fake.notifyCalls.length, 0);
+});
+
+test("a missing dbus module means unsupported instead of a crash", async () => {
+  const { LinuxNotifier } = loadModule();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: null });
+
+  assert.equal(notifier.isSupported(), false);
+  assert.equal(await notifier.show(baseShowArgs()), null);
+});
+
+test("a server without the actions capability falls back for the whole session", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ capabilities: ["body"] });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  assert.equal(fake.notifyCalls.length, 0);
+  assert.equal(notifier.isSupported(), false);
+});
+
+test("a connection failure falls back for the whole session", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ interfaceError: new Error("no notification service") });
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  assert.equal(notifier.isSupported(), false);
+});
+
+test("a daemon that never answers Notify times out into fallback", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus({ hangNotify: true });
+  const notifier = new LinuxNotifier({
+    platform: "linux",
+    dbusModule: fake.module,
+    callTimeoutMs: 20,
+  });
+
+  assert.equal(await notifier.show(baseShowArgs()), null);
+  assert.equal(notifier.isSupported(), false);
+});
+
+test("Notify carries paired actions, byte urgency and the desktop-entry hint", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  const handle = await notifier.show(baseShowArgs({ actionKey: "join", actionLabel: "Join" }));
+  assert.equal(handle.id, 42);
+
+  const [appName, replacesId, appIcon, summary, body, actions, hints, expireTimeout] =
+    fake.notifyCalls[0];
+  assert.equal(appName, "OpenWhispr");
+  assert.equal(replacesId, 0);
+  assert.equal(appIcon, "open-whispr");
+  assert.equal(summary, "Meeting detected");
+  assert.equal(body, "Want to take notes?");
+  assert.deepEqual(actions, ["default", "Join", "join", "Join"]);
+  assert.deepEqual(hints, [
+    ["urgency", ["y", 1]],
+    ["desktop-entry", ["s", "open-whispr"]],
+  ]);
+  assert.equal(expireTimeout, 30000);
+});
+
+test("replacing a prompt forwards the previous notification id", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  await notifier.show(baseShowArgs({ replacesId: 42 }));
+  assert.equal(fake.notifyCalls[0][1], 42);
+});
+
+test("the body is entity-escaped only when the server parses markup", async () => {
+  const { LinuxNotifier } = loadModule();
+  const body = "a <b> & c";
+
+  const plain = createFakeDbus({ capabilities: ["actions", "body"] });
+  const plainNotifier = new LinuxNotifier({ platform: "linux", dbusModule: plain.module });
+  await plainNotifier.show(baseShowArgs({ body }));
+  assert.equal(plain.notifyCalls[0][4], "a <b> & c");
+
+  const markup = createFakeDbus({ capabilities: ["actions", "body", "body-markup"] });
+  const markupNotifier = new LinuxNotifier({ platform: "linux", dbusModule: markup.module });
+  await markupNotifier.show(baseShowArgs({ body }));
+  assert.equal(markup.notifyCalls[0][4], "a &lt;b&gt; &amp; c");
+});
+
+test("clicking the notification body invokes the primary action", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  const actions = [];
+  await notifier.show(baseShowArgs({ onAction: (a) => actions.push(a) }));
+  fake.iface.emit("ActionInvoked", 42, "default");
+  await flush();
+  assert.deepEqual(actions, ["start"]);
+});
+
+test("signals for other notification ids are ignored", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  const actions = [];
+  const closes = [];
+  await notifier.show(
+    baseShowArgs({ onAction: (a) => actions.push(a), onClose: (r) => closes.push(r) })
+  );
+  fake.iface.emit("ActionInvoked", 7, "start");
+  fake.iface.emit("NotificationClosed", 7, 2);
+  await flush();
+  assert.deepEqual(actions, []);
+  assert.deepEqual(closes, []);
+});
+
+test("user dismissal and expiry reach onClose, our own close does not", async () => {
+  const { LinuxNotifier } = loadModule();
+
+  for (const [reason, expected] of [
+    [1, [1]],
+    [2, [2]],
+    [3, []],
+  ]) {
+    const fake = createFakeDbus();
+    const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+    const closes = [];
+    await notifier.show(baseShowArgs({ onClose: (r) => closes.push(r) }));
+    fake.iface.emit("NotificationClosed", 42, reason);
+    await flush();
+    assert.deepEqual(closes, expected, `reason ${reason}`);
+  }
+});
+
+test("close() removes the notification and mutes the trailing closed signal", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  const closes = [];
+  const handle = await notifier.show(baseShowArgs({ onClose: (r) => closes.push(r) }));
+  handle.close();
+  fake.iface.emit("NotificationClosed", 42, 3);
+  await flush();
+  assert.deepEqual(fake.closeCalls, [42]);
+  assert.deepEqual(closes, []);
+});
+
+test("an invoked action settles the prompt before the daemon's close signal", async () => {
+  const { LinuxNotifier } = loadModule();
+  const fake = createFakeDbus();
+  const notifier = new LinuxNotifier({ platform: "linux", dbusModule: fake.module });
+
+  const actions = [];
+  const closes = [];
+  await notifier.show(
+    baseShowArgs({ onAction: (a) => actions.push(a), onClose: (r) => closes.push(r) })
+  );
+  fake.iface.emit("ActionInvoked", 42, "start");
+  fake.iface.emit("NotificationClosed", 42, 2);
+  await flush();
+  assert.deepEqual(actions, ["start"]);
+  assert.deepEqual(closes, []);
+});
+
+test("meeting prompt content mirrors the overlay copy", async () => {
+  const { buildMeetingPromptContent } = loadModule();
+  const { i18nMain } = require("../../src/helpers/i18nMain");
+  const t = (key, opts) => i18nMain.t(key, opts);
+
+  const detected = buildMeetingPromptContent(
+    { variant: "detected", event: { summary: "Weekly sync" }, joinUrl: null },
+    t
+  );
+  assert.equal(detected.title, "Meeting detected");
+  assert.equal(detected.body, "It sounds like you're in a meeting. Want to take notes?");
+  assert.equal(detected.actionKey, "start");
+  assert.equal(detected.actionLabel, "Take notes");
+
+  const starting = buildMeetingPromptContent(
+    { variant: "starting", event: { summary: "Weekly sync" }, joinUrl: "https://meet.example" },
+    t
+  );
+  assert.equal(starting.title, "Weekly sync");
+  assert.equal(starting.body, "Your meeting is starting. Want to take notes?");
+  assert.equal(starting.actionKey, "join");
+  assert.equal(starting.actionLabel, "Join & transcribe");
+
+  const underway = buildMeetingPromptContent({ variant: "underway", event: {} }, t);
+  assert.equal(underway.title, "Meeting detected");
+  assert.equal(underway.body, "It sounds like your meeting is underway. Want to take notes?");
+});
+
+test("an unknown prompt variant falls back to the detected copy", async () => {
+  const { buildMeetingPromptContent } = loadModule();
+  const { i18nMain } = require("../../src/helpers/i18nMain");
+
+  const content = buildMeetingPromptContent(
+    { variant: "surprise", event: { summary: "Weekly sync" } },
+    (key, opts) => i18nMain.t(key, opts)
+  );
+  assert.equal(content.title, "Meeting detected");
+  assert.equal(content.body, "It sounds like you're in a meeting. Want to take notes?");
+});
+
+test("update prompt content interpolates the version", async () => {
+  const { buildUpdatePromptContent } = loadModule();
+  const { i18nMain } = require("../../src/helpers/i18nMain");
+
+  const content = buildUpdatePromptContent({ version: "1.9.0" }, (key, opts) =>
+    i18nMain.t(key, opts)
+  );
+  assert.equal(content.title, "OpenWhispr Update Available");
+  assert.equal(content.body, "Version 1.9.0 is ready to download");
+  assert.equal(content.actionKey, "update");
+  assert.equal(content.actionLabel, "Update Now");
+});
+
+test("oversized calendar summaries are truncated before hitting the daemon", async () => {
+  const { buildMeetingPromptContent } = loadModule();
+
+  const content = buildMeetingPromptContent(
+    { variant: "starting", event: { summary: "x".repeat(2000) } },
+    (key) => key
+  );
+  assert.equal(content.title.length, 512);
+});

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -92,6 +92,16 @@ Module._load = function loadWindowManagerWithStubs(request, parent, isMain) {
     };
   }
   if (request === "./dockManager") return {};
+  // These cases cover the overlay, so the daemon must always report unsupported.
+  if (request === "./linuxNotifier") {
+    return {
+      linuxNotifier: { isSupported: () => false },
+      buildMeetingPromptContent: () => ({}),
+      buildUpdatePromptContent: () => ({}),
+      CLOSE_REASON_EXPIRED: 1,
+      CLOSE_REASON_DISMISSED: 2,
+    };
+  }
   if (request === "./i18nMain") return { i18nMain: { t: (key) => key } };
   if (request === "./windowConfig") {
     const detectionSize = { width: 392, height: 92 };

--- a/test/helpers/windowManagerNativeNotifications.test.js
+++ b/test/helpers/windowManagerNativeNotifications.test.js
@@ -1,0 +1,163 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const windowManagerPath = require.resolve("../../src/helpers/windowManager");
+const originalLoad = Module._load;
+
+class HotkeyManager {
+  static isGlobeLikeHotkey() {
+    return false;
+  }
+
+  unregisterAll() {}
+}
+
+class DragManager {}
+
+class FakeNotificationDismissTimer {
+  constructor() {
+    this.startedWith = [];
+    this.cancelCount = 0;
+  }
+
+  start(timeoutMs) {
+    this.startedWith.push(timeoutMs);
+  }
+
+  cancel() {
+    this.cancelCount += 1;
+  }
+
+  pause() {}
+
+  resume() {}
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function loadWindowManager(linuxNotifier) {
+  delete require.cache[windowManagerPath];
+
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        app: { on() {} },
+        screen: {},
+        BrowserWindow: class {},
+        shell: {},
+        dialog: {},
+      };
+    }
+    if (request === "./debugLogger") {
+      return { info() {}, warn() {}, debug() {}, error() {}, log() {} };
+    }
+    if (request === "./hotkeyManager") return HotkeyManager;
+    if (request === "./dragManager") return DragManager;
+    if (request === "./menuManager") return {};
+    if (request === "./devServerManager") return { DEV_SERVER_PORT: 3000 };
+    if (request === "./dockManager") return {};
+    if (request === "./i18nMain") return { i18nMain: { t: (key) => key } };
+    if (request === "./notificationTimer") {
+      return {
+        NotificationDismissTimer: FakeNotificationDismissTimer,
+        getNotificationTimeoutMs: () => 30 * 1000,
+      };
+    }
+    if (request === "./linuxNotifier") {
+      return {
+        linuxNotifier,
+        buildMeetingPromptContent: () => ({
+          title: "Meeting detected",
+          body: "Want to take notes?",
+          actionKey: "start",
+          actionLabel: "Take notes",
+        }),
+        buildUpdatePromptContent: () => ({
+          title: "Update available",
+          body: "Restart to update",
+          actionKey: "update",
+          actionLabel: "Update",
+        }),
+        CLOSE_REASON_EXPIRED: 1,
+        CLOSE_REASON_DISMISSED: 2,
+      };
+    }
+    if (request === "./windowConfig") {
+      return {
+        MAIN_WINDOW_CONFIG: {},
+        CONTROL_PANEL_CONFIG: {},
+        AGENT_OVERLAY_CONFIG: {},
+        NOTIFICATION_WINDOW_CONFIG: {},
+        TRANSCRIPTION_PREVIEW_CONFIG: {},
+        TRANSCRIPTION_PREVIEW_SIZE_LIMITS: {},
+        WINDOW_SIZES: {},
+        WindowPositionUtil: {},
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require(windowManagerPath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createNativeShowHarness() {
+  const pendingShow = deferred();
+  const closedIds = [];
+  const linuxNotifier = {
+    isSupported: () => true,
+    show: () => pendingShow.promise,
+  };
+  const WindowManager = loadWindowManager(linuxNotifier);
+  const manager = new WindowManager();
+  const resolveShow = (id) => {
+    pendingShow.resolve({
+      id,
+      close: () => closedIds.push(id),
+    });
+  };
+  return { manager, closedIds, resolveShow };
+}
+
+test("dismissing a meeting prompt cancels a native show still in flight", async () => {
+  const { manager, closedIds, resolveShow } = createNativeShowHarness();
+  const showPromise = manager.showMeetingNotification({
+    detectionId: "detection-1",
+    source: "calendar",
+  });
+
+  manager.dismissMeetingNotification();
+  resolveShow(41);
+  await showPromise;
+
+  assert.equal(manager._nativeMeetingNotification, null);
+  assert.deepEqual(closedIds, [41]);
+  assert.deepEqual(manager._notificationDismissTimer.startedWith, []);
+});
+
+test("dismissing an update prompt cancels a native show still in flight", async () => {
+  const { manager, closedIds, resolveShow } = createNativeShowHarness();
+  const showPromise = manager.showUpdateNotification({ version: "1.2.3" });
+
+  manager.dismissUpdateNotification();
+  resolveShow(42);
+  await showPromise;
+
+  try {
+    assert.equal(manager._nativeUpdateNotification, null);
+    assert.deepEqual(closedIds, [42]);
+    assert.equal(manager._updateNotificationAutoDismiss, undefined);
+  } finally {
+    manager.dismissUpdateNotification({ persistent: false });
+  }
+});


### PR DESCRIPTION
## Summary

The meeting prompt and the update notice are frameless always-on-top BrowserWindows, and Wayland compositors ignore client-side positioning, so on WMs like Niri the card pops up centered and steals focus. On Linux, `windowManager` now delivers both through `org.freedesktop.Notifications` on the session bus (the protocol behind notify-send) via the already-bundled `@homebridge/dbus-native`, with the new `linuxNotifier.js` helper mapping the existing semantics onto the daemon: a primary action button that is also the default click, user close as dismiss, expiry as the auto-dismiss timeout, `replaces_id` for the one-prompt-at-a-time rule. Any failure (no session bus, daemon without the `actions` capability, hung call) falls back to the current overlay, with a retry backoff (30s doubling up to 30min) so a daemon that was merely slow at login gets picked up again; one overall deadline bounds the whole native attempt, a broken connection expires live prompts so their owners recover, quitting closes any toast still on screen, and staleness guards keep near-simultaneous detections from double-posting. macOS, Windows and daemon-less Linux setups are untouched, and the existing notification preferences keep applying since they gate upstream of delivery.

One tradeoff to sign off: the meeting-detection docs say prompts use the in-app overlay specifically to survive DND and stay out of screen shares via content protection. Native daemon notifications honor DND and are visible to screen shares, which is what #1599 asks for (respect the user's notification preferences). If that is accepted the doc needs updating; if not, I can gate the native path to update notices only.

Fixes #1599

## Changes

- src/helpers/linuxNotifier.js: new helper speaking org.freedesktop.Notifications (capability check, action and close signal dispatch keyed by notification id, programmatic close, single-deadline calls, failure backoff) plus the localized prompt content builders reusing the overlay i18n keys.
- src/helpers/windowManager.js: showMeetingNotification and showUpdateNotification try the native path first with a staleness guard across the await, and keep the overlay as fallback; the dismiss paths also close the native notification.
- src/updater.js: the notification Update action lives in one method, downloadUpdateFromNotification, used by both the native path and the overlay IPC handler.
- src/helpers/ipcHandlers.js: update-notification-respond calls that shared method.
- src/helpers/linuxAutostart.js: exports LINUX_APP_NAME so the notifier reuses the packaged desktop-entry name instead of re-declaring it.
- main.js: stops the notifier during teardown.
- test/helpers/linuxNotifier.test.js: covers the Linux gating, fallback and backoff-retry paths, the shared deadline, Notify argument marshalling, signal dispatch, orphan recovery on connection loss, close-on-stop, body markup escaping and the content builders.

Verified against a live daemon (KDE Plasma): connection, capabilities, Notify with actions and hints, programmatic close. Clicking the action buttons and the behavior on Niri and GNOME still need a live desktop pass.
