### PR TITLE
fix(linux): stop re-paying stale portal sessions on every Wayland paste

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -39,6 +39,13 @@ typedef enum {
 #define PORTAL_IFACE "org.freedesktop.portal.RemoteDesktop"
 #define REQUEST_IFACE "org.freedesktop.portal.Request"
 
+/* Method replies are immediate on a healthy portal (user interaction arrives via
+ * Response signals, not the call reply). A stale RemoteDesktop session can leave
+ * a sync call hanging inside a signal callback, which blocks the main loop and
+ * defeats the 10s watchdog below — so bound every call instead of using the
+ * default (25s) D-Bus timeout. */
+#define PORTAL_CALL_TIMEOUT_MS 3000
+
 /* evdev keycodes for portal mode */
 #define PORTAL_KEY_LEFTCTRL  29
 #define PORTAL_KEY_LEFTSHIFT 42
@@ -85,7 +92,7 @@ static void portal_emit_key(PortalData *app, gint32 keycode, guint32 pressed,
     g_dbus_connection_call_sync(app->conn, PORTAL_BUS, PORTAL_PATH,
         PORTAL_IFACE, "NotifyKeyboardKeycode",
         g_variant_new("(o@a{sv}iu)", app->session_handle, opts, keycode, pressed),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
+        NULL, G_DBUS_CALL_FLAGS_NONE, PORTAL_CALL_TIMEOUT_MS, NULL, &err);
     if (err) { fprintf(stderr, "%s: %s\n", label, err->message); g_clear_error(&err); }
 }
 
@@ -196,7 +203,7 @@ static void on_select_devices_response(GDBusConnection *conn, const char *sender
         PORTAL_IFACE, "Start",
         g_variant_new("(os@a{sv})", app->session_handle, "",
                        g_variant_builder_end(&opts)),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
+        NULL, G_DBUS_CALL_FLAGS_NONE, PORTAL_CALL_TIMEOUT_MS, NULL, &err);
 
     g_free(request_path);
     if (err) {
@@ -260,7 +267,7 @@ static void on_create_session_response(GDBusConnection *conn, const char *sender
         PORTAL_IFACE, "SelectDevices",
         g_variant_new("(o@a{sv})", app->session_handle,
                        g_variant_builder_end(&opts)),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
+        NULL, G_DBUS_CALL_FLAGS_NONE, PORTAL_CALL_TIMEOUT_MS, NULL, &err);
 
     g_free(request_path);
     if (err) {
@@ -318,7 +325,7 @@ static int paste_via_portal(paste_mode_t mode, const char *restore_token, int co
     g_dbus_connection_call_sync(app.conn, PORTAL_BUS, PORTAL_PATH,
         PORTAL_IFACE, "CreateSession",
         g_variant_new("(@a{sv})", g_variant_builder_end(&opts)),
-        NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &err);
+        NULL, G_DBUS_CALL_FLAGS_NONE, PORTAL_CALL_TIMEOUT_MS, NULL, &err);
 
     g_free(request_path);
     if (err) {

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -117,6 +117,9 @@ class ClipboardManager {
     this.linuxFastPastePath = null;
     this.linuxFastPasteChecked = false;
     this.portalDenied = false;
+    this.portalFailed = false;
+    this.uinputTimedOut = false;
+    this.xtestTimedOut = false;
     this._kwinScriptPath = null;
     this.pasteQueue = Promise.resolve();
 
@@ -553,10 +556,14 @@ class ClipboardManager {
       });
 
       let timedOut = false;
+      // 15s only for the first grant (no token yet) so the permission dialog has
+      // time. With a saved token the session is pre-approved, so fail fast instead
+      // of hanging on a stale RemoteDesktop session that no longer responds (#1614).
+      const timeoutMs = restoreToken ? 2500 : 15000;
       const timeoutId = setTimeout(() => {
         timedOut = true;
         killProcess(proc, "SIGKILL");
-      }, 15000); // Portal may show a user dialog, allow more time
+      }, timeoutMs);
 
       proc.on("close", (code) => {
         if (timedOut) return reject(new Error("linux-fast-paste --portal timed out"));
@@ -1592,9 +1599,21 @@ class ClipboardManager {
 
       if (isWayland) {
         const tryUinputPaste = async () => {
+          if (this.uinputTimedOut) {
+            throw new Error("uinput timed out earlier this session, skipping");
+          }
           const args = ["--uinput"];
           appendModeFlag(args);
-          await spawnFastPaste(args, "uinput");
+          try {
+            await spawnFastPaste(args, "uinput");
+          } catch (error) {
+            // A timeout means uinput hangs in this environment (unlike a fast
+            // error, which can be transient) — don't re-pay 2s on every paste.
+            if (error?.message === "linux-fast-paste timed out") {
+              this.uinputTimedOut = true;
+            }
+            throw error;
+          }
           this.safeLog("✅ Paste successful using native linux-fast-paste (uinput)");
           debugLogger.info(
             "Paste successful",
@@ -1636,8 +1655,11 @@ class ClipboardManager {
                   "clipboard"
                 );
               } else {
+                // Timeout or service error: the session stays broken until app
+                // restart, so skip the portal from now on (#1614).
+                this.portalFailed = true;
                 debugLogger.warn(
-                  "linux-fast-paste --portal failed, falling back",
+                  "linux-fast-paste --portal failed, skipping portal for this session",
                   { error: portalError?.message },
                   "clipboard"
                 );
@@ -1652,7 +1674,7 @@ class ClipboardManager {
         // on X11. uinput causes clipboard desync (X11 clipboard vs Wayland input).
         // GNOME: uinput first because the portal often times out or shows a
         // confusing permission dialog, causing a 10s+ delay (issue #494).
-        if (isKde && linuxFastPaste && !this.portalDenied) {
+        if (isKde && linuxFastPaste && !this.portalDenied && !this.portalFailed) {
           const portalPaste = await tryPortalPaste();
           if (portalPaste) return { method: "portal", ...portalPaste };
           try {
@@ -1672,7 +1694,7 @@ class ClipboardManager {
               "clipboard"
             );
           }
-          if (!this.portalDenied) {
+          if (!this.portalDenied && !this.portalFailed) {
             const portalPaste = await tryPortalPaste();
             if (portalPaste) return { method: "portal", ...portalPaste };
           }
@@ -1687,7 +1709,7 @@ class ClipboardManager {
         }
 
         // XTest/XWayland fallback: works for XWayland apps on any Wayland compositor
-        if (xwaylandAvailable) {
+        if (xwaylandAvailable && !this.xtestTimedOut) {
           const xtestArgs = [];
           if (targetWindowId) xtestArgs.push("--window", targetWindowId);
           appendModeFlag(xtestArgs);
@@ -1705,6 +1727,9 @@ class ClipboardManager {
               restoreComplete: restoreClipboard(),
             };
           } catch (xtestError) {
+            if (xtestError?.message === "linux-fast-paste timed out") {
+              this.xtestTimedOut = true;
+            }
             debugLogger.warn(
               "XTest/XWayland fallback also failed",
               { error: xtestError?.message },

--- a/src/helpers/selectionManager.js
+++ b/src/helpers/selectionManager.js
@@ -368,14 +368,23 @@ class SelectionManager {
           const result = await runSpawn(binary, args, { timeout: COPY_TIMEOUT_MS });
           return { success: result.success, target };
         }
-        if (this.clipboardManager._runPortalPaste && !this.clipboardManager.portalDenied) {
+        if (
+          this.clipboardManager._runPortalPaste &&
+          !this.clipboardManager.portalDenied &&
+          !this.clipboardManager.portalFailed
+        ) {
           try {
             await this.clipboardManager._runPortalPaste(binary, {
               copy: true,
               terminal: isTerminal,
             });
             return { success: true, target };
-          } catch {
+          } catch (err) {
+            // Same session-level memory as the paste path (#1614): a stale
+            // portal session would otherwise stall every selection capture.
+            if (err?.message !== "portal-denied" && err?.message !== "portal-dismissed") {
+              this.clipboardManager.portalFailed = true;
+            }
             return { success: false };
           }
         }


### PR DESCRIPTION
Fixes #1614

## Problem

On KDE Plasma Wayland, dictation paste intermittently stalled **6–19s** while transcription itself was fast. Excellent diagnosis by @Trevor-K-Smith in #1614: when the XDG RemoteDesktop portal session goes stale (which happens after just a few minutes of idle on KDE), the portal attempt hangs for the full flat 15s timeout, then uinput (~2s) and XTest (~2s) also fail before ydotool finally lands the paste — and because only an explicit portal *denial* was remembered, every subsequent paste re-paid the entire cascade until app restart.

## Fix

`src/helpers/clipboard.js` (based on the patch proposed in the issue):
- **Remember non-denial portal failures for the session** (`portalFailed`, mirroring the existing `portalDenied`), so a stale session costs one paste, not all of them.
- **Token-gated portal timeout**: 2.5s when a saved `restore-token` exists (session already approved — a non-responsive call should fail fast), 15s only for the first grant so the permission dialog has time.
- **Remember uinput/XTest *timeouts* for the session** as well. A timeout (as opposed to a fast error) means the backend hangs in this environment and will hang again. This takes the steady state on affected machines from ~4.5s down to ~55ms (straight to ydotool).

`src/helpers/selectionManager.js`:
- The selection-capture portal copy path (`_runPortalPaste({copy: true})`, used on Wayland when uinput isn't accessible) now honors and sets the same `portalFailed` flag, so a stale session can't stall every selection capture either. Both consumers share the one `ClipboardManager` instance created in `main.js`.

`resources/linux-fast-paste.c` (root cause the issue's instrumentation surfaced — 15s observed despite the binary's internal 10s watchdog):
- Every portal D-Bus call used `g_dbus_connection_call_sync(..., -1)` (25s default) from inside GLib signal callbacks. A hung call blocks the main loop, so the 10s watchdog could never fire. Calls are now bounded at 3s — safe because method replies are immediate on a healthy portal (user interaction arrives via Response signals, not the call reply). The binary is compiled from source at build time, so this ships with the next Linux build.

## Latency impact (reporter's environment)

| Scenario | Before | After |
|---|---|---|
| First paste after session goes stale | ~19.4s | ~6.5s |
| Every subsequent paste | ~19.4s | **~55ms** |
| First paste after app restart (fast-error variant) | ~6s | ~6s once |
| Subsequent pastes | ~6s | **~55ms** |

## Blast radius

- **macOS / Windows**: untouched — all changes are inside `pasteLinux()` / `_runPortalPaste()` / the Linux selection-capture branch and the Linux portal binary.
- **X11 Linux**: portal and the new flags live only in the `isWayland` branch; the X11 XTest path is unchanged.
- **wlroots/Hyprland**: never used the portal; only gains the uinput-timeout memory.
- **GNOME Wayland**: portal is a fallback after uinput there; skipping a known-dead portal aligns with the existing #494 mitigation. ydotool/xdotool fallbacks unaffected.
- **Healthy KDE**: portal succeeds in ~350ms, far inside the 2.5s token timeout — no behavior change.
- **First-grant behavior change (deliberate)**: if the user ignores the portal permission dialog until it times out, the portal is skipped for the rest of that session instead of re-prompting on every paste; pasting continues via fallbacks and the dialog reappears next launch.
- Media toggle (`mediaPlayer.js`) uses the same binary but never `--portal`.

Note for maintainers: #1550 and #1316 touch the GNOME portal-ordering lines in the same file; whichever lands second needs a trivial rebase.

## Testing

- Full suite: 2008 pass / 0 fail (`npm test`), plus `npm run quality-check` (prettier, eslint, tsc) clean
- C change is confined to timeout constants on the four portal `call_sync` sites