### PR TITLE
fix(updater): stop automatic update checks when the App updates toggle is off — fixes #1605

### DIFF
--- a/src/helpers/updateCheckPolicy.js
+++ b/src/helpers/updateCheckPolicy.js
@@ -1,17 +1,8 @@
-// App-update policy, kept free of Electron so it can be unit-tested.
-//
-// One predicate backs both update gates in updater.js so they cannot drift:
-// the automatic checks (startup timer, periodic timer) and the update-available
-// popup. The "App updates" toggle (notifyUpdates) gates the checks themselves,
-// not just the notification they produce: with the toggle off the app must not
-// reach out to the update feed, and a background check that never runs can
-// never surface a connection error dialog on offline or firewalled machines
-// (#1605). A manual "Check for updates" from Settings is an explicit user
-// action and is never gated here.
-//
-// Same tri-state convention as the other notification prefs: only an explicit
-// false disables. An empty or partial prefs object (renderer sync not arrived
-// yet) keeps today's check-by-default behavior.
+// The "App updates" toggle gates the automatic checks themselves, not just the
+// popup: with it off the app must not reach the update feed, so offline or
+// firewalled machines never surface a connection error dialog (#1605).
+// Only an explicit false disables — missing prefs (renderer sync not arrived
+// yet) keep check-by-default behavior.
 function appUpdatesEnabled({ notificationsEnabled, notifyUpdates } = {}) {
   return notificationsEnabled !== false && notifyUpdates !== false;
 }

--- a/src/helpers/updateCheckPolicy.js
+++ b/src/helpers/updateCheckPolicy.js
@@ -1,18 +1,19 @@
-// Automatic update-check decisions, kept free of Electron so they can be
-// unit-tested.
+// App-update policy, kept free of Electron so it can be unit-tested.
 //
-// The "App updates" toggle (notifyUpdates) gates the automatic checks
-// themselves, not just the notification they produce: with the toggle off the
-// app must not reach out to the update feed at startup or on the periodic
-// timer, and a background check that never runs can never surface a connection
-// error dialog on offline or firewalled machines (#1605). A manual "Check for
-// updates" from Settings is an explicit user action and is never gated here.
+// One predicate backs both update gates in updater.js so they cannot drift:
+// the automatic checks (startup timer, periodic timer) and the update-available
+// popup. The "App updates" toggle (notifyUpdates) gates the checks themselves,
+// not just the notification they produce: with the toggle off the app must not
+// reach out to the update feed, and a background check that never runs can
+// never surface a connection error dialog on offline or firewalled machines
+// (#1605). A manual "Check for updates" from Settings is an explicit user
+// action and is never gated here.
 //
