### PR TITLE
fix(notification): skip Google Calendar time blocks without attendees

### DIFF
--- a/src/helpers/calendarReminderScheduler.js
+++ b/src/helpers/calendarReminderScheduler.js
@@ -1,9 +1,14 @@
 const debugLogger = require("./debugLogger");
+const { getMeetingJoinUrl } = require("./meetingJoinUrl");
 
 const MEETING_REMINDER_LEAD_MS = 60 * 1000;
 
 function notificationKey(event) {
   return `${event.provider || "google"}:${event.id}`;
+}
+
+function isReminderEligible(event) {
+  return event.provider !== "google" || event.attendees_count > 0 || getMeetingJoinUrl(event);
 }
 
 // Provider-agnostic meeting reminder scheduling. Reads only the shared
@@ -25,7 +30,9 @@ class CalendarReminderScheduler {
     }
 
     const upcoming = this.databaseManager.getUpcomingEvents(1440);
-    const next = upcoming.find((e) => !this.notifiedMeetings.has(notificationKey(e)));
+    const next = upcoming.find(
+      (event) => isReminderEligible(event) && !this.notifiedMeetings.has(notificationKey(event))
+    );
     if (!next) return;
 
     const delay = new Date(next.start_time).getTime() - MEETING_REMINDER_LEAD_MS - Date.now();
