### PR TITLE
feat(reasoning): log finish_reason and a normalized truncated flag on non-streaming success paths

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -4508,14 +4508,15 @@ class IPCHandlers {
             }
             const { text: generated, finishReason } = result;
 
-            if (
-              config?.requireCompleteOutput &&
-              ["length", "max-tokens", "max_tokens"].includes(finishReason)
-            ) {
+            // Normalize once so the selection-edit guard and the renderer's
+            // success log cannot disagree about what counts as truncated.
+            const truncated = ["length", "max-tokens", "max_tokens"].includes(finishReason);
+
+            if (config?.requireCompleteOutput && truncated) {
               throw new Error("Model output was truncated before the selection edit completed");
             }
 
-            return { success: true, text: (generated || "").trim() };
+            return { success: true, text: (generated || "").trim(), finishReason, truncated };
           } finally {
             if (controller) {
               sender.removeListener("destroyed", cancelSenderRequests);
@@ -4905,7 +4906,7 @@ class IPCHandlers {
           if (outputText === null) {
             throw new Error(describeMissingAnthropicText(data));
           }
-          return { success: true, text: outputText };
+          return { success: true, text: outputText, stopReason: data.stop_reason };
         } catch (error) {
           debugLogger.error("Anthropic reasoning error:", error);
           return { success: false, error: error.message };

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -404,7 +404,8 @@ class ReasoningService extends BaseReasoningService {
     }
 
     const choice = response.choices[0];
-    if (config.requireCompleteOutput && isTruncatedFinishReason(choice?.finish_reason)) {
+    const finishReason = choice?.finish_reason;
+    if (config.requireCompleteOutput && isTruncatedFinishReason(finishReason)) {
       throw new Error("Model output was truncated before the selection edit completed");
     }
     // Reasoning models leak <think> blocks into non-streamed output; strip them
@@ -416,7 +417,7 @@ class ReasoningService extends BaseReasoningService {
     if (!responseText) {
       logger.logReasoning(`${providerName.toUpperCase()}_EMPTY_RESPONSE`, {
         model,
-        finishReason: choice.finish_reason,
+        finishReason,
         hasMessage: !!choice.message,
         response: JSON.stringify(choice).substring(0, 500),
       });
@@ -427,6 +428,8 @@ class ReasoningService extends BaseReasoningService {
       model,
       responseLength: responseText.length,
       tokensUsed: response.usage?.total_tokens || 0,
+      finishReason,
+      truncated: isTruncatedFinishReason(finishReason),
       success: true,
     });
 

--- a/src/services/ai/inferenceProviders/anthropic.ts
+++ b/src/services/ai/inferenceProviders/anthropic.ts
@@ -43,6 +43,8 @@ export const anthropicProvider: InferenceProvider = {
       model,
       processingTimeMs,
       resultLength: result.text.length,
+      finishReason: result.stopReason,
+      truncated: result.stopReason === "max_tokens",
     });
     return result.text;
   },

--- a/src/services/ai/inferenceProviders/enterprise.ts
+++ b/src/services/ai/inferenceProviders/enterprise.ts
@@ -80,6 +80,8 @@ export const enterpriseProvider: InferenceProvider = {
       model,
       processingTimeMs,
       resultLength: result.text?.length || 0,
+      finishReason: result.finishReason,
+      truncated: result.truncated,
     });
     return result.text || "";
   },

--- a/src/services/ai/inferenceProviders/gemini.ts
+++ b/src/services/ai/inferenceProviders/gemini.ts
@@ -156,6 +156,8 @@ export const geminiProvider: InferenceProvider = {
       model,
       responseLength: responseText.length,
       tokensUsed: response.usageMetadata?.totalTokenCount || 0,
+      finishReason: candidate.finishReason,
+      truncated: candidate.finishReason === "MAX_TOKENS",
       success: true,
     });
     return responseText;

