### PR TITLE
chore: format files left unformatted on main

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -74,7 +74,10 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { validateHotkeyForSlot } from "../utils/hotkeyValidation";
 import { getPlatform, getCachedPlatform } from "../utils/platform";
 import { formatHotkeyLabel } from "../utils/hotkeys";
-import { getLinuxPasteInstallCommands, needsLinuxPasteToolGuidance } from "../utils/linuxPasteTools";
+import {
+  getLinuxPasteInstallCommands,
+  needsLinuxPasteToolGuidance,
+} from "../utils/linuxPasteTools";
 import { ActivationModeSelector } from "./ui/ActivationModeSelector";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import LinuxPttSetupInfo from "./ui/LinuxPttSetupInfo";

--- a/src/components/ui/PasteToolsInfo.tsx
+++ b/src/components/ui/PasteToolsInfo.tsx
@@ -3,7 +3,10 @@ import { Check, Terminal, Info } from "lucide-react";
 import { Button } from "./button";
 import { InfoBox } from "./InfoBox";
 import type { PasteToolsResult } from "../../types/electron";
-import { getLinuxPasteInstallCommands, needsLinuxPasteToolGuidance } from "../../utils/linuxPasteTools";
+import {
+  getLinuxPasteInstallCommands,
+  needsLinuxPasteToolGuidance,
+} from "../../utils/linuxPasteTools";
 
 interface PasteToolsInfoProps {
   pasteToolsInfo: PasteToolsResult | null;
@@ -121,8 +124,11 @@ export default function PasteToolsInfo({
                     t("pasteToolsInfo.wtypeFallbackDescription")
                   ) : (
                     <>
-                      {t("pasteToolsInfo.installPrefix")} {" "}
-                      <code className="bg-warning/20 px-1 rounded font-mono">{recommendedTool}</code>:
+                      {t("pasteToolsInfo.installPrefix")}{" "}
+                      <code className="bg-warning/20 px-1 rounded font-mono">
+                        {recommendedTool}
+                      </code>
+                      :
                     </>
                   )}
                 </p>

--- a/src/services/WorkspacesService.ts
+++ b/src/services/WorkspacesService.ts
@@ -24,10 +24,7 @@ async function create(name: string): Promise<Workspace> {
   return res.data;
 }
 
-async function update(
-  workspaceId: string,
-  patch: { name?: string }
-): Promise<Workspace> {
+async function update(workspaceId: string, patch: { name?: string }): Promise<Workspace> {
   const res = await cloudPatch<DataWrap<Workspace>>(`/api/workspaces/${workspaceId}`, patch);
   return res.data;
 }

--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -76,10 +76,12 @@ export function expandSnippets(text: string, snippets: Snippet[]): string {
  * Dictionary words plus snippet triggers — the hint list fed to the STT
  * prompt and cleanup-model dictionary suffix so triggers survive both.
  */
-export function getDictionaryHintWords(settings?: {
-  customDictionary?: string[] | null;
-  snippets?: Snippet[] | null;
-} | null): string[] {
+export function getDictionaryHintWords(
+  settings?: {
+    customDictionary?: string[] | null;
+    snippets?: Snippet[] | null;
+  } | null
+): string[] {
   const dictionary = Array.isArray(settings?.customDictionary) ? settings.customDictionary : [];
   const snippets = Array.isArray(settings?.snippets) ? settings.snippets : [];
   if (snippets.length === 0) return [...dictionary];


### PR DESCRIPTION
## Problem

The weekend merge wave left four files on main that don't pass the project's prettier check: `src/components/SettingsPage.tsx`, `src/components/ui/PasteToolsInfo.tsx`, `src/services/WorkspacesService.ts`, `src/utils/snippets.ts`. Since the quality-check CI job runs `prettier --check` over the whole `src` tree, every new branch cut from main fails CI before its author has touched anything, community PRs included.

## Solution

Ran the project's prettier on exactly those four files. The diff is formatting only (import wraps, argument wrapping, JSX whitespace), and `npm run quality-check` exits 0 on this branch.