### PR TITLE
fix(snippets): do not crash snippet expansion when the list is nullish

### DIFF
--- a/src/utils/snippets.ts
+++ b/src/utils/snippets.ts
@@ -52,8 +52,8 @@ function buildMatcher(snippets: Snippet[]): SnippetMatcher | null {
  * matcher is memoized against the snippets array reference (the settings
  * store replaces the array on every change).
  */
-export function expandSnippets(text: string, snippets: Snippet[]): string {
-  if (!text || snippets.length === 0) return text;
+export function expandSnippets(text: string, snippets?: Snippet[] | null): string {
+  if (!text || !Array.isArray(snippets) || snippets.length === 0) return text;
   if (snippets !== cachedSnippets) {
     cachedSnippets = snippets;
     cachedMatcher = buildMatcher(snippets);
@@ -76,10 +76,12 @@ export function expandSnippets(text: string, snippets: Snippet[]): string {
  * Dictionary words plus snippet triggers — the hint list fed to the STT
  * prompt and cleanup-model dictionary suffix so triggers survive both.
  */
-export function getDictionaryHintWords(settings?: {
-  customDictionary?: string[] | null;
-  snippets?: Snippet[] | null;
-} | null): string[] {
+export function getDictionaryHintWords(
+  settings?: {
+    customDictionary?: string[] | null;
+    snippets?: Snippet[] | null;
+  } | null
+): string[] {
   const dictionary = Array.isArray(settings?.customDictionary) ? settings.customDictionary : [];
   const snippets = Array.isArray(settings?.snippets) ? settings.snippets : [];
   if (snippets.length === 0) return [...dictionary];

--- a/test/utils/snippets.test.js
+++ b/test/utils/snippets.test.js
@@ -76,6 +76,11 @@ test("multiple occurrences and unmatched text are preserved", () => {
   assert.equal(expandSnippets("İmza and imza, done", snippets), "X and X, done");
 });
 
+test("expandSnippets leaves the transcript unchanged when snippets is nullish", () => {
+  assert.equal(expandSnippets("hello there", null), "hello there");
+  assert.equal(expandSnippets("hello there", undefined), "hello there");
+});
+
 test("getDictionaryHintWords returns empty list on nullish, empty, or partial settings", () => {
   assert.deepEqual(getDictionaryHintWords(null), []);
   assert.deepEqual(getDictionaryHintWords(undefined), []);


### PR DESCRIPTION
## Summary
- Dictation always runs `expandSnippets(text, getSettings().snippets)` after transcription.
- A null/undefined snippets list threw on `.length` and dropped the paste. Guard it the same way `getDictionaryHintWords` already does.

## Problem
On current `main`:

```js
expandSnippets("hello", null)
// TypeError: Cannot read properties of null (reading 'length')
```

Cloud/settings apply can call `setSnippets(settings.snippets)` when `snippets !== undefined`, including `null`.

## Root cause
`expandSnippets` assumed the settings store always holds an array. #1672 hardened the STT hint helper only.

## Fix
Treat a non-array or empty list as “no snippets” and return the transcript unchanged.

## Scope
- `src/utils/snippets.ts` and `test/utils/snippets.test.js`
- No settings-store or SQLite changes

## Tests

```bash
node --test test/utils/snippets.test.js
```

Fixes #1706