--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -321,14 +321,17 @@ export const openaiProvider: InferenceProvider = {
     const isResponsesApi = Array.isArray(response?.output);
     const isChatCompletions = Array.isArray(response?.choices);
 
-    if (config.requireCompleteOutput) {
-      const responseIncomplete =
-        response?.status === "incomplete" ||
-        !!response?.incomplete_details ||
-        response?.choices?.some((choice: any) => isTruncatedFinishReason(choice?.finish_reason));
-      if (responseIncomplete) {
-        throw new Error("Model output was truncated before the selection edit completed");
-      }
+    // Both API shapes report an incomplete generation differently; fold them
+    // into one answer so the selection-edit guard and the success log can never
+    // disagree about what counts as truncated.
+    const responseIncomplete =
+      response?.status === "incomplete" ||
+      !!response?.incomplete_details ||
+      (response?.choices?.some((choice: any) => isTruncatedFinishReason(choice?.finish_reason)) ??
+        false);
+
+    if (config.requireCompleteOutput && responseIncomplete) {
+      throw new Error("Model output was truncated before the selection edit completed");
     }
 
     logger.logReasoning("OPENAI_RAW_RESPONSE", {
@@ -396,6 +399,10 @@ export const openaiProvider: InferenceProvider = {
       model,
       responseLength: responseText.length,
       tokensUsed: response.usage?.total_tokens || 0,
+      finishReason: isResponsesApi
+        ? response?.incomplete_details?.reason
+        : response?.choices?.[0]?.finish_reason,
+      truncated: responseIncomplete,
       success: true,
       isEmpty: responseText.length === 0,
     });

--- a/src/services/ai/inferenceProviders/tinfoil.ts
+++ b/src/services/ai/inferenceProviders/tinfoil.ts
@@ -56,10 +56,11 @@ export const tinfoilProvider: InferenceProvider = {
         .find((content: unknown) => typeof content === "string" && content.trim())
         ?.trim() || "";
 
-    if (
-      config.requireCompleteOutput &&
-      response.choices?.some((choice: any) => isTruncatedFinishReason(choice?.finish_reason))
-    ) {
+    const truncated =
+      response.choices?.some((choice: any) => isTruncatedFinishReason(choice?.finish_reason)) ??
+      false;
+
+    if (config.requireCompleteOutput && truncated) {
       throw new Error("Model output was truncated before the selection edit completed");
     }
 
@@ -67,6 +68,8 @@ export const tinfoilProvider: InferenceProvider = {
       model,
       responseLength: responseText.length,
       tokensUsed: response.usage?.total_tokens || 0,
+      finishReason: response.choices?.map((choice: any) => choice?.finish_reason)?.[0],
+      truncated,
       success: true,
       isEmpty: responseText.length === 0,
     });

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1617,7 +1617,7 @@ declare global {
         modelId: string,
         agentName: string | null,
         config: any
-      ) => Promise<{ success: boolean; text?: string; error?: string }>;
+      ) => Promise<{ success: boolean; text?: string; error?: string; stopReason?: string }>;
 
       // Enterprise reasoning (Bedrock, Azure, Vertex)
       processEnterpriseReasoning: (
@@ -1635,6 +1635,8 @@ declare global {
         actionKey?: string;
         copyCommand?: string;
         retryable?: boolean;
+        finishReason?: string;
+        truncated?: boolean;
         technicalDetails?: {
           status?: number;
           exceptionType?: string;

--- a/test/helpers/bedrockEnterpriseIpc.test.js
+++ b/test/helpers/bedrockEnterpriseIpc.test.js
@@ -330,7 +330,12 @@ test("dictation cleanup uses the Bedrock retry policy and returns the eventual t
       }
     );
 
-    assert.deepEqual(result, { success: true, text: "cleaned dictation" });
+    assert.deepEqual(result, {
+      success: true,
+      text: "cleaned dictation",
+      finishReason: "stop",
+      truncated: false,
+    });
     assert.equal(generateCalls.length, 2);
     assert.ok(generateCalls.every((call) => call.maxRetries === 0));
   } finally {

--- a/test/services/finishReasonLogging.test.js
+++ b/test/services/finishReasonLogging.test.js
@@ -1,0 +1,132 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+// A cleanup that stops at its token cap still returns text, so the pipeline
+// keeps pasting it. These tests pin the part that used to be invisible: the
+// success log now carries the raw finish reason and a normalized `truncated`
+// flag, while the pasted text is byte-for-byte what it was before.
+const LAN_URL = "http://127.0.0.1:8585/v1";
+const LOG_KEY = "__openwhisprReasoningLogEntries";
+
+function chatCompletion(content, finishReason) {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content }, finish_reason: finishReason }],
+      usage: { total_tokens: 42 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+test("the non-streaming success log carries the finish reason", async (t) => {
+  installBrowserGlobals(t);
+  globalThis[LOG_KEY] = [];
+  t.after(() => {
+    delete globalThis[LOG_KEY];
+  });
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-finish-reason-test-",
+    mockModules: {
+      "/utils/logger": `
+        const noop = () => {};
+        export default {
+          trace: noop, debug: noop, info: noop, warn: noop, error: noop, fatal: noop,
+          refreshLogLevel: noop,
+          logReasoning: (stage, details) => {
+            globalThis["${LOG_KEY}"].push({ stage, details });
+          },
+        };
+      `,
+    },
+  });
+
+  const reasoningService = (await vite.ssrLoadModule("/services/ReasoningService.ts")).default;
+  t.after(() => reasoningService.destroy());
+  const { usePolicyStore } = await vite.ssrLoadModule("/stores/policyStore.ts");
+
+  usePolicyStore.setState({ status: "unmanaged", appVersion: "1.8.1", policy: null });
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const respondWith = (content, finishReason) => {
+    globalThis[LOG_KEY] = [];
+    globalThis.fetch = async () => chatCompletion(content, finishReason);
+  };
+  const successLog = () =>
+    globalThis[LOG_KEY].find((entry) => entry.stage === "LAN_RESPONSE")?.details;
+
+  await t.test("a cleanup stopped at the token cap is logged as truncated", async () => {
+    respondWith("Cleaned text that stops mid-", "length");
+
+    const result = await reasoningService.processText("raw transcript", "gemma", null, {
+      provider: "lan",
+      lanUrl: LAN_URL,
+    });
+
+    // Behavior is unchanged: the user still gets the (shortened) cleanup.
+    assert.equal(result, "Cleaned text that stops mid-");
+    assert.deepEqual(
+      { finishReason: successLog()?.finishReason, truncated: successLog()?.truncated },
+      { finishReason: "length", truncated: true }
+    );
+  });
+
+  await t.test("a complete cleanup logs the same fields, not truncated", async () => {
+    respondWith("Cleaned text.", "stop");
+
+    const result = await reasoningService.processText("raw transcript", "gemma", null, {
+      provider: "lan",
+      lanUrl: LAN_URL,
+    });
+
+    assert.equal(result, "Cleaned text.");
+    assert.deepEqual(
+      { finishReason: successLog()?.finishReason, truncated: successLog()?.truncated },
+      { finishReason: "stop", truncated: false }
+    );
+  });
+
+  await t.test("the selection-edit guard still rejects truncated output", async () => {
+    respondWith("Partial edit", "length");
+
+    await assert.rejects(
+      reasoningService.processText("edit this", "gemma", null, {
+        provider: "lan",
+        lanUrl: LAN_URL,
+        systemPrompt: "Edit the selection.",
+        requireCompleteOutput: true,
+      }),
+      { message: "Model output was truncated before the selection edit completed" }
+    );
+  });
+
+  // Enterprise runs in the main process, so the finish reason arrives already
+  // normalized over IPC; the renderer's job is only to log the pair it is given.
+  await t.test("an enterprise reply logs the finish reason it was handed", async () => {
+    globalThis[LOG_KEY] = [];
+    globalThis.window.electronAPI.processEnterpriseReasoning = async () => ({
+      success: true,
+      text: "Cleaned text that stops mid-",
+      finishReason: "length",
+      truncated: true,
+    });
+
+    const result = await reasoningService.processText("raw transcript", "claude-sonnet-4", null, {
+      provider: "bedrock",
+    });
+
+    assert.equal(result, "Cleaned text that stops mid-");
+    const details = globalThis[LOG_KEY].find(
+      (entry) => entry.stage === "ENTERPRISE_SUCCESS"
+    )?.details;
+    assert.deepEqual(
+      { finishReason: details?.finishReason, truncated: details?.truncated },
+      { finishReason: "length", truncated: true }
+    );
+  });
+});


### PR DESCRIPTION
### Problem

The non-streaming success logs drop the finish reason. A `*_RESPONSE` entry
records `responseLength`, `tokensUsed` and `success: true`, but not *why*
generation stopped — so a cleanup that hit its token cap
(`finish_reason: "length"`) is pasted shortened and logged as an ordinary
success, indistinguishable from a complete response. The codebase already
treats the finish reason as meaningful — the selection-edit guard
(`requireCompleteOutput`) throws on it at seven call sites
(`ReasoningService.ts`, `openai.ts`, `tinfoil.ts`, `gemini.ts`, the anthropic
and enterprise handlers in `ipcHandlers.js`, and `llamaServer.js`) — but on
the success path the field is discarded everywhere.

A second, smaller problem: the field comes back in five provider dialects
(`"length"`/`"max_tokens"` on chat-completions, `"MAX_TOKENS"` on Gemini,
`incomplete_details.reason: "max_output_tokens"` on the OpenAI Responses API,
`stop_reason: "max_tokens"` on Anthropic, and the AI SDK's `"length"`/
`"max-tokens"` on the enterprise path), so logging the raw value alone would
still leave diagnosis provider-specific.

### Fix

Pure observability — no behavior change, nothing user-visible:

- The raw `finishReason` **and** a normalized `truncated: boolean` (computed
  with each provider's own dialect) are added to the success log of every
  non-streaming path where the provider's finish reason is reachable:
  - the shared chat-completions path (LAN/self-hosted, Groq, Corti) in
    `ReasoningService.ts`;
  - `openai.ts` — both the Responses API and chat-completions arms;
  - `tinfoil.ts` and `gemini.ts`;
  - `anthropic.ts` and `enterprise.ts` — both main-process handlers already
    read the finish reason for the selection-edit guard, and now return it in
    the IPC result so `ANTHROPIC_SUCCESS` / `ENTERPRISE_SUCCESS` can log it
    (typed). Anthropic returns the raw `stop_reason` and the renderer
    normalizes it against a single literal; enterprise returns the normalized
    flag alongside the raw value, because its dialect list lives in the main
    process next to the guard and I'd rather not copy it across the process
    boundary.
- Wherever the guard and the log would otherwise be two independent
  definitions of "truncated" — `openai.ts`, `tinfoil.ts`, the enterprise
  handler — the guard's expression is hoisted into one `const` that both use,
  so they cannot drift apart.
- Deliberately not covered, with reasons rather than omissions:
  - the **OpenWhispr-cloud** path — its response carries `model`, `provider`,
    `promptMode` and `matchType`, but no finish reason at all, so exposing one
    is a server-side API change, not a client one;
  - the **local llama-server** path — the guard is there, but `runInference`
    resolves a bare string, so surfacing the finish reason means changing that
    promise's contract and every caller, which is more than an observability
    PR should carry;
  - the **streaming agent path**, which reports through a different channel.

With this, a shorter-than-dictated paste is diagnosable from the logs alone:
one grep for `"truncated": true`, regardless of provider.

### Testing

- New test (existing renderer SSR harness + stubbed `fetch`):
  `finish_reason: "length"` on the cleanup path still returns the text
  unchanged (pins the zero-behavior-change claim), `"stop"` likewise, and the
  selection-edit guard still throws on truncated output. The logged
  `finishReason`/`truncated` pair is asserted on the truncated response, on
  the complete one, and on the enterprise IPC result.
- `npm run typecheck`, `npm run lint`, `npm run build:renderer` — clean.
- Full `npm test`: the only failures (`extractArchive`/`gpuBinaryManager`/
  `systemTar`) reproduce identically on unpatched `main` on my machine
  (Windows tar), so they are not from this change.

### Notes

I run OpenWhispr against a self-hosted llama.cpp/llama-swap backend, where a
capped `n_predict` makes `finish_reason: "length"` easy to produce on demand
— that's how I noticed the field being dropped. (Unrelated to #1636, which is
a different silent-truncation class on the STT-prompt side; I ran into this
gap while instrumenting that repro.)

Possible follow-up, if there's appetite: a user-visible notice when a cleanup
comes back truncated. That one has real UX questions (which providers, and
the default cloud path doesn't expose a finish reason today), so I'd rather
propose it separately than bundle it here.
