### PR TITLE
fix(calendar): group date-only upcoming events on the local calendar day

### DIFF
--- a/src/components/UpcomingMeetings.tsx
+++ b/src/components/UpcomingMeetings.tsx
@@ -9,6 +9,7 @@ import type { CalendarAttendee, CalendarEvent } from "../types/calendar";
 import { useSystemAudioPermission } from "../hooks/useSystemAudioPermission";
 import { canManageSystemAudioInApp } from "../utils/systemAudioAccess";
 import { getMeetingJoinUrl } from "../helpers/meetingJoinUrl";
+import { parseEventDate } from "../utils/dateFormatting";
 
 interface UpcomingMeetingsProps {
   events: CalendarEvent[];
@@ -52,7 +53,8 @@ function groupEventsByDay(events: CalendarEvent[], now: Date): DayGroup[] {
   const groups: DayGroup[] = [];
   const byKey = new Map<string, DayGroup>();
   for (const event of events) {
-    const date = new Date(event.start_time);
+    const date = parseEventDate(event.start_time);
+    if (!date) continue;
     const key = date.toDateString();
     let group = byKey.get(key);
     if (!group) {

--- a/src/utils/dateFormatting.ts
+++ b/src/utils/dateFormatting.ts
@@ -1,3 +1,16 @@
+// Calendar events store all-day starts as date-only `YYYY-MM-DD` (Google's
+// `start.date`). The ECMAScript parser reads that form as UTC midnight, which
+// is still the previous local calendar day west of UTC, so date-only values
+// must be parsed as local dates.
+export function parseEventDate(value: string): Date | null {
+  if (typeof value !== "string" || !value) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  const parsed = dateOnly
+    ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+    : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 export function normalizeDbDate(dateStr: string): Date {
   const hasExplicitZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(dateStr);
   const source = hasExplicitZone ? dateStr : `${dateStr}Z`;

--- a/test/helpers/dateGroupFormatting.test.js
+++ b/test/helpers/dateGroupFormatting.test.js
@@ -61,6 +61,35 @@ test("string dates are accepted", async (t2) => {
   assert.equal(formatDateGroup(new Date(NOON_JUNE_15).toISOString(), t), "Today");
 });
 
+test("date-only event starts parse as the local calendar day, not UTC midnight", async () => {
+  const { parseEventDate } = await load();
+  const previousTimezone = process.env.TZ;
+  process.env.TZ = "America/Los_Angeles";
+
+  try {
+    // A UTC-midnight parse would land on June 14 in Los Angeles.
+    const parsed = parseEventDate("2024-06-15");
+    assert.equal(parsed.getFullYear(), 2024);
+    assert.equal(parsed.getMonth(), 5);
+    assert.equal(parsed.getDate(), 15);
+  } finally {
+    if (previousTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = previousTimezone;
+  }
+});
+
+test("timed event starts keep their instant and invalid values return null", async () => {
+  const { parseEventDate } = await load();
+
+  assert.equal(
+    parseEventDate("2024-06-15T10:00:00-07:00").getTime(),
+    Date.parse("2024-06-15T10:00:00-07:00")
+  );
+  assert.equal(parseEventDate("not-a-date"), null);
+  assert.equal(parseEventDate(""), null);
+  assert.equal(parseEventDate(null), null);
+});
+
 test("history groups zone-less SQLite timestamps as UTC near a local day boundary", async (t2) => {
   const { formatDateGroup } = await load();
   const previousTimezone = process.env.TZ;


### PR DESCRIPTION
## Summary
- `groupEventsByDay` in the Coming up sidebar parsed `event.start_time` with `new Date(...)`. For date-only `YYYY-MM-DD` values (Google all-day events) that is UTC midnight, which is still the previous local calendar day west of UTC, so the event would land on yesterday's day card.
- Adds `parseEventDate` to `src/utils/dateFormatting.ts`: date-only strings parse as local calendar dates, timed ISO strings and everything else keep their existing behavior, and unparseable values return `null` — the sidebar now skips those instead of rendering an `Invalid Date` card.

## Context
Replaces #1707, which fixed the same root cause in `formatUpcomingDateGroup` — a function removed in the Coming up sidebar redesign (a5e59ee4). This carries the same date-only local-parse approach into the new grouping code.

**Reachability note:** `getUpcomingEvents` (src/helpers/database.js) has filtered `is_all_day = 0` since the original calendar integration, so all-day events currently never reach this sidebar — this fix makes the grouping correct for date-only values rather than changing anything user-visible today. Whether all-day events (PTO, conferences) should appear on the day cards at all is a product decision, left as a follow-up: it needs a sidebar-scoped query change (the same query feeds meeting reminders), an "All day" row treatment, and i18n keys.

## Tests

```bash
node --test test/helpers/dateGroupFormatting.test.js
```

- date-only starts parse as the local calendar day under `TZ=America/Los_Angeles`
- timed ISO starts keep their instant; invalid/empty/null return `null`
- typecheck, eslint, and prettier pass on the changed files

Fixes #1705