@@ -40,6 +47,11 @@ class CalendarReminderScheduler {
   }
 
   onMeetingStart(event) {
+    if (!isReminderEligible(event)) {
+      this.scheduleNextMeeting();
+      return;
+    }
+
     const events = this.databaseManager.getActiveEvents();
     const stillExists =
       events.some((e) => notificationKey(e) === notificationKey(event)) ||

--- a/src/helpers/googleCalendarManager.js
+++ b/src/helpers/googleCalendarManager.js
@@ -2,6 +2,7 @@ const { net } = require("electron");
 const debugLogger = require("./debugLogger");
 const GoogleCalendarOAuth = require("./googleCalendarOAuth");
 const CalendarSyncInterval = require("./calendarSyncInterval");
+const { extractMeetingUrl } = require("./meetingJoinUrl");
 const { broadcastToWindows } = require("./windowBroadcast");
 
 const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
@@ -227,7 +228,7 @@ class GoogleCalendarManager {
         end_time: item.end?.dateTime || item.end?.date,
         is_all_day: isAllDay,
         status: item.status || "confirmed",
-        hangout_link: item.hangoutLink || null,
+        hangout_link: item.hangoutLink || extractMeetingUrl([item.location, item.description]),
         conference_data: item.conferenceData ? JSON.stringify(item.conferenceData) : null,
         organizer_email: item.organizer?.email || null,
         attendees_count: item.attendees?.length || 0,

--- a/test/helpers/calendarReminderScheduler.test.js
+++ b/test/helpers/calendarReminderScheduler.test.js
@@ -11,8 +11,52 @@ function activeEvent(provider, id) {
     summary: `${provider} meeting`,
     start_time: new Date(now - 1000).toISOString(),
     end_time: new Date(now + 60_000).toISOString(),
+    attendees_count: 1,
   };
 }
+
+test("does not remind for a Google time block without attendees or a meeting link", () => {
+  const timeBlock = activeEvent("google", "time-block");
+  timeBlock.attendees_count = 0;
+  const databaseManager = {
+    getUpcomingEvents: () => [timeBlock],
+    getActiveEvents: () => [timeBlock],
+  };
+  const scheduler = new CalendarReminderScheduler(databaseManager);
+  let promptCount = 0;
+  scheduler.meetingDetectionEngine = {
+    handleCalendarReminder: () => {
+      promptCount += 1;
+    },
+  };
+
+  scheduler.scheduleNextMeeting();
+
+  assert.equal(promptCount, 0);
+  scheduler.stop();
+});
+
+test("reminds for a Google time block with a Google Meet link", () => {
+  const timeBlock = activeEvent("google", "meet-block");
+  timeBlock.attendees_count = 0;
+  timeBlock.hangout_link = "https://meet.google.com/abc-defg-hij";
+  const databaseManager = {
+    getUpcomingEvents: () => [timeBlock],
+    getActiveEvents: () => [timeBlock],
+  };
+  const scheduler = new CalendarReminderScheduler(databaseManager);
+  let promptCount = 0;
+  scheduler.meetingDetectionEngine = {
+    handleCalendarReminder: () => {
+      promptCount += 1;
+    },
+  };
+
+  scheduler.scheduleNextMeeting();
+
+  assert.equal(promptCount, 1);
+  scheduler.stop();
+});
 
 test("resetting one provider preserves reminders delivered by another provider", () => {
   const googleEvent = activeEvent("google", "meeting-1");
@@ -94,6 +138,7 @@ test("resetting a provider re-arms the next meeting timer for upcoming events", 
     summary: "Future meeting",
     start_time: new Date(Date.now() + 600_000).toISOString(),
     end_time: new Date(Date.now() + 1200_000).toISOString(),
+    attendees_count: 1,
   };
   const databaseManager = {
     getUpcomingEvents: () => [futureEvent],

--- a/test/helpers/googleCalendarManager.test.js
+++ b/test/helpers/googleCalendarManager.test.js
@@ -136,3 +136,68 @@ test("_syncCalendar preserves incremental sync parameters across pages", async (
   assert.equal(secondPageParams.get("syncToken"), "sync-token-previous");
   assert.equal(secondPageParams.get("pageToken"), "token-page-2");
 });
+
+test("_syncCalendar preserves meeting links from Google event location and description", async () => {
+  const GoogleCalendarManager = loadManagerModule();
+
+  const upsertedEvents = [];
+  const databaseManager = {
+    getGoogleAccounts: () => [],
+    removeStaleCalendarEvents: () => {},
+    upsertCalendarEvents: (events) => {
+      upsertedEvents.push(...events);
+    },
+    removeCalendarEvents: () => {},
+    updateCalendarSyncToken: () => {},
+    upsertContacts: () => {},
+  };
+  const reminderScheduler = {
+    scheduleNextMeeting: () => {},
+    reset: () => {},
+  };
+  const manager = new GoogleCalendarManager(databaseManager, null, reminderScheduler);
+
+  manager._apiGet = async () => ({
+    items: [
+      {
+        id: "location-link",
+        summary: "Location call",
+        location: "Zoom: https://example.zoom.us/j/123456789",
+        start: { dateTime: "2026-08-14T10:00:00Z" },
+        end: { dateTime: "2026-08-14T10:30:00Z" },
+        status: "confirmed",
+      },
+      {
+        id: "description-link",
+        summary: "Description call",
+        description: "Join via https://teams.live.com/meet/9876543210",
+        start: { dateTime: "2026-08-14T11:00:00Z" },
+        end: { dateTime: "2026-08-14T11:30:00Z" },
+        status: "confirmed",
+      },
+    ],
+    nextSyncToken: "sync-token-final",
+  });
+
+  await manager._syncCalendar({ id: "cal-1", account_email: "test@example.com" });
+
+  assert.deepEqual(
+    upsertedEvents.map(({ id, hangout_link, attendees_count }) => ({
+      id,
+      hangout_link,
+      attendees_count,
+    })),
+    [
+      {
+        id: "location-link",
+        hangout_link: "https://example.zoom.us/j/123456789",
+        attendees_count: 0,
+      },
+      {
+        id: "description-link",
+        hangout_link: "https://teams.live.com/meet/9876543210",
+        attendees_count: 0,
+      },
+    ]
+  );
+});


### PR DESCRIPTION
Skip calendar reminders for Google events without attendees, unless they include a meeting link. This prevents personal time blocks from triggering meeting notifications while preserving reminders for link-based meetings.

This PR is based on the suggestion made by samkay on discord [message link](https://discord.com/channels/1463590782689612014/1463591135254413413/1536487421544370216)