### PR TITLE
fix(reasoning): make the non-streaming request timeout configurable — fixes #1479

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -141,6 +141,13 @@ export const MODEL_CONSTRAINTS = {
 // List length above which pickers switch to a searchable variant.
 export const LIST_SEARCH_THRESHOLD = 12;
 
+// Reasoning request timeouts (ms). REASONING is the non-streaming default and
+// can be overridden per-install via the reasoningTimeoutMs setting (0 = default).
+export const REQUEST_TIMEOUTS = {
+  REASONING: 30000,
+  REASONING_STREAMING: 60000,
+} as const;
+
 // Token Limits
 export const TOKEN_LIMITS = {
   MIN_TOKENS: 512,

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -9,7 +9,14 @@ import {
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy, httpError } from "../utils/retry";
-import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, ensureV1Suffix } from "../config/constants";
+import {
+  API_ENDPOINTS,
+  REQUEST_TIMEOUTS,
+  TOKEN_LIMITS,
+  buildApiUrl,
+  ensureV1Suffix,
+} from "../config/constants";
+import { resolveReasoningTimeoutMs } from "../utils/reasoningTimeout";
 import logger from "../utils/logger";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
 import { wrapCleanupTranscript } from "../config/prompts";
@@ -308,9 +315,10 @@ class ReasoningService extends BaseReasoningService {
       requestBody: JSON.stringify(requestBody).substring(0, 200),
     });
 
