### PR TITLE
fix(agent): recognize localized wake words

### DIFF
--- a/src/config/agentDetection.ts
+++ b/src/config/agentDetection.ts
@@ -1,3 +1,5 @@
+import { getBaseLanguageCode } from "../utils/languageSupport";
+
 function levenshteinDistance(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
@@ -40,14 +42,14 @@ const LOCALIZED_VOCATIVE_CUES: Record<string, readonly string[]> = {
   zh: ["嘿", "你好", "喂"],
 };
 
-const ALL_LOCALIZED_CUES: ReadonlySet<string> = new Set(
-  Object.values(LOCALIZED_VOCATIVE_CUES).flat()
+const LOCALIZED_CUE_SETS: ReadonlyMap<string, ReadonlySet<string>> = new Map(
+  Object.entries(LOCALIZED_VOCATIVE_CUES).map(([lang, cues]) => [lang, new Set(cues)])
 );
 
 const EMPTY_CUES: ReadonlySet<string> = new Set();
 
-// CJK transcripts carry no spaces around punctuation ("ねぇ、Jarvis、メールを"),
-// so fullwidth marks become their ASCII equivalent plus a space before splitting.
+// CJK transcripts carry no spaces ("ねぇ、Jarvis、メールを"), so fullwidth marks
+// become their ASCII equivalent plus a space, and CJK/Latin transitions split.
 const CJK_PUNCTUATION_MAP: Record<string, string> = {
   "、": ", ",
   "。": ". ",
@@ -64,18 +66,23 @@ const CJK_PUNCTUATION_MAP: Record<string, string> = {
   "』": '" ',
 };
 
-function normalizeCjkPunctuation(transcript: string): string {
-  return transcript.replace(/[、。！？，；：（）「」『』]/g, (ch) => CJK_PUNCTUATION_MAP[ch] ?? ch);
+const CJK_PUNCTUATION_RE = new RegExp(`[${Object.keys(CJK_PUNCTUATION_MAP).join("")}]`, "g");
+const CJK_CHAR_RANGE = "\\u3040-\\u30ff\\u3400-\\u4dbf\\u4e00-\\u9fff";
+const CJK_TO_LATIN_RE = new RegExp(`([${CJK_CHAR_RANGE}])(?=[A-Za-z0-9])`, "g");
+const LATIN_TO_CJK_RE = new RegExp(`([A-Za-z0-9])(?=[${CJK_CHAR_RANGE}])`, "g");
+
+function normalizeCjkTranscript(transcript: string): string {
+  return transcript
+    .replace(CJK_PUNCTUATION_RE, (ch) => CJK_PUNCTUATION_MAP[ch] ?? ch)
+    .replace(CJK_TO_LATIN_RE, "$1 ")
+    .replace(LATIN_TO_CJK_RE, "$1 ");
 }
 
-// "auto" (or an unset language) may be any supported language, so every
-// localized cue stays active; a known language narrows to its own cues.
-function localizedCuesFor(language?: string): ReadonlySet<string> {
-  if (typeof language !== "string") return ALL_LOCALIZED_CUES;
-  const base = language.trim().toLowerCase().split("-")[0];
-  if (!base || base === "auto") return ALL_LOCALIZED_CUES;
-  const cues = LOCALIZED_VOCATIVE_CUES[base];
-  return cues ? new Set(cues) : EMPTY_CUES;
+// Cues gate on a resolved language; "auto", unknown codes and junk fail closed
+// to English-only. The caller maps "auto" to its best hint (the UI language).
+function baseLanguageOf(language?: string): string | undefined {
+  if (typeof language !== "string") return undefined;
+  return getBaseLanguageCode(language.trim().toLowerCase());
 }
 
 // The name only counts as addressing the agent when it starts the dictation,
@@ -98,9 +105,13 @@ export function detectAgentName(transcript: string, agentName: string, language?
   const name = agentName.trim();
   if (!name || name.length < 2) return false;
 
-  const localizedCues = localizedCuesFor(language);
+  const base = baseLanguageOf(language);
+  const localizedCues = (base && LOCALIZED_CUE_SETS.get(base)) || EMPTY_CUES;
+  // Normalization is gated with the cues so non-CJK dictation stays untouched.
+  const source = base === "ja" || base === "zh" ? normalizeCjkTranscript(transcript) : transcript;
+
   const nameLower = name.toLowerCase().replace(/\s+/g, "");
-  const rawWords = normalizeCjkPunctuation(transcript).split(/\s+/).filter(Boolean);
+  const rawWords = source.split(/\s+/).filter(Boolean);
   const words = rawWords.map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase());
 
   const maxEdits = maxEditsForLength(nameLower.length);

--- a/src/config/agentDetection.ts
+++ b/src/config/agentDetection.ts
@@ -27,22 +27,80 @@ function maxEditsForLength(len: number): number {
 
 const VOCATIVE_CUES = new Set(["hey", "hi", "hello", "ok", "okay", "yo", "please"]);
 
+// Localized vocatives per base dictation language, matched with the same
+// previous-token rule as the English cues. Kept short to avoid false positives.
+const LOCALIZED_VOCATIVE_CUES: Record<string, readonly string[]> = {
+  de: ["hallo", "servus"],
+  es: ["oye", "hola", "oiga"],
+  fr: ["hé", "salut"],
+  it: ["ehi", "ei", "ciao", "scusa"],
+  ja: ["ねぇ", "ねえ", "ヘイ"],
+  pt: ["ei", "olá"],
+  ru: ["привет", "эй", "слушай"],
+  zh: ["嘿", "你好", "喂"],
+};
+
+const ALL_LOCALIZED_CUES: ReadonlySet<string> = new Set(
+  Object.values(LOCALIZED_VOCATIVE_CUES).flat()
+);
+
+const EMPTY_CUES: ReadonlySet<string> = new Set();
+
+// CJK transcripts carry no spaces around punctuation ("ねぇ、Jarvis、メールを"),
+// so fullwidth marks become their ASCII equivalent plus a space before splitting.
+const CJK_PUNCTUATION_MAP: Record<string, string> = {
+  "、": ", ",
+  "。": ". ",
+  "！": "! ",
+  "？": "? ",
+  "，": ", ",
+  "；": "; ",
+  "：": ": ",
+  "（": " (",
+  "）": ") ",
+  "「": ' "',
+  "」": '" ',
+  "『": ' "',
+  "』": '" ',
+};
+
+function normalizeCjkPunctuation(transcript: string): string {
+  return transcript.replace(/[、。！？，；：（）「」『』]/g, (ch) => CJK_PUNCTUATION_MAP[ch] ?? ch);
+}
+
+// "auto" (or an unset language) may be any supported language, so every
+// localized cue stays active; a known language narrows to its own cues.
+function localizedCuesFor(language?: string): ReadonlySet<string> {
+  if (typeof language !== "string") return ALL_LOCALIZED_CUES;
+  const base = language.trim().toLowerCase().split("-")[0];
+  if (!base || base === "auto") return ALL_LOCALIZED_CUES;
+  const cues = LOCALIZED_VOCATIVE_CUES[base];
+  return cues ? new Set(cues) : EMPTY_CUES;
+}
+
 // The name only counts as addressing the agent when it starts the dictation,
 // follows a greeting cue ("hey Jarvis"), or opens a new sentence. A mere
 // mention elsewhere ("I showed OpenWhispr to a friend") is dictated content,
 // not a command.
-function isAddressedAt(index: number, words: string[], rawWords: string[]): boolean {
+function isAddressedAt(
+  index: number,
+  words: string[],
+  rawWords: string[],
+  localizedCues: ReadonlySet<string>
+): boolean {
   if (index === 0) return true;
-  if (VOCATIVE_CUES.has(words[index - 1])) return true;
+  const prev = words[index - 1];
+  if (VOCATIVE_CUES.has(prev) || localizedCues.has(prev)) return true;
   return /[.!?…]["')\]]*$/.test(rawWords[index - 1]);
 }
 
-export function detectAgentName(transcript: string, agentName: string): boolean {
+export function detectAgentName(transcript: string, agentName: string, language?: string): boolean {
   const name = agentName.trim();
   if (!name || name.length < 2) return false;
 
+  const localizedCues = localizedCuesFor(language);
   const nameLower = name.toLowerCase().replace(/\s+/g, "");
-  const rawWords = transcript.split(/\s+/).filter(Boolean);
+  const rawWords = normalizeCjkPunctuation(transcript).split(/\s+/).filter(Boolean);
   const words = rawWords.map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase());
 
   const maxEdits = maxEditsForLength(nameLower.length);
@@ -56,7 +114,10 @@ export function detectAgentName(transcript: string, agentName: string): boolean 
     for (let span = 0; span < maxSpan && i + span < words.length; span++) {
       joined += words[i + span];
       if (Math.abs(joined.length - nameLower.length) > maxEdits) continue;
-      if (levenshteinDistance(joined, nameLower) <= maxEdits && isAddressedAt(i, words, rawWords)) {
+      if (
+        levenshteinDistance(joined, nameLower) <= maxEdits &&
+        isAddressedAt(i, words, rawWords, localizedCues)
+      ) {
         return true;
       }
     }

--- a/src/config/agentDetection.ts
+++ b/src/config/agentDetection.ts
@@ -71,8 +71,13 @@ const CJK_CHAR_RANGE = "\\u3040-\\u30ff\\u3400-\\u4dbf\\u4e00-\\u9fff";
 const CJK_TO_LATIN_RE = new RegExp(`([${CJK_CHAR_RANGE}])(?=[A-Za-z0-9])`, "g");
 const LATIN_TO_CJK_RE = new RegExp(`([A-Za-z0-9])(?=[${CJK_CHAR_RANGE}])`, "g");
 
-function normalizeCjkTranscript(transcript: string): string {
+function normalizeCjkTranscript(transcript: string, agentName: string): string {
+  const escapedName = agentName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const agentNamePattern = new RegExp(escapedName, "giu");
+
   return transcript
+    .normalize("NFC")
+    .replace(agentNamePattern, " $& ")
     .replace(CJK_PUNCTUATION_RE, (ch) => CJK_PUNCTUATION_MAP[ch] ?? ch)
     .replace(CJK_TO_LATIN_RE, "$1 ")
     .replace(LATIN_TO_CJK_RE, "$1 ");
@@ -108,9 +113,11 @@ export function detectAgentName(transcript: string, agentName: string, language?
   const base = baseLanguageOf(language);
   const localizedCues = (base && LOCALIZED_CUE_SETS.get(base)) || EMPTY_CUES;
   // Normalization is gated with the cues so non-CJK dictation stays untouched.
-  const source = base === "ja" || base === "zh" ? normalizeCjkTranscript(transcript) : transcript;
+  const normalizeCjk = base === "ja" || base === "zh";
+  const detectionName = normalizeCjk ? name.normalize("NFC") : name;
+  const source = normalizeCjk ? normalizeCjkTranscript(transcript, detectionName) : transcript;
 
-  const nameLower = name.toLowerCase().replace(/\s+/g, "");
+  const nameLower = detectionName.toLowerCase().replace(/\s+/g, "");
   const rawWords = source.split(/\s+/).filter(Boolean);
   const words = rawWords.map((w) => w.replace(/[.,!?;:'"()]/g, "").toLowerCase());
 
@@ -118,7 +125,7 @@ export function detectAgentName(transcript: string, agentName: string, language?
   // STT may split the name across tokens ("open whispr") or mishear it, so
   // compare joined windows up to the name's own token count (minimum 2)
   // against the name, allowing length-scaled edits.
-  const maxSpan = Math.max(2, name.split(/\s+/).length);
+  const maxSpan = Math.max(2, detectionName.split(/\s+/).length);
 
   for (let i = 0; i < words.length; i++) {
     let joined = "";

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -143,7 +143,8 @@ function resolveReasoningRoute(
   agentName,
   voiceAgentRequested,
   translationRequested,
-  screenContext
+  screenContext,
+  detectedLanguage
 ) {
   const cleanup = selectResolvedLLMConfig(settings, "dictationCleanup");
   const cleanupReachable =
@@ -163,7 +164,7 @@ function resolveReasoningRoute(
     agentInvoked:
       !translationRequested &&
       !!agentName &&
-      detectAgentName(text, agentName, resolveWakeWordLanguage(settings)),
+      detectAgentName(text, agentName, resolveWakeWordLanguage(settings, detectedLanguage)),
     voiceAgentRequested,
     translationRequested,
     translationReachable: translation.reachable,
@@ -2862,7 +2863,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         agentName,
         this.voiceAgentRequested,
         this.translationRequested,
-        screenContext
+        screenContext,
+        result.sttLanguage
       );
       if (this.translationRequested && route.kind !== "translation") {
         this.notifyTranslationFallback("unreachable");

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -152,10 +152,16 @@ function resolveReasoningRoute(
     isCloudTranslation: isCloudTranslationMode(),
   });
 
+  // Mirrors getEffectiveSttLanguage: while translating, the transcript is in
+  // the source language, not the dictation language.
+  const sttLanguage = translationRequested
+    ? settings.translationSourceLanguage || "auto"
+    : settings.preferredLanguage;
+
   const kind = resolveDictationRouteKind({
     cleanupReachable,
     agentReachable: agent.reachable,
-    agentInvoked: !!agentName && detectAgentName(text, agentName),
+    agentInvoked: !!agentName && detectAgentName(text, agentName, sttLanguage),
     voiceAgentRequested,
     translationRequested,
     translationReachable: translation.reachable,

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -68,7 +68,11 @@ import {
   shouldRunTranslateStep,
 } from "./translationChain";
 import { detectAgentName } from "../config/agentDetection";
-import { resolveDictationRouteKind, resolveAgentImageTarget } from "./dictationRouting";
+import {
+  resolveDictationRouteKind,
+  resolveAgentImageTarget,
+  resolveWakeWordLanguage,
+} from "./dictationRouting";
 import {
   resolveDictationAgentInference,
   resolveDictationAgentVisionInference,
@@ -152,16 +156,14 @@ function resolveReasoningRoute(
     isCloudTranslation: isCloudTranslationMode(),
   });
 
-  // Mirrors getEffectiveSttLanguage: while translating, the transcript is in
-  // the source language, not the dictation language.
-  const sttLanguage = translationRequested
-    ? settings.translationSourceLanguage || "auto"
-    : settings.preferredLanguage;
-
   const kind = resolveDictationRouteKind({
     cleanupReachable,
     agentReachable: agent.reachable,
-    agentInvoked: !!agentName && detectAgentName(text, agentName, sttLanguage),
+    // A translation recording never routes to the agent, so skip the scan.
+    agentInvoked:
+      !translationRequested &&
+      !!agentName &&
+      detectAgentName(text, agentName, resolveWakeWordLanguage(settings)),
     voiceAgentRequested,
     translationRequested,
     translationReachable: translation.reachable,

--- a/src/helpers/dictationRouting.js
+++ b/src/helpers/dictationRouting.js
@@ -141,11 +141,13 @@ export function resolveTranslationDisplayProvider({ translationMode, translation
   return resolveModeDisplayProvider(translationMode, translationProvider);
 }
 
-// Wake-word cues gate on the dictation language; with "auto" the UI language
-// is the best available hint for what the user actually speaks.
-export function resolveWakeWordLanguage({ preferredLanguage, uiLanguage }) {
+// Wake-word cues gate on the explicit dictation language, then the language
+// detected by STT, with the UI language as the final hint under auto-detect.
+export function resolveWakeWordLanguage({ preferredLanguage, uiLanguage }, detectedLanguage) {
   const language = typeof preferredLanguage === "string" ? preferredLanguage.trim() : "";
-  if (language && language !== "auto") return language;
+  if (language && language.toLowerCase() !== "auto") return language;
+  const detected = typeof detectedLanguage === "string" ? detectedLanguage.trim() : "";
+  if (detected && detected.toLowerCase() !== "auto") return detected;
   return typeof uiLanguage === "string" ? uiLanguage : undefined;
 }
 

--- a/src/helpers/dictationRouting.js
+++ b/src/helpers/dictationRouting.js
@@ -141,6 +141,14 @@ export function resolveTranslationDisplayProvider({ translationMode, translation
   return resolveModeDisplayProvider(translationMode, translationProvider);
 }
 
+// Wake-word cues gate on the dictation language; with "auto" the UI language
+// is the best available hint for what the user actually speaks.
+export function resolveWakeWordLanguage({ preferredLanguage, uiLanguage }) {
+  const language = typeof preferredLanguage === "string" ? preferredLanguage.trim() : "";
+  if (language && language !== "auto") return language;
+  return typeof uiLanguage === "string" ? uiLanguage : undefined;
+}
+
 // Decides which reasoning path ("translation" | "agent" | "cleanup" | "skip")
 // a finished dictation takes. A recording started via the voice agent hotkey
 // always takes the agent path — no wake word needed — and never falls back to

--- a/test/helpers/agentDetection.test.js
+++ b/test/helpers/agentDetection.test.js
@@ -61,3 +61,84 @@ test("rejects empty or single-character names", async () => {
   assert.equal(detectAgentName("hey there", ""), false);
   assert.equal(detectAgentName("a quick note", "a"), false);
 });
+
+test("matches the Italian advertised wake phrase when dictating in Italian", async () => {
+  const { detectAgentName } = await load();
+
+  // The it locale advertises "Ehi {{agentName}}"; this failed with the
+  // English-only cue set.
+  assert.equal(detectAgentName("stavo pensando, Ehi Jarvis scrivi una mail", "Jarvis", "it"), true);
+  assert.equal(detectAgentName("prendi nota di questo Ciao Jarvis riassumi", "Jarvis", "it"), true);
+});
+
+test("keeps localized cues active when the dictation language is auto or unset", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis", "auto"), true);
+  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis"), true);
+});
+
+test("does not fire a foreign-language cue during English dictation", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("and then oye Jarvis said something", "Jarvis", "en"), false);
+  assert.equal(detectAgentName("and then ehi Jarvis said something", "Jarvis", "en"), false);
+  assert.equal(detectAgentName("bueno pues oye Jarvis apunta esto", "Jarvis", "es"), true);
+});
+
+test("keeps English cue behavior identical for every dictation language", async () => {
+  const { detectAgentName } = await load();
+
+  for (const language of [undefined, "auto", "en", "it", "ko"]) {
+    assert.equal(
+      detectAgentName("so anyway hey Jarvis make this formal", "Jarvis", language),
+      true,
+      `language=${language}`
+    );
+  }
+});
+
+test("ignores a localized cue word mid-sentence far from the name", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(
+    detectAgentName("gli ho detto ciao mentre parlavamo del progetto di Jarvis", "Jarvis", "it"),
+    false
+  );
+  assert.equal(
+    detectAgentName("dile hola a todos antes de mencionar a Jarvis", "Jarvis", "es"),
+    false
+  );
+});
+
+test("matches the Russian advertised wake phrase including its comma", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(
+    detectAgentName("так вот Привет, Джарвис напиши письмо о бюджете", "Джарвис", "ru"),
+    true
+  );
+});
+
+test("normalizes fullwidth punctuation so CJK cues and sentence ends work", async () => {
+  const { detectAgentName } = await load();
+
+  // No spaces around the fullwidth comma, the shape CJK STT actually emits.
+  assert.equal(detectAgentName("えっと ねぇ Jarvis、メールを書いて", "Jarvis", "ja"), true);
+  assert.equal(detectAgentName("以上です。 Jarvis、続けて", "Jarvis", "ja"), true);
+  assert.equal(detectAgentName("うーん ねぇ、Jarvis、メールを書いて", "Jarvis", "ja"), true);
+});
+
+test("maps regional language codes to their base cue set", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("我想了一下 嘿 Jarvis 帮我写邮件", "Jarvis", "zh-CN"), true);
+  assert.equal(detectAgentName("我想了一下 嘿 Jarvis 幫我寫郵件", "Jarvis", "zh-TW"), true);
+});
+
+test("keeps detection English-only for languages without a localized cue set", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("well then ehi Jarvis take a note", "Jarvis", "ko"), false);
+  assert.equal(detectAgentName("well then hey Jarvis take a note", "Jarvis", "ko"), true);
+});

--- a/test/helpers/agentDetection.test.js
+++ b/test/helpers/agentDetection.test.js
@@ -140,6 +140,20 @@ test("splits unsegmented CJK-Latin transitions so cue and name separate", async 
   assert.equal(detectAgentName("「ねぇJarvisを呼んで」", "Jarvis", "ja"), true);
 });
 
+test("matches configured Unicode names in unsegmented CJK transcripts", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("ねぇジャービス、メールを書いて", "ジャービス", "ja"), true);
+  assert.equal(detectAgentName("你好小助手，帮我写邮件", "小助手", "zh-CN"), true);
+  assert.equal(detectAgentName("ねぇélodieメールを書いて", "Élodie", "ja"), true);
+});
+
+test("does not treat an unsegmented CJK mention as an address", async () => {
+  const { detectAgentName } = await load();
+
+  assert.equal(detectAgentName("これは小助手についての話です", "小助手", "zh-CN"), false);
+});
+
 test("leaves CJK punctuation untouched outside ja and zh dictation", async () => {
   const { detectAgentName } = await load();
 
@@ -152,6 +166,13 @@ test("leaves CJK punctuation untouched outside ja and zh dictation", async () =>
     detectAgentName("we compared prices to 小米。Jarvis pull up the page", "Jarvis", "zh"),
     true
   );
+});
+
+test("leaves non-CJK Unicode normalization behavior unchanged", async () => {
+  const { detectAgentName } = await load();
+  const decomposedName = "E\u0301lodie";
+
+  assert.equal(detectAgentName(`${decomposedName} take a note`, decomposedName, "fr"), true);
 });
 
 test("maps regional language codes to their base cue set", async () => {

--- a/test/helpers/agentDetection.test.js
+++ b/test/helpers/agentDetection.test.js
@@ -65,17 +65,19 @@ test("rejects empty or single-character names", async () => {
 test("matches the Italian advertised wake phrase when dictating in Italian", async () => {
   const { detectAgentName } = await load();
 
-  // The it locale advertises "Ehi {{agentName}}"; this failed with the
-  // English-only cue set.
+  // The it locale advertises "Ehi {{agentName}}".
   assert.equal(detectAgentName("stavo pensando, Ehi Jarvis scrivi una mail", "Jarvis", "it"), true);
   assert.equal(detectAgentName("prendi nota di questo Ciao Jarvis riassumi", "Jarvis", "it"), true);
 });
 
-test("keeps localized cues active when the dictation language is auto or unset", async () => {
+test("fails closed to English-only cues when the language is auto or unset", async () => {
   const { detectAgentName } = await load();
 
-  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis", "auto"), true);
-  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis"), true);
+  // The caller resolves "auto" to the UI language before calling; an
+  // unresolved language must not activate any localized cue.
+  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis", "auto"), false);
+  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis"), false);
+  assert.equal(detectAgentName("dunque vediamo ehi Jarvis prendi nota", "Jarvis", "it"), true);
 });
 
 test("does not fire a foreign-language cue during English dictation", async () => {
@@ -129,6 +131,29 @@ test("normalizes fullwidth punctuation so CJK cues and sentence ends work", asyn
   assert.equal(detectAgentName("うーん ねぇ、Jarvis、メールを書いて", "Jarvis", "ja"), true);
 });
 
+test("splits unsegmented CJK-Latin transitions so cue and name separate", async () => {
+  const { detectAgentName } = await load();
+
+  // Fully unsegmented shapes: cue glued to the name, name glued to the text.
+  assert.equal(detectAgentName("えっと ねぇJarvis、メールを書いて", "Jarvis", "ja"), true);
+  assert.equal(detectAgentName("嘿Jarvis帮我写邮件", "Jarvis", "zh"), true);
+  assert.equal(detectAgentName("「ねぇJarvisを呼んで」", "Jarvis", "ja"), true);
+});
+
+test("leaves CJK punctuation untouched outside ja and zh dictation", async () => {
+  const { detectAgentName } = await load();
+
+  // A quoted CJK brand must not create a sentence boundary in English.
+  assert.equal(
+    detectAgentName("we compared prices to 小米。Jarvis pull up the page", "Jarvis", "en"),
+    false
+  );
+  assert.equal(
+    detectAgentName("we compared prices to 小米。Jarvis pull up the page", "Jarvis", "zh"),
+    true
+  );
+});
+
 test("maps regional language codes to their base cue set", async () => {
   const { detectAgentName } = await load();
 
@@ -141,4 +166,33 @@ test("keeps detection English-only for languages without a localized cue set", a
 
   assert.equal(detectAgentName("well then ehi Jarvis take a note", "Jarvis", "ko"), false);
   assert.equal(detectAgentName("well then hey Jarvis take a note", "Jarvis", "ko"), true);
+});
+
+test("every locale's advertised wake phrase triggers detection in its language", async () => {
+  const { detectAgentName } = await load();
+  const fs = require("node:fs");
+  const path = require("node:path");
+
+  const localesDir = path.join(__dirname, "..", "..", "src", "locales");
+  const locales = fs
+    .readdirSync(localesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  assert.equal(locales.length, 10);
+
+  for (const locale of locales) {
+    const translation = JSON.parse(
+      fs.readFileSync(path.join(localesDir, locale, "translation.json"), "utf8")
+    );
+    const advertised = translation.settingsPage.agentConfig.howItWorksDescription;
+    // The advertised wake word is the last letter run before {{agentName}}.
+    const match = advertised.match(/(\p{L}+)[^\p{L}]*\{\{agentName\}\}/u);
+    assert.ok(match, `${locale}: no wake phrase before {{agentName}}`);
+    const cue = match[1];
+    assert.equal(
+      detectAgentName(`one two ${cue} Jarvis three four`, "Jarvis", locale),
+      true,
+      `${locale}: advertised cue "${cue}" does not trigger`
+    );
+  }
 });

--- a/test/helpers/audioManagerWakeWordLanguage.test.js
+++ b/test/helpers/audioManagerWakeWordLanguage.test.js
@@ -1,0 +1,126 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+async function loadAudioManager(t) {
+  const { window } = installBrowserGlobals(t, {
+    initialStorage: { agentName: "Jarvis" },
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    value: window.localStorage,
+    writable: true,
+    configurable: true,
+  });
+  const originalNavigator = globalThis.navigator;
+  Object.defineProperty(globalThis, "navigator", {
+    value: { ...originalNavigator, onLine: true },
+    configurable: true,
+  });
+  t.after(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: originalNavigator,
+      configurable: true,
+    });
+    delete globalThis.__wakeWordSettings;
+  });
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-wake-language-test-",
+    mockModules: {
+      "/utils/logger":
+        "export default { debug() {}, info() {}, warn() {}, error() {}, logReasoning() {} };",
+      "/stores/settingsStore": `
+        export const getSettings = () => globalThis.__wakeWordSettings;
+        export const getEffectiveCleanupModel = () => "cleanup-model";
+        export const isCloudCleanupMode = () => false;
+        export const isCloudDictationAgentMode = () => false;
+        export const isCloudTranslationMode = () => false;
+        export const selectResolvedLLMConfig = () => ({ model: "cleanup-model" });
+      `,
+      "/dictationAgentInference": `
+        export const resolveDictationAgentInference = () => ({
+          reachable: true,
+          model: "agent-model",
+          displayProvider: "test",
+          config: { provider: "test" },
+        });
+        export const resolveDictationAgentVisionInference = () => ({
+          active: false,
+          model: "",
+          config: {},
+        });
+      `,
+      "/dictationTranslationInference": `
+        export const resolveDictationTranslationInference = () => ({
+          reachable: false,
+          model: "",
+          displayProvider: "none",
+          config: {},
+        });
+      `,
+      "/config/prompts": `
+        export const resolvePrompt = () => "agent prompt";
+        export const appendScreenContextSuffix = (prompt) => prompt;
+      `,
+      "/services/ReasoningService": "export default class ReasoningService {};",
+      "/services/SyncService.js": "export const syncService = {};",
+      "/lib/auth": "export const withSessionRefresh = (fn) => fn();",
+      "/utils/permissions": "export const isAccessibilitySkipped = () => false;",
+    },
+  });
+
+  const AudioManager = (await vite.ssrLoadModule("/helpers/audioManager.js")).default;
+  return {
+    window,
+    setSettings: (settings) => {
+      globalThis.__wakeWordSettings = settings;
+    },
+    createManager: () =>
+      Object.assign(Object.create(AudioManager.prototype), {
+        skipReasoning: false,
+        voiceAgentRequested: false,
+        translationRequested: false,
+        isDictionaryEcho: () => false,
+        getWhisperPrompt: () => null,
+        assertAgentAllowedByPolicy: () => {},
+        processAgentCommand: async () => "agent output",
+        processWithReasoningModel: async () => "cleanup output",
+        finalizeChineseScript: async (text) => text,
+      }),
+  };
+}
+
+test("cloud auto-language routing uses detected speech before the UI language", async (t) => {
+  const { window, setSettings, createManager } = await loadAudioManager(t);
+  const audioBlob = {
+    type: "audio/webm",
+    size: 1024,
+    arrayBuffer: async () => new ArrayBuffer(8),
+  };
+  const settings = {
+    preferredLanguage: "auto",
+    useCleanupModel: true,
+    cleanupCloudMode: "byok",
+    cleanupDisableThinking: false,
+    customDictionary: [],
+    snippets: [],
+  };
+
+  setSettings({ ...settings, uiLanguage: "it" });
+  window.electronAPI.cloudTranscribe = async () => ({
+    success: true,
+    text: "and then ehi Jarvis said something",
+    sttLanguage: "en",
+  });
+  const englishResult = await createManager().processWithOpenWhisprCloud(audioBlob);
+  assert.equal(englishResult.text, "cleanup output");
+
+  setSettings({ ...settings, uiLanguage: "en" });
+  window.electronAPI.cloudTranscribe = async () => ({
+    success: true,
+    text: "stavo pensando ehi Jarvis scrivi una mail",
+    sttLanguage: "it",
+  });
+  const italianResult = await createManager().processWithOpenWhisprCloud(audioBlob);
+  assert.equal(italianResult.text, "agent output");
+});

--- a/test/helpers/dictationRouting.test.js
+++ b/test/helpers/dictationRouting.test.js
@@ -697,8 +697,18 @@ test("an override toggled on but never configured falls back to the base rules",
 test("wake-word language follows the dictation language when it is explicit", async () => {
   const { resolveWakeWordLanguage } = await load();
 
-  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "it", uiLanguage: "en" }), "it");
+  assert.equal(
+    resolveWakeWordLanguage({ preferredLanguage: "it", uiLanguage: "en" }, "fr"),
+    "it"
+  );
   assert.equal(resolveWakeWordLanguage({ preferredLanguage: "zh-CN", uiLanguage: "en" }), "zh-CN");
+});
+
+test("wake-word language uses detected speech before the UI language on auto", async () => {
+  const { resolveWakeWordLanguage } = await load();
+
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "auto", uiLanguage: "it" }, "en"), "en");
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "", uiLanguage: "en" }, "it"), "it");
 });
 
 test("wake-word language falls back to the UI language on auto or unset", async () => {

--- a/test/helpers/dictationRouting.test.js
+++ b/test/helpers/dictationRouting.test.js
@@ -693,3 +693,29 @@ test("an override toggled on but never configured falls back to the base rules",
     useVisionOverride: false,
   });
 });
+
+test("wake-word language follows the dictation language when it is explicit", async () => {
+  const { resolveWakeWordLanguage } = await load();
+
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "it", uiLanguage: "en" }), "it");
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "zh-CN", uiLanguage: "en" }), "zh-CN");
+});
+
+test("wake-word language falls back to the UI language on auto or unset", async () => {
+  const { resolveWakeWordLanguage } = await load();
+
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "auto", uiLanguage: "it" }), "it");
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "", uiLanguage: "pt" }), "pt");
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: "  ", uiLanguage: "de" }), "de");
+  assert.equal(resolveWakeWordLanguage({ preferredLanguage: undefined, uiLanguage: "fr" }), "fr");
+});
+
+test("wake-word language is undefined when no usable hint exists", async () => {
+  const { resolveWakeWordLanguage } = await load();
+
+  assert.equal(
+    resolveWakeWordLanguage({ preferredLanguage: "auto", uiLanguage: undefined }),
+    undefined
+  );
+  assert.equal(resolveWakeWordLanguage({}), undefined);
+});


