### PR TITLE
chore(format): fix prettier drift in windowConfig.js

### DIFF
--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -16,11 +16,7 @@ function resolveOverlayWindowType({ role, platform, linuxSession }) {
 
   // Sway asks wlroots whether an unmanaged XWayland surface wants focus.
   // "toolbar" opts in; "notification" keeps the existing text field focused.
-  if (
-    linuxSession.isSway &&
-    linuxSession.xwaylandAvailable &&
-    FOCUSLESS_OVERLAY_ROLES.has(role)
-  ) {
+  if (linuxSession.isSway && linuxSession.xwaylandAvailable && FOCUSLESS_OVERLAY_ROLES.has(role)) {
     return "notification";
   }
 


### PR DESCRIPTION
Round two of #1712, same disease, new file.

`npm run format:check` fails on `main` again: `src/helpers/windowConfig.js` landed unformatted via #1718, merged after #1712 went in. Every open PR shows the red quality-check again because of it. I rebased my three fix PRs (#1709, #1710, #1711) onto current main yesterday expecting green and got this instead, so I traced it the same way.

This PR is `prettier --write` on that one file. +1/-5, wrapping only.

## Test

- `npm run quality-check` (the failing CI command): fails on clean main, passes with this diff.

Might be worth making the quality-check job a required status check, since drift keeps landing through PRs merged while it's red. Happy to leave that call to you.