### PR TITLE
fix(linux): Preserve focus for Sway overlays

### DIFF
--- a/src/helpers/linuxSession.js
+++ b/src/helpers/linuxSession.js
@@ -1,31 +1,43 @@
 const WLROOTS_DESKTOPS = ["sway", "hyprland", "wayfire", "river", "dwl", "labwc", "cage"];
 
-function getLinuxSessionInfo() {
+function getLinuxSessionInfo(environment = process.env) {
   const isWayland =
-    (process.env.XDG_SESSION_TYPE || "").toLowerCase() === "wayland" ||
-    !!process.env.WAYLAND_DISPLAY;
+    (environment.XDG_SESSION_TYPE || "").toLowerCase() === "wayland" ||
+    !!environment.WAYLAND_DISPLAY;
   const desktopEnv = [
-    process.env.XDG_CURRENT_DESKTOP,
-    process.env.XDG_SESSION_DESKTOP,
-    process.env.DESKTOP_SESSION,
+    environment.XDG_CURRENT_DESKTOP,
+    environment.XDG_SESSION_DESKTOP,
+    environment.DESKTOP_SESSION,
   ]
     .filter(Boolean)
     .join(":")
     .toLowerCase();
+  const isGnome = isWayland && desktopEnv.includes("gnome");
+  const isKde = isWayland && desktopEnv.includes("kde");
+  const isHyprland = isWayland && !!environment.HYPRLAND_INSTANCE_SIGNATURE;
+  // SWAYSOCK can survive a compositor switch, so trust it only when no desktop
+  // metadata identifies the current session.
+  const isSway =
+    isWayland &&
+    !isGnome &&
+    !isKde &&
+    !isHyprland &&
+    (desktopEnv.includes("sway") || (!desktopEnv && !!environment.SWAYSOCK));
   const isWlroots =
     isWayland &&
     (WLROOTS_DESKTOPS.some((desktop) => desktopEnv.includes(desktop)) ||
-      !!process.env.SWAYSOCK ||
-      !!process.env.HYPRLAND_INSTANCE_SIGNATURE);
+      !!environment.SWAYSOCK ||
+      !!environment.HYPRLAND_INSTANCE_SIGNATURE);
 
   return {
     isWayland,
-    xwaylandAvailable: isWayland && !!process.env.DISPLAY,
+    xwaylandAvailable: isWayland && !!environment.DISPLAY,
     desktopEnv,
-    isGnome: isWayland && desktopEnv.includes("gnome"),
-    isKde: isWayland && desktopEnv.includes("kde"),
+    isGnome,
+    isKde,
     isWlroots,
-    isHyprland: isWayland && !!process.env.HYPRLAND_INSTANCE_SIGNATURE,
+    isHyprland,
+    isSway,
   };
 }
 

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -1,32 +1,50 @@
 const path = require("path");
+const { getLinuxSessionInfo } = require("./linuxSession");
 
-const isGnomeWayland =
-  process.platform === "linux" &&
-  process.env.XDG_SESSION_TYPE === "wayland" &&
-  /gnome|ubuntu|unity/i.test(process.env.XDG_CURRENT_DESKTOP || "");
+const FOCUSLESS_OVERLAY_ROLES = new Set(["main", "notification", "transcription-preview"]);
 
-const isKDEWayland =
-  process.platform === "linux" &&
-  process.env.XDG_SESSION_TYPE === "wayland" &&
-  /kde/i.test(process.env.XDG_CURRENT_DESKTOP || "");
+function usesGnomeOverlayPolicy(linuxSession) {
+  return (
+    linuxSession.isWayland &&
+    (linuxSession.isGnome || /ubuntu|unity/.test(linuxSession.desktopEnv || ""))
+  );
+}
 
