### PR TITLE
feat(policy): Mirror the server-only memoryEnabled org-policy field

### DIFF
--- a/src/types/policy.ts
+++ b/src/types/policy.ts
@@ -27,6 +27,11 @@ export interface OrgPolicy {
     webSearchEnabled: boolean;
     /** Absent on servers that predate the field; absent means allowed. */
     screenContextEnabled?: boolean;
+    /**
+     * Server-only Mem0 agent-memory gate, enforced by the API on
+     * `/api/agent/stream`; the app never reads it. Absent on older servers.
+     */
+    memoryEnabled?: boolean;
   };
   sharing: {
     externalLinkSharing: ExternalSharingMode;

--- a/test/helpers/policyValidation.test.js
+++ b/test/helpers/policyValidation.test.js
@@ -65,6 +65,16 @@ test("rejects a malformed screenContextEnabled", () => {
   }
 });
 
+test("tolerates the server-only memoryEnabled flag", () => {
+  // The API gates Mem0 agent memory itself and the app never reads the field,
+  // so its presence must not invalidate an otherwise valid policy.
+  for (const value of [true, false]) {
+    const policy = validPolicy();
+    policy.features.memoryEnabled = value;
+    assert.equal(isValidPolicyShape(policy), true, String(value));
+  }
+});
+
 test("requires the supported policy schema version", () => {
   for (const version of [undefined, null, 0, 2, "1"]) {
     const policy = validPolicy();


### PR DESCRIPTION
## Summary

Mirrors the server-only `features.memoryEnabled` field in the desktop organization-policy type.

The API owns enforcement of this setting. The desktop app does not read or apply it, but it must tolerate the field so an otherwise valid policy response is not rejected.

## What changed

- Add optional `memoryEnabled` typing to `OrgPolicy.features`.
- Keep the field optional for compatibility with servers that predate it.
- Confirm the desktop policy validator accepts both `true` and `false`.
- Leave all desktop agent behavior unchanged; Mem0 retrieval and persistence are controlled by the API.

## Compatibility

- Older API responses without the field remain valid.
- New API responses containing the field remain valid.
- The field cannot independently cause the desktop policy validator to fail closed.
- No user-facing desktop UI or behavior changes are introduced.

## Testing

- `node --import tsx --test test/helpers/policyValidation.test.js` — 16 tests passing
- `npm run typecheck`