### PR TITLE
fix(meetings): name the active provider in realtime streaming logs

### DIFF
--- a/src/helpers/openaiRealtimeStreaming.js
+++ b/src/helpers/openaiRealtimeStreaming.js
@@ -48,6 +48,9 @@ class OpenAIRealtimeStreaming {
     this.connectionTimeout = null;
     this.isDisconnecting = false;
     this.audioBytesSent = 0;
+    // Subclasses (Tinfoil) override this so logs name the provider actually
+    // carrying the audio — a Tinfoil session must never log as OpenAI.
+    this.providerLabel = "OpenAI Realtime";
     this.model = "gpt-4o-mini-transcribe";
     this.inputRate = SAMPLE_RATE;
     this.captureRate = SAMPLE_RATE;
@@ -73,10 +76,10 @@ class OpenAIRealtimeStreaming {
 
   async connect(options = {}) {
     const { apiKey, model, preconfigured, inputRate, captureRate, createSocket } = options;
-    if (!apiKey) throw new Error("OpenAI API key is required");
+    if (!apiKey) throw new Error(`${this.providerLabel} API key is required`);
 
     if (this.isConnected || this.isConnecting) {
-      debugLogger.debug("OpenAI Realtime already connected/connecting");
+      debugLogger.debug(`${this.providerLabel} already connected/connecting`);
       return;
     }
 
@@ -97,7 +100,7 @@ class OpenAIRealtimeStreaming {
     this._connectionLossNotified = false;
 
     const url = "wss://api.openai.com/v1/realtime?intent=transcription";
-    debugLogger.debug("OpenAI Realtime connecting", { model: this.model });
+    debugLogger.debug(`${this.providerLabel} connecting`, { model: this.model });
 
     // Attested providers (Tinfoil) supply their socket via an async factory.
     let ws;
@@ -118,13 +121,13 @@ class OpenAIRealtimeStreaming {
       this.connectionTimeout = setTimeout(() => {
         this.isConnecting = false;
         this.cleanup();
-        reject(new Error("OpenAI Realtime connection timeout"));
+        reject(new Error(`${this.providerLabel} connection timeout`));
       }, WEBSOCKET_TIMEOUT_MS);
 
       this.ws = ws;
 
       this.ws.on("open", () => {
-        debugLogger.debug("OpenAI Realtime WebSocket opened");
+        debugLogger.debug(`${this.providerLabel} WebSocket opened`);
       });
 
       this.ws.on("message", (data) => {
@@ -133,7 +136,7 @@ class OpenAIRealtimeStreaming {
 
       this.ws.on("error", (error) => {
         const wasActive = this.isConnected;
-        debugLogger.error("OpenAI Realtime WebSocket error", { error: error.message });
+        debugLogger.error(`${this.providerLabel} WebSocket error`, { error: error.message });
         this.isConnecting = false;
         this.cleanup();
         if (this.pendingReject) {
@@ -151,7 +154,7 @@ class OpenAIRealtimeStreaming {
       this.ws.on("close", (code, reason) => {
         const wasActive = this.isConnected;
         this.isConnecting = false;
-        debugLogger.debug("OpenAI Realtime WebSocket closed", {
+        debugLogger.debug(`${this.providerLabel} WebSocket closed`, {
           code,
           reason: reason?.toString(),
           wasActive,
@@ -179,12 +182,12 @@ class OpenAIRealtimeStreaming {
           if (this.preconfigured) {
             // Server-side ephemeral token already configured the session;
             // sending an update would strip language and noise-reduction.
-            debugLogger.debug("OpenAI Realtime session created (preconfigured)", {
+            debugLogger.debug(`${this.providerLabel} session created (preconfigured)`, {
               model: this.model,
             });
             this._markConnected();
           } else {
-            debugLogger.debug("OpenAI Realtime session created, sending configuration", {
+            debugLogger.debug(`${this.providerLabel} session created, sending configuration`, {
               model: this.model,
             });
             if (!this.ws || this.ws.readyState !== WebSocket.OPEN) break;
@@ -214,7 +217,7 @@ class OpenAIRealtimeStreaming {
 
         case "session.updated": {
           if (this.pendingResolve) {
-            debugLogger.debug("OpenAI Realtime session configured", {
+            debugLogger.debug(`${this.providerLabel} session configured`, {
               model: this.model,
             });
             this._markConnected();
@@ -242,7 +245,7 @@ class OpenAIRealtimeStreaming {
           if (transcript) {
             const fullText = this.getFullTranscript();
             this.onFinalTranscript?.(fullText, speechTimestamp);
-            debugLogger.debug("OpenAI Realtime turn completed", {
+            debugLogger.debug(`${this.providerLabel} turn completed`, {
               turnText: transcript.slice(0, 100),
               totalLength: fullText.length,
               segments: this.completedSegments.length,
@@ -260,11 +263,11 @@ class OpenAIRealtimeStreaming {
 
         case "error": {
           const errCode = event.error?.code;
-          const errMsg = event.error?.message || "OpenAI Realtime error";
+          const errMsg = event.error?.message || `${this.providerLabel} error`;
           // Only consumers that attach onSessionExpired (meetings) get the
           // reconnect path; others (dictation) keep the onError/onSessionEnd flow.
           if (errCode === "session_expired" && this.onSessionExpired) {
-            debugLogger.warn("OpenAI Realtime session expired", { message: errMsg });
+            debugLogger.warn(`${this.providerLabel} session expired`, { message: errMsg });
             this._sessionExpired = true;
             this.onSessionExpired({ proactive: false });
             break;
@@ -274,11 +277,11 @@ class OpenAIRealtimeStreaming {
             errMsg.includes("buffer too small") ||
             errMsg.includes("commit_empty");
           if (isEmptyBuffer) {
-            debugLogger.debug("OpenAI Realtime empty buffer (server VAD already committed)", {
+            debugLogger.debug(`${this.providerLabel} empty buffer (server VAD already committed)`, {
               code: errCode,
             });
           } else {
-            debugLogger.error("OpenAI Realtime error event", {
+            debugLogger.error(`${this.providerLabel} error event`, {
               code: errCode,
               message: errMsg,
             });
@@ -291,7 +294,7 @@ class OpenAIRealtimeStreaming {
           break;
       }
     } catch (err) {
-      debugLogger.error("OpenAI Realtime message parse error", { error: err.message });
+      debugLogger.error(`${this.providerLabel} message parse error`, { error: err.message });
     }
   }
 
@@ -322,7 +325,9 @@ class OpenAIRealtimeStreaming {
     clearTimeout(this._sessionTimer);
     this._sessionTimer = setTimeout(() => {
       if (!this.isConnected) return;
-      debugLogger.debug("OpenAI Realtime session approaching 60min limit, requesting reconnect");
+      debugLogger.debug(
+        `${this.providerLabel} session approaching 60min limit, requesting reconnect`
+      );
       this.onSessionExpired?.({ proactive: true });
     }, SESSION_PREEMPT_MS);
   }
@@ -347,7 +352,9 @@ class OpenAIRealtimeStreaming {
         return;
       }
       if (socket.isAlive === false) {
-        debugLogger.debug("OpenAI Realtime keep-alive missed pong, terminating stale connection");
+        debugLogger.debug(
+          `${this.providerLabel} keep-alive missed pong, terminating stale connection`
+        );
         socket.terminate();
         return;
       }
@@ -355,7 +362,7 @@ class OpenAIRealtimeStreaming {
       try {
         socket.ping();
       } catch (err) {
-        debugLogger.debug("OpenAI Realtime keep-alive ping failed", { error: err.message });
+        debugLogger.debug(`${this.providerLabel} keep-alive ping failed`, { error: err.message });
         socket.terminate();
       }
     }, KEEPALIVE_INTERVAL_MS);
@@ -397,7 +404,7 @@ class OpenAIRealtimeStreaming {
     }
 
     if (this.coldStartBuffer.length > 0) {
-      debugLogger.debug("OpenAI Realtime flushing cold-start buffer", {
+      debugLogger.debug(`${this.providerLabel} flushing cold-start buffer`, {
         chunks: this.coldStartBuffer.length,
         bytes: this.coldStartBufferSize,
       });
@@ -421,7 +428,7 @@ class OpenAIRealtimeStreaming {
   }
 
   async disconnect({ commit = true } = {}) {
-    debugLogger.debug("OpenAI Realtime disconnect", {
+    debugLogger.debug(`${this.providerLabel} disconnect`, {
       audioBytesSent: this.audioBytesSent,
       segments: this.completedSegments.length,
       textLength: this.getFullTranscript().length,
@@ -446,7 +453,7 @@ class OpenAIRealtimeStreaming {
 
         await new Promise((resolve) => {
           const tid = setTimeout(() => {
-            debugLogger.debug("OpenAI Realtime commit timeout, using accumulated text");
+            debugLogger.debug(`${this.providerLabel} commit timeout, using accumulated text`);
             resolve();
           }, DISCONNECT_TIMEOUT_MS);
 

--- a/src/helpers/tinfoilRealtimeStreaming.js
+++ b/src/helpers/tinfoilRealtimeStreaming.js
@@ -39,6 +39,7 @@ const hasSpeechEnergy = (pcmBuffer) => {
 class TinfoilRealtimeStreaming extends OpenAIRealtimeStreaming {
   constructor(createSocketImpl = createTinfoilRealtimeSocket) {
     super();
+    this.providerLabel = "Tinfoil Realtime";
     this._createSocketImpl = createSocketImpl;
     this._commitTimer = null;
     this._commitInFlight = false;
@@ -165,7 +166,7 @@ class TinfoilRealtimeStreaming extends OpenAIRealtimeStreaming {
       return true;
     } catch (error) {
       this._settleCommit();
-      debugLogger.debug("Tinfoil Realtime commit send failed", { error: error.message });
+      debugLogger.debug(`${this.providerLabel} commit send failed`, { error: error.message });
       return false;
     }
   }
@@ -173,7 +174,7 @@ class TinfoilRealtimeStreaming extends OpenAIRealtimeStreaming {
   _requestRecovery(error, surfaceError = true) {
     if (this._recoveryRequested) return;
     this._recoveryRequested = true;
-    debugLogger.warn("Tinfoil Realtime connection recovery requested", {
+    debugLogger.warn(`${this.providerLabel} connection recovery requested`, {
       error: error.message,
     });
     if (this.onConnectionLost) {

--- a/test/helpers/meetingStreamingProviders.test.js
+++ b/test/helpers/meetingStreamingProviders.test.js
@@ -48,6 +48,26 @@ test("client lookup fails closed instead of defaulting to OpenAI", async () => {
   assert.throws(() => getMeetingStreamingClient("unknown-realtime"), /Unsupported meeting/);
 });
 
+test("OpenAI-derived streaming clients carry their own provider log label", async () => {
+  const { STREAMING_CLIENT_BY_PROVIDER } = await load();
+  const OpenAIRealtimeStreaming = (await import("../../src/helpers/openaiRealtimeStreaming.js"))
+    .default;
+  const baseLabel = new OpenAIRealtimeStreaming().providerLabel;
+
+  assert.equal(typeof baseLabel, "string");
+  assert.ok(baseLabel.length > 0, "the base class must define a provider log label");
+
+  for (const [provider, StreamingClient] of Object.entries(STREAMING_CLIENT_BY_PROVIDER)) {
+    if (StreamingClient === OpenAIRealtimeStreaming) continue;
+    if (!(StreamingClient.prototype instanceof OpenAIRealtimeStreaming)) continue;
+    assert.notEqual(
+      new StreamingClient().providerLabel,
+      baseLabel,
+      `${provider} inherits the OpenAI log label and would misreport where audio goes`
+    );
+  }
+});
+
 test("connection identity includes every provider-specific option", async () => {
   const { getMeetingConnectionKey } = await load();
   const options = {

--- a/test/helpers/tinfoilRealtimeStreaming.test.js
+++ b/test/helpers/tinfoilRealtimeStreaming.test.js
@@ -111,6 +111,39 @@ test("connect defaults to the supported Tinfoil realtime model", async () => {
   streaming.cleanup();
 });
 
+test("connection lifecycle logs name Tinfoil, never OpenAI", async () => {
+  const debugLogger = require("../../src/helpers/debugLogger");
+  const { TinfoilRealtimeStreaming } = await load();
+  const socket = makeFakeSocket(WS.CONNECTING);
+  const { factory } = makeRecordingFactory(socket);
+  const streaming = new TinfoilRealtimeStreaming(factory);
+
+  const messages = [];
+  const levels = ["debug", "warn", "error"];
+  const originals = Object.fromEntries(levels.map((level) => [level, debugLogger[level]]));
+  for (const level of levels) {
+    debugLogger[level] = (message) => messages.push(message);
+  }
+  try {
+    const connected = streaming.connect({ apiKey: "tk-secret" });
+    await finishConnect(streaming, socket);
+    await connected;
+    await streaming.disconnect();
+  } finally {
+    for (const level of levels) debugLogger[level] = originals[level];
+  }
+
+  assert.ok(
+    messages.some((message) => message.startsWith("Tinfoil Realtime")),
+    `expected Tinfoil-labelled logs, got: ${JSON.stringify(messages)}`
+  );
+  assert.deepEqual(
+    messages.filter((message) => message.includes("OpenAI")),
+    [],
+    "a Tinfoil session must never log the OpenAI label"
+  );
+});
+
 test("the default factory is the pinned Tinfoil transport", async () => {
   const { TinfoilRealtimeStreaming } = await load();
   const { createTinfoilRealtimeSocket } = require("../../src/helpers/tinfoilSecureClient");


### PR DESCRIPTION
## Problem

A correctly-routed Tinfoil meeting session logs:

```
[DEBUG] OpenAI Realtime connecting { model: 'voxtral-mini-4b-realtime' }
[DEBUG] OpenAI Realtime session configured { model: 'voxtral-mini-4b-realtime' }
```

`TinfoilRealtimeStreaming` extends `OpenAIRealtimeStreaming` and every connection/session/error log line lives in the parent with a hardcoded "OpenAI Realtime" prefix — only the `model` field distinguishes the providers.

This is worse than cosmetic: it is exactly the string one greps for when verifying CUS-65 ("meeting transcription silently routes to OpenAI instead of Tinfoil"). On 1.8.3 the routing is fixed, yet the log still names OpenAI, so the fastest check reports the bug as present on a build where it isn't — and a privacy-sensitive customer reading their own debug log sees the product claiming their audio went to a vendor it did not.

## Fix

- `OpenAIRealtimeStreaming` gains `this.providerLabel = "OpenAI Realtime"`; all its log prefixes and prefix-derived error messages (missing API key, connection timeout) use it.
- `TinfoilRealtimeStreaming` overrides it with `"Tinfoil Realtime"` and its own literal log lines now use the same property.
- OpenAI sessions log byte-for-byte identically to before; Tinfoil sessions now say `Tinfoil Realtime connecting` etc.

## Tests

- New: a Tinfoil connect/disconnect lifecycle asserts logs are Tinfoil-labelled and never mention OpenAI (this reproduced the bug before the fix).
- New: a registry-wide guard in `meetingStreamingProviders.test.js` — any registered client derived from `OpenAIRealtimeStreaming` must override `providerLabel`, so the next subclass can't silently inherit the wrong name.
- Full suite: 1806 pass / 0 fail (169 known local Electron-ABI skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)