### PR TITLE
fix(notes): escape control characters in mirrored note frontmatter

### DIFF
--- a/src/helpers/markdownMirror.js
+++ b/src/helpers/markdownMirror.js
@@ -33,8 +33,22 @@ class MarkdownMirror {
   _buildFrontmatter(note, folderName) {
     const escYaml = (str) => {
       if (!str) return '""';
-      if (/[:#{}[\],&*?|>!%@`]/.test(str) || str.includes('"') || str.includes("'")) {
-        return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+      // A control character (newline, carriage return, tab) in a title splits the
+      // mapping onto a bare line and makes the whole frontmatter block unparseable,
+      // so force quoting and escape them like `"` and `\` — keeping the value on
+      // one line and round-tripping back to the original when parsed.
+      if (
+        /[:#{}[\],&*?|>!%@`]/.test(str) ||
+        /[\n\r\t]/.test(str) ||
+        str.includes('"') ||
+        str.includes("'")
+      ) {
+        return `"${str
+          .replace(/\\/g, "\\\\")
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, "\\n")
+          .replace(/\r/g, "\\r")
+          .replace(/\t/g, "\\t")}"`;
       }
       return str;
     };

--- a/test/helpers/markdownMirror.test.js
+++ b/test/helpers/markdownMirror.test.js
@@ -81,6 +81,53 @@ test("renaming a mirrored note cleans up both stale files and reveals the note",
   assert.match(fs.readFileSync(notePath, "utf-8"), /Updated notes$/);
 });
 
+function readFrontmatter(fileContent) {
+  const match = fileContent.match(/^---\n([\s\S]*?)\n---\n/);
+  assert.ok(match, "file should start with a --- fenced frontmatter block");
+  const map = {};
+  for (const line of match[1].split("\n")) {
+    const kv = line.match(/^([A-Za-z_]+): (.*)$/);
+    assert.ok(kv, `frontmatter line is a "key: value" mapping entry: ${JSON.stringify(line)}`);
+    let value = kv[2];
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value
+        .slice(1, -1)
+        .replace(/\\n/g, "\n")
+        .replace(/\\r/g, "\r")
+        .replace(/\\t/g, "\t")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+    map[kv[1]] = value;
+  }
+  return map;
+}
+
+test("a title with control characters keeps the frontmatter a valid single-line mapping", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+
+  const note = {
+    id: 5,
+    title: "Q3 Review\nconfidential\ttag",
+    content: "Body text",
+    created_at: "2026-07-21T12:00:00Z",
+  };
+
+  markdownMirror.init(basePath);
+  markdownMirror.writeNote(note, "Personal");
+
+  const notePath = markdownMirror.getNotePath(note.id);
+  assert.ok(notePath, "the note file is discoverable, so its frontmatter parsed as a note");
+  const frontmatter = readFrontmatter(fs.readFileSync(notePath, "utf-8"));
+
+  // Every key survives and the title round-trips, control characters intact.
+  assert.equal(frontmatter.id, "5");
+  assert.equal(frontmatter.type, "personal");
+  assert.equal(frontmatter.folder, "Personal");
+  assert.equal(frontmatter.title, note.title);
+});
+
 test("a note file re-saved with a BOM or CRLF is still recognised as its note", (t) => {
   const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
   t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

The on-disk markdown mirror (`src/helpers/markdownMirror.js`) writes each note as a `.md` file with a YAML frontmatter block. Its `escYaml` helper quotes values containing YAML metacharacters, but ignores control characters. A note title (or folder name) containing a line break is written into the frontmatter verbatim, which splits the mapping onto a bare line and makes the **entire** block invalid YAML — every metadata field (`id`, `title`, `type`, `folder`, `created`, `updated`) is lost, not just the offending value.

Fixes #1643.

## Problem

Note titles can legitimately contain a newline. `generateNoteTitle` (`src/utils/generateTitle.ts`) only trims *outer* whitespace from the model's response, so a model that answers with a two-line title stores it verbatim; a user rename or a content-derived title can do the same.

Writing such a note produces:

```
---
id: 5
title: Q3 Review
confidential
type: personal
folder: Personal
created: 2026-07-21T12:00:00Z
updated: 2026-08-14T21:39:05.477Z
---
```

The bare `confidential` line is not a `key: value` mapping entry. Parsing this with the project's own `js-yaml` dependency throws:

```
YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key (4:5)
```

so external markdown tools (and the markdown-import migration path proposed in #1633) cannot read any of the note's metadata.

## Root cause

`escYaml`'s quote-trigger regex omits `\n`/`\r`/`\t`, and its escaping only handled `\` and `"`, so control characters slipped through both unquoted and unescaped.

## Fix

`escYaml` now treats `\n`/`\r`/`\t` as characters that require quoting, and escapes them (`\n` → `\n`, `\r` → `\r`, `\t` → `\t`) inside the double-quoted form alongside the existing `\` and `"` escaping. The value stays on one line and round-trips back to the original string when parsed.

## Behavior before / after

For a note titled `Q3 Review\nconfidential`:

| | `title:` line | `js-yaml` parse |
| --- | --- | --- |
| Before | `title: Q3 Review` + a bare `confidential` line | throws — all metadata lost |
| After | `title: "Q3 Review\nconfidential"` | parses back to `Q3 Review\nconfidential` |

Output for values that contain no control characters is unchanged.

## Scope / non-goals

- Only control characters (`\n`/`\r`/`\t`) are addressed — the concrete corruption that makes the block unparseable. Other YAML niceties (e.g. quoting a plain scalar that begins with `-`) are out of scope.
- No change to filenames, the `_slugify` path, or any other behavior.

## Tests

Added a regression test in `test/helpers/markdownMirror.test.js`: it mirrors a note whose title contains a newline and a tab, then parses the frontmatter back and asserts every key survives and the title round-trips exactly. It fails on the pre-fix code (the note file is unrecognizable / the block is not a valid mapping) and passes with the fix.

## Validation

Run from a clean worktree on `upstream/main`:

- `node --test test/helpers/markdownMirror.test.js` → **4 pass / 0 fail** (new test green; verified red without the fix)
- `prettier --check` on both changed files → clean
- `node scripts/check-i18n.js` (`npm run i18n:check`) → consistent
- `cd src && tsc --noEmit` (`npm run typecheck`) → exit 0
- `node --check src/helpers/markdownMirror.js` → OK
- `git diff --check` → clean

Environment note: the full `npm test` uses `node --import tsx`; this environment reused an existing `node_modules` that lacked `tsx`, and a fresh `npm ci` pulls the Electron toolchain/binaries. The changed code is a pure CommonJS helper, so the affected test file was run directly with `node --test` (its dependencies resolved), which is deterministic and needs no native modules, credentials, or network.
