### PR TITLE
feat: add shortcut to add a note to folder

### DIFF
--- a/src/components/notes/SpacesTree.tsx
+++ b/src/components/notes/SpacesTree.tsx
@@ -580,6 +580,7 @@ function FolderRow({
   canManageDestructive,
   onActivate,
   onToggle,
+  onNewNote,
   onRename,
   onMoveToSpace,
   onDelete,
@@ -600,6 +601,7 @@ function FolderRow({
   canManageDestructive: boolean;
   onActivate: () => void;
   onToggle: () => void;
+  onNewNote: () => void;
   onRename: () => void;
   onMoveToSpace: (space: SpaceItem) => void;
   onDelete: () => void;
@@ -666,102 +668,116 @@ function FolderRow({
         {folder.name}
       </span>
       <ContainerRowTrailing count={count} isActive={isActive} isDropSuccess={isDropSuccess} />
-      {(!folder.is_default || noteFilesEnabled) && (
-        <DropdownMenu onOpenChange={(open) => !open && setSpaceSearch("")}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label={t("common.actions")}
-              onClick={(e) => e.stopPropagation()}
-              className={KEBAB_TRIGGER_CLASS}
-            >
-              <MoreHorizontal size={12} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" sideOffset={4} className="min-w-32">
-            {noteFilesEnabled && (
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  window.electronAPI?.showFolderInExplorer?.(folder.name);
-                }}
-                className={MENU_ITEM_CLASS}
+      <span className="absolute right-1.5 flex items-center gap-px">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t("notes.list.newNote")}
+          onClick={(e) => {
+            e.stopPropagation();
+            onNewNote();
+          }}
+          className={KEBAB_BUTTON_CLASS}
+        >
+          <Plus size={12} />
+        </Button>
+        {(!folder.is_default || noteFilesEnabled) && (
+          <DropdownMenu onOpenChange={(open) => !open && setSpaceSearch("")}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={t("common.actions")}
+                onClick={(e) => e.stopPropagation()}
+                className={KEBAB_BUTTON_CLASS}
               >
-                <ExternalLink size={11} className="text-muted-foreground/60" />
-                {t("notes.context.showInFileManager", { manager: fileManagerName })}
-              </DropdownMenuItem>
-            )}
-            {!folder.is_default && (
-              <>
-                {noteFilesEnabled && <DropdownMenuSeparator />}
+                <MoreHorizontal size={12} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={4} className="min-w-32">
+              {noteFilesEnabled && (
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    onRename();
+                    window.electronAPI?.showFolderInExplorer?.(folder.name);
                   }}
                   className={MENU_ITEM_CLASS}
                 >
-                  <Pencil size={11} className="text-muted-foreground/60" />
-                  {t("notes.context.rename")}
+                  <ExternalLink size={11} className="text-muted-foreground/60" />
+                  {t("notes.context.showInFileManager", { manager: fileManagerName })}
                 </DropdownMenuItem>
-                {canMoveToSpace && (
-                  <SearchableMoveSubmenu
-                    icon={<Users size={11} className="text-muted-foreground/60" />}
-                    label={t("notes.spaces.moveToSpace")}
-                    itemCount={spaces.length}
-                    search={spaceSearch}
-                    onSearchChange={setSpaceSearch}
-                    searchPlaceholder={t("notes.spaces.searchSpaces")}
+              )}
+              {!folder.is_default && (
+                <>
+                  {noteFilesEnabled && <DropdownMenuSeparator />}
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRename();
+                    }}
+                    className={MENU_ITEM_CLASS}
                   >
-                    {filteredSpaces.map((space) => {
-                      const isCurrent = space.id === folder.space_id;
-                      return (
-                        <DropdownMenuItem
-                          key={space.id}
-                          disabled={isCurrent}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onMoveToSpace(space);
-                          }}
-                          className={MENU_ITEM_CLASS}
-                        >
-                          <SpaceMenuIcon space={space} />
-                          <span className="truncate flex-1">{spaceDisplayName(space, t)}</span>
-                          {isCurrent && <Check size={9} className="text-primary shrink-0" />}
-                        </DropdownMenuItem>
-                      );
-                    })}
-                    {spaceSearch && filteredSpaces.length === 0 && (
-                      <p className="text-xs text-foreground/20 text-center py-1.5">
-                        {t("notes.spaces.noSpacesFound")}
-                      </p>
-                    )}
-                  </SearchableMoveSubmenu>
-                )}
-                {canManageDestructive && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete();
-                      }}
-                      className={cn(
-                        MENU_ITEM_CLASS,
-                        "text-destructive focus:text-destructive focus:bg-destructive/10"
-                      )}
+                    <Pencil size={11} className="text-muted-foreground/60" />
+                    {t("notes.context.rename")}
+                  </DropdownMenuItem>
+                  {canMoveToSpace && (
+                    <SearchableMoveSubmenu
+                      icon={<Users size={11} className="text-muted-foreground/60" />}
+                      label={t("notes.spaces.moveToSpace")}
+                      itemCount={spaces.length}
+                      search={spaceSearch}
+                      onSearchChange={setSpaceSearch}
+                      searchPlaceholder={t("notes.spaces.searchSpaces")}
                     >
-                      <Trash2 size={11} />
-                      {t("notes.context.delete")}
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+                      {filteredSpaces.map((space) => {
+                        const isCurrent = space.id === folder.space_id;
+                        return (
+                          <DropdownMenuItem
+                            key={space.id}
+                            disabled={isCurrent}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onMoveToSpace(space);
+                            }}
+                            className={MENU_ITEM_CLASS}
+                          >
+                            <SpaceMenuIcon space={space} />
+                            <span className="truncate flex-1">{spaceDisplayName(space, t)}</span>
+                            {isCurrent && <Check size={9} className="text-primary shrink-0" />}
+                          </DropdownMenuItem>
+                        );
+                      })}
+                      {spaceSearch && filteredSpaces.length === 0 && (
+                        <p className="text-xs text-foreground/20 text-center py-1.5">
+                          {t("notes.spaces.noSpacesFound")}
+                        </p>
+                      )}
+                    </SearchableMoveSubmenu>
+                  )}
+                  {canManageDestructive && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete();
+                        }}
+                        className={cn(
+                          MENU_ITEM_CLASS,
+                          "text-destructive focus:text-destructive focus:bg-destructive/10"
+                        )}
+                      >
+                        <Trash2 size={11} />
+                        {t("notes.context.delete")}
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </span>
     </div>
   );
 }
