### PR TITLE
fix(hotkeys): fall back when Hyprland rejects the bind under the Lua config provider

### DIFF
--- a/src/helpers/hyprctlResponse.js
+++ b/src/helpers/hyprctlResponse.js
@@ -1,0 +1,16 @@
+// hyprctl exits 0 even when the compositor rejects the command, reporting the
+// failure only in its response text — e.g. under the Lua config provider,
+// `hyprctl keyword bind` prints "keyword can't work with non-legacy parsers.
+// Use eval." and the bind never registers (#1675). A successful keyword
+// command answers "ok" (one per request); anything else is a rejection. Empty
+// output is tolerated so a hyprctl build that prints nothing on success does
+// not regress to a permanently failing bind.
+function isHyprctlResponseOk(output) {
+  const lines = String(output ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.every((line) => line.toLowerCase() === "ok");
+}
+
+module.exports = { isHyprctlResponseOk };

--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const debugLogger = require("./debugLogger");
+const { isHyprctlResponseOk } = require("./hyprctlResponse");
 
 const DBUS_SERVICE_NAME = "com.openwhispr.App";
 const DBUS_OBJECT_PATH = "/com/openwhispr/App";
@@ -393,10 +394,14 @@ class HyprlandShortcutManager {
         );
       }
 
-      execFileSync("hyprctl", ["keyword", "bind", bindValue], {
+      const bindResponse = execFileSync("hyprctl", ["keyword", "bind", bindValue], {
         stdio: "pipe",
         timeout: 5000,
+        encoding: "utf8",
       });
+      if (!isHyprctlResponseOk(bindResponse)) {
+        throw new Error(`hyprctl rejected the bind: ${bindResponse.trim()}`);
+      }
 
       this.currentBinding = converted.bindKey;
       this.isRegistered = true;

--- a/test/helpers/hyprlandShortcutResponse.test.js
+++ b/test/helpers/hyprlandShortcutResponse.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isHyprctlResponseOk } = require("../../src/helpers/hyprctlResponse");
+
+test("plain ok responses are accepted", () => {
+  assert.equal(isHyprctlResponseOk("ok"), true);
+  assert.equal(isHyprctlResponseOk("ok\n"), true);
+  assert.equal(isHyprctlResponseOk("ok\nok\n"), true);
+  assert.equal(isHyprctlResponseOk("OK"), true);
+});
+
+test("empty output is not treated as a rejection", () => {
+  assert.equal(isHyprctlResponseOk(""), true);
+  assert.equal(isHyprctlResponseOk("\n"), true);
+  assert.equal(isHyprctlResponseOk(null), true);
+  assert.equal(isHyprctlResponseOk(undefined), true);
+});
+
+test("the Lua config provider rejection is detected (#1675)", () => {
+  // hyprctl exits 0 for this — the rejection exists only in the response text.
+  assert.equal(isHyprctlResponseOk("keyword can't work with non-legacy parsers. Use eval."), false);
+});
+
+test("other compositor error texts are detected", () => {
+  assert.equal(isHyprctlResponseOk("Invalid dispatcher"), false);
+  assert.equal(
+    isHyprctlResponseOk("ok\nkeyword can't work with non-legacy parsers. Use eval."),
+    false
+  );
+});


### PR DESCRIPTION
Closes #1675

The nasty part of this bug: hyprctl exits 0 when the compositor rejects the command. Under the Lua config provider it answers "keyword can't work with non-legacy parsers. Use eval." with a clean exit code. `registerKeybinding()` ran execFileSync with `stdio: "pipe"`, never read the output, and returned true unconditionally. So the app believed the hotkey registered, the Settings UI reported OK, and the fallback chain in `hotkeyManager` never got a chance to run.

## Changes

- `src/helpers/hyprctlResponse.js` (new): a keyword response counts as success only when every non-empty line is "ok". Empty output is tolerated so a hyprctl build that prints nothing on success doesn't regress to a permanently failing bind.
- `src/helpers/hyprlandShortcut.js`: captures the bind response and throws on rejection. The existing catch logs it and returns false, which activates the fallbacks that were already there: alternate keys via `tryNativeFallbacks`, then globalShortcut/portal. Persisting the bind to the config file is also skipped on rejection, so a dead bind no longer gets written to disk.

I can't run Hyprland with the Lua provider here, so the compositor-side behavior rests on the issue's repro (`hyprctl binds` stays empty after a 0-exit bind) plus the documented "ok" response contract. The response validation itself is unit-tested.

Writing binds into `hyprland.lua` directly would be the fuller fix for Lua-provider setups; this PR keeps scope to "stop lying about success and let the fallback chain work".

## Test

- `test/helpers/hyprlandShortcutResponse.test.js`, 4 cases, including the exact Lua rejection string and a mixed ok+error response.
- `npm test`: no new failures vs main. `npm run lint` and prettier clean.