### PR TITLE
fix(logging): Suppress packaged Windows console output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,11 @@ Enable with `--log-level=debug` or `OPENWHISPR_LOG_LEVEL=debug` (can be set in `
 - Audio level analysis
 - Complete reasoning pipeline debugging with stage-by-stage logging
 
+Packaged Windows builds keep logger output off stdout/stderr by default. Launch with
+`--console-logs` to opt into terminal output independently of the configured log level.
+Default INFO entries are not persisted in this mode; enabling debug logging retains them
+in the existing log file without enabling terminal output.
+
 ### 12. Windows Push-to-Talk
 
 Native Windows support for true push-to-talk functionality using low-level keyboard hooks:

--- a/src/helpers/debugLogger.js
+++ b/src/helpers/debugLogger.js
@@ -31,6 +31,8 @@ const readArgLogLevel = () => {
   return null;
 };
 
+const hasConsoleLogOptIn = () => (process.argv || []).includes("--console-logs");
+
 class DebugLogger {
   constructor() {
     this.logLevel = this.resolveLogLevel();
@@ -40,6 +42,7 @@ class DebugLogger {
     this.logStream = null;
     this.fileLoggingEnabled = false;
     this.fileLoggingPending = this.debugMode; // Track if we need to initialize file logging later
+    this.consoleLoggingEnabled = this.resolveConsoleLogging();
 
     // IMPORTANT: Do NOT call initializeFileLogging() here!
     // It uses app.getPath() which is unsafe before app.whenReady().
@@ -108,6 +111,11 @@ class DebugLogger {
     }
 
     return "info";
+  }
+
+  resolveConsoleLogging() {
+    // Packaged Windows apps can inherit the launching shell's standard handles.
+    return process.platform !== "win32" || !app.isPackaged || hasConsoleLogOptIn();
   }
 
   refreshLogLevel() {
@@ -191,18 +199,20 @@ class DebugLogger {
     const metaText = this.formatMeta(meta);
     const logLine = metaText ? `${baseLine} ${metaText}\n` : `${baseLine}\n`;
 
-    const consoleFn =
-      normalized === "error" || normalized === "fatal"
-        ? console.error
-        : normalized === "warn"
-          ? console.warn
-          : console.log;
+    if (this.consoleLoggingEnabled) {
+      const consoleFn =
+        normalized === "error" || normalized === "fatal"
+          ? console.error
+          : normalized === "warn"
+            ? console.warn
+            : console.log;
 
-    if (meta !== undefined) {
-      // Pass the prefix as a %s arg, not as a format string. See CodeQL js/tainted-format-string.
-      consoleFn("%s", `${levelTag}${scopeTag}${sourceTag} ${message}`, meta);
-    } else {
-      consoleFn(`${levelTag}${scopeTag}${sourceTag} ${message}`);
+      if (meta !== undefined) {
+        // Pass the prefix as a %s arg, not as a format string. See CodeQL js/tainted-format-string.
+        consoleFn("%s", `${levelTag}${scopeTag}${sourceTag} ${message}`, meta);
+      } else {
+        consoleFn(`${levelTag}${scopeTag}${sourceTag} ${message}`);
+      }
     }
 
     if (this.logStream) {

--- a/src/helpers/dragManager.js
+++ b/src/helpers/dragManager.js
@@ -1,5 +1,6 @@
 const { screen } = require("electron");
 const { WindowPositionUtil } = require("./windowConfig");
+const debugLogger = require("./debugLogger");
 
 class DragManager {
   constructor() {
@@ -34,7 +35,7 @@ class DragManager {
       // Start tracking mouse movements
       this.setupMouseTracking();
 
-      console.log("🖱️ Window drag started");
+      debugLogger.info("Window drag started", undefined, "window-drag");
       return { success: true };
     } catch (error) {
       console.error("Failed to start window drag:", error);
@@ -47,7 +48,7 @@ class DragManager {
     try {
       this.isDragging = false;
       this.stopMouseTracking();
-      console.log("🖱️ Window drag stopped");
+      debugLogger.info("Window drag stopped", undefined, "window-drag");
       return { success: true };
     } catch (error) {
       console.error("Failed to stop window drag:", error);

--- a/test/helpers/debugLoggerConsolePolicy.test.js
+++ b/test/helpers/debugLoggerConsolePolicy.test.js
@@ -1,0 +1,256 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+const loggerPath = require.resolve("../../src/helpers/debugLogger.js");
+const dragManagerPath = require.resolve("../../src/helpers/dragManager.js");
+const originalLoad = Module._load;
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function withRuntime({ platform, argv = [], env = {}, electron }, loadModule) {
+  const previousArgv = process.argv;
+  const previousEnvironment = {
+    LOG_LEVEL: process.env.LOG_LEVEL,
+    NODE_ENV: process.env.NODE_ENV,
+    OPENWHISPR_LOG_LEVEL: process.env.OPENWHISPR_LOG_LEVEL,
+  };
+
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  process.argv = ["node", "main.js", ...argv];
+  delete process.env.LOG_LEVEL;
+  delete process.env.NODE_ENV;
+  delete process.env.OPENWHISPR_LOG_LEVEL;
+  Object.assign(process.env, env);
+
+  Module._load = function loadWithElectronMock(request, parent, isMain) {
+    if (request === "electron") return electron;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    return loadModule();
+  } finally {
+    Module._load = originalLoad;
+    Object.defineProperty(process, "platform", originalPlatform);
+    process.argv = previousArgv;
+    delete process.env.LOG_LEVEL;
+    delete process.env.NODE_ENV;
+    delete process.env.OPENWHISPR_LOG_LEVEL;
+    for (const [name, value] of Object.entries(previousEnvironment)) {
+      if (value !== undefined) process.env[name] = value;
+    }
+  }
+}
+
+function loadLogger({
+  platform,
+  isPackaged,
+  argv,
+  env,
+  isReady = false,
+  userDataPath = os.tmpdir(),
+}) {
+  delete require.cache[loggerPath];
+  return withRuntime(
+    {
+      platform,
+      argv,
+      env,
+      electron: {
+        app: {
+          getAppPath: () => "/openwhispr",
+          getPath: () => userDataPath,
+          isPackaged,
+          isReady: () => isReady,
+        },
+      },
+    },
+    () => require(loggerPath)
+  );
+}
+
+async function captureConsole(run) {
+  const calls = [];
+  const originalConsole = {
+    error: console.error,
+    log: console.log,
+    warn: console.warn,
+  };
+
+  console.error = (...args) => calls.push(["error", ...args]);
+  console.log = (...args) => calls.push(["log", ...args]);
+  console.warn = (...args) => calls.push(["warn", ...args]);
+  try {
+    await run();
+  } finally {
+    Object.assign(console, originalConsole);
+  }
+  return calls;
+}
+
+async function closeLogStream(logger) {
+  if (!logger.logStream) return;
+  const logStream = logger.logStream;
+  logger.logStream = null;
+  await new Promise((resolve, reject) => {
+    logStream.once("error", reject);
+    logStream.end(resolve);
+  });
+}
+
+test(
+  "packaged Windows suppresses main and renderer console logging at the default level",
+  async () => {
+    const logger = loadLogger({ platform: "win32", isPackaged: true });
+
+    const calls = await captureConsole(() => {
+      logger.info("Recording started", { microphone: "Default" }, "audio");
+      logger.warn("Recording warning");
+      logger.error("Recording failure");
+      logger.logEntry({
+        level: "info",
+        message: "Pipeline timing",
+        meta: { roundTripDurationMs: 42 },
+        scope: "performance",
+        source: "renderer",
+      });
+    });
+
+    assert.deepEqual(calls, []);
+    assert.equal(logger.getLogPath(), null, "default INFO logging remains non-persistent");
+  }
+);
+
+test("log-level settings never opt a packaged Windows build into console logging", async (t) => {
+  const cases = [
+    { name: "--log-level", argv: ["--log-level=debug"] },
+    {
+      name: "OPENWHISPR_LOG_LEVEL=debug",
+      env: { OPENWHISPR_LOG_LEVEL: "debug" },
+    },
+    {
+      name: "OPENWHISPR_LOG_LEVEL=info",
+      env: { OPENWHISPR_LOG_LEVEL: "info" },
+    },
+    { name: "LOG_LEVEL", env: { LOG_LEVEL: "debug" } },
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      const logger = loadLogger({
+        platform: "win32",
+        isPackaged: true,
+        argv: testCase.argv,
+        env: testCase.env,
+      });
+
+      const calls = await captureConsole(() => logger.info("Configured log level"));
+
+      assert.deepEqual(calls, []);
+    });
+  }
+});
+
+test("--console-logs explicitly enables console logging in packaged Windows", async () => {
+  const logger = loadLogger({
+    platform: "win32",
+    isPackaged: true,
+    argv: ["--console-logs"],
+  });
+
+  const calls = await captureConsole(() => logger.info("Console diagnostics enabled"));
+
+  assert.deepEqual(calls, [["log", "[INFO] Console diagnostics enabled"]]);
+});
+
+test("development and non-Windows packaged builds preserve console logging", async (t) => {
+  const cases = [
+    { name: "Windows development", platform: "win32", isPackaged: false },
+    { name: "packaged macOS", platform: "darwin", isPackaged: true },
+    { name: "packaged Linux", platform: "linux", isPackaged: true },
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      const logger = loadLogger(testCase);
+
+      const calls = await captureConsole(() => logger.info("Existing console behavior"));
+
+      assert.deepEqual(calls, [["log", "[INFO] Existing console behavior"]]);
+    });
+  }
+});
+
+test(
+  "packaged Windows retains debug logs in the file sink while suppressing the console",
+  async () => {
+    const userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-debug-logger-"));
+    const logger = loadLogger({
+      platform: "win32",
+      isPackaged: true,
+      env: { OPENWHISPR_LOG_LEVEL: "debug" },
+      isReady: true,
+      userDataPath,
+    });
+
+    try {
+      const calls = await captureConsole(() => {
+        logger.logEntry({
+          level: "info",
+          message: "Pipeline timing",
+          scope: "performance",
+          source: "renderer",
+        });
+      });
+      const logPath = logger.getLogPath();
+      await closeLogStream(logger);
+
+      assert.deepEqual(calls, []);
+      assert.ok(logPath);
+      assert.match(
+        fs.readFileSync(logPath, "utf8"),
+        /\[INFO\]\[performance\]\[renderer\] Pipeline timing/
+      );
+    } finally {
+      await closeLogStream(logger);
+      fs.rmSync(userDataPath, { recursive: true, force: true });
+    }
+  }
+);
+
+test("routine window-drag activity obeys the packaged Windows console policy", async () => {
+  delete require.cache[loggerPath];
+  delete require.cache[dragManagerPath];
+  const DragManager = withRuntime(
+    {
+      platform: "win32",
+      electron: {
+        app: {
+          getAppPath: () => "/openwhispr",
+          getPath: () => os.tmpdir(),
+          isPackaged: true,
+          isReady: () => false,
+        },
+        screen: {
+          getCursorScreenPoint: () => ({ x: 120, y: 80 }),
+        },
+      },
+    },
+    () => require(dragManagerPath)
+  );
+  const dragManager = new DragManager();
+  dragManager.setTargetWindow({
+    getPosition: () => [100, 50],
+    isDestroyed: () => false,
+  });
+
+  const calls = await captureConsole(async () => {
+    assert.deepEqual(await dragManager.startWindowDrag(), { success: true });
+    assert.deepEqual(await dragManager.stopWindowDrag(), { success: true });
+  });
+
+  assert.deepEqual(calls, []);
+});


### PR DESCRIPTION
## Summary

Fixes packaged Windows builds writing routine OpenWhispr logs to the launching terminal’s stdout/stderr.

- Suppresses centralized logger console output in packaged Windows builds.
- Preserves Windows development and all macOS/Linux console behavior.
- Adds `--console-logs` as a dedicated explicit opt-in.
- Keeps log level configuration separate from console consent.
- Preserves existing debug-file logging.
- Routes routine window-drag messages through the centralized logger.

Closes #1058  
Related to #1075; acceptance of that issue remains separate.

## Investigation

Issue #1058 was reported against Windows 11 and OpenWhispr 1.7.3. The behavior was still present on current `main` at 1.8.3.

The traced path is:

1. Recording and pipeline events call the renderer logger.
2. Renderer entries cross the preload bridge through the `app-log` IPC channel.
3. The main process passes them to `debugLogger.logEntry()`.
4. `debugLogger.write()` unconditionally called `console.log`, `console.warn`, or `console.error`.
5. When a packaged Windows process inherited the launching shell’s standard handles, those entries appeared in the parent terminal.

The reported messages, including “Recording started” and “Pipeline timing,” use this exact path.

The CLI bridge does not read stdout or forward log entries into the paste path. It is a loopback HTTP server, while pasted text comes exclusively from the transcription result. This PR therefore addresses the shared packaged-console root cause without claiming independent acceptance of #1075.

A previous unmerged approach treated `OPENWHISPR_LOG_LEVEL` and `LOG_LEVEL` as console opt-ins. That would not reliably fix the issue because the UI persists `OPENWHISPR_LOG_LEVEL=debug` when enabled and `OPENWHISPR_LOG_LEVEL=info` when disabled.

## Fix

`debugLogger` now enables console output when any of the following is true:

- The platform is not Windows.
- The Electron build is not packaged.
- The user explicitly launches with `--console-logs`.

Log-level arguments and environment variables continue to control verbosity only. They do not enable console output.

File retention remains unchanged:

- Default INFO logging does not create a log file.
- Debug logging continues writing to the existing debug-file sink.
- Suppressing packaged Windows console output does not disable debug-file logging.

Routine drag start/stop messages now use `debugLogger` instead of bypassing the policy with direct `console.log` calls. Exceptional direct stderr paths, including crash and startup failure diagnostics, remain unchanged.

## Behavior matrix

| Environment | Default console output | With `--console-logs` |
| --- | --- | --- |
| Packaged Windows | Suppressed | Enabled |
| Windows development | Enabled | Enabled |
| Packaged macOS | Unchanged: enabled | Enabled |
| Packaged Linux | Unchanged: enabled | Enabled |

## Tests

The regression suite was written first and failed against the original implementation because main, renderer-forwarded, log-level-configured, debug-file, and direct drag entries reached `console.*`.

Final focused and related verification:

```text
tests 35
pass 34
fail 0
skipped 1
```

The skipped test is an existing Windows-only live-helper probe.

Coverage includes:

- Packaged Windows main-process logging.
- Renderer-forwarded `app-log` entries.
- stdout and stderr log levels.
- `--console-logs` explicit opt-in.
- `--log-level`, `OPENWHISPR_LOG_LEVEL`, and `LOG_LEVEL` not granting consent.
- Both persisted `OPENWHISPR_LOG_LEVEL=debug` and `=info`.
- Debug-file retention while console output is suppressed.
- Windows development behavior.
- Packaged macOS and Linux behavior.
- Direct routine window-drag logging.
- Existing Windows child-process and window-position coverage.

Also verified:

```text
node --check src/helpers/debugLogger.js
node --check src/helpers/dragManager.js
node --check test/helpers/debugLoggerConsolePolicy.test.js
git diff --check
```

## Environment limitations

The complete repository commands were attempted but could not run in this checkout because `node_modules` is absent:

- `npm test`: missing `tsx`
- `npm run lint` / `npm run format:check`: missing `eslint`
- `npm run typecheck`: missing React and other dependency declarations

No packages were installed.

## Remaining validation

Before merging, validate a packaged Windows NSIS or portable build by:

- Launching from PowerShell with stdout and stderr captured.
- Starting and stopping a recording.
- Confirming routine recording and pipeline logs are absent.
- Repeating with `--console-logs` and confirming console diagnostics return.

## Scope and risk

- No IPC channels or payloads changed.
- No public APIs or function signatures changed.
- No dependencies, environment files, migrations, or persistent settings changed.
- macOS, Linux, and development console behavior remain unchanged.