### PR TITLE
fix(calendar): backfill stripped Microsoft occurrences from series master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - Incremental sync via `syncToken`; full re-sync on 410 prunes stale events (note-linked rows retained)
 - **microsoftCalendarManager.js**: Microsoft Calendar sync via Graph API (OAuth via `microsoftCalendarOAuth.js`)
   - `calendarView/delta` incremental sync over a 14-day window; delta token discarded after 7 days (Graph delta links never roll their window forward)
+  - Delta can return recurring-series occurrences as bare stubs (no subject/attendees/meeting link); they're backfilled from their series master, one `GET /me/events/{id}` per series
   - Full re-sync (410 or expired token) prunes stale events like Google
 - **appleCalendarManager.js**: Apple Calendar (EventKit) via the `macos-calendar-listener` Swift helper — macOS only, snapshot-push over stdout, no tokens ("connected" = `apple_calendars` has rows)
 - **calendarReminderScheduler.js**: Provider-agnostic meeting reminder scheduling over the shared `calendar_events` table (provider-scoped reset keys, so one provider's disconnect doesn't re-fire another's reminders)

--- a/src/helpers/microsoftCalendarManager.js
+++ b/src/helpers/microsoftCalendarManager.js
@@ -7,6 +7,9 @@ const { broadcastToWindows } = require("./windowBroadcast");
 
 const GRAPH_API_BASE = "https://graph.microsoft.com/v1.0";
 
+const SERIES_MASTER_FIELDS =
+  "subject,isAllDay,isCancelled,onlineMeeting,onlineMeetingUrl,location,bodyPreview,organizer,attendees";
+
 // Graph's deltaLink permanently encodes the calendarView window it was created
 // with — it never rolls forward. Sync a 14-day window and discard the token
 // after 7 days so coverage never drops below the app's 7-day lookahead.
@@ -24,6 +27,13 @@ const RESPONSE_STATUS_BY_GRAPH = {
 // (Prefer: outlook.timezone), so trim the fraction and append "Z".
 function normalizeGraphDateTime({ dateTime }) {
   return `${dateTime.slice(0, 19)}Z`;
+}
+
+// calendarView/delta can return recurring-series occurrences as bare
+// { id, type, seriesMasterId, start, end } stubs — no subject, attendees,
+// or meeting link. Those fields live on the series master.
+function isStrippedOccurrence(item) {
+  return item.subject === undefined && Boolean(item.seriesMasterId);
 }
 
 class MicrosoftCalendarManager {
@@ -169,9 +179,8 @@ class MicrosoftCalendarManager {
   async _syncCalendar(calendar) {
     const accountEmail = calendar.account_email;
 
-    const toUpsert = [];
+    const items = [];
     const toRemove = [];
-    const contactsToUpsert = [];
     let deltaLink = null;
 
     const hasFreshToken = calendar.sync_token && calendar.sync_token_expires_at > Date.now();
@@ -197,23 +206,28 @@ class MicrosoftCalendarManager {
       }
 
       for (const item of data.value || []) {
-        if (item["@removed"]) {
-          toRemove.push(item.id);
-          continue;
-        }
-        toUpsert.push(this._mapEvent(item, calendar));
-        for (const a of item.attendees || []) {
-          if (a.emailAddress?.address) {
-            contactsToUpsert.push({
-              email: a.emailAddress.address,
-              displayName: a.emailAddress.name || null,
-            });
-          }
-        }
+        if (item["@removed"]) toRemove.push(item.id);
+        else items.push(item);
       }
 
       deltaLink = data["@odata.deltaLink"] || deltaLink;
       url = data["@odata.nextLink"] || null;
+    }
+
+    const events = await this._backfillStrippedOccurrences(items, accountEmail);
+
+    const toUpsert = [];
+    const contactsToUpsert = [];
+    for (const item of events) {
+      toUpsert.push(this._mapEvent(item, calendar));
+      for (const a of item.attendees || []) {
+        if (a.emailAddress?.address) {
+          contactsToUpsert.push({
+            email: a.emailAddress.address,
+            displayName: a.emailAddress.name || null,
+          });
+        }
+      }
     }
 
     // A full sync has no delta baseline, so deletions that happened while the
@@ -232,6 +246,38 @@ class MicrosoftCalendarManager {
       this.databaseManager.updateMicrosoftCalendarSyncToken(calendar.id, deltaLink, tokenExpiresAt);
     }
     if (contactsToUpsert.length > 0) this.databaseManager.upsertContacts(contactsToUpsert);
+  }
+
+  // Merges each stripped occurrence with its series master (fetched once per
+  // series); the occurrence's own id/start/end win. A failed master fetch
+  // leaves its occurrences bare instead of failing the calendar's sync.
+  async _backfillStrippedOccurrences(items, accountEmail) {
+    const masterIds = new Set(
+      items.filter(isStrippedOccurrence).map((item) => item.seriesMasterId)
+    );
+    if (masterIds.size === 0) return items;
+
+    const masters = new Map();
+    for (const id of masterIds) {
+      try {
+        const master = await this._apiGet(
+          `/me/events/${encodeURIComponent(id)}?$select=${SERIES_MASTER_FIELDS}`,
+          accountEmail
+        );
+        masters.set(id, master);
+      } catch (err) {
+        debugLogger.error(
+          "Error fetching series master",
+          { seriesMasterId: id, error: err.message },
+          "mcal"
+        );
+      }
+    }
+
+    return items.map((item) => {
+      const master = isStrippedOccurrence(item) ? masters.get(item.seriesMasterId) : null;
+      return master ? { ...master, ...item } : item;
+    });
   }
 
   _mapEvent(item, calendar) {

--- a/test/helpers/microsoftCalendarManager.test.js
+++ b/test/helpers/microsoftCalendarManager.test.js
@@ -100,3 +100,104 @@ test("_mapEvent falls back to a meeting link found in location or body text", ()
   assert.equal(mapped.hangout_link, "https://example.zoom.us/j/123456789");
   assert.equal(mapped.attendees, null);
 });
+
+function createManager(MicrosoftCalendarManager, upserted, contacts = []) {
+  return new MicrosoftCalendarManager(
+    {
+      removeStaleCalendarEvents: () => {},
+      upsertCalendarEvents: (events) => upserted.push(...events),
+      removeCalendarEvents: () => {},
+      updateMicrosoftCalendarSyncToken: () => {},
+      upsertContacts: (rows) => contacts.push(...rows),
+    },
+    {}
+  );
+}
+
+const STRIPPED_OCCURRENCE = {
+  id: "occ-1",
+  type: "occurrence",
+  seriesMasterId: "master-1",
+  start: { dateTime: "2026-07-20T09:25:00.0000000" },
+  end: { dateTime: "2026-07-20T09:30:00.0000000" },
+};
+
+test("_syncCalendar backfills stripped recurring occurrences from their series master", async () => {
+  const MicrosoftCalendarManager = loadManagerModule();
+  const upserted = [];
+  const contacts = [];
+  const manager = createManager(MicrosoftCalendarManager, upserted, contacts);
+
+  const masterFetches = [];
+  manager._apiGet = async (url) => {
+    if (url.includes("/calendarView/delta")) {
+      return {
+        "@odata.deltaLink": "delta-link",
+        value: [
+          STRIPPED_OCCURRENCE,
+          {
+            ...STRIPPED_OCCURRENCE,
+            id: "occ-2",
+            start: { dateTime: "2026-07-21T09:25:00.0000000" },
+            end: { dateTime: "2026-07-21T09:30:00.0000000" },
+          },
+          {
+            id: "evt-1",
+            subject: "One-off",
+            start: { dateTime: "2026-07-20T17:00:00.0000000" },
+            end: { dateTime: "2026-07-20T17:30:00.0000000" },
+          },
+        ],
+      };
+    }
+    masterFetches.push(url);
+    return {
+      id: "master-1",
+      subject: "Standup",
+      isAllDay: false,
+      onlineMeeting: { joinUrl: "https://teams.microsoft.com/l/meetup-join/abc" },
+      organizer: { emailAddress: { address: "organizer@example.com" } },
+      attendees: [
+        {
+          emailAddress: { address: "me@example.com", name: "Me" },
+          status: { response: "accepted" },
+        },
+      ],
+    };
+  };
+
+  await manager._syncCalendar({ id: "cal-1", account_email: "me@example.com" });
+
+  assert.equal(masterFetches.length, 1);
+  assert.match(masterFetches[0], /^\/me\/events\/master-1\?\$select=/);
+
+  const occurrence = upserted.find((event) => event.id === "occ-1");
+  assert.equal(occurrence.summary, "Standup");
+  assert.equal(occurrence.start_time, "2026-07-20T09:25:00Z");
+  assert.equal(occurrence.hangout_link, "https://teams.microsoft.com/l/meetup-join/abc");
+  assert.equal(occurrence.organizer_email, "organizer@example.com");
+  assert.equal(occurrence.attendees_count, 1);
+  assert.equal(upserted.find((event) => event.id === "occ-2").summary, "Standup");
+  assert.equal(upserted.find((event) => event.id === "evt-1").summary, "One-off");
+  assert.ok(contacts.some((contact) => contact.email === "me@example.com"));
+});
+
+test("_syncCalendar keeps stripped occurrences when the series master fetch fails", async () => {
+  const MicrosoftCalendarManager = loadManagerModule();
+  const upserted = [];
+  const manager = createManager(MicrosoftCalendarManager, upserted);
+
+  manager._apiGet = async (url) => {
+    if (url.includes("/calendarView/delta")) {
+      return { "@odata.deltaLink": "delta-link", value: [STRIPPED_OCCURRENCE] };
+    }
+    throw new Error("master gone");
+  };
+
+  await manager._syncCalendar({ id: "cal-1", account_email: "me@example.com" });
+
+  assert.equal(upserted.length, 1);
+  assert.equal(upserted[0].id, "occ-1");
+  assert.equal(upserted[0].summary, null);
+  assert.equal(upserted[0].start_time, "2026-07-20T09:25:00Z");
+});


### PR DESCRIPTION
## Problem

After connecting a Microsoft account, recurring meetings show up as **"Untitled Event"** in Upcoming Meetings.

Graph's `calendarView/delta` can return recurring-series occurrences as bare stubs — only `id`, `type`, `seriesMasterId`, `start`, `end` — with no `subject`, `attendees`, `organizer`, or online-meeting link ([Microsoft's guidance](https://learn.microsoft.com/en-us/answers/questions/5727433/about-recurrance-event-syncing-from-outlook-to-my) is to treat delta as change detection and fetch full details separately). `_mapEvent` trusted `item.subject`, so these rows persisted with a NULL summary; the UI falls back to `upcoming.untitledEvent`, and meeting-reminder prompts lose their Join action since the join URL is stripped too.

## Fix

- Collect delta items first, then backfill: any item with no `subject` and a `seriesMasterId` gets its series master fetched once per series (`GET /me/events/{id}?$select=…`) and merged under the occurrence's own `id`/`start`/`end` before mapping/upserting.
- Backfill runs on every sync pass, so a later delta round can't overwrite a backfilled title with NULL.
- A failed master fetch logs and keeps the bare occurrence — one 404 can't fail the calendar's sync.
- Single-instance events and full-payload exceptions are untouched.

## Testing

- New tests: stripped occurrences inherit title/join link/organizer/attendees from a single master fetch (deduped across occurrences of the same series, occurrence times preserved); master-fetch failure still upserts the bare occurrence and completes the sync.
- Full suite: 2090 tests, 0 failures.