### PR TITLE
fix(i18n): map zh-Hans and zh-Hant locale tags to Chinese UI

### DIFF
--- a/main.js
+++ b/main.js
@@ -413,8 +413,7 @@ function initializeCoreManagers() {
   debugLogger.ensureFileLogging();
 
   environmentManager = new EnvironmentManager();
-  const uiLanguage = environmentManager.getUiLanguage();
-  process.env.UI_LANGUAGE = uiLanguage;
+  const uiLanguage = environmentManager.getUiLanguage(app.getLocale());
   changeLanguage(uiLanguage);
   debugLogger.refreshLogLevel();
 

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -489,8 +489,9 @@ class EnvironmentManager {
     return result;
   }
 
-  getUiLanguage() {
-    return normalizeUiLanguage(this._getKey("UI_LANGUAGE"));
+  getUiLanguage(fallbackLanguage = "") {
+    const language = this._getKey("UI_LANGUAGE") || fallbackLanguage;
+    return language ? normalizeUiLanguage(language) : "";
   }
 
   saveUiLanguage(language) {

--- a/src/helpers/i18nMain.js
+++ b/src/helpers/i18nMain.js
@@ -28,14 +28,26 @@ function normalizeUiLanguage(language) {
   const candidate = (language || "").trim();
 
   // Check full language-region code first (e.g. "zh-CN", "zh-TW")
-  const normalized = candidate.replace("_", "-");
+  const normalized = candidate.replace(/_/g, "-");
   const fullMatch = SUPPORTED_UI_LANGUAGES.find(
     (lang) => lang.toLowerCase() === normalized.toLowerCase()
   );
   if (fullMatch) return fullMatch;
 
+  // Chinese is the only UI language that is not the primary subtag. OS/browser
+  // tags are zh-Hans-CN, zh-Hant-TW, zh-HK, zh_Hant_TW, or bare zh — none of
+  // those equal zh-CN/zh-TW, and falling through to "zh" is not in the list.
+  const lower = normalized.toLowerCase();
+  if (lower === "zh" || lower.startsWith("zh-")) {
+    const parts = lower.split("-");
+    if (parts.some((part) => part === "hant" || part === "tw" || part === "hk" || part === "mo")) {
+      return "zh-TW";
+    }
+    return "zh-CN";
+  }
+
   // Fall back to base language code (e.g. "en" from "en-US")
-  const base = candidate.split("-")[0].split("_")[0].toLowerCase();
+  const base = lower.split("-")[0];
   return SUPPORTED_UI_LANGUAGES.includes(base) ? base : "en";
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,14 +21,25 @@ export function normalizeUiLanguage(language: string | null | undefined): UiLang
   const candidate = (language || "").trim();
 
   // Check full language-region code first (e.g. "zh-CN", "zh-TW")
-  const normalized = candidate.replace("_", "-");
+  const normalized = candidate.replace(/_/g, "-");
   const fullMatch = SUPPORTED_UI_LANGUAGES.find(
     (lang) => lang.toLowerCase() === normalized.toLowerCase()
   );
   if (fullMatch) return fullMatch;
 
+  // Keep in sync with src/helpers/i18nMain.js. Chinese is the only UI language
+  // that is not the primary subtag; OS/browser tags must map onto zh-CN/zh-TW.
+  const lower = normalized.toLowerCase();
+  if (lower === "zh" || lower.startsWith("zh-")) {
+    const parts = lower.split("-");
+    if (parts.some((part) => part === "hant" || part === "tw" || part === "hk" || part === "mo")) {
+      return "zh-TW";
+    }
+    return "zh-CN";
+  }
+
   // Fall back to base language code (e.g. "en" from "en-US")
-  const base = candidate.split("-")[0].split("_")[0].toLowerCase() as UiLanguage;
+  const base = lower.split("-")[0] as UiLanguage;
   if (SUPPORTED_UI_LANGUAGES.includes(base)) {
     return base;
   }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1164,7 +1164,9 @@ function syncAfterLocalWrite(method: "syncDictionaryNow" | "syncSnippetsNow"): v
 }
 
 export const useSettingsStore = create<SettingsState>()((set, get) => ({
-  uiLanguage: normalizeUiLanguage(isBrowser ? localStorage.getItem("uiLanguage") : null),
+  uiLanguage: normalizeUiLanguage(
+    isBrowser ? localStorage.getItem("uiLanguage") || i18n.language : null
+  ),
   useLocalWhisper: readBoolean("useLocalWhisper", false),
   whisperModel: readString("whisperModel", "base"),
   localTranscriptionProvider: (readString("localTranscriptionProvider", "whisper") === "nvidia"

--- a/test/helpers/i18nMain.test.js
+++ b/test/helpers/i18nMain.test.js
@@ -1,0 +1,28 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { normalizeUiLanguage } = require("../../src/helpers/i18nMain");
+
+describe("normalizeUiLanguage", () => {
+  it("keeps exact supported tags, including underscore zh_CN / zh_TW", () => {
+    assert.equal(normalizeUiLanguage("zh-CN"), "zh-CN");
+    assert.equal(normalizeUiLanguage("zh_TW"), "zh-TW");
+    assert.equal(normalizeUiLanguage("en-US"), "en");
+    assert.equal(normalizeUiLanguage("pt-BR"), "pt");
+  });
+
+  it("maps Chinese script and region tags onto zh-CN / zh-TW", () => {
+    assert.equal(normalizeUiLanguage("zh-Hans"), "zh-CN");
+    assert.equal(normalizeUiLanguage("zh-Hans-CN"), "zh-CN");
+    assert.equal(normalizeUiLanguage("zh"), "zh-CN");
+    assert.equal(normalizeUiLanguage("zh-Hant"), "zh-TW");
+    assert.equal(normalizeUiLanguage("zh-Hant-TW"), "zh-TW");
+    assert.equal(normalizeUiLanguage("zh_Hant_TW"), "zh-TW");
+    assert.equal(normalizeUiLanguage("zh-HK"), "zh-TW");
+  });
+
+  it("falls back to English for unknown languages", () => {
+    assert.equal(normalizeUiLanguage("ko-KR"), "en");
+    assert.equal(normalizeUiLanguage(""), "en");
+  });
+});

--- a/test/helpers/uiLanguageStartup.test.js
+++ b/test/helpers/uiLanguageStartup.test.js
@@ -1,0 +1,129 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+function installNavigatorLanguage(t, language) {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { language, languages: [language] },
+  });
+  t.after(() => {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", originalNavigator);
+    } else {
+      delete globalThis.navigator;
+    }
+  });
+}
+
+function loadEnvironmentManager(t, userDataDirectory) {
+  const originalLoad = Module._load;
+  const environmentPath = require.resolve("../../src/helpers/environment");
+  delete require.cache[environmentPath];
+
+  Module._load = function loadWithElectronStub(request, parent, isMain) {
+    if (request === "electron") {
+      return {
+        app: {
+          getPath: () => userDataDirectory,
+          getAppPath: () => userDataDirectory,
+          isReady: () => false,
+        },
+        safeStorage: {
+          isEncryptionAvailable: () => false,
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return require("../../src/helpers/environment");
+  } finally {
+    Module._load = originalLoad;
+    t.after(() => delete require.cache[environmentPath]);
+  }
+}
+
+test("fresh Chinese browser locale survives settings hydration", async (t) => {
+  installNavigatorLanguage(t, "zh-Hans-CN");
+  installBrowserGlobals(t, {
+    initialStorage: {
+      customDictionary: JSON.stringify(["OpenWhispr"]),
+    },
+    window: {
+      electronAPI: {
+        getDictionary: async () => ["OpenWhispr"],
+        getUiLanguage: async () => "",
+        setDictionary: async () => ({ success: true }),
+      },
+    },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-ui-language-startup-test-",
+  });
+
+  const { default: i18n } = await vite.ssrLoadModule("/i18n.ts");
+  const { initializeSettings, useSettingsStore } = await vite.ssrLoadModule(
+    "/stores/settingsStore.ts"
+  );
+  const initialLanguage = i18n.language;
+  const initialStoreLanguage = useSettingsStore.getState().uiLanguage;
+
+  await initializeSettings();
+
+  assert.deepEqual(
+    {
+      initialLanguage,
+      initialStoreLanguage,
+      hydratedLanguage: i18n.language,
+      hydratedStoreLanguage: useSettingsStore.getState().uiLanguage,
+      persistedLanguage: localStorage.getItem("uiLanguage"),
+    },
+    {
+      initialLanguage: "zh-CN",
+      initialStoreLanguage: "zh-CN",
+      hydratedLanguage: "zh-CN",
+      hydratedStoreLanguage: "zh-CN",
+      persistedLanguage: null,
+    }
+  );
+});
+
+test("main locale fallback remains implicit and yields to an explicit preference", (t) => {
+  const userDataDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-ui-language-"));
+  const originalEnvironment = { ...process.env };
+  const originalResourcesPath = process.resourcesPath;
+  process.resourcesPath = userDataDirectory;
+  delete process.env.UI_LANGUAGE;
+  t.after(() => {
+    process.env = originalEnvironment;
+    process.resourcesPath = originalResourcesPath;
+    fs.rmSync(userDataDirectory, { recursive: true, force: true });
+  });
+
+  const EnvironmentManager = loadEnvironmentManager(t, userDataDirectory);
+  const environmentManager = new EnvironmentManager();
+  const unsetLanguage = environmentManager.getUiLanguage();
+  const detectedLanguage = environmentManager.getUiLanguage("zh-Hant-TW");
+  const environmentAfterDetection = process.env.UI_LANGUAGE;
+
+  process.env.UI_LANGUAGE = "de-DE";
+  const explicitLanguage = environmentManager.getUiLanguage("zh-Hant-TW");
+
+  assert.deepEqual(
+    { unsetLanguage, detectedLanguage, environmentAfterDetection, explicitLanguage },
+    {
+      unsetLanguage: "",
+      detectedLanguage: "zh-TW",
+      environmentAfterDetection: undefined,
+      explicitLanguage: "de",
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- `navigator.language` / OS tags like `zh-Hans-CN` and `zh-Hant-TW` were not treated as Chinese, so the UI loaded English.
- Map those BCP-47 tags onto the existing `zh-CN` / `zh-TW` locale packs in both renderer and main-process helpers.

## Problem
`normalizeUiLanguage()` matches exact `zh-CN` / `zh-TW` (plus a single `_` → `-`). The base-language fallback is `"zh"`, which is not in `SUPPORTED_UI_LANGUAGES`.

| Input | Before | After |
| --- | --- | --- |
| `zh-CN` / `zh_TW` | `zh-CN` / `zh-TW` | unchanged |
| `zh-Hans-CN`, `zh-Hans`, `zh` | `en` | `zh-CN` |
| `zh-Hant-TW`, `zh_Hant_TW`, `zh-HK` | `en` | `zh-TW` |
| `en-US`, `pt-BR` | `en`, `pt` | unchanged |

## Root cause
Chinese is the only shipped UI language whose primary subtag is not itself a locale id. `replace("_", "-")` also only rewrote the first underscore.

## Fix
- Rewrite every `_` to `-`
- Map Hans / CN / SG / bare `zh` → `zh-CN`
- Map Hant / TW / HK / MO → `zh-TW`
- Same logic in `src/i18n.ts` and `src/helpers/i18nMain.js`

## Scope
- No new translation files
- No Settings UI changes

## Tests
`test/helpers/i18nMain.test.js`

```bash
node --test test/helpers/i18nMain.test.js
```

Fixes #1689