### PR TITLE
fix(network): classify EAI_AGAIN and EPIPE as known cloud errors

### DIFF
--- a/src/helpers/networkErrors.js
+++ b/src/helpers/networkErrors.js
@@ -2,8 +2,10 @@ const debugLogger = require("./debugLogger");
 
 const CODE_TO_KEY = {
   ENOTFOUND: "streaming.errors.cloudUnreachable.dnsBlocked",
+  EAI_AGAIN: "streaming.errors.cloudUnreachable.dnsBlocked",
   ECONNREFUSED: "streaming.errors.cloudUnreachable.refused",
   ECONNRESET: "streaming.errors.cloudUnreachable.refused",
+  EPIPE: "streaming.errors.cloudUnreachable.refused",
   UND_ERR_SOCKET: "streaming.errors.cloudUnreachable.refused",
   ETIMEDOUT: "streaming.errors.cloudUnreachable.timeout",
   UND_ERR_CONNECT_TIMEOUT: "streaming.errors.cloudUnreachable.timeout",

--- a/test/helpers/networkErrors.test.js
+++ b/test/helpers/networkErrors.test.js
@@ -1,0 +1,35 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { classifyNetworkError } = require("../../src/helpers/networkErrors");
+
+describe("classifyNetworkError", () => {
+  it("treats ENOTFOUND as a DNS failure", () => {
+    const classified = classifyNetworkError({ code: "ENOTFOUND" });
+    assert.equal(classified.isNetworkError, true);
+    assert.equal(classified.messageKey, "streaming.errors.cloudUnreachable.dnsBlocked");
+  });
+
+  it("treats transient DNS (EAI_AGAIN) the same as ENOTFOUND", () => {
+    const classified = classifyNetworkError({ code: "EAI_AGAIN" });
+    assert.equal(classified.isNetworkError, true);
+    assert.equal(classified.messageKey, "streaming.errors.cloudUnreachable.dnsBlocked");
+  });
+
+  it("reads EAI_AGAIN from error.cause when the top-level code is missing", () => {
+    const classified = classifyNetworkError({ cause: { code: "EAI_AGAIN" } });
+    assert.equal(classified.isNetworkError, true);
+    assert.equal(classified.messageKey, "streaming.errors.cloudUnreachable.dnsBlocked");
+  });
+
+  it("treats a broken pipe as a refused connection", () => {
+    const classified = classifyNetworkError({ code: "EPIPE" });
+    assert.equal(classified.isNetworkError, true);
+    assert.equal(classified.messageKey, "streaming.errors.cloudUnreachable.refused");
+  });
+
+  it("leaves unknown codes unclassified", () => {
+    assert.deepEqual(classifyNetworkError({ code: "EPERM" }), { isNetworkError: false });
+    assert.deepEqual(classifyNetworkError(null), { isNetworkError: false });
+  });
+});


### PR DESCRIPTION
## Summary
- Transient DNS (`EAI_AGAIN`) and broken-pipe (`EPIPE`) errors were not in `classifyNetworkError()`, so cloud health / streaming showed the generic unreachable copy.
- `downloadUtils` already retries those codes; this maps them to the existing DNS and refused i18n keys.

## Problem
`ENOTFOUND` is classified as DNS-blocked. Node often reports a flaky resolver as `EAI_AGAIN` (sometimes only on `error.cause`). That path returned `{ isNetworkError: false }`, so `cloud-health-check` used `streaming.errors.cloudUnreachable.generic`.

## Root cause
`CODE_TO_KEY` listed a subset of Node/undici codes and was never aligned with `RETRYABLE_CODES` in `downloadUtils.js`.

## Fix
| Code | Copy |
| --- | --- |
| `EAI_AGAIN` | same as `ENOTFOUND` (`dnsBlocked`) |
| `EPIPE` | same as `ECONNRESET` (`refused`) |

`err.cause?.code` already works; it just needed map entries.

## Scope
- `src/helpers/networkErrors.js` and a unit test only
- No download, retry-strategy, or translation-string changes

## Tests
`test/helpers/networkErrors.test.js`

```bash
ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/networkErrors.test.js
```

(`debugLogger` loads Electron; the stub is the same pattern as other helper tests.)

Fixes #1680