### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ React 19, TypeScript, Tailwind CSS v4, Electron 41, better-sqlite3, whisper.cpp,
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenWhispr/openwhispr&type=date&legend=top-left)](https://www.star-history.com/#OpenWhispr/openwhispr&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenWhispr/openwhispr&type=date&legend=top-left)](https://star-history.dera.page/#OpenWhispr/openwhispr&type=date&legend=top-left)
 
 ## Sponsors
 


### PR DESCRIPTION
The star history chart in the README is broken: the upstream service can no longer render it under GitHub's stargazer API restrictions, so the image fails to load. This switches the chart to star-history.dera.page, an alternative that uses a different data source requiring no API token and that serves both the chart image and the page from the same domain. The chart endpoint, query parameters, and hash-based link format are preserved.