### PR TITLE
fix(linux): treat Ptyxis and GNOME Console as terminals for paste

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -352,7 +352,8 @@ static const char *terminal_classes[] = {
     "konsole", "gnome-terminal", "terminal", "kitty", "alacritty",
     "terminator", "xterm", "urxvt", "rxvt", "tilix", "terminology",
     "wezterm", "foot", "st", "yakuake", "ghostty", "guake", "tilda",
-    "hyper", "tabby", "sakura", "warp", "termius", "waveterm", NULL
+    "hyper", "tabby", "sakura", "warp", "termius", "waveterm",
+    "ptyxis", "kgx", "org.gnome.console", NULL
 };
 
 static int is_terminal(const char *wm_class) {

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -89,6 +89,9 @@ const LINUX_TERMINAL_CLASSES = [
   "warp",
   "termius",
   "waveterm",
+  "ptyxis",
+  "kgx",
+  "org.gnome.console",
 ];
 
 // macOS reports localized app names rather than window classes, and iTerm2 has

--- a/test/helpers/linuxTerminalClasses.test.js
+++ b/test/helpers/linuxTerminalClasses.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const clipboardModulePath = require.resolve("../../src/helpers/clipboard");
+const originalLoad = Module._load;
+
+function loadClipboardManager() {
+  delete require.cache[clipboardModulePath];
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        clipboard: {
+          readText() {
+            return "";
+          },
+          writeText() {},
+        },
+        systemPreferences: { isTrustedAccessibilityClient: () => true },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    return require("../../src/helpers/clipboard");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+const ClipboardManager = loadClipboardManager();
+
+test("Ptyxis and GNOME Console window classes are terminals", () => {
+  const clipboard = new ClipboardManager();
+  assert.equal(clipboard.isLinuxTerminalWindowClass("org.gnome.Ptyxis"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("ptyxis"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("org.gnome.Console"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("kgx"), true);
+});
+
+test("existing terminals still match", () => {
+  const clipboard = new ClipboardManager();
+  assert.equal(clipboard.isLinuxTerminalWindowClass("kitty"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("ghostty"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("gnome-terminal"), true);
+});
+
+test("ordinary GUI apps are not terminals", () => {
+  const clipboard = new ClipboardManager();
+  assert.equal(clipboard.isLinuxTerminalWindowClass("Code"), false);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("firefox"), false);
+  assert.equal(clipboard.isLinuxTerminalWindowClass(""), false);
+  assert.equal(clipboard.isLinuxTerminalWindowClass(null), false);
+});


### PR DESCRIPTION
## Summary

- Classify Ptyxis and GNOME Console as terminals so auto-paste uses Ctrl+Shift+V.
- Keep the JS and native `linux-fast-paste` class lists in sync.

## Problem

Ubuntu 24.10+ and current GNOME default to Ptyxis (`org.gnome.Ptyxis`) or GNOME Console (`org.gnome.Console` / `kgx`). Neither window class matched `LINUX_TERMINAL_CLASSES` / `terminal_classes`, so dictation paste was sent as Ctrl+V and did not insert in the terminal.

## Root cause

The terminal class lists include Ghostty, WezTerm, Kitty, etc., but not the current GNOME/Ubuntu defaults. Matching is substring-based (`includes` / `strcasestr`), so `org.gnome.Ptyxis` would match `ptyxis` once listed; `org.gnome.Console` does not contain `terminal`.

## Fix

- Add `ptyxis`, `kgx`, and `org.gnome.console` to `src/helpers/clipboard.js` and `resources/linux-fast-paste.c`.

## Behavior before / after

| Window class | Before | After |
| --- | --- | --- |
| `org.gnome.Ptyxis` | GUI paste (Ctrl+V) | terminal paste (Ctrl+Shift+V) |
| `kgx` / `org.gnome.Console` | GUI paste | terminal paste |
| `kitty` / `ghostty` | terminal paste | terminal paste |
| `Code` / `firefox` | GUI paste | GUI paste |

## Scope / non-goals

- In scope: terminal class lists and classification tests.
- Out of scope: Wayland portal paste, ydotool, layout-specific keycodes.

## Tests added

- Ptyxis and GNOME Console ids match
- existing terminals still match
- ordinary GUI apps do not match

## Validation

```text
ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/linuxTerminalClasses.test.js
# 3 pass, 0 fail

npx prettier --write src/helpers/clipboard.js test/helpers/linuxTerminalClasses.test.js
git diff --check
# clean
```

## Platform / environment limitations

- Native C helper is not compiled in this unit test; the JS matcher is the same class list the C source documents as needing to stay in sync.

Fixes #1656