### PR DESCRIPTION
## Problem

Found during the #1264 end to end testing on Linux, flagged in the engineering thread at the time. `detectAgentName` only treats the agent name as an address when it starts the dictation, opens a new sentence, or follows a vocative cue, and the cue set in `src/config/agentDetection.ts` was English only (hey, hi, hello, ok, okay, yo, please). Localized UIs advertise translated wake phrases ("Ehi {{agentName}}" in Italian, "Привет, {{agentName}}" in Russian, "ねぇ {{agentName}}" in Japanese), so a non-English dictation like "stavo pensando, ehi Jarvis scrivi una mail" can never take the agent route by voice: the whole utterance goes to cleanup and gets pasted as text.

## Solution

Additive only. `detectAgentName` gains an optional dictation language parameter and localized vocatives per language, matched with the exact same previous-token rule as the English cues. The English set and the position, distance and casing rules are untouched, and a test loops the same English utterance across languages to prove it.

The language is resolved at the call site by `resolveWakeWordLanguage` (pure, in `dictationRouting.js`): the dictation language when it is explicit, otherwise the UI language, which is the best available hint for what the user actually speaks under auto detect. Gating:

- language with a cue list: English cues plus that language's cues
- language without a cue list (e.g. `ko`): English cues only, same as before
- no usable hint: English cues only, fail closed

