### PR TITLE
fix(debug-log): include app version in the System Info header

### DIFF
--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -74,6 +74,7 @@ class DebugLogger {
 
       this.debug("Debug logging enabled", { logFile: this.logFile });
       this.info("System Info", {
+        appVersion: app.getVersion(),
         platform: process.platform,
         nodeVersion: process.version,
         electronVersion: process.versions.electron,

--- a/test/helpers/debugLogger.test.js
+++ b/test/helpers/debugLogger.test.js
@@ -1,0 +1,53 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+// Regression: the System Info header logged platform/node/electron but not the
+// app version, so the first triage question ("which release is this?") was
+// unanswerable from a customer debug log (CUS-113 had to infer 1.8.x from the
+// Electron version).
+test("debug log System Info header includes the app version", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "debugLogger-test-"));
+  const electronPath = require.resolve("electron");
+  const debugLoggerPath = require.resolve("../../src/helpers/debugLogger.js");
+  const originalElectronCache = require.cache[electronPath];
+  const originalLoggerCache = require.cache[debugLoggerPath];
+
+  require.cache[electronPath] = {
+    exports: {
+      app: {
+        isReady: () => true,
+        getPath: () => tempDir,
+        getAppPath: () => "/mock/app",
+        getVersion: () => "9.9.9-test",
+      },
+    },
+  };
+  delete require.cache[debugLoggerPath];
+
+  try {
+    const debugLogger = require(debugLoggerPath);
+    debugLogger.initializeFileLogging();
+
+    const logFile = debugLogger.getLogPath();
+    const stream = debugLogger.logStream;
+    if (typeof stream.fd !== "number") {
+      await new Promise((resolve) => stream.once("open", resolve));
+    }
+    debugLogger.close();
+    await new Promise((resolve) => stream.once("finish", resolve));
+
+    const contents = fs.readFileSync(logFile, "utf8");
+    assert.match(contents, /System Info/);
+    assert.match(contents, /appVersion/);
+    assert.match(contents, /9\.9\.9-test/);
+  } finally {
+    delete require.cache[debugLoggerPath];
+    if (originalLoggerCache) require.cache[debugLoggerPath] = originalLoggerCache;
+    if (originalElectronCache) require.cache[electronPath] = originalElectronCache;
+    else delete require.cache[electronPath];
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/helpers/debugLoggerConsolePolicy.test.js
+++ b/test/helpers/debugLoggerConsolePolicy.test.js
@@ -63,6 +63,7 @@ function loadLogger({
         app: {
           getAppPath: () => "/openwhispr",
           getPath: () => userDataPath,
+          getVersion: () => "9.9.9-test",
           isPackaged,
           isReady: () => isReady,
         },


### PR DESCRIPTION
**Problem:** Customer debug logs record platform, Node, and Electron versions but not the app's own version, so the first triage question — which release produced this log — is unanswerable.

**Fix:** Add `appVersion: app.getVersion()` as the first field of the System Info header that debugLogger writes when file logging initializes; regression test covers the header contents.

## Root cause
`debugLogger.initializeFileLogging()` logs a System Info header built only from `process`-derived fields; `app.getVersion()` was never included, and nothing else in the log carries the release version.

## Tests
- **RED:** new `test/helpers/debugLogger.test.js` (electron mocked via require-cache, per the existing `downloadUtils.test.js` pattern) fails on current main: `The input did not match the regular expression /appVersion/`.
- **GREEN:** passes with the fix; full suite 2091 tests, 0 fail (170 = known Electron-ABI better-sqlite3 local skips).

## Provenance
Contributing defect #4 from the CUS-113 RCA (Titan `wiki/areas/engineering/whisper-server-dll-not-found-rca.md`): triaging `debug-2026-08-17T12-23-22-137Z.log` required inferring the app version 1.8.x from Electron 41.10.0. Companion packaging fix: #1687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)