### PR TITLE
Pin minimal reasoning effort for the gpt-5 family on cleanup

### DIFF
--- a/src/services/ai/modelFamilyConstraints.ts
+++ b/src/services/ai/modelFamilyConstraints.ts
@@ -9,7 +9,7 @@
  * like thinkingSuppressionDialects.
  */
 export interface ModelFamilyConstraints {
-  family: "gpt-oss" | "qwen" | "magistral";
+  family: "gpt-oss" | "gpt-5" | "qwen" | "magistral";
   reasoningEffort?: {
     /** Value that best approximates "thinking off" for reasoning_effort. */
     suppressValue: string;
@@ -27,6 +27,18 @@ export interface ModelFamilyConstraints {
 }
 
 const FAMILIES: Array<ModelFamilyConstraints & { match: RegExp }> = [
+  {
+    family: "gpt-5",
+    // Boundary keeps provider-prefixed ids (openai/gpt-5-mini) in and ids that
+    // merely contain the substring out; gpt-oss has its own entry below.
+    match: /(^|\/)gpt-5/,
+    // gpt-5* are reasoning models whose default effort spends seconds of
+    // hidden reasoning per request — on a dictation cleanup that is nearly
+    // all of the user-visible paste latency. "minimal" keeps the transform
+    // fast; a backend that rejects the value degrades gracefully via the
+    // param-strip ladder in chatRequestBody.
+    reasoningEffort: { suppressValue: "minimal", cleanupValue: "minimal" },
+  },
   {
     family: "gpt-oss",
     match: /gpt-oss/,

--- a/test/helpers/thinkingSuppressionDialects.test.js
+++ b/test/helpers/thinkingSuppressionDialects.test.js
@@ -112,7 +112,7 @@ test("unlisted providers keep the legacy reasoning_effort none plus chat_templat
   const { suppressThinking } = await load();
 
   const body = {};
-  suppressThinking(body, "openai", "gpt-5.2");
+  suppressThinking(body, "openai", "llama-4-maverick");
 
   assert.deepEqual(body, {
     reasoning_effort: "none",

--- a/test/services/llmRequestShapeMatrix.test.js
+++ b/test/services/llmRequestShapeMatrix.test.js
@@ -40,8 +40,8 @@ const MATRIX = [
   // --- OpenAI / custom / OpenRouter (registry-driven shape) ---
   ["openai legacy model keeps max_tokens and temperature", "openai", "gpt-4o", null, CLEANUP,
     { max_tokens: MAX_TOKENS, temperature: 0 }],
-  ["openai gpt-5 family uses max_completion_tokens and omits temperature", "openai", "gpt-5-mini", null, CLEANUP,
-    { max_completion_tokens: MAX_TOKENS }],
+  ["openai gpt-5 family uses max_completion_tokens, omits temperature, pins minimal cleanup effort", "openai", "gpt-5-mini", null, CLEANUP,
+    { max_completion_tokens: MAX_TOKENS, reasoning_effort: "minimal" }],
   ["openrouter vendor-prefixed id speaks plain chat completions", "openrouter", "openai/gpt-4o", null, AGENT,
     { max_tokens: MAX_TOKENS, temperature: 0.3 }],
   ["openrouter forwards sampling upstream: temperature-rejecting Claude omits it (#1417)", "openrouter", "anthropic/claude-sonnet-5", null, AGENT,

--- a/test/services/modelFamilyConstraints.test.js
+++ b/test/services/modelFamilyConstraints.test.js
@@ -23,3 +23,22 @@ test("gpt-oss has no reasoning off switch: suppress and cleanup both floor at lo
   const effort = getModelFamilyConstraints("gpt-oss-120b")?.reasoningEffort;
   assert.deepEqual(effort, { suppressValue: "low", cleanupValue: "low" });
 });
+
+test("gpt-5 family pins minimal effort for cleanup and suppression", async () => {
+  const { getModelFamilyConstraints } = await load();
+  for (const id of ["gpt-5-nano", "gpt-5-mini", "gpt-5.2", "openai/gpt-5-mini", "GPT-5-Nano"]) {
+    const constraints = getModelFamilyConstraints(id);
+    assert.equal(constraints?.family, "gpt-5", id);
+    assert.deepEqual(constraints?.reasoningEffort, {
+      suppressValue: "minimal",
+      cleanupValue: "minimal",
+    });
+  }
+});
+
+test("gpt-5 boundary excludes lookalike ids and leaves gpt-oss on its own entry", async () => {
+  const { getModelFamilyConstraints } = await load();
+  assert.equal(getModelFamilyConstraints("gpt-oss-120b")?.family, "gpt-oss");
+  assert.equal(getModelFamilyConstraints("somegpt-5x"), null);
+  assert.equal(getModelFamilyConstraints("gpt-4.1-mini"), null);
+});


### PR DESCRIPTION
## Problem
gpt-5* models are reasoning models, but no entry exists for them in `modelFamilyConstraints`, so cleanup requests go out with no `reasoning_effort` — the model reasons at default depth, adding seconds of hidden latency to every dictation cleanup. There is also no thinking-suppression path for the OpenAI provider, so users cannot work around it from settings.

## Fix
Add the gpt-5 family to `modelFamilyConstraints` with `reasoningEffort: { suppressValue: "minimal", cleanupValue: "minimal" }` — the same mechanism gpt-oss uses (#1611). Deterministic transforms (cleanup, selection edits) now pin minimal effort automatically; a backend that rejects the value degrades gracefully via the existing param-strip ladder in `chatRequestBody`.

## Testing
- New cases in `test/services/modelFamilyConstraints.test.js` (family match incl. provider-prefixed ids, boundary exclusions)
- Updated the request-shape matrix row and the dialect test that used gpt-5.2 as an unlisted-family example
- All 51 tests across the three affected files pass; `npm run typecheck` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPi3TH7iMTbDEjo1AbcPr)_