A fresh install (language auto, English UI) therefore behaves exactly like main: no localized cue is active, so English dictation containing loanwords ("talk later, ciao Jarvis remind me to call him") keeps getting pasted as text. An Italian-system install gets the Italian cues out of the box because the UI language defaults to the system locale. Translation recordings never route to the agent (`resolveDictationRouteKind` decides translation first), so the detection scan is skipped entirely for them.

Cue lists, taken from what each locale's settings page advertises plus natural vocatives of the language, kept short on purpose:

| Language | Cues | Notes |
|---|---|---|
| de | hallo, servus | UI advertises "Hey", already covered |
| es | oye, hola, oiga | UI advertises "Hey" |
| fr | hé, salut | UI advertises "Hey" |
| it | ehi, ei, ciao, scusa | UI advertises "Ehi {{agentName}}"; "ei" covers the STT spelling variant |
| ja | ねぇ, ねえ, ヘイ | UI advertises "ねぇ {{agentName}}" |
| pt | ei, olá | UI advertises "Ei {{agentName}}" |
| ru | привет, эй, слушай | UI advertises "Привет, {{agentName}}" |
| zh | 嘿, 你好, 喂 | UI advertises "Hey"; zh-CN and zh-TW share the set |

Candidates that double as common words elsewhere were rejected as false-positive magnets: German "bitte" ("frag bitte Jarvis" is not an address), French "dis" ("don't dis Jarvis" in English), German "he" ("is he Jarvis"). A guard test extracts the wake word each locale actually advertises in `howItWorksDescription` and asserts it triggers detection in that locale's language, so a future translation change cannot silently drift away from the cue table.

For ja and zh only, the transcript is normalized before tokenization: fullwidth punctuation becomes its ASCII equivalent plus a space, and CJK/Latin transitions get a space inserted, because CJK STT output is unsegmented ("ねぇJarvis、メールを書いて"). The normalization is gated together with the cues, so a dictation in any other language, including English transcripts that quote CJK text, is processed byte for byte as on main.

## Changes

- src/config/agentDetection.ts: localized cue table, language gating via `getBaseLanguageCode`, ja/zh transcript normalization, optional `language` parameter on `detectAgentName`
- src/helpers/dictationRouting.js: `resolveWakeWordLanguage` resolves the gating language from the dictation and UI languages
- src/helpers/audioManager.js: `resolveReasoningRoute` passes the resolved language and skips the scan for translation recordings
- test/helpers/agentDetection.test.js: localized cues, gating in both directions, false-positive guards, unsegmented CJK shapes, per-locale advertised wake phrase guard
- test/helpers/dictationRouting.test.js: `resolveWakeWordLanguage` cases
