### PR TITLE
fix(notes): persist diarization metadata on upload and URL-ingest notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Uploaded and URL-ingested notes remember their speaker detection.** A note created through Upload ran speaker detection but stored none of it — the note now records that diarization ran, the speaker count you chose, and the audio duration, so it behaves like a meeting note when you record into it or resolve participants. An upload with speaker detection off writes nothing, preserving your global speaker setting. Present since upload speaker detection shipped in 1.7.6. (#1610)
+
 ## [1.8.3] - 2026-08-12
 
 GPU acceleration for local transcription gets an overhaul: the status you see is now the truth, enabling it works without a restart, older NVIDIA cards are routed to a backend that actually works on them, and a GPU failure can never cost you a dictation. LLM routing gains the same fail-closed treatment speech-to-text received in 1.8.2. Launch at login arrives on Linux, and transcription errors stop blaming your microphone.

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -64,6 +64,7 @@ import { isTranscriptionContextAllowed } from "../../stores/policyRules";
 import { usePolicyStore } from "../../stores/policyStore";
 import { usePolicySnapshot, useTranscriptionContextAllowed } from "../../hooks/usePolicy";
 import { resolveTranscriptionRoute } from "../../helpers/transcriptionRoute";
+import { buildUploadNoteMetadata } from "../../helpers/uploadNoteMetadata";
 
 type UploadState = "idle" | "selected" | "downloading" | "transcribing" | "complete" | "error";
 
@@ -656,14 +657,15 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     }
 
     try {
+      const diarization: DiarizationSettings = {
+        enabled: diarizationEnabled,
+        localModelsReady: !!diarizationModelsReady,
+        numSpeakers: diarizationNumSpeakers ? Number(diarizationNumSpeakers) : null,
+      };
       const res: FileTranscriptionResult = await transcribeFileWithSpeakers(
         currentFile.path,
         buildTranscriptionConfig(),
-        {
-          enabled: diarizationEnabled,
-          localModelsReady: !!diarizationModelsReady,
-          numSpeakers: diarizationNumSpeakers ? Number(diarizationNumSpeakers) : null,
-        },
+        diarization,
         currentFile.durationSeconds,
         { requestId }
       ).finally(() => {
@@ -700,14 +702,24 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
         }
 
         const folderId = selectedFolderId ? Number(selectedFolderId) : null;
+        const { audioDurationSeconds, noteUpdates } = buildUploadNoteMetadata(
+          diarization,
+          res.durationSeconds
+        );
         const noteRes = await window.electronAPI.saveNote(
           title,
           res.text,
           "upload",
           currentFile.name,
-          null,
+          audioDurationSeconds,
           folderId
         );
+        if (noteRes.success && noteRes.note) {
+          // Same columns the meeting path maintains, via the same updateNote
+          // route (they are not saveNote insert columns). Metadata is
+          // best-effort: a failed write must not error a saved note.
+          await window.electronAPI.updateNote(noteRes.note.id, noteUpdates).catch(() => {});
+        }
         if (runId !== runIdRef.current) return;
         if (noteRes.success && noteRes.note) setNoteId(noteRes.note.id);
         if (currentTempPath) {

--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -714,10 +714,8 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
           audioDurationSeconds,
           folderId
         );
-        if (noteRes.success && noteRes.note) {
-          // Same columns the meeting path maintains, via the same updateNote
-          // route (they are not saveNote insert columns). Metadata is
-          // best-effort: a failed write must not error a saved note.
+        if (noteRes.success && noteRes.note && noteUpdates) {
+          // Best-effort: a failed metadata write must not error a saved note.
           await window.electronAPI.updateNote(noteRes.note.id, noteUpdates).catch(() => {});
         }
         if (runId !== runIdRef.current) return;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3076,7 +3076,9 @@ class IPCHandlers {
             segments,
             numSpeakers > 0 ? numSpeakers : MAX_SPEAKER_COUNT
           );
-          return { success: true, segments };
+          // Callers persist this as audio_duration_seconds: for picked files
+          // the renderer has no other duration source.
+          return { success: true, segments, durationSeconds };
         } finally {
           try {
             fs.unlinkSync(wavPath);

--- a/src/helpers/uploadNoteMetadata.js
+++ b/src/helpers/uploadNoteMetadata.js
@@ -11,22 +11,23 @@ function normalizeSpeakerCount(value) {
 }
 
 // What the upload and URL-ingest flows persist onto the note row about the
-// diarizer invocation. The meeting path writes the same columns with the same
-// semantics: diarization_enabled is 1|0 (null means unknown), and
-// expected_speaker_count is only ever a user-chosen total — auto detection
-// stays null so isExplicitSpeakerCount never mistakes it for an explicit
-// choice. A disabled run also stays null: numSpeakers lingers in localStorage
-// while its input is hidden, and only counts the diarizer was actually invoked
-// with are the user's choice for this note.
+// diarizer invocation, matching the meeting path's write semantics: the columns
+// are written only when diarization ran. A null diarization_enabled means "user
+// never chose" and consumers fall back to the global speaker setting — writing
+// 0 would force diarization off when recording into the note later. The
+// expected_speaker_count is only ever a count the diarizer was actually invoked
+// with (numSpeakers lingers in localStorage while its input is hidden); auto
+// detection stays null so isExplicitSpeakerCount never mistakes it for an
+// explicit choice.
 export function buildUploadNoteMetadata(diarization, durationSeconds) {
   return {
     audioDurationSeconds:
       Number.isFinite(durationSeconds) && durationSeconds > 0 ? durationSeconds : null,
-    noteUpdates: {
-      diarization_enabled: diarization?.enabled ? 1 : 0,
-      expected_speaker_count: diarization?.enabled
-        ? normalizeSpeakerCount(diarization.numSpeakers)
-        : null,
-    },
+    noteUpdates: diarization?.enabled
+      ? {
+          diarization_enabled: 1,
+          expected_speaker_count: normalizeSpeakerCount(diarization.numSpeakers),
+        }
+      : null,
   };
 }

--- a/src/helpers/uploadNoteMetadata.js
+++ b/src/helpers/uploadNoteMetadata.js
@@ -15,14 +15,18 @@ function normalizeSpeakerCount(value) {
 // semantics: diarization_enabled is 1|0 (null means unknown), and
 // expected_speaker_count is only ever a user-chosen total — auto detection
 // stays null so isExplicitSpeakerCount never mistakes it for an explicit
-// choice.
+// choice. A disabled run also stays null: numSpeakers lingers in localStorage
+// while its input is hidden, and only counts the diarizer was actually invoked
+// with are the user's choice for this note.
 export function buildUploadNoteMetadata(diarization, durationSeconds) {
   return {
     audioDurationSeconds:
       Number.isFinite(durationSeconds) && durationSeconds > 0 ? durationSeconds : null,
     noteUpdates: {
       diarization_enabled: diarization?.enabled ? 1 : 0,
-      expected_speaker_count: normalizeSpeakerCount(diarization?.numSpeakers),
+      expected_speaker_count: diarization?.enabled
+        ? normalizeSpeakerCount(diarization.numSpeakers)
+        : null,
     },
   };
 }

--- a/src/helpers/uploadNoteMetadata.js
+++ b/src/helpers/uploadNoteMetadata.js
@@ -1,0 +1,28 @@
+import { MAX_SPEAKER_COUNT } from "../constants/speakerDetection.json";
+
+// Renderer twin of normalizeStoredSpeakerCount in ./speakerCount.js. That file
+// is CommonJS for the main process (database.js, ipcHandlers.js), and renderer
+// source cannot load CJS modules under Vite — test/helpers/uploadNoteMetadata
+// .test.js holds the two implementations to identical outputs.
+function normalizeSpeakerCount(value) {
+  const count = Number(value);
+  if (!Number.isInteger(count) || count < 1) return null;
+  return Math.min(count, MAX_SPEAKER_COUNT);
+}
+
+// What the upload and URL-ingest flows persist onto the note row about the
+// diarizer invocation. The meeting path writes the same columns with the same
+// semantics: diarization_enabled is 1|0 (null means unknown), and
+// expected_speaker_count is only ever a user-chosen total — auto detection
+// stays null so isExplicitSpeakerCount never mistakes it for an explicit
+// choice.
+export function buildUploadNoteMetadata(diarization, durationSeconds) {
+  return {
+    audioDurationSeconds:
+      Number.isFinite(durationSeconds) && durationSeconds > 0 ? durationSeconds : null,
+    noteUpdates: {
+      diarization_enabled: diarization?.enabled ? 1 : 0,
+      expected_speaker_count: normalizeSpeakerCount(diarization?.numSpeakers),
+    },
+  };
+}

--- a/src/services/fileTranscription.ts
+++ b/src/services/fileTranscription.ts
@@ -12,6 +12,9 @@ export interface FileTranscriptionResult {
   // Set alongside `warning` by the chunked cloud path: how much audio was lost.
   failedChunks?: number;
   totalChunks?: number;
+  // Measured duration of the source audio, for persisting as
+  // audio_duration_seconds. Only transcribeFileWithSpeakers sets it.
+  durationSeconds?: number | null;
 }
 
 export interface DiarizationSettings {
@@ -142,10 +145,15 @@ export async function transcribeFileWithSpeakers(
           .catch(() => null) ?? Promise.resolve(null))
       : Promise.resolve(null);
 
-  const [result, diar] = await Promise.all([
+  const [transcribed, diar] = await Promise.all([
     transcribeFile(filePath, cfg, byokDiarize, opts),
     diarizePromise,
   ]);
+
+  // The diarizer measures the converted audio, so it covers picked files whose
+  // duration the caller never knew. 0/NaN mean "unknown", hence ||.
+  const measuredDuration = durationSeconds || (diar?.success && diar.durationSeconds) || null;
+  const result = { ...transcribed, durationSeconds: measuredDuration };
 
   if (!result.success || !result.text || result.diarized) return result;
   if (!diar?.success || !diar.segments?.length) return result;

--- a/src/stores/batchQueueStore.ts
+++ b/src/stores/batchQueueStore.ts
@@ -244,10 +244,10 @@ export function processBatchQueue(
       );
 
       if (noteRes.success && noteRes.note) {
-        // Same columns the meeting path maintains, via the same updateNote
-        // route (they are not saveNote insert columns). Metadata is
-        // best-effort: a failed write must not error a saved transcription.
-        await window.electronAPI.updateNote(noteRes.note.id, noteUpdates).catch(() => {});
+        if (noteUpdates) {
+          // Best-effort: a failed metadata write must not error a saved transcription.
+          await window.electronAPI.updateNote(noteRes.note.id, noteUpdates).catch(() => {});
+        }
         updateItem(item.id, {
           status: "done",
           progress: 100,

--- a/src/stores/batchQueueStore.ts
+++ b/src/stores/batchQueueStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { transcribeFileWithSpeakers } from "../services/fileTranscription";
 import type { FileTranscriptionConfig, DiarizationSettings } from "../services/fileTranscription";
 import { DOWNLOAD_ERROR_KEYS, transcriptionErrorKey } from "../components/notes/shared";
+import { buildUploadNoteMetadata } from "../helpers/uploadNoteMetadata";
 import { getSettings } from "./settingsStore";
 import { isTranscriptionContextAllowed } from "./policyRules";
 import { usePolicyStore } from "./policyStore";
@@ -229,16 +230,24 @@ export function processBatchQueue(
         if (run !== runId) return;
       }
 
+      const { audioDurationSeconds, noteUpdates } = buildUploadNoteMetadata(
+        diarization,
+        transcriptionResult.durationSeconds
+      );
       const noteRes = await window.electronAPI.saveNote(
         noteTitle,
         finalText,
         "upload",
         noteName,
-        null,
+        audioDurationSeconds,
         transcribeOpts.folderId
       );
 
       if (noteRes.success && noteRes.note) {
+        // Same columns the meeting path maintains, via the same updateNote
+        // route (they are not saveNote insert columns). Metadata is
+        // best-effort: a failed write must not error a saved transcription.
+        await window.electronAPI.updateNote(noteRes.note.id, noteUpdates).catch(() => {});
         updateItem(item.id, {
           status: "done",
           progress: 100,

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -2384,6 +2384,7 @@ declare global {
       ) => Promise<{
         success: boolean;
         segments?: Array<{ start: number; end: number; speaker: string }>;
+        durationSeconds?: number;
         error?: string;
       }>;
       onDiarizationDownloadProgress?: (callback: (data: any) => void) => () => void;

--- a/test/helpers/uploadNoteMetadata.test.js
+++ b/test/helpers/uploadNoteMetadata.test.js
@@ -30,20 +30,20 @@ test("auto speaker detection stores no explicit count", async () => {
   assert.equal(noteUpdates.diarization_enabled, 1);
 });
 
-test("disabled diarization is stored as 0, not left unknown", async () => {
+test("disabled diarization writes no columns at all", async () => {
   const { buildUploadNoteMetadata } = await load();
 
-  // numSpeakers lingers in localStorage from past sessions while its input is
-  // hidden whenever diarization is off, so a disabled run must not stamp that
-  // stale value onto the note as an explicit choice — isExplicitSpeakerCount
-  // would then block roster-derived speaker caps in later recordings.
-  const { noteUpdates } = buildUploadNoteMetadata(
+  // A null diarization_enabled defers to the global speaker setting when the
+  // user records into the note later (a 0 would force it off), and writing no
+  // count keeps the numSpeakers value lingering in localStorage while its
+  // input is hidden from being stamped onto the note as an explicit choice.
+  const { audioDurationSeconds, noteUpdates } = buildUploadNoteMetadata(
     { enabled: false, localModelsReady: false, numSpeakers: 3 },
-    null
+    120
   );
 
-  assert.equal(noteUpdates.diarization_enabled, 0);
-  assert.equal(noteUpdates.expected_speaker_count, null);
+  assert.equal(noteUpdates, null);
+  assert.equal(audioDurationSeconds, 120);
 });
 
 test("speaker counts reuse the stored-count clamp", async () => {

--- a/test/helpers/uploadNoteMetadata.test.js
+++ b/test/helpers/uploadNoteMetadata.test.js
@@ -1,0 +1,89 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/uploadNoteMetadata.js");
+const { MAX_SPEAKER_COUNT } = require("../../src/constants/speakerDetection.json");
+
+test("maps the diarizer invocation onto the note columns", async () => {
+  const { buildUploadNoteMetadata } = await load();
+
+  const { audioDurationSeconds, noteUpdates } = buildUploadNoteMetadata(
+    { enabled: true, localModelsReady: true, numSpeakers: 2 },
+    4359.87
+  );
+
+  assert.equal(audioDurationSeconds, 4359.87);
+  assert.deepEqual(noteUpdates, { diarization_enabled: 1, expected_speaker_count: 2 });
+});
+
+test("auto speaker detection stores no explicit count", async () => {
+  const { buildUploadNoteMetadata } = await load();
+
+  const { noteUpdates } = buildUploadNoteMetadata(
+    { enabled: true, localModelsReady: true, numSpeakers: null },
+    60
+  );
+
+  // isExplicitSpeakerCount treats any positive integer as the user's own
+  // choice, so auto detection must land as null, never a default.
+  assert.equal(noteUpdates.expected_speaker_count, null);
+  assert.equal(noteUpdates.diarization_enabled, 1);
+});
+
+test("disabled diarization is stored as 0, not left unknown", async () => {
+  const { buildUploadNoteMetadata } = await load();
+
+  const { noteUpdates } = buildUploadNoteMetadata(
+    { enabled: false, localModelsReady: false, numSpeakers: 3 },
+    null
+  );
+
+  assert.equal(noteUpdates.diarization_enabled, 0);
+});
+
+test("speaker counts reuse the stored-count clamp", async () => {
+  const { buildUploadNoteMetadata } = await load();
+
+  const above = buildUploadNoteMetadata(
+    { enabled: true, localModelsReady: true, numSpeakers: MAX_SPEAKER_COUNT + 5 },
+    null
+  );
+  assert.equal(above.noteUpdates.expected_speaker_count, MAX_SPEAKER_COUNT);
+
+  const unusable = buildUploadNoteMetadata(
+    { enabled: true, localModelsReady: true, numSpeakers: 0 },
+    null
+  );
+  assert.equal(unusable.noteUpdates.expected_speaker_count, null);
+});
+
+test("unusable durations degrade to null", async () => {
+  const { buildUploadNoteMetadata } = await load();
+  const diarization = { enabled: true, localModelsReady: true, numSpeakers: 2 };
+
+  for (const value of [null, undefined, 0, -1, NaN, Infinity]) {
+    assert.equal(
+      buildUploadNoteMetadata(diarization, value).audioDurationSeconds,
+      null,
+      `expected ${value} to degrade to null`
+    );
+  }
+});
+
+// uploadNoteMetadata.js carries a renderer twin of the main-process
+// normalizeStoredSpeakerCount (CJS, unloadable from renderer source). Hold the
+// two implementations to identical outputs so they cannot drift apart.
+test("speaker-count normalization matches the main-process implementation", async () => {
+  const { buildUploadNoteMetadata } = await load();
+  const { normalizeStoredSpeakerCount } = require("../../src/helpers/speakerCount");
+
+  const inputs = [1, 2, 3, MAX_SPEAKER_COUNT, MAX_SPEAKER_COUNT + 1, MAX_SPEAKER_COUNT + 5];
+  for (const value of [...inputs, 0, -1, 1.5, NaN, Infinity, -Infinity, null, undefined, "", {}]) {
+    assert.equal(
+      buildUploadNoteMetadata({ enabled: true, numSpeakers: value }).noteUpdates
+        .expected_speaker_count,
+      normalizeStoredSpeakerCount(value),
+      `diverged from normalizeStoredSpeakerCount for ${JSON.stringify(value)}`
+    );
+  }
+});

--- a/test/helpers/uploadNoteMetadata.test.js
+++ b/test/helpers/uploadNoteMetadata.test.js
@@ -33,12 +33,17 @@ test("auto speaker detection stores no explicit count", async () => {
 test("disabled diarization is stored as 0, not left unknown", async () => {
   const { buildUploadNoteMetadata } = await load();
 
+  // numSpeakers lingers in localStorage from past sessions while its input is
+  // hidden whenever diarization is off, so a disabled run must not stamp that
+  // stale value onto the note as an explicit choice — isExplicitSpeakerCount
+  // would then block roster-derived speaker caps in later recordings.
   const { noteUpdates } = buildUploadNoteMetadata(
     { enabled: false, localModelsReady: false, numSpeakers: 3 },
     null
   );
 
   assert.equal(noteUpdates.diarization_enabled, 0);
+  assert.equal(noteUpdates.expected_speaker_count, null);
 });
 
 test("speaker counts reuse the stored-count clamp", async () => {

--- a/test/services/uploadDiarizationPersistence.test.js
+++ b/test/services/uploadDiarizationPersistence.test.js
@@ -1,0 +1,146 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+// Regression for the upload/URL-ingest path dropping diarization metadata: the
+// batch queue ran the diarizer but persisted none of diarization_enabled,
+// expected_speaker_count, or audio_duration_seconds, so an uploaded note that
+// WAS diarized presented to the app as though it was not (the meeting path
+// persists all of them).
+
+const transcription = {
+  useLocalWhisper: true,
+  localTranscriptionProvider: "whisper",
+  whisperModel: "base",
+  parakeetModel: "parakeet-tdt-0.6b-v3",
+  isOpenWhisprCloud: false,
+  getApiKey: () => "",
+  cloudTranscriptionProvider: "openai",
+  cloudTranscriptionBaseUrl: "",
+  cloudTranscriptionModel: "whisper-1",
+  language: "en",
+};
+
+const diarization = { enabled: true, localModelsReady: true, numSpeakers: 2 };
+
+const gateMocks = {
+  "/lib/auth": "export const withSessionRefresh = (fn) => fn();",
+  "./settingsStore": "export const getSettings = () => ({});",
+  "./policyStore": "export const usePolicyStore = { getState: () => ({}) };",
+  "./policyRules": "export const isTranscriptionContextAllowed = () => true;",
+};
+
+async function waitForQueueSettled(store, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { queue, isProcessing } = store.getState();
+    if (!isProcessing && queue.every((i) => i.status === "done" || i.status === "error")) {
+      return queue;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`queue never settled: ${JSON.stringify(store.getState().queue)}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function installUploadElectronAPI(window, { diarizedDurationSeconds }) {
+  const calls = { saveNote: [], updateNote: [], diarize: [], deletedTempFiles: [] };
+  Object.assign(window.electronAPI, {
+    transcribeAudioFile: async () => ({ success: true, text: "hello from the recording" }),
+    diarizeAudioFile: async (_filePath, options) => {
+      calls.diarize.push(options);
+      return {
+        success: true,
+        segments: [
+          { start: 0, end: 30, speaker: "Speaker 1" },
+          { start: 30, end: 60, speaker: "Speaker 2" },
+        ],
+        durationSeconds: diarizedDurationSeconds,
+      };
+    },
+    mergeSpeakerText: async () => ({ success: true, text: "[Speaker 1] hello [Speaker 2] hi" }),
+    saveNote: async (...args) => {
+      calls.saveNote.push(args);
+      return { success: true, note: { id: 7 } };
+    },
+    updateNote: async (id, updates) => {
+      calls.updateNote.push([id, updates]);
+      return { success: true, note: { id } };
+    },
+    deleteTempFile: (path) => calls.deletedTempFiles.push(path),
+    cancelUrlDownload: () => {},
+  });
+  return calls;
+}
+
+test("a diarized file upload persists the diarization metadata", async (t) => {
+  const { window } = installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-upload-diarization-file-test-",
+    mockModules: gateMocks,
+  });
+  // The renderer never knows a picked file's duration up front; the diarizer's
+  // measured duration is the only source, so it must land on the note row.
+  const calls = installUploadElectronAPI(window, { diarizedDurationSeconds: 4359.87 });
+
+  const store = await vite.ssrLoadModule("/stores/batchQueueStore.ts");
+  store.addFiles([{ name: "board-meeting.m4a", path: "/tmp/board-meeting.m4a", sizeBytes: 2048 }]);
+  store.processBatchQueue({ transcription, folderId: null }, diarization);
+
+  const queue = await waitForQueueSettled(store.useBatchQueueStore);
+  assert.equal(queue[0].status, "done");
+  assert.equal(queue[0].noteId, 7);
+
+  assert.equal(calls.saveNote.length, 1);
+  const [, content, noteType, sourceFile, audioDuration] = calls.saveNote[0];
+  assert.equal(content, "[Speaker 1] hello [Speaker 2] hi");
+  assert.equal(noteType, "upload");
+  assert.equal(sourceFile, "board-meeting.m4a");
+  assert.equal(audioDuration, 4359.87);
+
+  // The persisted count is the same one the diarizer was invoked with.
+  assert.deepEqual(calls.diarize, [{ numSpeakers: 2 }]);
+  assert.deepEqual(calls.updateNote, [
+    [7, { diarization_enabled: 1, expected_speaker_count: 2 }],
+  ]);
+});
+
+test("a diarized URL ingest persists the diarization metadata", async (t) => {
+  const { window } = installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-upload-diarization-url-test-",
+    mockModules: gateMocks,
+  });
+  // The download's known duration beats the diarizer's measurement.
+  const calls = installUploadElectronAPI(window, { diarizedDurationSeconds: 9999 });
+  Object.assign(window.electronAPI, {
+    onUrlDownloadProgress: () => () => {},
+    downloadUrlAudio: async () => ({
+      success: true,
+      tempPath: "/tmp/ow-url-download.m4a",
+      title: "Board Meeting Recording",
+      sizeBytes: 4096,
+      durationSeconds: 4359.87,
+    }),
+  });
+
+  const store = await vite.ssrLoadModule("/stores/batchQueueStore.ts");
+  store.addUrls(["https://www.youtube.com/watch?v=abc123"]);
+  store.processBatchQueue({ transcription, folderId: null }, diarization);
+
+  const queue = await waitForQueueSettled(store.useBatchQueueStore);
+  assert.equal(queue[0].status, "done");
+
+  assert.equal(calls.saveNote.length, 1);
+  const [title, , noteType, sourceFile, audioDuration] = calls.saveNote[0];
+  assert.equal(title, "Board Meeting Recording");
+  assert.equal(noteType, "upload");
+  assert.equal(sourceFile, "Board Meeting Recording");
+  assert.equal(audioDuration, 4359.87);
+
+  assert.deepEqual(calls.updateNote, [
+    [7, { diarization_enabled: 1, expected_speaker_count: 2 }],
+  ]);
+  assert.deepEqual(calls.deletedTempFiles, ["/tmp/ow-url-download.m4a"]);
+});

--- a/test/services/uploadDiarizationPersistence.test.js
+++ b/test/services/uploadDiarizationPersistence.test.js
@@ -144,3 +144,30 @@ test("a diarized URL ingest persists the diarization metadata", async (t) => {
   ]);
   assert.deepEqual(calls.deletedTempFiles, ["/tmp/ow-url-download.m4a"]);
 });
+
+test("an upload without diarization leaves the note columns untouched", async (t) => {
+  const { window } = installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-upload-diarization-off-test-",
+    mockModules: gateMocks,
+  });
+  const calls = installUploadElectronAPI(window, { diarizedDurationSeconds: 4359.87 });
+
+  const store = await vite.ssrLoadModule("/stores/batchQueueStore.ts");
+  store.addFiles([{ name: "memo.m4a", path: "/tmp/memo.m4a", sizeBytes: 2048 }]);
+  store.processBatchQueue(
+    { transcription, folderId: null },
+    { enabled: false, localModelsReady: true, numSpeakers: 2 }
+  );
+
+  const queue = await waitForQueueSettled(store.useBatchQueueStore);
+  assert.equal(queue[0].status, "done");
+
+  // diarization_enabled must stay null: consumers treat null as "use the
+  // global speaker setting" when recording into the note later, and a stored 0
+  // would force it off.
+  assert.equal(calls.diarize.length, 0);
+  assert.equal(calls.updateNote.length, 0);
+  assert.equal(calls.saveNote.length, 1);
+  assert.equal(calls.saveNote[0][4], null);
+});


### PR DESCRIPTION
## Problem

A note created through the file-upload / URL-ingest path runs speaker diarization but never persists the diarization metadata. Observed on 1.8.3: a 72.7-minute URL ingest with diarization enabled (`numSpeakers: 2`) produced a fully speaker-labelled note — 633 segments merged, labels covering the whole duration — whose row still read `diarization_enabled: null`, `expected_speaker_count: null`, `audio_duration_seconds: null`.

This is not a 1.8.3 regression: the gap has existed since upload speaker detection shipped in 1.7.6 (#754), and the duration column has been passed as `null` since the upload view was created (#261). 1.8.3 is merely where it was noticed.

Not cosmetic: `PersonalNotesView` derives `diarizationEnabled` from the column, and `isExplicitSpeakerCount()` (`src/utils/participants.ts`) resolves participants from `expected_speaker_count` — so an uploaded note that *was* diarized behaves differently from a meeting recording that went through the identical diarizer. All three columns also cloud-sync, so the CLI, API, and other devices see them.

Root cause: both upload save sites — `batchQueueStore.processItem` and `UploadAudioView.handleTranscribe` — called `saveNote(..., null, folderId)` with the diarization settings in scope and discarded them. The meeting path (`meetingRecordingStore`) persists both diarization columns via `updateNote`.

## Fix

Both upload flows (file **and** URL, batch **and** single) now persist the metadata:

- **`audio_duration_seconds` → initial `saveNote`.** The 5th positional arg and insert column already exist (the CLI bridge uses them); `updateNote` does **not** whitelist this column, so creation is its only writer. No API change.
- **`diarization_enabled` + `expected_speaker_count` → one `updateNote` immediately after creation, only when diarization ran.** These are not `saveNote` insert columns; they are whitelisted `updateNote` fields, the same route the meeting path writes them through. The write is skipped entirely for non-diarized uploads — the meeting path writes these columns only on explicit user action, so `null` retains its meaning of "user never chose". This matters because both consumers (`meetingRecordingStore`'s `initialEnabled ?? …` chain and `_resolveInitialMeetingSpeakerConfig` in main) fall back to the global speaker setting on `null` but treat `0` as a hard off: writing `0` would have silently forced speaker labeling off when recording into an uploaded note. Skipping the write also means non-diarized uploads (the common case) pay no second vector-index embed / mirror write / `note-updated` broadcast — `db-update-note` runs those unconditionally; its meeting-session side effects gate on `updates.participants`, which this payload never carries. The `updateNote` re-queues `sync_status: 'pending'`, which is correct — these fields cloud-sync.
- **Semantics for diarized uploads**: `diarization_enabled` is `1`, and the speaker count is only ever one the diarizer was actually invoked with — auto detection stores `null` so `isExplicitSpeakerCount` never mistakes it for a user choice, and a stale `numSpeakers` lingering in localStorage while its input is hidden can never be stamped onto a non-diarized note.

New helper `src/helpers/uploadNoteMetadata.js` holds the mapping. It carries a renderer twin of `normalizeStoredSpeakerCount` because the original in `src/helpers/speakerCount.js` is CommonJS for the main process (`database.js`, `ipcHandlers.js`) and renderer source cannot load CJS modules under Vite. The twin is **parity-locked by test**: `test/helpers/uploadNoteMetadata.test.js` sweeps both implementations and fails on any divergence.

Duration for picked files: the renderer never knows a local file's duration up front, but the `diarize-audio-file` handler already measured it (converted-wav size) and threw it away. It now returns `durationSeconds`, and `transcribeFileWithSpeakers` surfaces it on the result — a source-known duration (URL downloads) takes precedence. Deliberate non-change: `mergeSpeakerText` still receives only the caller-known duration, so transcript merging behaves exactly as before. Known remaining gap (pre-existing): a file upload whose local diarizer never runs (diarization off, or BYOK-native diarization) still has no duration source.

A meeting recording is unchanged — `meetingRecordingStore` is untouched.

## Tests

- `test/helpers/uploadNoteMetadata.test.js` — field mapping, diarized-only write semantics, auto-detection → null, disabled → no columns at all, clamp, duration degradation, and the parity sweep against `normalizeStoredSpeakerCount`.
- `test/services/uploadDiarizationPersistence.test.js` — regression through the real `batchQueueStore` + `fileTranscription` module graph (renderer test harness, `electronAPI` stubbed at the IPC boundary): a diarized **file upload** and a diarized **URL ingest** both end with `saveNote` receiving the measured duration and `updateNote` receiving `{ diarization_enabled: 1, expected_speaker_count: 2 }`; a **non-diarized upload** ends with no `updateNote` call at all. Each asserted failing on the code it guards against: the diarized tests fail pre-fix (duration `null`, no `updateNote` call), the non-diarized test fails on the intermediate code that wrote `diarization_enabled: 0`.
- Full suite: 1983 tests, 1977 pass, 0 fail, 5 skipped. `npm run typecheck` and `npm run lint` clean.
- Changelog entry added under `[Unreleased]`.
