### PR TITLE
fix(translation): treat whitespace-only chain results as empty

### DIFF
--- a/src/helpers/translationChain.js
+++ b/src/helpers/translationChain.js
@@ -34,7 +34,7 @@ export async function executeTranslationChain({
   if (cleanupReachable) {
     try {
       const cleaned = await runCleanup(out);
-      if (cleaned) out = cleaned;
+      if (normalizeComparableText(cleaned)) out = cleaned;
       // Cloud cleanup counts as cloud reasoning once its call succeeds, even if it
       // returned empty text.
       if (cleanupIsCloud) usedCloudReasoning = true;
@@ -64,5 +64,5 @@ export async function executeTranslationChain({
 // Keep the chain result only when it produced text; an empty/missing result
 // preserves the input so a dictation is never overwritten with nothing.
 export function resolveTranslatedText(previousText, chainResult) {
-  return chainResult?.text ? chainResult.text : previousText;
+  return normalizeComparableText(chainResult?.text) ? chainResult.text : previousText;
 }

--- a/test/helpers/translationChain.test.js
+++ b/test/helpers/translationChain.test.js
@@ -81,6 +81,51 @@ test("cleanup throws: onCleanupError fires, translate runs on original text", as
   assert.equal(result.text, "translated(raw)");
 });
 
+test("cleanup returns whitespace-only: text unchanged, translate still runs", async () => {
+  const { executeTranslationChain } = await load();
+
+  const result = await executeTranslationChain(
+    makeOpts({
+      runCleanup: async () => "   ",
+      runTranslate: async (currentText) => `translated(${currentText})`,
+    })
+  );
+
+  assert.equal(result.text, "translated(raw)");
+});
+
+test("translate returns whitespace-only: onEmptyTranslate fires, cleaned text kept", async () => {
+  const { executeTranslationChain } = await load();
+  let emptyCalled = false;
+
+  const result = await executeTranslationChain(
+    makeOpts({
+      runCleanup: async () => "cleaned",
+      runTranslate: async () => "\u00a0",
+      onEmptyTranslate: () => {
+        emptyCalled = true;
+      },
+    })
+  );
+
+  assert.equal(emptyCalled, true);
+  assert.equal(result.text, "cleaned");
+});
+
+test("shouldTranslate false: whitespace-only cleanup keeps the original text", async () => {
+  const { executeTranslationChain } = await load();
+
+  const result = await executeTranslationChain(
+    makeOpts({
+      text: "hello world",
+      shouldTranslate: false,
+      runCleanup: async () => "   ",
+    })
+  );
+
+  assert.equal(result.text, "hello world");
+});
+
 test("cleanup returns empty: text unchanged, translate still runs", async () => {
   const { executeTranslationChain } = await load();
 
@@ -301,6 +346,8 @@ test("resolveTranslatedText: empty chain result keeps processedText", async () =
   const { resolveTranslatedText } = await load();
 
   assert.equal(resolveTranslatedText("raw dictation", { text: "" }), "raw dictation");
+  assert.equal(resolveTranslatedText("raw dictation", { text: "   " }), "raw dictation");
+  assert.equal(resolveTranslatedText("raw dictation", { text: "\u00a0" }), "raw dictation");
   assert.equal(resolveTranslatedText("raw dictation", { text: null }), "raw dictation");
   assert.equal(resolveTranslatedText("raw dictation", {}), "raw dictation");
 });


### PR DESCRIPTION
## Summary

- Treat whitespace-only cleanup and chain results as empty so they cannot overwrite a dictation.
- Reuse the existing `normalizeComparableText()` check already used by the translate step.
- Add regression tests for `"   "` and NBSP.

## Problem

`#1258` guards `""` / `null` / missing `text`, but `"   "` and `"\u00a0"` are still truthy. Cleanup used `if (cleaned)` and `resolveTranslatedText()` used `chainResult?.text ? ...`, so a blank-looking model reply replaced the spoken text.

## Root cause

Truthiness checks instead of the same trim/collapse helper the translate step already uses.

## Fix

- Apply `normalizeComparableText()` before accepting a cleanup result.
- Apply the same check in `resolveTranslatedText()`.
- Leave real non-empty results (including padded words) unchanged.

## Behavior before / after

| Input | Before | After |
| --- | --- | --- |
| `resolveTranslatedText("raw", { text: "   " })` | `"   "` | `"raw"` |
| `resolveTranslatedText("raw", { text: "\u00a0" })` | `"\u00a0"` | `"raw"` |
| cleanup `"   "` and `shouldTranslate: false` | `"   "` | original text |
| cleanup `""` | original (unchanged) | original |
| cleanup `"cleaned"` | `"cleaned"` | `"cleaned"` |

## Scope / non-goals

- In scope: empty-result handling in `translationChain.js`.
- Out of scope: provider routing, audio pipeline, and translate-step unchanged-text detection (already normalized).

## Tests added

- cleanup whitespace-only still runs translate on the original text
- translate whitespace-only fires `onEmptyTranslate` and keeps cleaned text
- cleanup-only whitespace keeps the original dictation
- `resolveTranslatedText` treats `"   "` and NBSP as empty

## Validation

```text
node --version
# v24.9.0

npm ci --ignore-scripts

ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/translationChain.test.js
# 27 pass, 0 fail

npx prettier --check src/helpers/translationChain.js test/helpers/translationChain.test.js
# All matched files use Prettier code style!

git diff --check
# clean
```

`npm test` (`node --import tsx --test`) fails to load named exports from this ESM `.js` helper in this local Node 24.9 / tsx combination, including on unmodified `upstream/main`. The repository test command for this file is therefore exercised with `node --test` (same assertions). Typecheck/lint/i18n/renderer build were not required for this JS-only helper change.

## Platform / environment limitations

- Pure helper; no Electron, models, or API keys.
- Extends #1258; does not change successful cleanup/translate behavior.

Fixes #1616
