### PR TITLE
fix: dismiss transcription preview on no speech

### DIFF
--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -452,6 +452,7 @@ export const useAudioRecording = (toast, options = {}) => {
     });
 
     const handleNoAudioDetected = () => {
+      window.electronAPI?.hideDictationPreview?.();
       if (getSettings().pauseMediaOnDictation) {
         window.electronAPI?.resumeMediaPlayback?.();
       }


### PR DESCRIPTION
Dismiss the transcription preview when no speech is detected, preventing it from getting stuck in the cleanup state.

fixes #1642 