### PR TITLE
fix(linux): make auto-learn corrections more reliable

### DIFF
--- a/resources/linux-text-monitor.c
+++ b/resources/linux-text-monitor.c
@@ -17,7 +17,7 @@
  *   First line: original pasted text (informational)
  *
  * Compile:
- *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2) -lgobject-2.0
+ *   gcc -O2 linux-text-monitor.c -o linux-text-monitor $(pkg-config --cflags --libs atspi-2) -lgobject-2.0 -lgio-2.0
  *
  * Note: -lgobject-2.0 must be added explicitly because atspi-2.pc lists
  * gobject-2.0 under Requires.private rather than Requires, so a plain
@@ -32,13 +32,35 @@
 #include <time.h>
 #include <unistd.h>
 #include <atspi/atspi.h>
+#include <gio/gio.h>
 
 #define TIMEOUT_SECONDS 30
 #define POLL_INTERVAL_MS 500
 #define MAX_OUTPUT_CHARS 10240
+#define EFFECTIVE_TEXT_MAX_DEPTH 8
+#define WAKE_PROBE_MAX_DEPTH 4
+#define WAKE_SETTLE_MS 400
+#define FIND_RETRIES 3
+#define FIND_RETRY_DELAY_MS 250
+
+/* UTF-8 encoding of U+FFFC OBJECT REPLACEMENT CHARACTER */
+#define ORC0 0xEF
+#define ORC1 0xBF
+#define ORC2 0xBC
 
 static volatile sig_atomic_t running = 1;
 static const char BASE64_TABLE[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/* Session a11y advertise — restore on exit if we flipped a property. */
+typedef struct {
+    int touched;
+    int set_screen_reader;
+    int set_is_enabled;
+    gboolean prior_screen_reader;
+    gboolean prior_is_enabled;
+} A11yAdvertiseState;
+
+static A11yAdvertiseState g_a11y_state = {0};
 
 static void signal_handler(int sig) {
     (void)sig;
@@ -93,39 +115,39 @@ static void print_text_output(const char *name, const char *value) {
     fflush(stdout);
 }
 
-static AtspiAccessible *find_focused(AtspiAccessible *accessible) {
-    GError *error = NULL;
+static int is_orc_at(const unsigned char *p) {
+    return p[0] == ORC0 && p[1] == ORC1 && p[2] == ORC2;
+}
 
-    AtspiStateSet *states = atspi_accessible_get_state_set(accessible);
-    if (states) {
-        if (atspi_state_set_contains(states, ATSPI_STATE_FOCUSED)) {
-            g_object_unref(states);
-            return g_object_ref(accessible);
-        }
-        g_object_unref(states);
-    }
-
-    int count = atspi_accessible_get_child_count(accessible, &error);
-    if (error) {
-        g_error_free(error);
-        return NULL;
-    }
-
-    for (int i = 0; i < count; i++) {
-        AtspiAccessible *child = atspi_accessible_get_child_at_index(accessible, i, &error);
-        if (error) {
-            g_error_free(error);
-            error = NULL;
+/* Usable = has non-ORC, non-whitespace content (Chromium composers often return
+ * only U+FFFC on the focused entry itself). */
+static int is_usable_text(const char *s) {
+    if (!s || !*s) return 0;
+    const unsigned char *p = (const unsigned char *)s;
+    while (*p) {
+        if (is_orc_at(p)) {
+            p += 3;
             continue;
         }
-        if (!child) continue;
-
-        AtspiAccessible *result = find_focused(child);
-        g_object_unref(child);
-        if (result) return result;
+        if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r') return 1;
+        p++;
     }
+    return 0;
+}
 
-    return NULL;
+static size_t usable_content_len(const char *s) {
+    if (!s) return 0;
+    size_t n = 0;
+    const unsigned char *p = (const unsigned char *)s;
+    while (*p) {
+        if (is_orc_at(p)) {
+            p += 3;
+            continue;
+        }
+        if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r') n++;
+        p++;
+    }
+    return n;
 }
 
 static char *read_text_value(AtspiText *text_iface) {
@@ -148,9 +170,430 @@ static char *read_text_value(AtspiText *text_iface) {
     return value;
 }
 
+static char *read_direct_text(AtspiAccessible *node) {
+    AtspiText *text_iface = atspi_accessible_get_text_iface(node);
+    if (!text_iface) return NULL;
+    char *value = read_text_value(text_iface);
+    g_object_unref(text_iface);
+    return value;
+}
+
+static int is_text_field_role(AtspiRole role) {
+    return role == ATSPI_ROLE_ENTRY || role == ATSPI_ROLE_TEXT ||
+           role == ATSPI_ROLE_PASSWORD_TEXT || role == ATSPI_ROLE_SPIN_BUTTON;
+}
+
+static int is_editable_field(AtspiAccessible *node) {
+    AtspiStateSet *states = atspi_accessible_get_state_set(node);
+    gboolean editable = states && atspi_state_set_contains(states, ATSPI_STATE_EDITABLE);
+    if (states) g_object_unref(states);
+    if (editable) return 1;
+
+    GError *error = NULL;
+    AtspiRole role = atspi_accessible_get_role(node, &error);
+    if (error) {
+        g_error_free(error);
+        return 0;
+    }
+    return is_text_field_role(role);
+}
+
+static int should_walk_child(AtspiAccessible *child, int depth) {
+    AtspiStateSet *states = atspi_accessible_get_state_set(child);
+    gboolean editable = states && atspi_state_set_contains(states, ATSPI_STATE_EDITABLE);
+    if (states) g_object_unref(states);
+    if (editable) return 1;
+
+    GError *error = NULL;
+    AtspiRole role = atspi_accessible_get_role(child, &error);
+    if (error) {
+        g_error_free(error);
+        return depth < 3;
+    }
+
+    if (is_text_field_role(role) || role == ATSPI_ROLE_SECTION || role == ATSPI_ROLE_STATIC ||
+        role == ATSPI_ROLE_PARAGRAPH) {
+        return 1;
+    }
+    return depth < 3;
+}
+
+/* Prefer longest usable text among this node and editable/text descendants.
+ * Chromium composers: entry Text is U+FFFC; draft lives on a child section. */
+static char *read_effective_text(AtspiAccessible *node, int depth) {
+    if (!node || depth > EFFECTIVE_TEXT_MAX_DEPTH) return NULL;
+
+    char *best = NULL;
+    char *direct = read_direct_text(node);
+    if (is_usable_text(direct)) {
+        best = direct;
+    } else {
+        g_free(direct);
+    }
+
+    GError *error = NULL;
+    int count = atspi_accessible_get_child_count(node, &error);
+    if (error) {
+        g_error_free(error);
+        return best;
+    }
+
+    for (int i = 0; i < count; i++) {
+        AtspiAccessible *child = atspi_accessible_get_child_at_index(node, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!child) continue;
+
+        if (should_walk_child(child, depth)) {
+            char *child_text = read_effective_text(child, depth + 1);
+            if (is_usable_text(child_text)) {
+                if (!best || usable_content_len(child_text) >= usable_content_len(best)) {
+                    g_free(best);
+                    best = child_text;
+                } else {
+                    g_free(child_text);
+                }
+            } else {
+                g_free(child_text);
+            }
+        }
+
+        g_object_unref(child);
+    }
+
+    return best;
+}
+
+/* Rank focused nodes. Prefer editable composers over a focused document web
+ * that merely has usable descendant chrome text (notifications, etc.). */
+static int focused_field_rank(AtspiAccessible *node) {
+    int editable = is_editable_field(node);
+    char *effective = read_effective_text(node, 0);
+    int usable = is_usable_text(effective);
+    g_free(effective);
+
+    if (editable && usable) return 4;
+    if (editable) return 3;
+    if (usable) return 2;
+
+    char *direct = read_direct_text(node);
+    int direct_usable = is_usable_text(direct);
+    g_free(direct);
+    return direct_usable ? 1 : 0;
+}
+
+static void find_best_focused(AtspiAccessible *accessible, AtspiAccessible **best, int *best_rank) {
+    GError *error = NULL;
+
+    AtspiStateSet *states = atspi_accessible_get_state_set(accessible);
+    gboolean focused = states && atspi_state_set_contains(states, ATSPI_STATE_FOCUSED);
+    if (states) g_object_unref(states);
+
+    if (focused) {
+        int rank = focused_field_rank(accessible);
+        if (rank > *best_rank) {
+            if (*best) g_object_unref(*best);
+            *best = g_object_ref(accessible);
+            *best_rank = rank;
+        }
+    }
+
+    /* Editable+usable is best; keep searching otherwise so an empty focused
+     * entry does not hide a better sibling composer. */
+    if (*best_rank >= 4) return;
+
+    int count = atspi_accessible_get_child_count(accessible, &error);
+    if (error) {
+        g_error_free(error);
+        return;
+    }
+
+    for (int i = 0; i < count; i++) {
+        AtspiAccessible *child = atspi_accessible_get_child_at_index(accessible, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!child) continue;
+
+        find_best_focused(child, best, best_rank);
+        g_object_unref(child);
+
+        if (*best_rank >= 4) return;
+    }
+}
+
+/* When focus sits on document chrome, prefer an editable descendant that
+ * actually holds the draft (Chromium composers, Cursor Agents, t3code). */
+static void find_best_editable_descendant(
+    AtspiAccessible *node,
+    AtspiAccessible **best,
+    size_t *best_len,
+    int depth
+) {
+    if (!node || depth > EFFECTIVE_TEXT_MAX_DEPTH) return;
+
+    if (is_editable_field(node)) {
+        char *text = read_effective_text(node, 0);
+        size_t len = usable_content_len(text);
+        g_free(text);
+        if (!*best || len > *best_len) {
+            if (*best) g_object_unref(*best);
+            *best = g_object_ref(node);
+            *best_len = len;
+        }
+    }
+
+    GError *error = NULL;
+    int count = atspi_accessible_get_child_count(node, &error);
+    if (error) {
+        g_error_free(error);
+        return;
+    }
+
+    for (int i = 0; i < count; i++) {
+        AtspiAccessible *child = atspi_accessible_get_child_at_index(node, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!child) continue;
+        find_best_editable_descendant(child, best, best_len, depth + 1);
+        g_object_unref(child);
+    }
+}
+
+static AtspiAccessible *resolve_monitor_target(AtspiAccessible *focused) {
+    if (!focused) return NULL;
+    if (is_editable_field(focused)) return g_object_ref(focused);
+
+    AtspiAccessible *best = NULL;
+    size_t best_len = 0;
+    find_best_editable_descendant(focused, &best, &best_len, 0);
+    if (best) return best;
+    return g_object_ref(focused);
+}
+
+static gboolean dbus_get_a11y_bool(GDBusConnection *conn, const char *prop, gboolean *out) {
+    GError *error = NULL;
+    GVariant *result = g_dbus_connection_call_sync(
+        conn,
+        "org.a11y.Bus",
+        "/org/a11y/bus",
+        "org.freedesktop.DBus.Properties",
+        "Get",
+        g_variant_new("(ss)", "org.a11y.Status", prop),
+        G_VARIANT_TYPE("(v)"),
+        G_DBUS_CALL_FLAGS_NONE,
+        1000,
+        NULL,
+        &error
+    );
+    if (error) {
+        g_error_free(error);
+        return FALSE;
+    }
+
+    GVariant *inner = NULL;
+    g_variant_get(result, "(v)", &inner);
+    g_variant_unref(result);
+    if (!inner || !g_variant_is_of_type(inner, G_VARIANT_TYPE_BOOLEAN)) {
+        if (inner) g_variant_unref(inner);
+        return FALSE;
+    }
+    *out = g_variant_get_boolean(inner);
+    g_variant_unref(inner);
+    return TRUE;
+}
+
+static gboolean dbus_set_a11y_bool(GDBusConnection *conn, const char *prop, gboolean value) {
+    GError *error = NULL;
+    GVariant *result = g_dbus_connection_call_sync(
+        conn,
+        "org.a11y.Bus",
+        "/org/a11y/bus",
+        "org.freedesktop.DBus.Properties",
+        "Set",
+        g_variant_new("(ssv)", "org.a11y.Status", prop, g_variant_new_boolean(value)),
+        NULL,
+        G_DBUS_CALL_FLAGS_NONE,
+        1000,
+        NULL,
+        &error
+    );
+    if (error) {
+        g_error_free(error);
+        return FALSE;
+    }
+    if (result) g_variant_unref(result);
+    return TRUE;
+}
+
+static void restore_a11y_advertise(void) {
+    if (!g_a11y_state.touched) return;
+
+    GError *error = NULL;
+    GDBusConnection *conn = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
+    if (error || !conn) {
+        if (error) g_error_free(error);
+        g_a11y_state.touched = 0;
+        return;
+    }
+
+    if (g_a11y_state.set_screen_reader) {
+        dbus_set_a11y_bool(conn, "ScreenReaderEnabled", g_a11y_state.prior_screen_reader);
+    }
+    if (g_a11y_state.set_is_enabled) {
+        dbus_set_a11y_bool(conn, "IsEnabled", g_a11y_state.prior_is_enabled);
+    }
+
+    g_object_unref(conn);
+    g_a11y_state.touched = 0;
+}
+
+/* Soft-advertise AT so Chromium/Electron enable their accessibility cache.
+ * Restored via restore_a11y_advertise() — never leave ScreenReaderEnabled stuck on
+ * if we were the ones who flipped it (same caution as macOS AXEnhancedUserInterface). */
+static void ensure_a11y_advertised(void) {
+    GError *error = NULL;
+    GDBusConnection *conn = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
+    if (error || !conn) {
+        if (error) g_error_free(error);
+        return;
+    }
+
+    gboolean screen_reader = FALSE;
+    gboolean is_enabled = FALSE;
+    int have_sr = dbus_get_a11y_bool(conn, "ScreenReaderEnabled", &screen_reader);
+    int have_en = dbus_get_a11y_bool(conn, "IsEnabled", &is_enabled);
+
+    if (have_sr && !screen_reader) {
+        if (dbus_set_a11y_bool(conn, "ScreenReaderEnabled", TRUE)) {
+            g_a11y_state.prior_screen_reader = FALSE;
+            g_a11y_state.set_screen_reader = 1;
+            g_a11y_state.touched = 1;
+        }
+    }
+    if (have_en && !is_enabled) {
+        if (dbus_set_a11y_bool(conn, "IsEnabled", TRUE)) {
+            g_a11y_state.prior_is_enabled = FALSE;
+            g_a11y_state.set_is_enabled = 1;
+            g_a11y_state.touched = 1;
+        }
+    }
+
+    g_object_unref(conn);
+}
+
+/* Orca-style probes: Chromium EnableAXMode hooks on GetAttributes / RefRelationSet. */
+static void wake_probe_node(AtspiAccessible *node, int depth) {
+    if (!node || depth > WAKE_PROBE_MAX_DEPTH) return;
+
+    GError *error = NULL;
+    GHashTable *attrs = atspi_accessible_get_attributes(node, &error);
+    if (error) {
+        g_error_free(error);
+        error = NULL;
+    }
+    if (attrs) g_hash_table_unref(attrs);
+
+    GArray *rels = atspi_accessible_get_relation_set(node, &error);
+    if (error) {
+        g_error_free(error);
+        error = NULL;
+    }
+    if (rels) {
+        for (guint i = 0; i < rels->len; i++) {
+            AtspiRelation *rel = g_array_index(rels, AtspiRelation *, i);
+            if (rel) g_object_unref(rel);
+        }
+        g_array_free(rels, TRUE);
+    }
+
+    int count = atspi_accessible_get_child_count(node, &error);
+    if (error) {
+        g_error_free(error);
+        return;
+    }
+
+    int limit = count;
+    if (depth == 0 && limit > 8) limit = 8;
+    if (depth > 0 && limit > 20) limit = 20;
+
+    for (int i = 0; i < limit; i++) {
+        AtspiAccessible *child = atspi_accessible_get_child_at_index(node, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!child) continue;
+        wake_probe_node(child, depth + 1);
+        g_object_unref(child);
+    }
+}
+
+static void wake_accessibility_trees(AtspiAccessible *desktop) {
+    GError *error = NULL;
+    int app_count = atspi_accessible_get_child_count(desktop, &error);
+    if (error) {
+        g_error_free(error);
+        return;
+    }
+
+    for (int i = 0; i < app_count; i++) {
+        AtspiAccessible *app = atspi_accessible_get_child_at_index(desktop, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!app) continue;
+        wake_probe_node(app, 0);
+        g_object_unref(app);
+    }
+}
+
+static AtspiAccessible *find_focused_on_desktop(AtspiAccessible *desktop) {
+    AtspiAccessible *focused = NULL;
+    int best_rank = -1;
+    GError *error = NULL;
+    int app_count = atspi_accessible_get_child_count(desktop, &error);
+    if (error) {
+        g_error_free(error);
+        return NULL;
+    }
+
+    for (int i = 0; i < app_count; i++) {
+        AtspiAccessible *app = atspi_accessible_get_child_at_index(desktop, i, &error);
+        if (error) {
+            g_error_free(error);
+            error = NULL;
+            continue;
+        }
+        if (!app) continue;
+
+        find_best_focused(app, &focused, &best_rank);
+        g_object_unref(app);
+        if (best_rank >= 4) break;
+    }
+
+    if (!focused) return NULL;
+
+    AtspiAccessible *target = resolve_monitor_target(focused);
+    g_object_unref(focused);
+    return target;
+}
+
 int main(void) {
     signal(SIGTERM, signal_handler);
     signal(SIGINT, signal_handler);
+    atexit(restore_a11y_advertise);
 
     /* Read original text from stdin (consume but don't use) */
     char stdin_buf[4096];
@@ -165,7 +608,8 @@ int main(void) {
         return 1;
     }
 
-    GError *error = NULL;
+    ensure_a11y_advertised();
+
     AtspiAccessible *desktop = atspi_get_desktop(0);
     if (!desktop) {
         printf("NO_ELEMENT\n");
@@ -173,26 +617,17 @@ int main(void) {
         return 1;
     }
 
-    /* Search for focused element across all applications */
+    wake_accessibility_trees(desktop);
+    usleep(WAKE_SETTLE_MS * 1000);
+
     AtspiAccessible *focused = NULL;
-    int app_count = atspi_accessible_get_child_count(desktop, &error);
-    if (error) {
-        g_error_free(error);
-        error = NULL;
-        app_count = 0;
-    }
-
-    for (int i = 0; i < app_count && !focused; i++) {
-        AtspiAccessible *app = atspi_accessible_get_child_at_index(desktop, i, &error);
-        if (error) {
-            g_error_free(error);
-            error = NULL;
-            continue;
+    for (int attempt = 0; attempt < FIND_RETRIES; attempt++) {
+        focused = find_focused_on_desktop(desktop);
+        if (focused) break;
+        if (attempt + 1 < FIND_RETRIES) {
+            wake_accessibility_trees(desktop);
+            usleep(FIND_RETRY_DELAY_MS * 1000);
         }
-        if (!app) continue;
-
-        focused = find_focused(app);
-        g_object_unref(app);
     }
 
     g_object_unref(desktop);
@@ -203,28 +638,17 @@ int main(void) {
         return 1;
     }
 
-    /* Get the Text interface */
-    AtspiText *text_iface = atspi_accessible_get_text_iface(focused);
-    if (!text_iface) {
-        printf("NO_VALUE\n");
-        fflush(stdout);
-        g_object_unref(focused);
-        return 0;
-    }
-
-    /* Read initial value */
-    char *last_value = read_text_value(text_iface);
+    /* Re-read effective text each poll — Chromium rebuilds descendant text nodes. */
+    char *last_value = read_effective_text(focused, 0);
     if (!last_value) {
         printf("NO_VALUE\n");
         fflush(stdout);
-        g_object_unref(text_iface);
         g_object_unref(focused);
         return 0;
     }
 
     print_text_output("INITIAL_VALUE", last_value);
 
-    /* Poll for changes */
     struct timespec start;
     clock_gettime(CLOCK_MONOTONIC, &start);
 
@@ -237,7 +661,7 @@ int main(void) {
 
         usleep(POLL_INTERVAL_MS * 1000);
 
-        char *current_value = read_text_value(text_iface);
+        char *current_value = read_effective_text(focused, 0);
         if (!current_value) continue;
 
         if (strcmp(current_value, last_value) != 0) {
@@ -250,7 +674,6 @@ int main(void) {
     }
 
     g_free(last_value);
-    g_object_unref(text_iface);
     g_object_unref(focused);
 
     return 0;

--- a/resources/linux-text-monitor.py
+++ b/resources/linux-text-monitor.py
@@ -20,39 +20,343 @@ Input (stdin):
 Requires: python3-atspi / pyatspi (gi.repository.Atspi)
 """
 
-import sys
-import signal
-import threading
+import atexit
 import base64
+import signal
+import sys
+import threading
+import time
 
 TIMEOUT_SECONDS = 30
 MAX_OUTPUT_CHARS = 10240
+EFFECTIVE_TEXT_MAX_DEPTH = 8
+WAKE_PROBE_MAX_DEPTH = 4
+WAKE_SETTLE_MS = 400
+FIND_RETRIES = 3
+FIND_RETRY_DELAY_MS = 250
+OBJECT_REPLACEMENT = "\ufffc"
 
 try:
     import gi
+
     gi.require_version("Atspi", "2.0")
-    from gi.repository import Atspi, GLib
+    gi.require_version("Gio", "2.0")
+    from gi.repository import Atspi, GLib, Gio
+
     HAS_ATSPI = True
 except (ImportError, ValueError):
     HAS_ATSPI = False
 
+_a11y_state = {
+    "touched": False,
+    "set_screen_reader": False,
+    "set_is_enabled": False,
+    "prior_screen_reader": False,
+    "prior_is_enabled": False,
+}
 
-def _find_focused(accessible):
-    """Recursively find the focused accessible element."""
+
+def _is_usable_text(value):
+    if not value:
+        return False
+    cleaned = "".join(c for c in value if c != OBJECT_REPLACEMENT).strip()
+    return bool(cleaned)
+
+
+def _usable_content_len(value):
+    if not value:
+        return 0
+    return sum(1 for c in value if c != OBJECT_REPLACEMENT and not c.isspace())
+
+
+def _text_of(accessible):
+    try:
+        n = Atspi.Text.get_character_count(accessible)
+        if n is None or n <= 0:
+            return None
+        return Atspi.Text.get_text(accessible, 0, min(int(n), MAX_OUTPUT_CHARS))
+    except Exception:
+        return None
+
+
+def _is_editable_field(accessible):
+    try:
+        state_set = accessible.get_state_set()
+        if state_set.contains(Atspi.StateType.EDITABLE):
+            return True
+        role = accessible.get_role_name() or ""
+        return role in ("entry", "text", "password text", "spin button")
+    except Exception:
+        return False
+
+
+def _should_walk_child(child, depth):
+    try:
+        state_set = child.get_state_set()
+        if state_set.contains(Atspi.StateType.EDITABLE):
+            return True
+        role = child.get_role_name() or ""
+        if role in ("entry", "text", "password text", "spin button", "section", "static", "paragraph"):
+            return True
+        return depth < 3
+    except Exception:
+        return depth < 3
+
+
+def _read_effective_text(accessible, depth=0):
+    if accessible is None or depth > EFFECTIVE_TEXT_MAX_DEPTH:
+        return None
+
+    best = None
+    direct = _text_of(accessible)
+    if _is_usable_text(direct):
+        best = direct
+
+    try:
+        count = accessible.get_child_count()
+    except Exception:
+        return best
+
+    for i in range(count):
+        try:
+            child = accessible.get_child_at_index(i)
+        except Exception:
+            continue
+        if child is None:
+            continue
+        if not _should_walk_child(child, depth):
+            continue
+        child_text = _read_effective_text(child, depth + 1)
+        if not _is_usable_text(child_text):
+            continue
+        if best is None or _usable_content_len(child_text) >= _usable_content_len(best):
+            best = child_text
+
+    return best
+
+
+def _focused_field_rank(accessible):
+    editable = _is_editable_field(accessible)
+    usable = _is_usable_text(_read_effective_text(accessible))
+    if editable and usable:
+        return 4
+    if editable:
+        return 3
+    if usable:
+        return 2
+    return 1 if _is_usable_text(_text_of(accessible)) else 0
+
+
+def _find_best_focused(accessible, best=None):
+    """Return (accessible, rank) for the best focused field under accessible."""
+    if best is None:
+        best = [None, -1]
+
     try:
         state_set = accessible.get_state_set()
         if state_set.contains(Atspi.StateType.FOCUSED):
-            return accessible
-        for i in range(accessible.get_child_count()):
-            child = accessible.get_child_at_index(i)
-            if child is None:
-                continue
-            result = _find_focused(child)
-            if result is not None:
-                return result
+            rank = _focused_field_rank(accessible)
+            if rank > best[1]:
+                best[0] = accessible
+                best[1] = rank
     except Exception:
         pass
-    return None
+
+    if best[1] >= 4:
+        return best
+
+    try:
+        count = accessible.get_child_count()
+    except Exception:
+        return best
+
+    for i in range(count):
+        try:
+            child = accessible.get_child_at_index(i)
+        except Exception:
+            continue
+        if child is None:
+            continue
+        _find_best_focused(child, best)
+        if best[1] >= 4:
+            break
+
+    return best
+
+
+def _find_best_editable_descendant(node, best=None, depth=0):
+    if best is None:
+        best = [None, -1]
+    if node is None or depth > EFFECTIVE_TEXT_MAX_DEPTH:
+        return best
+
+    if _is_editable_field(node):
+        length = _usable_content_len(_read_effective_text(node))
+        if best[0] is None or length > best[1]:
+            best[0] = node
+            best[1] = length
+
+    try:
+        count = node.get_child_count()
+    except Exception:
+        return best
+
+    for i in range(count):
+        try:
+            child = node.get_child_at_index(i)
+        except Exception:
+            continue
+        if child is None:
+            continue
+        _find_best_editable_descendant(child, best, depth + 1)
+
+    return best
+
+
+def _resolve_monitor_target(focused):
+    if focused is None:
+        return None
+    if _is_editable_field(focused):
+        return focused
+    best, _length = _find_best_editable_descendant(focused)
+    return best or focused
+
+
+def _dbus_get_bool(prop):
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        result = bus.call_sync(
+            "org.a11y.Bus",
+            "/org/a11y/bus",
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            GLib.Variant("(ss)", ("org.a11y.Status", prop)),
+            GLib.VariantType("(v)"),
+            Gio.DBusCallFlags.NONE,
+            1000,
+            None,
+        )
+        inner = result.unpack()[0]
+        return True, bool(inner)
+    except Exception:
+        return False, False
+
+
+def _dbus_set_bool(prop, value):
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        bus.call_sync(
+            "org.a11y.Bus",
+            "/org/a11y/bus",
+            "org.freedesktop.DBus.Properties",
+            "Set",
+            GLib.Variant("(ssv)", ("org.a11y.Status", prop, GLib.Variant("b", value))),
+            None,
+            Gio.DBusCallFlags.NONE,
+            1000,
+            None,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _restore_a11y_advertise():
+    if not _a11y_state["touched"]:
+        return
+    if _a11y_state["set_screen_reader"]:
+        _dbus_set_bool("ScreenReaderEnabled", _a11y_state["prior_screen_reader"])
+    if _a11y_state["set_is_enabled"]:
+        _dbus_set_bool("IsEnabled", _a11y_state["prior_is_enabled"])
+    _a11y_state["touched"] = False
+
+
+def _ensure_a11y_advertised():
+    have_sr, screen_reader = _dbus_get_bool("ScreenReaderEnabled")
+    have_en, is_enabled = _dbus_get_bool("IsEnabled")
+
+    if have_sr and not screen_reader and _dbus_set_bool("ScreenReaderEnabled", True):
+        _a11y_state["prior_screen_reader"] = False
+        _a11y_state["set_screen_reader"] = True
+        _a11y_state["touched"] = True
+
+    if have_en and not is_enabled and _dbus_set_bool("IsEnabled", True):
+        _a11y_state["prior_is_enabled"] = False
+        _a11y_state["set_is_enabled"] = True
+        _a11y_state["touched"] = True
+
+
+def _wake_probe_node(node, depth=0):
+    if node is None or depth > WAKE_PROBE_MAX_DEPTH:
+        return
+    try:
+        _ = node.get_attributes()
+    except Exception:
+        pass
+    try:
+        _ = node.get_relation_set()
+    except Exception:
+        pass
+
+    try:
+        count = node.get_child_count()
+    except Exception:
+        return
+
+    limit = count
+    if depth == 0 and limit > 8:
+        limit = 8
+    if depth > 0 and limit > 20:
+        limit = 20
+
+    for i in range(limit):
+        try:
+            child = node.get_child_at_index(i)
+        except Exception:
+            continue
+        if child is None:
+            continue
+        _wake_probe_node(child, depth + 1)
+
+
+def _wake_accessibility_trees(desktop):
+    try:
+        count = desktop.get_child_count()
+    except Exception:
+        return
+    for i in range(count):
+        try:
+            app = desktop.get_child_at_index(i)
+        except Exception:
+            continue
+        if app is None:
+            continue
+        _wake_probe_node(app, 0)
+
+
+def _find_focused_on_desktop(desktop):
+    focused = None
+    best_rank = -1
+    try:
+        count = desktop.get_child_count()
+    except Exception:
+        return None
+
+    for i in range(count):
+        try:
+            app = desktop.get_child_at_index(i)
+            if app is None:
+                continue
+            candidate, rank = _find_best_focused(app)
+            if candidate is not None and rank > best_rank:
+                focused = candidate
+                best_rank = rank
+            if best_rank >= 4:
+                break
+        except Exception:
+            continue
+
+    return _resolve_monitor_target(focused)
 
 
 def _emit_text(prefix, value):
@@ -75,59 +379,44 @@ def main():
         print("NO_ELEMENT", flush=True)
         sys.exit(1)
 
+    atexit.register(_restore_a11y_advertise)
     Atspi.init()
+    _ensure_a11y_advertised()
 
-    # Get the focused accessible element
     desktop = Atspi.get_desktop(0)
-    focused = None
+    _wake_accessibility_trees(desktop)
+    time.sleep(WAKE_SETTLE_MS / 1000.0)
 
-    # Search for the focused element across all applications
-    for i in range(desktop.get_child_count()):
-        try:
-            app = desktop.get_child_at_index(i)
-            if app is None:
-                continue
-            focused = _find_focused(app)
-            if focused is not None:
-                break
-        except Exception:
-            continue
+    focused = None
+    for attempt in range(FIND_RETRIES):
+        focused = _find_focused_on_desktop(desktop)
+        if focused is not None:
+            break
+        if attempt + 1 < FIND_RETRIES:
+            _wake_accessibility_trees(desktop)
+            time.sleep(FIND_RETRY_DELAY_MS / 1000.0)
 
     if focused is None:
         print("NO_ELEMENT", flush=True)
         sys.exit(1)
 
-    # Check if the element supports the Text interface
-    try:
-        text_iface = focused.get_text_iface()
-        if text_iface is None:
-            print("NO_VALUE", flush=True)
-            sys.exit(0)
-    except Exception:
+    initial_value = _read_effective_text(focused)
+    if not initial_value:
         print("NO_VALUE", flush=True)
         sys.exit(0)
 
-    # Read initial value
-    try:
-        char_count = text_iface.get_character_count()
-        initial_value = text_iface.get_text(0, min(char_count, MAX_OUTPUT_CHARS))
-        _emit_text("INITIAL_VALUE", initial_value)
-    except Exception:
-        print("NO_VALUE", flush=True)
-        sys.exit(0)
+    _emit_text("INITIAL_VALUE", initial_value)
 
-    # Set up event listener for text changes
     last_value = [initial_value]
     loop = GLib.MainLoop()
 
-    def on_text_changed(event):
+    def on_text_changed(_event):
+        # Re-read effective text from the captured focused entry — Chromium
+        # fires text-changed on descendant static/section nodes, not the entry.
         try:
-            source = event.source
-            ti = source.get_text_iface()
-            if ti is None:
+            new_value = _read_effective_text(focused)
+            if not new_value:
                 return
-            cc = ti.get_character_count()
-            new_value = ti.get_text(0, min(cc, MAX_OUTPUT_CHARS))
             if new_value != last_value[0]:
                 last_value[0] = new_value
                 _emit_text("CHANGED", new_value)
@@ -141,16 +430,16 @@ def main():
         on_text_changed, "object:text-changed:delete"
     )
 
-    # Set up timeout
     def timeout_handler():
         loop.quit()
+
     timer = threading.Timer(TIMEOUT_SECONDS, timeout_handler)
     timer.daemon = True
     timer.start()
 
-    # Handle SIGTERM
     def sigterm_handler(signum, frame):
         loop.quit()
+
     signal.signal(signal.SIGTERM, sigterm_handler)
     signal.signal(signal.SIGINT, sigterm_handler)
 

--- a/scripts/build-linux-text-monitor.js
+++ b/scripts/build-linux-text-monitor.js
@@ -121,9 +121,11 @@ function getPkgConfigFlags() {
 
     // atspi-2.pc lists gobject-2.0 under Requires.private, so plain --libs
     // omits -lgobject-2.0; add it explicitly for --as-needed linkers.
+    // gio is required for org.a11y.Status advertise (g_bus_get_sync).
     return [
       ...result.stdout.toString().trim().split(/\s+/).filter(Boolean),
       "-lgobject-2.0",
+      "-lgio-2.0",
     ];
   } catch {
     return null;

--- a/src/utils/correctionLearner.js
+++ b/src/utils/correctionLearner.js
@@ -184,8 +184,7 @@ function extractCorrections(originalText, fieldValue, existingDictionary) {
     // Single-word: keep the strict phonetic gate. Multi-word name fixes often
     // have one close pair and one looser pair — gate on the block average so
     // "Shunade Byrn" → "Sinead Byrne" can learn both.
-    const gate =
-      block.length === 1 ? ratios[0] : ratios.reduce((a, b) => a + b, 0) / ratios.length;
+    const gate = block.length === 1 ? ratios[0] : ratios.reduce((a, b) => a + b, 0) / ratios.length;
     // 0.65 threshold allows phonetic corrections like "Shunade" → "Sinead" (dist 4/7 = 0.57)
     // while filtering out unrelated word replacements.
     if (gate > 0.65) continue;

--- a/src/utils/correctionLearner.js
+++ b/src/utils/correctionLearner.js
@@ -79,8 +79,10 @@ function findEditedRegion(originalText, fieldValue) {
   return fieldWords.slice(bestStart, bestStart + windowSize).join(" ");
 }
 
-/** Word-level LCS to find [originalWord, editedWord] substitution pairs. */
-function findSubstitutions(origWords, editedWords) {
+/** Word-level LCS to find substitution blocks: arrays of [originalWord, editedWord].
+ * A mismatched span often aligns as N deletes then N inserts; those are zipped
+ * into one block so multi-word name fixes stay paired. */
+function findSubstitutionBlocks(origWords, editedWords) {
   const m = origWords.length;
   const n = editedWords.length;
 
@@ -112,18 +114,35 @@ function findSubstitutions(origWords, editedWords) {
     }
   }
 
-  // Consecutive [origWord, null] + [null, editedWord] = substitution
-  const subs = [];
-  for (let k = 0; k < aligned.length - 1; k++) {
+  const blocks = [];
+  let k = 0;
+  while (k < aligned.length) {
     const [origW, editW] = aligned[k];
-    const [nextOrigW, nextEditW] = aligned[k + 1];
-
-    if (origW !== null && editW === null && nextOrigW === null && nextEditW !== null) {
-      subs.push([origW, nextEditW]);
+    if (origW !== null && editW !== null) {
+      k++;
+      continue;
     }
+
+    const deletes = [];
+    const inserts = [];
+    while (k < aligned.length) {
+      const [o, e] = aligned[k];
+      if (o !== null && e !== null) break;
+      if (o !== null && e === null) deletes.push(o);
+      else if (o === null && e !== null) inserts.push(e);
+      k++;
+    }
+
+    const paired = Math.min(deletes.length, inserts.length);
+    if (paired === 0) continue;
+    const block = [];
+    for (let p = 0; p < paired; p++) {
+      block.push([deletes[p], inserts[p]]);
+    }
+    blocks.push(block);
   }
 
-  return subs;
+  return blocks;
 }
 
 /**
@@ -146,8 +165,9 @@ function extractCorrections(originalText, fieldValue, existingDictionary) {
 
   if (origWords.length === 0 || editedWords.length === 0) return [];
 
+  const blocks = findSubstitutionBlocks(origWords, editedWords);
+  const subs = blocks.flat();
   // If more than 50% of words changed, this is a rewrite, not corrections
-  const subs = findSubstitutions(origWords, editedWords);
   if (subs.length > origWords.length * 0.5) return [];
 
   const safeDict = Array.isArray(existingDictionary) ? existingDictionary : [];
@@ -155,22 +175,32 @@ function extractCorrections(originalText, fieldValue, existingDictionary) {
   const seenCorrections = new Set();
   const results = [];
 
-  for (const [origWord, correctedWord] of subs) {
-    const normalizedCorrected = correctedWord.toLowerCase();
-
-    if (dictSet.has(normalizedCorrected)) continue;
-    if (seenCorrections.has(normalizedCorrected)) continue;
-    if (origWord.toLowerCase() === normalizedCorrected) continue;
-    if (correctedWord.length < 3) continue;
-
+  for (const block of blocks) {
+    const ratios = block.map(([origWord, correctedWord]) => {
+      const dist = editDistance(origWord.toLowerCase(), correctedWord.toLowerCase());
+      const maxLen = Math.max(origWord.length, correctedWord.length);
+      return maxLen === 0 ? 1 : dist / maxLen;
+    });
+    // Single-word: keep the strict phonetic gate. Multi-word name fixes often
+    // have one close pair and one looser pair — gate on the block average so
+    // "Shunade Byrn" → "Sinead Byrne" can learn both.
+    const gate =
+      block.length === 1 ? ratios[0] : ratios.reduce((a, b) => a + b, 0) / ratios.length;
     // 0.65 threshold allows phonetic corrections like "Shunade" → "Sinead" (dist 4/7 = 0.57)
     // while filtering out unrelated word replacements.
-    const dist = editDistance(origWord.toLowerCase(), correctedWord.toLowerCase());
-    const maxLen = Math.max(origWord.length, correctedWord.length);
-    if (dist / maxLen > 0.65) continue;
+    if (gate > 0.65) continue;
 
-    results.push(correctedWord);
-    seenCorrections.add(normalizedCorrected);
+    for (const [origWord, correctedWord] of block) {
+      const normalizedCorrected = correctedWord.toLowerCase();
+
+      if (dictSet.has(normalizedCorrected)) continue;
+      if (seenCorrections.has(normalizedCorrected)) continue;
+      if (origWord.toLowerCase() === normalizedCorrected) continue;
+      if (correctedWord.length < 3) continue;
+
+      results.push(correctedWord);
+      seenCorrections.add(normalizedCorrected);
+    }
   }
 
   return results;

--- a/test/helpers/correctionLearner.test.js
+++ b/test/helpers/correctionLearner.test.js
@@ -20,6 +20,29 @@ test("a phonetic mishearing fixed by the user is learned", () => {
   assert.ok(result.includes("Sinead"));
 });
 
+test("consecutive multi-word mishearings are learned as paired substitutions", () => {
+  // LCS aligns these as delete-block then insert-block; pairing must zip by
+  // position (Shunade→Sinead, Byrn→Byrne), not only adjacent delete+insert.
+  const result = extractCorrections(
+    "Hey Shunade Byrn how are you",
+    "Hey Sinead Byrne how are you",
+    []
+  );
+  assert.ok(result.includes("Sinead"), `expected Sinead in ${JSON.stringify(result)}`);
+  assert.ok(result.includes("Byrne"), `expected Byrne in ${JSON.stringify(result)}`);
+});
+
+test("two-word Irish name corrections are learned", () => {
+  const result = extractCorrections(
+    "Meeting with Sheona Walshe tomorrow",
+    "Meeting with Sinead Walsh tomorrow",
+    ["OpenWhispr"]
+  );
+  assert.ok(result.includes("Sinead"), `expected Sinead in ${JSON.stringify(result)}`);
+  assert.ok(result.includes("Walsh"), `expected Walsh in ${JSON.stringify(result)}`);
+});
+
+
 test("corrections already in the dictionary are not re-learned, case-insensitively", () => {
   const original = "Hey Shunade how are you";
   const edited = "Hey Sinead how are you";


### PR DESCRIPTION
## Summary

Auto-learn watches the text field after you paste a dictation, notices what you fix by hand, and adds those words to the custom dictionary. This PR makes that path more reliable on Linux.

Some Electron apps like Cursor and T3Code hide their accessibility tree by default making auto-learning impossible. Even in apps like Helium (Chromium) which DO expose a full accessibility tree, we were not latching on to the correct element in the tree, again making auto learning fail. I've introduced a fix that solves both these issues by 
1. Reading the AT-SPI2 tree correctly
2. Requesting full tree from electron apps via DBus protocols, and cleaning up afterwards.

I'm outlining my changes below:

### Read the real text in the focused field

Some apps (especially Chromium-based ones) put the draft in a child node while the focused control only reports a placeholder. We now follow that and read the text the user actually sees and edits.

<details>
<summary>Technical details</summary>

In `linux-text-monitor` (C + Python fallback), the focused node’s direct text is often only U+FFFC (object replacement) even when the control is focused and editable. We added `read_effective_text`: try the node’s own text interface, then walk editable/text-bearing descendants (bounded depth) and keep the longest usable string (ignoring ORC/whitespace-only). Polling and event handlers re-read through that helper so Chromium composers that rebuild child text nodes still surface corrections.

</details>

### Wake apps that hide their accessibility tree

Some Electron apps start with an almost empty accessibility tree, so we could not see edits at all. Before watching, we briefly signal that an accessibility client is present and poke the tree so the app publishes real controls—then we restore the previous setting if we changed it.

<details>
<summary>Technical details</summary>

On monitor start we best-effort read `org.a11y.Status` on the session bus (`IsEnabled`, `ScreenReaderEnabled`). If either is false, we set it true and remember the prior values for `atexit` restore. We then walk each AT-SPI application shallowly calling attribute and relation-set getters (the probes Chromium uses as a signal that a real AT is present), wait briefly for the tree to rebuild, and retry focused-field resolution a few times. This is what lets stub Electron apps (Hermes, Cursor Agents, t3code) expose editable fields without a relaunch. Compile links `-lgio-2.0` for the D-Bus Status calls.

</details>

### Prefer real text inputs over surrounding UI

When focus sits on a big page/document chrome node, we look for an editable input underneath (the composer) instead of learning from unrelated UI text.

<details>
<summary>Technical details</summary>

Focused-field ranking now prefers editable + usable effective text over merely-focused document nodes that happen to have usable descendant chrome (notifications, etc.). After picking the best focused node, if it is not editable we resolve to the best editable descendant with usable text before monitoring. Early-exit only happens once we have an editable+usable match, so an empty focused entry does not hide a better sibling composer.

</details>

### Learn multi-word corrections

Edits like turning a misheard two-word name into the right two words were dropped by the old matcher. We now pair those word-for-word so both corrected words can land in the dictionary.

<details>
<summary>Technical details</summary>

In `correctionLearner`, word-level LCS alignment emits a mismatched span as a delete-block then an insert-block. The old code only paired a single adjacent delete+insert edge, which mismatched multi-word name fixes and failed the phonetic distance gate. We now zip equal-length delete/insert runs into substitution blocks. Single-word blocks still use per-pair edit-distance ≤ 0.65; multi-word blocks gate on the **average** ratio so one close pair can carry a looser sibling (typical for two-word names). Unchanged: rewrite detection (>50% of words substituted), short-word filter, and dictionary dedupe.

</details>

### Build note

Compiling the Linux text-monitor helper also links GIO, which the wake step needs.

<details>
<summary>Technical details</summary>

`scripts/build-linux-text-monitor.js` adds `-lgio-2.0` alongside the existing explicit `-lgobject-2.0` when invoking `pkg-config` flags. Download-first vs compile-first policy is unchanged from main; only the link line grew for the new D-Bus Status code.

</details>

## New behaviors / conceptual changes

- **Effective text, not just the focused node’s string.** Auto-learn’s Linux monitor treats “what’s in the field” as a small subtree read, not a single AT-SPI text interface call.
- **Accessibility wake is part of monitoring.** Starting a watch may temporarily advertise assistive-tech status session-wide, then restore it—monitoring is no longer purely passive for Electron stubs.
- **Composer targeting over document focus.** The monitor may attach to an editable descendant when focus is on page chrome.
- **Multi-word substitution blocks.** Correction learning models consecutive name-like edits as zipped pairs with a block-level similarity gate, not only one-word phonetic swaps.

## Test plan

- [x] Browser (e.g. Helium / Zen): dictate, fix a word or two, confirm the dictionary updates
- [x] Electron app (e.g. Cursor Agents, Hermes, t3code): same flow after restarting OpenWhispr with a freshly built Linux text-monitor
- [x] Native app (e.g. Kate): still learns corrections; no regression
- [x] A two-word name-style fix is learned (not only single-word typos)
- [x] If the monitor turned accessibility signaling on, it turns it back off when it exits

## What this doesn't fix

Terminal apps like Ghostty and entry boxes in widget systems like Quickshell still expose either no AT-SPI2 tree or an illegible one, making learning in these apps impossible.