### PR TITLE
fix(reasoning): stop gpt-oss on Tinfoil failing every request with a 400

### DIFF
--- a/src/services/ai/thinkingSuppressionDialects.ts
+++ b/src/services/ai/thinkingSuppressionDialects.ts
@@ -32,6 +32,11 @@ export function suppressThinking(
   providerKey: string,
   model: string
 ): void {
+  const modelFamily = (model || "").toLowerCase();
+  // gpt-oss accepts low|medium|high only; it has no off switch. A property of the
+  // model family, not the provider — Tinfoil 400s on "none" just like Groq would.
+  const isGptOss = modelFamily.includes("gpt-oss");
+
   if (providerKey === "gemini") {
     requestBody.reasoning_effort = "minimal";
     return;
@@ -47,12 +52,10 @@ export function suppressThinking(
   // Groq rejects unknown fields outright and takes a different reasoning_effort
   // enum per model family, so send nothing unless the family is known.
   if (providerKey === "groq") {
-    const groqModel = (model || "").toLowerCase();
-    if (groqModel.includes("qwen")) {
+    if (modelFamily.includes("qwen")) {
       // qwen3 accepts none|default only.
       requestBody.reasoning_effort = "none";
-    } else if (groqModel.includes("gpt-oss")) {
-      // gpt-oss accepts low|medium|high only; it has no off switch.
+    } else if (isGptOss) {
       requestBody.reasoning_effort = "low";
     }
     return;
@@ -61,7 +64,7 @@ export function suppressThinking(
   // Mistral rejects unknown fields with a 422; reasoning_effort is its native switch.
   if (providerKey === "mistral") {
     // Legacy magistral models reason natively and may reject reasoning_effort.
-    if ((model || "").toLowerCase().includes("magistral")) return;
+    if (modelFamily.includes("magistral")) return;
     requestBody.reasoning_effort = "none";
     return;
   }
@@ -73,7 +76,7 @@ export function suppressThinking(
     // disables Ollama thinking; other backends drop it (flat reasoning_effort trips vLLM).
     requestBody.reasoning = { effort: "none" };
   } else {
-    requestBody.reasoning_effort = "none";
+    requestBody.reasoning_effort = isGptOss ? "low" : "none";
   }
   requestBody.chat_template_kwargs = { enable_thinking: false };
 }

--- a/test/helpers/thinkingSuppressionDialects.test.js
+++ b/test/helpers/thinkingSuppressionDialects.test.js
@@ -107,6 +107,30 @@ test("unlisted providers keep the legacy reasoning_effort none plus chat_templat
   });
 });
 
+test("generic-dialect providers send gpt-oss the low floor, not the rejected none", async () => {
+  const { suppressThinking } = await load();
+
+  const body = {};
+  suppressThinking(body, "tinfoil", "gpt-oss-120b");
+
+  assert.deepEqual(body, {
+    reasoning_effort: "low",
+    chat_template_kwargs: { enable_thinking: false },
+  });
+});
+
+test("the gpt-oss floor covers the whole family case-insensitively", async () => {
+  const { suppressThinking } = await load();
+
+  const safeguard = {};
+  suppressThinking(safeguard, "tinfoil", "gpt-oss-safeguard-120b");
+  assert.equal(safeguard.reasoning_effort, "low");
+
+  const mixedCase = {};
+  suppressThinking(mixedCase, "openai", "GPT-OSS-20B");
+  assert.equal(mixedCase.reasoning_effort, "low");
+});
+
 test("mistral gets reasoning_effort none and never chat_template_kwargs", async () => {
   const { suppressThinking } = await load();
 


### PR DESCRIPTION
## Problem

Tinfoil + any `gpt-oss-*` model is 100% broken: every request on all five LLM surfaces (Note Formatting, Dictation Cleanup, Chat, Voice Agent, Translation) returns:

```
400 Harmony does not support reasoning_effort='none'
```

Reproduced live on packaged 1.8.3 (Note Formatting → Tinfoil / `gpt-oss-120b`), and confirmed directly against `https://inference.tinfoil.sh/v1/chat/completions`:

| model | `reasoning_effort` | result |
|---|---|---|
| `gpt-oss-120b` | `none` | **400** |
| `gpt-oss-120b` | `low` | **200** |
| `gpt-oss-safeguard-120b` | `none` | **400** |
| `deepseek-v4-flash` | `none` | 200 |
| `llama3-3-70b` | `none` | 200 |

## Root cause

`suppressThinking()` keyed the gpt-oss exception on `providerKey === "groq"`. The constraint — gpt-oss accepts `low|medium|high` only, no off switch — is a property of the **model family**, not of Groq, so every other provider serving gpt-oss fell into the generic dialect and sent the rejected `"none"`. Tinfoil serves `gpt-oss-120b` and `gpt-oss-safeguard-120b`.

## Fix

Hoist the family check into a shared `isGptOss` predicate: the Groq branch keeps its existing behavior, and the generic dialect now sends `"low"` (the floor) instead of `"none"` for gpt-oss on any provider.

Deliberately untouched: the OpenRouter, `local`, and `lan` dialects. Each uses its own native suppression shape, and flat `reasoning_effort` would be wrong there (the `lan` comment already notes it trips vLLM). No behavior change for any non-gpt-oss model on any provider.

## Tests

Two new cases in `test/helpers/thinkingSuppressionDialects.test.js`, written first and watched fail with exactly the bug's value (`'none' !== 'low'`):
- generic-dialect provider (`tinfoil`) + `gpt-oss-120b` → `reasoning_effort: "low"` + `chat_template_kwargs`
- family match covers `gpt-oss-safeguard-120b` and is case-insensitive

Full suite: 1806 pass / 0 fail. Typecheck, eslint, prettier clean.

Linear: CUS-65
