### PR TITLE
test(llm): Keep electron mock hermetic across lazy modelDirUtils require

### DIFF
--- a/test/helpers/gemmaMtpDrafter.test.js
+++ b/test/helpers/gemmaMtpDrafter.test.js
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const modelManagerModulePath = require.resolve("../../src/helpers/modelManagerBridge.js");
+const modelDirUtilsModulePath = require.resolve("../../src/helpers/modelDirUtils.js");
 const originalLoad = Module._load;
 let electronHome = os.tmpdir();
 
@@ -14,6 +15,7 @@ const NON_QAT_ID = "gemma-4-e2b-it-q4_k_m";
 
 function loadModelManager() {
   delete require.cache[modelManagerModulePath];
+  delete require.cache[modelDirUtilsModulePath];
 
   Module._load = function loadWithMocks(request) {
     if (request === "electron") {
@@ -30,6 +32,11 @@ function loadModelManager() {
   };
 
   try {
+    // modelManagerBridge requires modelDirUtils lazily (inside getModelsDir),
+    // after this mock is uninstalled — load it now so its electron binding is
+    // the stub and modelsDir resolves inside the per-test temp home instead of
+    // the real ~/.cache/openwhispr (where deleteModel would touch real files).
+    require("../../src/helpers/modelDirUtils.js");
     return require("../../src/helpers/modelManagerBridge.js").default;
   } finally {
     Module._load = originalLoad;

--- a/test/helpers/modelManagerBridgeDownloadStatus.test.js
+++ b/test/helpers/modelManagerBridgeDownloadStatus.test.js
@@ -9,10 +9,12 @@ const modelRegistryData = require("../../src/models/modelRegistryData.json");
 
 const originalLoad = Module._load;
 const modelManagerModulePath = require.resolve("../../src/helpers/modelManagerBridge.js");
+const modelDirUtilsModulePath = require.resolve("../../src/helpers/modelDirUtils.js");
 let electronHome = os.tmpdir();
 
 function loadModelManager() {
   delete require.cache[modelManagerModulePath];
+  delete require.cache[modelDirUtilsModulePath];
 
   Module._load = function loadWithMocks(request, parent, isMain) {
     if (request === "electron") {
@@ -30,6 +32,11 @@ function loadModelManager() {
   };
 
   try {
+    // modelManagerBridge requires modelDirUtils lazily (inside getModelsDir),
+    // after this mock is uninstalled — load it now so its electron binding is
+    // the stub and modelsDir resolves inside the per-test temp home instead of
+    // the real ~/.cache/openwhispr.
+    require("../../src/helpers/modelDirUtils.js");
     return require("../../src/helpers/modelManagerBridge.js").default;
   } finally {
     Module._load = originalLoad;


### PR DESCRIPTION
## What

Fixes the test harness in `modelManagerBridgeDownloadStatus.test.js` and `gemmaMtpDrafter.test.js` so their electron mock covers `modelDirUtils`, which `modelManagerBridge` requires lazily.

## Why

Since 5a6c7f9b (#1514), `getModelsDir()` resolves through a lazy `require("./modelDirUtils")` that binds electron *after* the harness has uninstalled its `Module._load` stub. `getCacheRoot()` then falls back to `os.homedir()`, so the tests read the real `~/.cache/openwhispr/models`:

- **getAllModels surfaces in-flight local model download state** fails on any machine that has the first registry model (Qwen3.5-9B) actually downloaded — `isDownloaded` comes back `true` from the real 6.1 GB file.
- Worse, the gemma drafter `resolveDraftPath`/`deleteModel` tests silently **write and delete files inside the user's real model cache**.

## Fix

Preload `modelDirUtils` while the stub is still installed (and clear it from the require cache), so `modelsDir` resolves inside each test's temp home regardless of local machine state. No production code changes — in the real app `app` is always available and `getCacheRoot()` behaves correctly.

## Reviewer notes

CI never caught this because the model isn't present there; the test only fails on machines with a downloaded model. Verified: 20/20 tests pass across both files plus `modelDirUtils.test.js` on a machine where the real cache contains the Qwen model.