### PR TITLE
fix(dictation): run the dictionary-echo check against the prompt actually sent — fixes #1636

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -85,8 +85,11 @@ import { evaluateFinishedRecording, withSalvageWarning } from "./recordingValida
 import { isEmptyRecording } from "./recordingGuard";
 import {
   DICTIONARY_ECHO_CODE,
+  DEFAULT_MAX_PROMPT_CHARS,
+  GROQ_MAX_PROMPT_CHARS,
   dictionaryEchoError,
-  matchesDictionaryPrompt,
+  matchesSentDictionaryPrompt,
+  truncateDictionaryPrompt,
 } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
 import { normalizeAgentSelectionContext } from "../utils/agentSelectionContext";
@@ -649,10 +652,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
   // Check the dictionary on its own as well as the full prompt: the echo filter needs
   // 70% of the prompt's words to appear, and a Chinese script bias counts as one more
   // word, which alone pushes a one- or two-term dictionary under the threshold.
+  // Each is also compared against its sent-size prefixes, since the request path
+  // caps the prompt at ~900 chars and an echo of that prefix can never clear the
+  // usage threshold against a much larger full join (#1636).
   isDictionaryEcho(text) {
     return (
-      matchesDictionaryPrompt(text, this.getCustomDictionaryPrompt()) ||
-      matchesDictionaryPrompt(text, this.getWhisperPrompt())
+      matchesSentDictionaryPrompt(text, this.getCustomDictionaryPrompt()) ||
+      matchesSentDictionaryPrompt(text, this.getWhisperPrompt())
     );
   }
 
@@ -3325,16 +3331,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       const endpoint = this.getTranscriptionEndpoint(model);
 
       // Groq rejects prompts > 896 chars (incl. when reached via "custom" provider).
-      // 890 leaves margin for UTF-16 vs codepoint counting drift.
+      // Caps and truncation live in dictionaryEchoFilter.js so the echo check can
+      // reconstruct exactly what was sent (#1636).
       const isGroqEndpoint = provider === "groq" || endpoint.includes("api.groq.com");
