### PR TITLE
fix(snippets): handle nullish and partial settings in getDictionaryHintWords

### DIFF
--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -76,10 +76,16 @@ export function expandSnippets(text: string, snippets: Snippet[]): string {
  * Dictionary words plus snippet triggers — the hint list fed to the STT
  * prompt and cleanup-model dictionary suffix so triggers survive both.
  */
-export function getDictionaryHintWords(settings: {
-  customDictionary: string[];
-  snippets: Snippet[];
-}): string[] {
-  if (settings.snippets.length === 0) return settings.customDictionary;
-  return [...settings.customDictionary, ...settings.snippets.map((s) => s.trigger)];
+export function getDictionaryHintWords(settings?: {
+  customDictionary?: string[] | null;
+  snippets?: Snippet[] | null;
+} | null): string[] {
+  const dictionary = Array.isArray(settings?.customDictionary) ? settings.customDictionary : [];
+  const snippets = Array.isArray(settings?.snippets) ? settings.snippets : [];
+  if (snippets.length === 0) return [...dictionary];
+
+  const triggers = snippets
+    .map((s) => s?.trigger)
+    .filter((t): t is string => typeof t === "string" && t.length > 0);
+  return [...dictionary, ...triggers];
 }

--- a/test/utils/snippets.test.js
+++ b/test/utils/snippets.test.js
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { expandSnippets } = require("../../src/utils/snippets.ts");
+const { expandSnippets, getDictionaryHintWords } = require("../../src/utils/snippets.ts");
 
 test("expands a trigger containing Turkish capital İ", () => {
   const snippets = [{ trigger: "İmza", replacement: "Best regards,\nUmut" }];
@@ -74,4 +74,53 @@ test("plain ASCII triggers still fold case both ways", () => {
 test("multiple occurrences and unmatched text are preserved", () => {
   const snippets = [{ trigger: "İmza", replacement: "X" }];
   assert.equal(expandSnippets("İmza and imza, done", snippets), "X and X, done");
+});
+
+test("getDictionaryHintWords returns empty list on nullish, empty, or partial settings", () => {
+  assert.deepEqual(getDictionaryHintWords(null), []);
+  assert.deepEqual(getDictionaryHintWords(undefined), []);
+  assert.deepEqual(getDictionaryHintWords({}), []);
+  assert.deepEqual(getDictionaryHintWords({ customDictionary: null }), []);
+  assert.deepEqual(getDictionaryHintWords({ snippets: null }), []);
+  assert.deepEqual(getDictionaryHintWords({ customDictionary: null, snippets: null }), []);
+});
+
+test("getDictionaryHintWords preserves customDictionary when snippets are absent or empty", () => {
+  const customDictionary = ["OpenWhispr", "Supabase"];
+  const result = getDictionaryHintWords({ customDictionary });
+  assert.deepEqual(result, ["OpenWhispr", "Supabase"]);
+  // Must return a fresh array, not the input reference
+  assert.notEqual(result, customDictionary);
+
+  const emptySnippetsResult = getDictionaryHintWords({ customDictionary, snippets: [] });
+  assert.deepEqual(emptySnippetsResult, ["OpenWhispr", "Supabase"]);
+  assert.notEqual(emptySnippetsResult, customDictionary);
+});
+
+test("getDictionaryHintWords extracts triggers when customDictionary is absent or empty", () => {
+  const snippets = [
+    { trigger: "my cal", replacement: "cal.com/me" },
+    { trigger: "zoom link", replacement: "zoom.us/j/123" },
+  ];
+  assert.deepEqual(getDictionaryHintWords({ snippets }), ["my cal", "zoom link"]);
+  assert.deepEqual(getDictionaryHintWords({ customDictionary: [], snippets }), [
+    "my cal",
+    "zoom link",
+  ]);
+});
+
+test("getDictionaryHintWords combines dictionary words and snippet triggers safely", () => {
+  const settings = {
+    customDictionary: ["OpenWhispr", "Supabase"],
+    snippets: [
+      { trigger: "my cal", replacement: "cal.com/me" },
+      { trigger: "zoom link", replacement: "zoom.us/j/123" },
+    ],
+  };
+  assert.deepEqual(getDictionaryHintWords(settings), [
+    "OpenWhispr",
+    "Supabase",
+    "my cal",
+    "zoom link",
+  ]);
 });


### PR DESCRIPTION
Fixes #1671

### Problem
`getDictionaryHintWords` in `src/utils/snippets.ts` assumed `settings`, `settings.snippets`, and `settings.customDictionary` are always present and populated arrays. When called with `null`, `undefined`, empty object `{}`, or partial settings (e.g. `stSettings` during streaming transcription or `effectiveSettings` in PromptStudio), it threw uncaught `TypeError` exceptions (`Cannot read properties of undefined/null` or `settings.customDictionary is not iterable`).

Additionally, when `settings.snippets` was empty, it returned the underlying `settings.customDictionary` array reference directly instead of a new array copy, leaking mutable state to callers.

### Solution
- Handle nullish, empty, or partial `settings` objects safely by validating array presence for both `customDictionary` and `snippets`.
- Safely extract non-empty string triggers from `snippets`.
- Always return a new array copy rather than mutating or returning internal state references.
- Added regression tests in `test/utils/snippets.test.js` covering nullish inputs, partial settings, empty dictionaries/snippets, and combined trigger extraction.

### Verification
- `node --test test/utils/snippets.test.js` (passes, 14/14 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes cleanly)
- `git diff --check` (clean)