### PR TITLE
fix(notes): parse share-dialog email domains without leftover whitespace

### DIFF
--- a/src/utils/personalEmailDomains.ts
+++ b/src/utils/personalEmailDomains.ts
@@ -36,10 +36,19 @@ const PERSONAL_EMAIL_DOMAINS = new Set<string>([
 ]);
 
 export function emailDomain(email: string): string {
-  const at = email.indexOf("@");
-  return at === -1 ? "" : email.slice(at + 1).toLowerCase();
+  if (typeof email !== "string") return "";
+  const trimmed = email.trim();
+  const angle = /<([^<>]+)>/.exec(trimmed);
+  const addr = (angle ? angle[1] : trimmed).trim();
+  const at = addr.lastIndexOf("@");
+  if (at === -1) return "";
+  return addr
+    .slice(at + 1)
+    .trim()
+    .toLowerCase();
 }
 
 export function isPersonalEmailDomain(domain: string): boolean {
+  if (typeof domain !== "string") return false;
   return PERSONAL_EMAIL_DOMAINS.has(domain.toLowerCase());
 }

--- a/test/helpers/personalEmailDomains.test.js
+++ b/test/helpers/personalEmailDomains.test.js
@@ -1,0 +1,25 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+
+const load = () => import("../../src/utils/personalEmailDomains.ts");
+
+test("strips surrounding whitespace before taking the domain", async () => {
+  const { emailDomain, isPersonalEmailDomain } = await load();
+  assert.equal(emailDomain("  user@Gmail.com  "), "gmail.com");
+  assert.equal(isPersonalEmailDomain(emailDomain("  user@Gmail.com  ")), true);
+});
+
+test("reads the mailbox inside display-name angle brackets", async () => {
+  const { emailDomain, isPersonalEmailDomain } = await load();
+  assert.equal(emailDomain("Jane <jane@acme.com>"), "acme.com");
+  assert.equal(isPersonalEmailDomain(emailDomain("Jane <jane@acme.com>")), false);
+});
+
+test("does not throw on non-string input", async () => {
+  const { emailDomain, isPersonalEmailDomain } = await load();
+  assert.equal(emailDomain(null), "");
+  assert.equal(isPersonalEmailDomain(null), false);
+});


### PR DESCRIPTION
## Summary
- Share Note uses `emailDomain()` to decide whether to offer “share with company domain”.
- Whitespace and `Name <addr>` wrappers left junk in the domain, so personal Gmail could look like a company domain.

## Problem
On current `main`:

| Input | `emailDomain()` |
| --- | --- |
| `"  user@Gmail.com  "` | `"gmail.com  "` (not in the personal set) |
| `"Jane <jane@acme.com>"` | `"acme.com>"` |

`isPersonalEmailDomain` then returns false for padded Gmail, so `showDomainOption` turns on incorrectly.

## Root cause
`emailDomain` used `indexOf("@")` on the raw string with no trim and no mailbox extraction.

## Fix
Trim the input, prefer an `<addr>` mailbox when present, take the domain after the last `@`, and ignore non-string values in both helpers.

## Scope
- `src/utils/personalEmailDomains.ts` and a unit test only
- No sharing API or personal-domain list changes

## Tests
`test/helpers/personalEmailDomains.test.js`

```bash
ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/personalEmailDomains.test.js
```

Fixes #1681