-      const MAX_PROMPT_CHARS = isGroqEndpoint ? 890 : 900;
+      const MAX_PROMPT_CHARS = isGroqEndpoint ? GROQ_MAX_PROMPT_CHARS : DEFAULT_MAX_PROMPT_CHARS;
       let dictionaryPrompt = this.getWhisperPrompt(apiSettings);
       if (dictionaryPrompt) {
         if (dictionaryPrompt.length > MAX_PROMPT_CHARS) {
           const originalLength = dictionaryPrompt.length;
-          const truncated = dictionaryPrompt.slice(0, MAX_PROMPT_CHARS);
-          const lastComma = truncated.lastIndexOf(",");
-          dictionaryPrompt = lastComma > 0 ? truncated.slice(0, lastComma) : truncated;
+          dictionaryPrompt = truncateDictionaryPrompt(dictionaryPrompt, MAX_PROMPT_CHARS);
           logger.debug(
             "Custom dictionary prompt truncated",
             {

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -29,6 +29,35 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   return textComposition >= 0.9 && dictionaryUsage >= 0.7;
 }
 
+// Request-side caps for the dictionary hint prompt, mirrored here so the echo
+// check can reconstruct exactly what was sent (#1636). Groq rejects prompts
+// > 896 chars (890 leaves margin for UTF-16 vs codepoint counting drift);
+// everything else is capped at 900.
+export const GROQ_MAX_PROMPT_CHARS = 890;
+export const DEFAULT_MAX_PROMPT_CHARS = 900;
+const SENT_PROMPT_CAPS = [GROQ_MAX_PROMPT_CHARS, DEFAULT_MAX_PROMPT_CHARS];
+
+export function truncateDictionaryPrompt(prompt, maxChars) {
+  if (!prompt || prompt.length <= maxChars) return prompt;
+  const truncated = prompt.slice(0, maxChars);
+  const lastComma = truncated.lastIndexOf(",");
+  return lastComma > 0 ? truncated.slice(0, lastComma) : truncated;
+}
+
+// A capped request sends only a prefix of the dictionary join, so an echo of
+// what the recognizer was actually primed with has dictionaryUsage bounded by
+// roughly sentChars / joinChars against the full join — once the dictionary
+// meaningfully exceeds the cap, a perfect echo of the sent prompt can never
+// clear the 0.7 threshold (#1636). Compare against the sent-size prefixes as
+// well as the full prompt, which still covers paths that send it whole.
+export function matchesSentDictionaryPrompt(text, prompt) {
+  if (matchesDictionaryPrompt(text, prompt)) return true;
+  return SENT_PROMPT_CAPS.some((cap) => {
+    const truncated = truncateDictionaryPrompt(prompt, cap);
+    return truncated !== prompt && matchesDictionaryPrompt(text, truncated);
+  });
+}
+
 export const DICTIONARY_ECHO_CODE = "DICTIONARY_ECHO";
 
 // Keeps the "No audio detected" message so the existing message comparisons and

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -124,3 +124,62 @@ test("returns false when text or prompt normalizes to empty string (punctuation 
   assert.equal(matchesDictionaryPrompt("???", "OpenWhispr, Parakeet"), false);
   assert.equal(matchesDictionaryPrompt("OpenWhispr, Parakeet", "!!!"), false);
 });
+
+// #1636: the request path caps the sent prompt at ~900 chars (890 for Groq),
+// but the echo check compared against the full dictionary join. An exact echo
+// of the sent prefix has dictionaryUsage ≈ sentChars / joinChars against the
+// full join, so a large dictionary made the echo mathematically undetectable.
+
+function buildLargeDictionary(termCount = 390) {
+  const terms = [];
+  for (let i = 0; i < termCount; i++) terms.push(`term${i}alpha`);
+  return terms.join(", ");
+}
+
+test("truncateDictionaryPrompt trims to the last comma within the cap", async () => {
+  const { truncateDictionaryPrompt } = await import("../../src/utils/dictionaryEchoFilter.js");
+  assert.equal(truncateDictionaryPrompt("Alpha, Bravo, Charlie", 999), "Alpha, Bravo, Charlie");
+  assert.equal(truncateDictionaryPrompt("Alpha, Bravo, Charlie", 14), "Alpha, Bravo");
+  assert.equal(truncateDictionaryPrompt("NoCommaHere", 5), "NoCom");
+  assert.equal(truncateDictionaryPrompt(null, 900), null);
+});
+
+test("detects an exact echo of the sent (900-char capped) prompt against a large dictionary", async () => {
+  const { matchesSentDictionaryPrompt, matchesDictionaryPrompt, truncateDictionaryPrompt } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+  const fullPrompt = buildLargeDictionary();
+  assert.ok(fullPrompt.length > 3000);
+  const sentPrompt = truncateDictionaryPrompt(fullPrompt, 900);
+
+  // the old full-list-only comparison misses the echo of what was actually sent
+  assert.equal(matchesDictionaryPrompt(sentPrompt, fullPrompt), false);
+  // the sent-prefix-aware check catches it
+  assert.equal(matchesSentDictionaryPrompt(sentPrompt, fullPrompt), true);
+});
+
+test("detects an echo of the Groq-capped (890-char) prompt", async () => {
+  const { matchesSentDictionaryPrompt, truncateDictionaryPrompt } = await import(
+    "../../src/utils/dictionaryEchoFilter.js"
+  );
+  const fullPrompt = buildLargeDictionary();
+  const sentPrompt = truncateDictionaryPrompt(fullPrompt, 890);
+  assert.equal(matchesSentDictionaryPrompt(sentPrompt, fullPrompt), true);
+});
+
+test("sent-prefix check still detects a verbatim full echo and stays quiet on real speech", async () => {
+  const { matchesSentDictionaryPrompt } = await import("../../src/utils/dictionaryEchoFilter.js");
+  const smallDict = "OpenWhispr, Parakeet, Alcahest";
+  assert.equal(matchesSentDictionaryPrompt("OpenWhispr, Parakeet, Alcahest", smallDict), true);
+
+  const fullPrompt = buildLargeDictionary();
+  // dictation that merely uses a few dictionary terms is not an echo
+  assert.equal(
+    matchesSentDictionaryPrompt(
+      "remember to file the term1alpha report before the term2alpha meeting tomorrow",
+      fullPrompt
+    ),
+    false
+  );
+  assert.equal(matchesSentDictionaryPrompt("The quick brown fox jumps over it", fullPrompt), false);
+  assert.equal(matchesSentDictionaryPrompt("anything", null), false);
+});


### PR DESCRIPTION
Closes #1636

The request path caps the dictionary hint at ~900 chars (890 for Groq), but `isDictionaryEcho` compared transcripts only against the full dictionary join. An echo of the sent prefix has `dictionaryUsage ≈ sentChars / joinChars` against the full join, so once the dictionary meaningfully exceeds the cap a perfect echo of everything the recognizer was actually primed with could never reach the 0.7 threshold — it pasted as a normal transcript and went on through cleanup (deterministic loopback repro in the issue).

## Changes

- `src/utils/dictionaryEchoFilter.js`: request-side caps moved here (`GROQ_MAX_PROMPT_CHARS = 890`, `DEFAULT_MAX_PROMPT_CHARS = 900`) with the shared `truncateDictionaryPrompt()`; new `matchesSentDictionaryPrompt()` checks the full prompt plus each sent-size prefix. The check reconstructs what was sent instead of threading request state through the pipeline.
- `src/helpers/audioManager.js`: `isDictionaryEcho` uses the sent-prefix-aware matcher for both arms (dictionary-only and merged whisper prompt); request-side truncation calls the shared helper, so the caps have a single source of truth.
- The full-list arm still covers paths that send the dictionary whole (the issue's suggested direction).

## Test

- 4 regression tests in `test/helpers/dictionaryEchoFilter.test.js`, including the issue's exact shape (390 terms, ~3.9k-char join, 900-char echo): fail without the fix, pass with it. False-positive guard included — dictation that merely uses a few dictionary terms stays unflagged.
- Full suite: failures identical to clean `main` (73 pre-existing); +4 tests, +4 passes.
- How to test: the issue's loopback mock (echoes the received `prompt` field back) with a 390-term dictionary — the echo is now discarded via the dictionary-echo path instead of pasting.