-// Prefs default to enabled: an empty or partial prefs object (renderer sync
-// not arrived yet) keeps today's check-by-default behavior.
-function shouldAutoCheckForUpdates(prefs) {
-  const p = prefs || {};
-  return p.notificationsEnabled !== false && p.notifyUpdates !== false;
+// Same tri-state convention as the other notification prefs: only an explicit
+// false disables. An empty or partial prefs object (renderer sync not arrived
+// yet) keeps today's check-by-default behavior.
+function appUpdatesEnabled({ notificationsEnabled, notifyUpdates } = {}) {
+  return notificationsEnabled !== false && notifyUpdates !== false;
 }
 
-module.exports = { shouldAutoCheckForUpdates };
+module.exports = { appUpdatesEnabled };

--- a/src/helpers/updateCheckPolicy.js
+++ b/src/helpers/updateCheckPolicy.js
@@ -1,0 +1,18 @@
+// Automatic update-check decisions, kept free of Electron so they can be
+// unit-tested.
+//
+// The "App updates" toggle (notifyUpdates) gates the automatic checks
+// themselves, not just the notification they produce: with the toggle off the
+// app must not reach out to the update feed at startup or on the periodic
+// timer, and a background check that never runs can never surface a connection
+// error dialog on offline or firewalled machines (#1605). A manual "Check for
+// updates" from Settings is an explicit user action and is never gated here.
+//
+// Prefs default to enabled: an empty or partial prefs object (renderer sync
+// not arrived yet) keeps today's check-by-default behavior.
+function shouldAutoCheckForUpdates(prefs) {
+  const p = prefs || {};
+  return p.notificationsEnabled !== false && p.notifyUpdates !== false;
+}
+
+module.exports = { shouldAutoCheckForUpdates };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,5 +1,5 @@
 const { autoUpdater } = require("electron-updater");
-const { shouldAutoCheckForUpdates } = require("./helpers/updateCheckPolicy");
+const { appUpdatesEnabled } = require("./helpers/updateCheckPolicy");
 
 class UpdateManager {
   constructor() {
@@ -87,9 +87,7 @@ class UpdateManager {
           };
         }
         this.notifyRenderers("update-available", info);
-        const nPrefs = this.windowManager?.notificationPrefs || {};
-        const notifAllowed =
-          nPrefs.notificationsEnabled !== false && nPrefs.notifyUpdates !== false;
+        const notifAllowed = appUpdatesEnabled(this.windowManager?.notificationPrefs);
         if (this.windowManager && info && !this._suppressNotification && notifAllowed) {
           this.windowManager.showUpdateNotification(info).catch((err) => {
             console.error("Failed to show update notification:", err);
@@ -305,7 +303,7 @@ class UpdateManager {
   // Prefs are read at fire time, not scheduling time, so flipping the
   // "App updates" toggle takes effect without a restart (#1605).
   _autoCheckForUpdates(label) {
-    if (!shouldAutoCheckForUpdates(this.windowManager?.notificationPrefs)) {
+    if (!appUpdatesEnabled(this.windowManager?.notificationPrefs)) {
       console.log(`⏭️ ${label} update check skipped (app updates disabled)`);
       return;
     }

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,4 +1,5 @@
 const { autoUpdater } = require("electron-updater");
+const { shouldAutoCheckForUpdates } = require("./helpers/updateCheckPolicy");
 
 class UpdateManager {
   constructor() {
@@ -301,21 +302,28 @@ class UpdateManager {
     }
   }
 
+  // Prefs are read at fire time, not scheduling time, so flipping the
+  // "App updates" toggle takes effect without a restart (#1605).
+  _autoCheckForUpdates(label) {
+    if (!shouldAutoCheckForUpdates(this.windowManager?.notificationPrefs)) {
+      console.log(`⏭️ ${label} update check skipped (app updates disabled)`);
+      return;
+    }
+    console.log(`🔄 ${label} update check...`);
+    autoUpdater.checkForUpdates().catch((err) => {
+      console.error(`${label} update check failed:`, err);
+    });
+  }
+
   checkForUpdatesOnStartup() {
     if (process.env.NODE_ENV !== "development") {
       setTimeout(() => {
-        console.log("🔄 Checking for updates on startup...");
-        autoUpdater.checkForUpdates().catch((err) => {
-          console.error("Startup update check failed:", err);
-        });
+        this._autoCheckForUpdates("Startup");
       }, 3000);
 
       const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
       this.updateCheckInterval = setInterval(() => {
-        console.log("🔄 Periodic update check...");
-        autoUpdater.checkForUpdates().catch((err) => {
-          console.error("Periodic update check failed:", err);
-        });
+        this._autoCheckForUpdates("Periodic");
       }, FOUR_HOURS_MS);
     }
   }

--- a/test/helpers/updateCheckPolicy.test.js
+++ b/test/helpers/updateCheckPolicy.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/updateCheckPolicy.js");
+
+test("the App updates toggle gates automatic checks, not just the popup", async () => {
+  const { shouldAutoCheckForUpdates } = await load();
+
+  // Regression guard for #1605: with the toggle off, the app kept hitting the
+  // update feed at startup and every 4 hours, and offline machines surfaced
+  // the resulting connection errors as dialogs when Settings opened.
+  assert.equal(shouldAutoCheckForUpdates({ notifyUpdates: false }), false);
+  assert.equal(
+    shouldAutoCheckForUpdates({ notificationsEnabled: true, notifyUpdates: false }),
+    false
+  );
+});
+
+test("the master notifications switch also disables automatic checks", async () => {
+  const { shouldAutoCheckForUpdates } = await load();
+
+  assert.equal(
+    shouldAutoCheckForUpdates({ notificationsEnabled: false, notifyUpdates: true }),
+    false
+  );
+});
+
+test("checks stay enabled by default before renderer prefs arrive", async () => {
+  const { shouldAutoCheckForUpdates } = await load();
+
+  // Same tri-state convention as the notification gate in updater.js: only an
+  // explicit false disables; missing prefs keep check-by-default behavior.
+  assert.equal(shouldAutoCheckForUpdates(undefined), true);
+  assert.equal(shouldAutoCheckForUpdates({}), true);
+  assert.equal(
+    shouldAutoCheckForUpdates({ notificationsEnabled: true, notifyUpdates: true }),
+    true
+  );
+});

--- a/test/helpers/updateCheckPolicy.test.js
+++ b/test/helpers/updateCheckPolicy.test.js
@@ -4,36 +4,27 @@ const assert = require("node:assert/strict");
 const load = () => import("../../src/helpers/updateCheckPolicy.js");
 
 test("the App updates toggle gates automatic checks, not just the popup", async () => {
-  const { shouldAutoCheckForUpdates } = await load();
+  const { appUpdatesEnabled } = await load();
 
   // Regression guard for #1605: with the toggle off, the app kept hitting the
   // update feed at startup and every 4 hours, and offline machines surfaced
   // the resulting connection errors as dialogs when Settings opened.
-  assert.equal(shouldAutoCheckForUpdates({ notifyUpdates: false }), false);
-  assert.equal(
-    shouldAutoCheckForUpdates({ notificationsEnabled: true, notifyUpdates: false }),
-    false
-  );
+  assert.equal(appUpdatesEnabled({ notifyUpdates: false }), false);
+  assert.equal(appUpdatesEnabled({ notificationsEnabled: true, notifyUpdates: false }), false);
 });
 
 test("the master notifications switch also disables automatic checks", async () => {
-  const { shouldAutoCheckForUpdates } = await load();
+  const { appUpdatesEnabled } = await load();
 
-  assert.equal(
-    shouldAutoCheckForUpdates({ notificationsEnabled: false, notifyUpdates: true }),
-    false
-  );
+  assert.equal(appUpdatesEnabled({ notificationsEnabled: false, notifyUpdates: true }), false);
 });
 
 test("checks stay enabled by default before renderer prefs arrive", async () => {
-  const { shouldAutoCheckForUpdates } = await load();
+  const { appUpdatesEnabled } = await load();
 
-  // Same tri-state convention as the notification gate in updater.js: only an
+  // Same tri-state convention as the other notification prefs: only an
   // explicit false disables; missing prefs keep check-by-default behavior.
-  assert.equal(shouldAutoCheckForUpdates(undefined), true);
-  assert.equal(shouldAutoCheckForUpdates({}), true);
-  assert.equal(
-    shouldAutoCheckForUpdates({ notificationsEnabled: true, notifyUpdates: true }),
-    true
-  );
+  assert.equal(appUpdatesEnabled(undefined), true);
+  assert.equal(appUpdatesEnabled({}), true);
+  assert.equal(appUpdatesEnabled({ notificationsEnabled: true, notifyUpdates: true }), true);
 });

--- a/test/helpers/updater.test.js
+++ b/test/helpers/updater.test.js
@@ -1,0 +1,211 @@
+const test = require("node:test");
+const { afterEach, beforeEach } = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+// UpdateManager no-ops in development; pin the env so a developer shell with
+// NODE_ENV=development cannot turn every assertion below into a false pass.
+process.env.NODE_ENV = "test";
+
+const updaterModulePath = require.resolve("../../src/updater.js");
+const originalLoad = Module._load;
+
+const STARTUP_DELAY_MS = 3000;
+const PERIODIC_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+// Builds a fake electron-updater whose checkForUpdates records each call and,
+// when `offline` is set, behaves like a machine with no network: it emits the
+// `error` event on the updater (as electron-updater does) and rejects.
+function makeAutoUpdater({ offline = false } = {}) {
+  const listeners = {};
+  const autoUpdater = {
+    calls: 0,
+    listeners,
+    setFeedURL() {},
+    on(event, handler) {
+      listeners[event] = handler;
+    },
+    removeListener() {},
+    checkForUpdates() {
+      autoUpdater.calls += 1;
+      if (offline) {
+        const error = new Error("net::ERR_INTERNET_DISCONNECTED");
+        listeners.error?.(error);
+        return Promise.reject(error);
+      }
+      return Promise.resolve({ isUpdateAvailable: false });
+    },
+  };
+  return autoUpdater;
+}
+
+// UpdateManager requires electron lazily — in the constructor
+// (before-quit-for-update hook), in cleanup(), and on Intel Macs child_process
+// (Rosetta probe) — so the mocks stay installed for the whole test and are
+// restored in afterEach rather than right after the module load.
+function createUpdateManager(autoUpdater) {
+  delete require.cache[updaterModulePath];
+  Module._load = function loadWithMocks(request, parent, isMain) {
+    if (request === "electron-updater") return { autoUpdater };
+    if (request === "electron") return { autoUpdater: { on() {}, removeListener() {} } };
+    if (request === "child_process") return { execSync: () => "0" };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  const UpdateManager = require(updaterModulePath);
+  return new UpdateManager();
+}
+
+function makeRendererWindow(sent) {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      send(channel) {
+        sent.push(channel);
+      },
+    },
+  };
+}
+
+beforeEach((t) => {
+  t.mock.method(console, "log", () => {});
+  t.mock.method(console, "error", () => {});
+});
+
+afterEach(() => {
+  Module._load = originalLoad;
+});
+
+test("with App updates off, startup and periodic checks never reach the update feed", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+  const autoUpdater = makeAutoUpdater();
+  const manager = createUpdateManager(autoUpdater);
+  manager.setWindowManager({
+    notificationPrefs: { notificationsEnabled: true, notifyUpdates: false },
+  });
+
+  manager.checkForUpdatesOnStartup();
+  t.mock.timers.tick(STARTUP_DELAY_MS);
+  assert.equal(autoUpdater.calls, 0, "startup check must be skipped");
+  t.mock.timers.tick(PERIODIC_INTERVAL_MS);
+  assert.equal(autoUpdater.calls, 0, "periodic check must be skipped");
+
+  manager.cleanup();
+});
+
+test("with App updates on, startup and periodic checks run as before", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+  const autoUpdater = makeAutoUpdater();
+  const manager = createUpdateManager(autoUpdater);
+  manager.setWindowManager({
+    notificationPrefs: { notificationsEnabled: true, notifyUpdates: true },
+  });
+
+  manager.checkForUpdatesOnStartup();
+  t.mock.timers.tick(STARTUP_DELAY_MS);
+  assert.equal(autoUpdater.calls, 1);
+  t.mock.timers.tick(PERIODIC_INTERVAL_MS);
+  assert.equal(autoUpdater.calls, 2);
+
+  manager.cleanup();
+});
+
+test("prefs are read at fire time, so toggling App updates takes effect without a restart", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+  const autoUpdater = makeAutoUpdater();
+  const manager = createUpdateManager(autoUpdater);
+  // sync-notification-preferences mutates this object in place; the timers
+  // were scheduled while the toggle was off.
+  const windowManager = {
+    notificationPrefs: { notificationsEnabled: true, notifyUpdates: false },
+  };
+  manager.setWindowManager(windowManager);
+  manager.checkForUpdatesOnStartup();
+  t.mock.timers.tick(STARTUP_DELAY_MS);
+  assert.equal(autoUpdater.calls, 0);
+
+  windowManager.notificationPrefs.notifyUpdates = true;
+  t.mock.timers.tick(PERIODIC_INTERVAL_MS);
+  assert.equal(autoUpdater.calls, 1, "next periodic tick runs once re-enabled");
+
+  windowManager.notificationPrefs.notifyUpdates = false;
+  t.mock.timers.tick(PERIODIC_INTERVAL_MS);
+  assert.equal(autoUpdater.calls, 1, "and is skipped again once disabled");
+
+  manager.cleanup();
+});
+
+test("before renderer prefs arrive, checks keep today's check-by-default behavior", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+  const autoUpdater = makeAutoUpdater();
+  const manager = createUpdateManager(autoUpdater);
+
+  manager.checkForUpdatesOnStartup();
+  t.mock.timers.tick(STARTUP_DELAY_MS);
+  assert.equal(autoUpdater.calls, 1);
+
+  manager.cleanup();
+});
+
+test("a manual Check for Updates is never gated by the toggle", async () => {
+  const autoUpdater = makeAutoUpdater();
+  const manager = createUpdateManager(autoUpdater);
+  manager.setWindowManager({
+    notificationPrefs: { notificationsEnabled: false, notifyUpdates: false },
+  });
+
+  const result = await manager.checkForUpdates();
+
+  assert.equal(autoUpdater.calls, 1);
+  assert.equal(result.updateAvailable, false);
+});
+
+test("offline with App updates off, no update-error reaches the renderers (#1605)", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+  const autoUpdater = makeAutoUpdater({ offline: true });
+  const manager = createUpdateManager(autoUpdater);
+  const sent = [];
+  const windowManager = {
+    notificationPrefs: { notificationsEnabled: true, notifyUpdates: false },
+    mainWindow: makeRendererWindow(sent),
+    controlPanelWindow: makeRendererWindow(sent),
+  };
+  manager.setWindowManager(windowManager);
+
+  manager.checkForUpdatesOnStartup();
+  t.mock.timers.tick(STARTUP_DELAY_MS);
+  assert.deepEqual(sent, [], "a skipped check produces no renderer traffic at all");
+
+  // Same machine with the toggle on: the connection error still surfaces, which
+  // is what a user who asked for update checks should see.
+  windowManager.notificationPrefs.notifyUpdates = true;
+  t.mock.timers.tick(PERIODIC_INTERVAL_MS);
+  assert.ok(sent.includes("update-error"));
+
+  manager.cleanup();
+});
+
+test("the update-available popup honors the same App updates gate", () => {
+  const cases = [
+    { prefs: { notificationsEnabled: true, notifyUpdates: true }, shown: 1 },
+    { prefs: { notificationsEnabled: true, notifyUpdates: false }, shown: 0 },
+    { prefs: { notificationsEnabled: false, notifyUpdates: true }, shown: 0 },
+  ];
+
+  for (const { prefs, shown } of cases) {
+    const autoUpdater = makeAutoUpdater();
+    const manager = createUpdateManager(autoUpdater);
+    const popups = [];
+    manager.setWindowManager({
+      notificationPrefs: prefs,
+      showUpdateNotification(info) {
+        popups.push(info);
+        return Promise.resolve();
+      },
+    });
+
+    autoUpdater.listeners["update-available"]({ version: "9.9.9" });
+
+    assert.equal(popups.length, shown, JSON.stringify(prefs));
+    manager.cleanup();
+  }
+});

--- a/test/helpers/updater.test.js
+++ b/test/helpers/updater.test.js
@@ -3,8 +3,6 @@ const { afterEach, beforeEach } = require("node:test");
 const assert = require("node:assert/strict");
 const Module = require("node:module");
 
-// UpdateManager no-ops in development; pin the env so a developer shell with
-// NODE_ENV=development cannot turn every assertion below into a false pass.
 process.env.NODE_ENV = "test";
 
 const updaterModulePath = require.resolve("../../src/updater.js");
@@ -13,9 +11,6 @@ const originalLoad = Module._load;
 const STARTUP_DELAY_MS = 3000;
 const PERIODIC_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
-// Builds a fake electron-updater whose checkForUpdates records each call and,
-// when `offline` is set, behaves like a machine with no network: it emits the
-// `error` event on the updater (as electron-updater does) and rejects.
 function makeAutoUpdater({ offline = false } = {}) {
   const listeners = {};
   const autoUpdater = {
@@ -29,6 +24,7 @@ function makeAutoUpdater({ offline = false } = {}) {
     checkForUpdates() {
       autoUpdater.calls += 1;
       if (offline) {
+        // electron-updater emits the error before rejecting
         const error = new Error("net::ERR_INTERNET_DISCONNECTED");
         listeners.error?.(error);
         return Promise.reject(error);
@@ -39,10 +35,8 @@ function makeAutoUpdater({ offline = false } = {}) {
   return autoUpdater;
 }
 
-// UpdateManager requires electron lazily — in the constructor
-// (before-quit-for-update hook), in cleanup(), and on Intel Macs child_process
-// (Rosetta probe) — so the mocks stay installed for the whole test and are
-// restored in afterEach rather than right after the module load.
+// updater.js requires electron and child_process lazily (constructor, cleanup(),
+// Rosetta probe), so the mocks stay installed until afterEach.
 function createUpdateManager(autoUpdater) {
   delete require.cache[updaterModulePath];
   Module._load = function loadWithMocks(request, parent, isMain) {
@@ -113,8 +107,6 @@ test("prefs are read at fire time, so toggling App updates takes effect without 
   t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
   const autoUpdater = makeAutoUpdater();
   const manager = createUpdateManager(autoUpdater);
-  // sync-notification-preferences mutates this object in place; the timers
-  // were scheduled while the toggle was off.
   const windowManager = {
     notificationPrefs: { notificationsEnabled: true, notifyUpdates: false },
   };
@@ -175,8 +167,6 @@ test("offline with App updates off, no update-error reaches the renderers (#1605
   t.mock.timers.tick(STARTUP_DELAY_MS);
   assert.deepEqual(sent, [], "a skipped check produces no renderer traffic at all");
 
-  // Same machine with the toggle on: the connection error still surfaces, which
-  // is what a user who asked for update checks should see.
   windowManager.notificationPrefs.notifyUpdates = true;
   t.mock.timers.tick(PERIODIC_INTERVAL_MS);
   assert.ok(sent.includes("update-error"));


### PR DESCRIPTION
Closes #1605

The "App updates" toggle only gated the update-available popup. The startup check (3s after launch) and the 4-hourly periodic check ran regardless, so offline/firewalled machines got network attempts on every start and the resulting `update-error` events surfaced as error dialogs whenever Settings opened — exactly the screenshots in the issue.

## Changes

- New `src/helpers/updateCheckPolicy.js` (Electron-free, same pattern as `dockPolicy.js`/`autoStartPolicy.js`): automatic checks require `notificationsEnabled !== false && notifyUpdates !== false` — the same tri-state convention the popup gate in `updater.js` already uses.
- `updater.js`: startup and periodic checks go through `_autoCheckForUpdates()`, which reads prefs at fire time, so flipping the toggle takes effect without a restart. With the toggle off, no check runs — no connection attempt, no error event, no dialog.
- Manual "Check for updates" from Settings is intentionally never gated.

## Test

- `test/helpers/updateCheckPolicy.test.js`: fails without the fix (3/3), passes with it.
- Full suite: failures identical to clean `main` (73 pre-existing); +3 tests, +3 passes.
- How to test: turn off Settings → Notifications → App updates, relaunch offline — no update dialog, log shows "update check skipped (app updates disabled)". Toggle back on — startup/periodic checks resume without a restart.