### PR TITLE
fix(reasoning): strip nested think blocks without leftover tags

### DIFF
--- a/src/helpers/stripThinking.js
+++ b/src/helpers/stripThinking.js
@@ -1,9 +1,14 @@
 // Strip <think>...</think> blocks (including unterminated ones) emitted by
-// reasoning models. Mirrors the regex in localReasoningBridge.js.
+// reasoning models. Innermost closed pairs are removed first so nested blocks
+// cannot leave a stray </think>, then a trailing unterminated <think> is removed.
 export function stripThinkingTags(text) {
   if (typeof text !== "string") return text;
-  return text
-    .replace(/<think>[\s\S]*?<\/think>/g, "")
-    .replace(/<think>[\s\S]*$/, "")
-    .trim();
+  const innermostClosed = /<think>(?:(?!<think>)[\s\S])*?<\/think>/;
+  let out = text;
+  let next = out.replace(innermostClosed, "");
+  while (next !== out) {
+    out = next;
+    next = out.replace(innermostClosed, "");
+  }
+  return next.replace(/<think>[\s\S]*$/, "").trim();
 }

--- a/src/services/localReasoningBridge.js
+++ b/src/services/localReasoningBridge.js
@@ -49,10 +49,7 @@ class LocalReasoningService {
       const result = await modelManager.runInference(modelId, text, inferenceConfig);
       const stripThinking = config.disableThinking !== false;
       const cleanResult = stripThinking
-        ? result
-            .replace(/<think>[\s\S]*?<\/think>/g, "")
-            .replace(/<think>[\s\S]*$/, "")
-            .trim()
+        ? (await import("../helpers/stripThinking.js")).stripThinkingTags(result)
         : result.trim();
 
       const processingTime = Date.now() - startTime;

--- a/test/helpers/stripThinking.test.js
+++ b/test/helpers/stripThinking.test.js
@@ -35,3 +35,21 @@ test("non-string input is returned as-is", async () => {
   const { stripThinkingTags } = await load();
   assert.equal(stripThinkingTags(undefined), undefined);
 });
+
+test("peels nested think blocks instead of leaving a stray close tag", async () => {
+  const { stripThinkingTags } = await load();
+  assert.equal(stripThinkingTags("<think>a<think>b</think>c</think>Answer"), "Answer");
+});
+
+test("peels doubly nested think blocks", async () => {
+  const { stripThinkingTags } = await load();
+  assert.equal(
+    stripThinkingTags("<think>outer<think>mid<think>inner</think>x</think>y</think>Done"),
+    "Done"
+  );
+});
+
+test("still keeps sequential (non-nested) think blocks from leaking", async () => {
+  const { stripThinkingTags } = await load();
+  assert.equal(stripThinkingTags("<think>one</think>Keep<think>two</think>This"), "KeepThis");
+});


### PR DESCRIPTION
## Summary

- Strip nested `<think>` blocks by removing innermost closed pairs first.
- Reuse the shared helper from the local reasoning bridge instead of a one-shot regex copy.
- Add regression tests for nested, doubly nested, and sequential think blocks.

## Problem

`stripThinkingTags()` used a single non-greedy `/<think>[\s\S]*?<\/think>/g` replace. For `<think>a<think>b</think>c</think>Answer` that matches the first open tag through the first close tag, leaving `c</think>Answer`. The unterminated-tail regex then does not match, so `</think>` leaks into titles and notes.

#178 covered leaking a well-formed single block. Nested leftovers were still unhandled. The same one-shot regex was duplicated in `localReasoningBridge.js`.

## Root cause

A one-pass non-greedy replace cannot peel nested pairs. Global `/g` also cannot be looped safely because `lastIndex` makes later passes miss remaining tags.

## Fix

- Repeatedly remove the innermost closed `<think>...</think>` pair (a block that does not itself contain `<think>`).
- Then strip a trailing unterminated `<think>...` as before.
- Load `stripThinkingTags` from the local bridge so both paths stay in sync.

## Behavior before / after

| Input | Before | After |
| --- | --- | --- |
| `<think>a<think>b</think>c</think>Answer` | `c</think>Answer` | `Answer` |
| `<think>let me reason</think>Meeting Notes Summary` | `Meeting Notes Summary` | unchanged |
| `Title Here<think>never closed` | `Title Here` | unchanged |
| `<think>one</think>Keep<think>two</think>This` | `KeepThis` | unchanged |

## Scope / non-goals

- In scope: `stripThinkingTags` and the local-bridge call site.
- Out of scope: streaming think-suppression dialects, provider APIs, case-insensitive tag matching, and treating a mention of `<think>` in prose as non-reasoning.

## Tests added

- nested think blocks do not leave `</think>`
- doubly nested think blocks collapse to the answer
- sequential (non-nested) blocks still strip

## Validation

```text
node --version
# v24.9.0

ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/stripThinking.test.js
# 9 pass, 0 fail

npx prettier --check src/helpers/stripThinking.js src/services/localReasoningBridge.js test/helpers/stripThinking.test.js
# All matched files use Prettier code style!

git diff --check
# clean
```

`npm test` uses `node --import tsx`, which in this local Node 24.9 / tsx combo fails to bind named exports from typeless ESM `.js` helpers (also on unmodified `upstream/main`). This file is exercised with `node --test`.

## Platform / environment limitations

- Pure string helper; no Electron, models, or API keys.

Fixes #1617
