### PR TITLE
fix(calendar): treat date-only upcoming events as local calendar days

### DIFF
--- a/src/utils/dateFormatting.ts
+++ b/src/utils/dateFormatting.ts
@@ -27,8 +27,32 @@ export function formatRelativeTime(
   return formatShortDate(dateStr);
 }
 
-export function formatUpcomingDateGroup(date: Date | string, t: (key: string) => string): string {
-  const d = typeof date === "string" ? new Date(date) : date;
+function toUpcomingGroupDate(date: Date | string | null | undefined): Date | null {
+  if (date instanceof Date) {
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof date !== "string") return null;
+  const trimmed = date.trim();
+  if (!trimmed) return null;
+
+  // Google all-day events are date-only (`YYYY-MM-DD`). `new Date("YYYY-MM-DD")`
+  // is UTC midnight, which is still the previous local day west of UTC.
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (dateOnly) {
+    const parsed = new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function formatUpcomingDateGroup(
+  date: Date | string | null | undefined,
+  t: (key: string) => string
+): string {
+  const d = toUpcomingGroupDate(date);
+  if (!d) return "";
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const tomorrow = new Date(today);

--- a/test/helpers/dateGroupFormatting.test.js
+++ b/test/helpers/dateGroupFormatting.test.js
@@ -95,3 +95,26 @@ test("upcoming groups fall back to a formatted date further out", async (t2) => 
   assert.notEqual(result, "Today");
   assert.notEqual(result, "Tomorrow");
 });
+
+test("upcoming groups date-only strings as the local calendar day, not UTC midnight", async (t2) => {
+  const { formatUpcomingDateGroup } = await load();
+  const previousTimezone = process.env.TZ;
+  process.env.TZ = "America/Los_Angeles";
+
+  try {
+    t2.mock.timers.enable({ apis: ["Date"], now: new Date("2024-06-15T16:00:00Z") });
+
+    assert.equal(formatUpcomingDateGroup("2024-06-15", t), "Today");
+    assert.equal(formatUpcomingDateGroup("2024-06-16", t), "Tomorrow");
+  } finally {
+    if (previousTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = previousTimezone;
+  }
+});
+
+test("upcoming groups ignore null or invalid dates instead of throwing", async () => {
+  const { formatUpcomingDateGroup } = await load();
+  assert.equal(formatUpcomingDateGroup(null, t), "");
+  assert.equal(formatUpcomingDateGroup(undefined, t), "");
+  assert.equal(formatUpcomingDateGroup("not-a-date", t), "");
+});


### PR DESCRIPTION
## Summary
- Google all-day events store `start.date` as `YYYY-MM-DD`. `formatUpcomingDateGroup()` passed that to `new Date()`, which is UTC midnight — west of UTC that is still yesterday.
- Parse date-only strings as local calendar dates, and return an empty label for null/invalid input instead of throwing.

## Problem
On current `main` in `America/Los_Angeles` when today is 2026-08-18:

| Input | Before |
| --- | --- |
| `"2026-08-18"` (Google all-day) | `Monday, Aug 17` |
| `new Date(2026, 7, 18, 12)` | `Today` |
| `null` | throws `getFullYear` |

History grouping already uses `normalizeDbDate()` (#1272). That helper appends `Z` and is correct for SQLite timestamps, not for date-only all-day values.

## Root cause
ECMAScript date-only forms are UTC. Upcoming Meetings never got a local date-only parse.

## Fix
- `YYYY-MM-DD` → local `Date(y, m - 1, d)`
- Timed ISO / `Date` objects unchanged
- Null, non-strings, and invalid strings → `""`

## Scope
- `src/utils/dateFormatting.ts` and `test/helpers/dateGroupFormatting.test.js`
- No Google sync, Microsoft Graph `T00:00:00Z` all-day, or UI copy changes

## Tests

```bash
node --test test/helpers/dateGroupFormatting.test.js
```

Fixes #1705