@@ -1832,6 +1848,7 @@ export default function SpacesTree({
             activateRow({ type: "folder", key: folderKey, folder, parentKey, level })
           }
           onToggle={() => toggleContainerExpanded(folderKey)}
+          onNewNote={() => onNewNote(folder.space_id, folder.id)}
           onRename={() => startRenameFolder(folder)}
           onMoveToSpace={(space) => requestMoveFolder(folder, space)}
           onDelete={() => requestDeleteFolder(folder)}


### PR DESCRIPTION
## Description:

Folder rows in the notes sidebar previously offered no direct way to create a note inside them — only spaces had a hover "+" (for new folders), and adding a note to a folder meant creating it elsewhere and moving it. This PR gives every folder row the same hover-revealed trailing-button treatment the space rows already have: a "+" that creates an untitled note inside that folder, next to the existing "…" menu.

Clicking "+" routes through the existing onNewNote(spaceId, folderId) path in PersonalNotesView, so behavior matches note creation everywhere else: the note is created in the folder, the folder is expanded/revealed, and the new note opens in the editor. The "…" menu (Show in Finder / Rename / Move to space / Delete) is unchanged in both contents and visibility rules; it just shifts left to share the corner with the "+". Default folders — which previously had no trailing controls at all when note files were disabled — now show the "+" too, since they can hold notes.

No new strings, styles, or code paths: the button reuses KEBAB_BUTTON_CLASS (hover/focus/active states included), the Plus icon already imported in the file, and the existing notes.list.newNote translation key, so all 10 locales are covered without changes.