+    const timeoutMs = resolveReasoningTimeoutMs(getSettings().reasoningTimeoutMs);
     const response = await withRetry(async () => {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 30000);
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
       try {
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
@@ -369,7 +377,7 @@ class ReasoningService extends BaseReasoningService {
         return jsonResponse;
       } catch (error) {
         if ((error as Error).name === "AbortError") {
-          throw new Error("Request timed out after 30s");
+          throw new Error(`Request timed out after ${Math.round(timeoutMs / 1000)}s`);
         }
         throw error;
       } finally {
@@ -587,7 +595,7 @@ class ReasoningService extends BaseReasoningService {
 
     this.streamAbortController = new AbortController();
     const controller = this.streamAbortController;
-    const timeoutId = setTimeout(() => controller.abort(), 60000);
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUTS.REASONING_STREAMING);
 
     let response: Response;
     try {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -296,6 +296,7 @@ const ARRAY_SETTINGS = new Set([
 
 const NUMERIC_SETTINGS = new Set([
   "micWarmHoldSeconds",
+  "reasoningTimeoutMs",
   "audioRetentionDays",
   "transcriptRetentionDays",
   "whisperVadThreshold",
@@ -597,6 +598,8 @@ export interface SettingsState
   dictationSileroEnabled: boolean;
   noteRecordingSileroEnabled: boolean;
   meetingSileroEnabled: boolean;
+  /** Non-streaming reasoning request timeout override in ms; 0 = built-in default (#1479). */
+  reasoningTimeoutMs: number;
   whisperVadThreshold: number;
   whisperVadMinSpeechDurationMs: number;
   whisperVadMinSilenceDurationMs: number;
@@ -873,6 +876,7 @@ export interface SettingsState
   setTheme: (value: "light" | "dark" | "auto") => void;
   setCloudBackupEnabled: (value: boolean) => void;
   setTelemetryEnabled: (value: boolean) => void;
+  setReasoningTimeoutMs: (ms: number) => void;
   setAudioRetentionDays: (days: number) => void;
   setTranscriptRetentionDays: (days: number) => void;
   setDataRetentionEnabled: (value: boolean) => void;
@@ -1271,6 +1275,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   cloudBackupEnabled: readBoolean("cloudBackupEnabled", false),
   telemetryEnabled: readBoolean("telemetryEnabled", false),
+  reasoningTimeoutMs: readNumber("reasoningTimeoutMs", 0),
   audioRetentionDays: readNumber("audioRetentionDays", 30),
   transcriptRetentionDays: readNumber("transcriptRetentionDays", 0),
   dataRetentionEnabled: readBoolean("dataRetentionEnabled", true),
@@ -2006,6 +2011,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     if (isBrowser) localStorage.setItem("micWarmHoldSeconds", String(snapped));
     set({ micWarmHoldSeconds: snapped });
   },
+  setReasoningTimeoutMs: createNumberSetter("reasoningTimeoutMs"),
   setAudioRetentionDays: createNumberSetter("audioRetentionDays"),
   setTranscriptRetentionDays: createNumberSetter("transcriptRetentionDays"),
   setDataRetentionEnabled: (value: boolean) => {

--- a/src/utils/reasoningTimeout.ts
+++ b/src/utils/reasoningTimeout.ts
@@ -1,0 +1,10 @@
+import { REQUEST_TIMEOUTS } from "../config/constants";
+
+// Resolves the non-streaming reasoning request timeout. A positive
+// reasoningTimeoutMs setting wins; anything else (0, unset, NaN, negative)
+// falls back to the default so a hand-edited localStorage value can never
+// disable the timeout entirely.
+export function resolveReasoningTimeoutMs(reasoningTimeoutMs: unknown): number {
+  const value = Number(reasoningTimeoutMs);
+  return Number.isFinite(value) && value > 0 ? value : REQUEST_TIMEOUTS.REASONING;
+}

--- a/test/utils/reasoningTimeout.test.js
+++ b/test/utils/reasoningTimeout.test.js
@@ -1,0 +1,28 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// #1479: the non-streaming reasoning timeout was hardcoded to 30s, aborting
+// note formatting / cleanup / translation on local models that need 35-46s.
+// resolveReasoningTimeoutMs makes it configurable via the reasoningTimeoutMs
+// setting while keeping a safe default.
+
+test("falls back to the 30s default when the setting is unset", async () => {
+  const { resolveReasoningTimeoutMs } = await import("../../src/utils/reasoningTimeout.ts");
+  const { REQUEST_TIMEOUTS } = await import("../../src/config/constants.ts");
+  assert.equal(resolveReasoningTimeoutMs(undefined), REQUEST_TIMEOUTS.REASONING);
+  assert.equal(REQUEST_TIMEOUTS.REASONING, 30000);
+});
+
+test("falls back to the default for 0, negative, and non-numeric values", async () => {
+  const { resolveReasoningTimeoutMs } = await import("../../src/utils/reasoningTimeout.ts");
+  const { REQUEST_TIMEOUTS } = await import("../../src/config/constants.ts");
+  for (const value of [0, -1, NaN, Infinity, "abc", null]) {
+    assert.equal(resolveReasoningTimeoutMs(value), REQUEST_TIMEOUTS.REASONING);
+  }
+});
+
+test("honors a positive override so local-model formatting can exceed 30s", async () => {
+  const { resolveReasoningTimeoutMs } = await import("../../src/utils/reasoningTimeout.ts");
+  assert.equal(resolveReasoningTimeoutMs(120000), 120000);
+  assert.equal(resolveReasoningTimeoutMs("90000"), 90000);
+});


### PR DESCRIPTION
Closes #1479

`callChatCompletionsApi` aborted every non-streaming reasoning request at a hardcoded 30s. Note formatting on local models takes 35-46s at healthy throughput (measurements in the issue), so results were reliably lost while the model was still working.

## Changes

- New `REQUEST_TIMEOUTS` in `src/config/constants.ts` (`REASONING: 30000`, `REASONING_STREAMING: 60000`); both literals in `ReasoningService` now read from it (streaming behavior unchanged).
- New `reasoningTimeoutMs` setting (numeric, localStorage-synced, 0 = default). `resolveReasoningTimeoutMs()` guards 0/NaN/negative/Infinity so the timeout can never be disabled by a bad value.
- Timeout error message reports the actual limit instead of a fixed "30s".
- No UI yet — the issue asked for the settings field + constant; a settings row can follow if wanted.

## Test

- `test/utils/reasoningTimeout.test.js`: fails on `main` (3/3, module absent), passes here.
- Full suite: pre-existing failures unchanged vs clean `main`; +3 tests, +3 passes. `npm run typecheck` clean, eslint clean on touched files.
- How to test: `node --import tsx --test test/utils/reasoningTimeout.test.js`; or set `localStorage.reasoningTimeoutMs = "120000"` and format a long note on a local model — the request is no longer cut off at 30s.