### PR TITLE
fix(ai): retry HTTP 408 request timeouts in the API retry strategy

### DIFF
--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -210,8 +210,10 @@ export const openaiProvider: InferenceProvider = {
       });
     }
 
+    const retryStrategy = createApiRetryStrategy();
     const response = await withRetry(async () => {
       let lastError: Error | null = null;
+      let lastRetryableError: Error | null = null;
 
       for (const { url: endpoint, type } of endpointCandidates) {
         const controller = new AbortController();
@@ -296,6 +298,9 @@ export const openaiProvider: InferenceProvider = {
             throw new Error("Request timed out after 30s");
           }
           lastError = error as Error;
+          if (retryStrategy.shouldRetry(lastError)) {
+            lastRetryableError = lastError;
+          }
           if (type === "responses") {
             logger.logReasoning("OPENAI_ENDPOINT_FALLBACK", {
               attemptedEndpoint: endpoint,
@@ -303,14 +308,14 @@ export const openaiProvider: InferenceProvider = {
             });
             continue;
           }
-          throw error;
+          throw lastRetryableError || error;
         } finally {
           clearTimeout(timeoutId);
         }
       }
 
-      throw lastError || new Error("No OpenAI endpoint responded");
-    }, createApiRetryStrategy());
+      throw lastRetryableError || lastError || new Error("No OpenAI endpoint responded");
+    }, retryStrategy);
 
     const isResponsesApi = Array.isArray(response?.output);
     const isChatCompletions = Array.isArray(response?.choices);

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -52,8 +52,9 @@ export function createApiRetryStrategy() {
       const status = error?.status ?? error?.response?.status;
       if (typeof status !== "number") return true;
 
-      // 4xx are deterministic rejections; only rate limits and server faults can clear on retry.
-      return status === 429 || (status >= 500 && status < 600);
+      // Most 4xx are deterministic rejections. 408 is a request timeout and 429 is
+      // a rate limit; both can clear on retry, as can 5xx server faults.
+      return status === 408 || status === 429 || (status >= 500 && status < 600);
     },
   };
 }

--- a/test/helpers/apiRetryStrategy.test.js
+++ b/test/helpers/apiRetryStrategy.test.js
@@ -22,6 +22,13 @@ test("4xx rejections do not retry, because the same request will be refused agai
   assert.equal(shouldRetry(Object.assign(new Error("not found"), { status: 404 })), false);
 });
 
+test("408 retries, since a request timeout can succeed on the next attempt", async () => {
+  const { createApiRetryStrategy } = await load();
+  const { shouldRetry } = createApiRetryStrategy();
+
+  assert.equal(shouldRetry(Object.assign(new Error("request timeout"), { status: 408 })), true);
+});
+
 test("429 retries, since rate limits clear on their own", async () => {
   const { createApiRetryStrategy } = await load();
   const { shouldRetry } = createApiRetryStrategy();

--- a/test/services/openaiEndpointRetry.test.js
+++ b/test/services/openaiEndpointRetry.test.js
@@ -1,0 +1,94 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/services/ai/inferenceProviders/openai.ts");
+
+test("Responses retries when a permanent Chat fallback follows a transient failure", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestedEndpoints = [];
+  let responsesAttempts = 0;
+
+  globalThis.fetch = async (input, init = {}) => {
+    const endpoint = String(input);
+    const method = init.method || "GET";
+    requestedEndpoints.push(`${method} ${endpoint}`);
+
+    if (method === "GET" && endpoint.endsWith("/models")) {
+      return new Response(JSON.stringify({ error: { message: "models unavailable" } }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (endpoint.endsWith("/responses")) {
+      responsesAttempts += 1;
+      if (responsesAttempts === 1) {
+        return new Response(JSON.stringify({ error: { message: "request timeout" } }), {
+          status: 408,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Recovered response" }],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    if (endpoint.endsWith("/chat/completions")) {
+      return new Response(JSON.stringify({ error: { message: "chat unsupported" } }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    throw new Error(`Unexpected request: ${method} ${endpoint}`);
+  };
+
+  const { openaiProvider } = await load();
+  const resultPromise = openaiProvider.call({
+    text: "Clean this transcript",
+    model: "responses-only-model",
+    agentName: null,
+    config: {
+      provider: "custom",
+      baseUrl: "https://responses-only.example/v1",
+      customApiKey: "test-key",
+      systemPrompt: "Clean the transcript",
+    },
+    ctx: {
+      getApiKey: async () => "test-key",
+      getSystemPrompt: () => "Clean the transcript",
+      getCustomDictionary: () => [],
+      getPreferredLanguage: () => "en",
+      getUiLanguage: () => "en",
+      callChatCompletionsApi: async () => {
+        throw new Error("Unexpected chat completions delegation");
+      },
+      calculateMaxTokens: () => 4096,
+    },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  t.mock.timers.tick(1000);
+  const result = await resultPromise;
+
+  assert.equal(result, "Recovered response");
+  assert.deepEqual(requestedEndpoints, [
+    "GET https://responses-only.example/v1/models",
+    "POST https://responses-only.example/v1/responses",
+    "POST https://responses-only.example/v1/chat/completions",
+    "POST https://responses-only.example/v1/responses",
+  ]);
+});


### PR DESCRIPTION
## Summary
- `createApiRetryStrategy()` retried network errors, 429, and 5xx, but not HTTP 408 Request Timeout.
- Cleanup / dictation-agent / other `withRetry` callers failed on the first 408 instead of backing off.

## Problem
On current `main`:

| Status | Retried? |
| --- | --- |
| no status (network) | yes |
| 400 / 404 | no |
| 408 | **no** |
| 429 | yes |
| 503 | yes |

RFC 9110 allows clients to retry 408; it is a timeout, not a deterministic rejection.

## Root cause
The 4xx branch treated every client error as permanent. 408 is transient, like 429.

## Fix
Retry 408 alongside 429 and 5xx. Leave other 4xx non-retryable.

## Scope
- `src/utils/retry.ts` and `test/helpers/apiRetryStrategy.test.js`
- No download retry, cloud-chunk upload, or i18n changes

## Tests

```bash
node --test test/helpers/apiRetryStrategy.test.js
```

Fixes #1732