-const MAIN_OVERLAY_TYPE =
-  process.platform === "darwin"
-    ? "panel"
-    : process.platform === "linux"
-      ? isGnomeWayland || isKDEWayland
-        ? "normal"
-        : "toolbar"
-      : "normal";
+function resolveOverlayWindowType({ role, platform, linuxSession }) {
+  if (platform === "darwin") return "panel";
+  if (platform !== "linux") return "normal";
 
-const FLOATING_OVERLAY_TYPE =
-  process.platform === "darwin"
-    ? "panel"
-    : process.platform === "linux"
-      ? isKDEWayland
-        ? "normal"
-        : "toolbar"
-      : "normal";
+  // Sway asks wlroots whether an unmanaged XWayland surface wants focus.
+  // "toolbar" opts in; "notification" keeps the existing text field focused.
+  if (
+    linuxSession.isSway &&
+    linuxSession.xwaylandAvailable &&
+    FOCUSLESS_OVERLAY_ROLES.has(role)
+  ) {
+    return "notification";
+  }
+
+  if (linuxSession.isKde || (role === "main" && usesGnomeOverlayPolicy(linuxSession))) {
+    return "normal";
+  }
+  return "toolbar";
+}
+
+const linuxSession = getLinuxSessionInfo();
+const OVERLAY_WINDOW_TYPES = {
+  main: resolveOverlayWindowType({ role: "main", platform: process.platform, linuxSession }),
+  notification: resolveOverlayWindowType({
+    role: "notification",
+    platform: process.platform,
+    linuxSession,
+  }),
+  transcriptionPreview: resolveOverlayWindowType({
+    role: "transcription-preview",
+    platform: process.platform,
+    linuxSession,
+  }),
+  agent: resolveOverlayWindowType({ role: "agent", platform: process.platform, linuxSession }),
+};
 
 const WINDOW_SIZES = {
   BASE: { width: 96, height: 96 },
@@ -57,7 +75,7 @@ const MAIN_WINDOW_CONFIG = {
   fullScreenable: false,
   hasShadow: false,
   acceptsFirstMouse: true,
-  type: MAIN_OVERLAY_TYPE,
+  type: OVERLAY_WINDOW_TYPES.main,
 };
 
 // Control panel window configuration
@@ -118,7 +136,7 @@ const NOTIFICATION_WINDOW_CONFIG = {
     sandbox: true,
   },
   visibleOnAllWorkspaces: process.platform !== "win32",
-  type: FLOATING_OVERLAY_TYPE,
+  type: OVERLAY_WINDOW_TYPES.notification,
 };
 
 const AUTO_END_NOTIFICATION_WINDOW_SIZE = {
@@ -164,7 +182,7 @@ const TRANSCRIPTION_PREVIEW_CONFIG = {
     sandbox: true,
   },
   visibleOnAllWorkspaces: process.platform !== "win32",
-  type: FLOATING_OVERLAY_TYPE,
+  type: OVERLAY_WINDOW_TYPES.transcriptionPreview,
 };
 
 class WindowPositionUtil {
@@ -259,7 +277,7 @@ class WindowPositionUtil {
       }
     } else if (process.platform === "win32") {
       window.setAlwaysOnTop(true, "pop-up-menu");
-    } else if (isGnomeWayland) {
+    } else if (usesGnomeOverlayPolicy(linuxSession)) {
       window.setAlwaysOnTop(true, "floating");
     } else {
       // KDE XWayland and other Linux — "screen-saver" is the strongest z-level
@@ -285,7 +303,7 @@ const AGENT_OVERLAY_CONFIG = {
   resizable: false,
   fullScreenable: false,
   acceptsFirstMouse: true,
-  type: FLOATING_OVERLAY_TYPE,
+  type: OVERLAY_WINDOW_TYPES.agent,
   visibleOnAllWorkspaces: process.platform !== "win32",
   webPreferences: {
     preload: path.join(__dirname, "..", "..", "preload.js"),
@@ -309,4 +327,5 @@ module.exports = {
   TRANSCRIPTION_PREVIEW_SIZE_LIMITS,
   WINDOW_SIZES,
   WindowPositionUtil,
+  resolveOverlayWindowType,
 };

--- a/test/helpers/linuxSession.test.js
+++ b/test/helpers/linuxSession.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { getLinuxSessionInfo } = require("../../src/helpers/linuxSession.js");
+
+test("detects Sway XWayland from desktop metadata", () => {
+  const session = getLinuxSessionInfo({
+    XDG_SESSION_TYPE: "wayland",
+    XDG_CURRENT_DESKTOP: "sway",
+    WAYLAND_DISPLAY: "wayland-1",
+    DISPLAY: ":0",
+  });
+
+  assert.equal(session.isSway, true);
+  assert.equal(session.xwaylandAvailable, true);
+});
+
+test("detects a TTY-launched Sway XWayland session from its sockets", () => {
+  const session = getLinuxSessionInfo({
+    XDG_SESSION_TYPE: "tty",
+    WAYLAND_DISPLAY: "wayland-1",
+    DISPLAY: ":0",
+    SWAYSOCK: "/run/user/1000/sway-ipc.sock",
+  });
+
+  assert.equal(session.isWayland, true);
+  assert.equal(session.isSway, true);
+  assert.equal(session.xwaylandAvailable, true);
+});
+
+test("does not let a stale SWAYSOCK override a named compositor", () => {
+  const sessions = [
+    {
+      name: "Hyprland",
+      environment: {
+        XDG_SESSION_TYPE: "wayland",
+        XDG_CURRENT_DESKTOP: "Hyprland",
+        WAYLAND_DISPLAY: "wayland-1",
+        DISPLAY: ":0",
+        SWAYSOCK: "/run/user/1000/stale-sway.sock",
+        HYPRLAND_INSTANCE_SIGNATURE: "hyprland-instance",
+      },
+      expectedFlag: "isHyprland",
+    },
+    {
+      name: "GNOME",
+      environment: {
+        XDG_SESSION_TYPE: "wayland",
+        XDG_CURRENT_DESKTOP: "GNOME",
+        WAYLAND_DISPLAY: "wayland-1",
+        DISPLAY: ":0",
+        SWAYSOCK: "/run/user/1000/stale-sway.sock",
+      },
+      expectedFlag: "isGnome",
+    },
+    {
+      name: "KDE",
+      environment: {
+        XDG_SESSION_TYPE: "wayland",
+        XDG_CURRENT_DESKTOP: "KDE",
+        WAYLAND_DISPLAY: "wayland-1",
+        DISPLAY: ":0",
+        SWAYSOCK: "/run/user/1000/stale-sway.sock",
+      },
+      expectedFlag: "isKde",
+    },
+  ];
+
+  for (const { name, environment, expectedFlag } of sessions) {
+    const session = getLinuxSessionInfo(environment);
+
+    assert.equal(session.isSway, false, name);
+    assert.equal(session[expectedFlag], true, name);
+  }
+});

--- a/test/helpers/windowConfigTypes.test.js
+++ b/test/helpers/windowConfigTypes.test.js
@@ -1,0 +1,240 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const WINDOW_CONFIG_PATH = require.resolve("../../src/helpers/windowConfig.js");
+const { resolveOverlayWindowType } = require(WINDOW_CONFIG_PATH);
+
+const SESSION_ENV_KEYS = [
+  "XDG_SESSION_TYPE",
+  "XDG_CURRENT_DESKTOP",
+  "XDG_SESSION_DESKTOP",
+  "DESKTOP_SESSION",
+  "WAYLAND_DISPLAY",
+  "DISPLAY",
+  "SWAYSOCK",
+  "HYPRLAND_INSTANCE_SIGNATURE",
+];
+
+function setEnvironmentValue(key, value) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function loadWindowConfig({ platform, environment }) {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalEnvironment = Object.fromEntries(
+    SESSION_ENV_KEYS.map((key) => [key, process.env[key]])
+  );
+
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  for (const key of SESSION_ENV_KEYS) setEnvironmentValue(key, environment[key]);
+  delete require.cache[WINDOW_CONFIG_PATH];
+
+  try {
+    return require(WINDOW_CONFIG_PATH);
+  } finally {
+    Object.defineProperty(process, "platform", originalPlatform);
+    for (const key of SESSION_ENV_KEYS) setEnvironmentValue(key, originalEnvironment[key]);
+    delete require.cache[WINDOW_CONFIG_PATH];
+  }
+}
+
+const OVERLAY_ROLES = ["main", "notification", "transcription-preview", "agent"];
+
+function resolveAllOverlayTypes(platform, session) {
+  return Object.fromEntries(
+    OVERLAY_ROLES.map((role) => [
+      role,
+      resolveOverlayWindowType({ role, platform, linuxSession: session }),
+    ])
+  );
+}
+
+test("Sway XWayland uses notification type only for focusless overlays", () => {
+  const windowConfig = loadWindowConfig({
+    platform: "linux",
+    environment: {
+      XDG_SESSION_TYPE: "wayland",
+      XDG_CURRENT_DESKTOP: "sway",
+      WAYLAND_DISPLAY: "wayland-1",
+      DISPLAY: ":0",
+    },
+  });
+
+  assert.deepEqual(
+    {
+      main: windowConfig.MAIN_WINDOW_CONFIG.type,
+      notification: windowConfig.NOTIFICATION_WINDOW_CONFIG.type,
+      transcriptionPreview: windowConfig.TRANSCRIPTION_PREVIEW_CONFIG.type,
+      agent: windowConfig.AGENT_OVERLAY_CONFIG.type,
+    },
+    {
+      main: "notification",
+      notification: "notification",
+      transcriptionPreview: "notification",
+      agent: "toolbar",
+    }
+  );
+  assert.equal(windowConfig.MAIN_WINDOW_CONFIG.focusable, false);
+  assert.equal(windowConfig.NOTIFICATION_WINDOW_CONFIG.focusable, false);
+  assert.equal(windowConfig.TRANSCRIPTION_PREVIEW_CONFIG.focusable, false);
+  assert.equal(windowConfig.AGENT_OVERLAY_CONFIG.focusable, true);
+});
+
+test("the overlay resolver preserves every unaffected platform and session", () => {
+  const cases = [
+    {
+      name: "Sway without XWayland",
+      platform: "linux",
+      session: { isSway: true, xwaylandAvailable: false, isGnome: false, isKde: false },
+      expected: {
+        main: "toolbar",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "Hyprland",
+      platform: "linux",
+      session: { isSway: false, xwaylandAvailable: true, isGnome: false, isKde: false },
+      expected: {
+        main: "toolbar",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "GNOME Wayland",
+      platform: "linux",
+      session: {
+        isWayland: true,
+        isSway: false,
+        xwaylandAvailable: true,
+        desktopEnv: "gnome",
+        isGnome: true,
+        isKde: false,
+      },
+      expected: {
+        main: "normal",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "Ubuntu Unity Wayland",
+      platform: "linux",
+      session: {
+        isWayland: true,
+        isSway: false,
+        xwaylandAvailable: true,
+        desktopEnv: "ubuntu:unity",
+        isGnome: false,
+        isKde: false,
+      },
+      expected: {
+        main: "normal",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "Ubuntu Unity X11",
+      platform: "linux",
+      session: {
+        isWayland: false,
+        isSway: false,
+        xwaylandAvailable: false,
+        desktopEnv: "ubuntu:unity",
+        isGnome: false,
+        isKde: false,
+      },
+      expected: {
+        main: "toolbar",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "KDE Wayland",
+      platform: "linux",
+      session: { isSway: false, xwaylandAvailable: true, isGnome: false, isKde: true },
+      expected: {
+        main: "normal",
+        notification: "normal",
+        "transcription-preview": "normal",
+        agent: "normal",
+      },
+    },
+    {
+      name: "i3 X11",
+      platform: "linux",
+      session: { isSway: false, xwaylandAvailable: false, isGnome: false, isKde: false },
+      expected: {
+        main: "toolbar",
+        notification: "toolbar",
+        "transcription-preview": "toolbar",
+        agent: "toolbar",
+      },
+    },
+    {
+      name: "macOS",
+      platform: "darwin",
+      session: {},
+      expected: {
+        main: "panel",
+        notification: "panel",
+        "transcription-preview": "panel",
+        agent: "panel",
+      },
+    },
+    {
+      name: "Windows",
+      platform: "win32",
+      session: {},
+      expected: {
+        main: "normal",
+        notification: "normal",
+        "transcription-preview": "normal",
+        agent: "normal",
+      },
+    },
+  ];
+
+  for (const { name, platform, session, expected } of cases) {
+    assert.deepEqual(resolveAllOverlayTypes(platform, session), expected, name);
+  }
+});
+
+test("a stale SWAYSOCK does not change Hyprland window types", () => {
+  const windowConfig = loadWindowConfig({
+    platform: "linux",
+    environment: {
+      XDG_SESSION_TYPE: "wayland",
+      XDG_CURRENT_DESKTOP: "Hyprland",
+      WAYLAND_DISPLAY: "wayland-1",
+      DISPLAY: ":0",
+      SWAYSOCK: "/run/user/1000/stale-sway.sock",
+      HYPRLAND_INSTANCE_SIGNATURE: "hyprland-instance",
+    },
+  });
+
+  assert.deepEqual(
+    {
+      main: windowConfig.MAIN_WINDOW_CONFIG.type,
+      notification: windowConfig.NOTIFICATION_WINDOW_CONFIG.type,
+      transcriptionPreview: windowConfig.TRANSCRIPTION_PREVIEW_CONFIG.type,
+      agent: windowConfig.AGENT_OVERLAY_CONFIG.type,
+    },
+    {
+      main: "toolbar",
+      notification: "toolbar",
+      transcriptionPreview: "toolbar",
+      agent: "toolbar",
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #719.

OpenWhispr’s overlay windows could blur the active text field when shown under Sway/XWayland, causing auto-paste to fail even though the underlying application still appeared focused.

This change assigns Sway’s non-focusable overlays the Electron `notification` window type while keeping the agent/chat overlay focusable. Existing behavior remains unchanged on Hyprland, GNOME, KDE, i3, macOS, and Windows.

## Investigation

The issue was previously believed fixed, but was reproduced on Sway 1.11 with the AppImage in Obsidian, Chrome, and WezTerm.

The investigation found that:

- `focusable: false` causes these Electron windows to be mapped as override-redirect XWayland surfaces.
- Sway/wlroots determines whether those surfaces may take focus partly from `_NET_WM_WINDOW_TYPE`.
- The existing `toolbar` type is not in wlroots’ no-focus set, so mapping the overlay can blur the active text field.
- Sway’s `no_focus` rule does not reliably help because override-redirect windows do not appear in the normal `get_tree` output.
- The `notification` type prevents focus theft on Sway while preserving pointer interaction.
- Prior testing in #1026 found that applying `notification` broadly to Hyprland could make overlay actions unclickable.
- The agent/chat overlay must remain focusable because it accepts keyboard input.

The approach in #1026 established the underlying mechanism, but its session predicate could miss TTY-launched Sway sessions, misclassify sessions with a stale `SWAYSOCK`, and lacked regression coverage. This implementation addresses those gaps rather than applying that patch unchanged.

## Changes

- Extend Linux session detection to identify Sway from:
  - desktop metadata in regular sessions;
  - `WAYLAND_DISPLAY` and `SWAYSOCK` in TTY-launched sessions.
- Prevent stale `SWAYSOCK` values from overriding identified Hyprland, GNOME, or KDE sessions.
- Add a role-aware overlay window-type resolver:
  - main dictation overlay: `notification` on Sway/XWayland;
  - meeting/update notification overlay: `notification` on Sway/XWayland;
  - transcription preview: `notification` on Sway/XWayland;
  - agent/chat overlay: remains `toolbar` and focusable.
- Preserve the existing GNOME, KDE, Hyprland, i3, macOS, and Windows policies.
- Add focused session-detection and cross-platform resolver coverage.

## Verification

- Focused window/session tests: 19 passed, 0 failed.
- Broader dependency-free Linux/window suite: 104 passed, 0 failed, 6 platform skips.
- JavaScript syntax checks passed.
- `git diff --check` passed.
- Coverage includes:
  - regular and TTY-launched Sway sessions;
  - stale `SWAYSOCK` values;
  - Sway without XWayland;
  - Hyprland;
  - GNOME and Ubuntu/Unity Wayland;
  - KDE Wayland;
  - i3/X11;
  - macOS and Windows;
  - preservation of the focusable agent overlay.

## Remaining manual validation

A packaged Electron build still needs validation on a real Sway/XWayland session before merge:

- Confirm showing the dictation, notification, and preview overlays does not blur the active text field.
- Confirm their buttons and dragging remain usable.
- Confirm the update-notification actions remain clickable.
- Confirm the agent/chat overlay still accepts keyboard focus.

The local validation environment was macOS and did not provide Sway/XWayland. Project dependencies were intentionally not installed, so the full `npm test`, typecheck, lint, and packaged Linux build are left to CI or a prepared Linux development environment.

Related: #1026