### PR TITLE
feat: add RTL text support for transcripts, notes, and chats

### DIFF
--- a/src/components/TranscriptionPreviewOverlay.tsx
+++ b/src/components/TranscriptionPreviewOverlay.tsx
@@ -322,7 +322,10 @@ export default function TranscriptionPreviewOverlay() {
                     : "border-border/25 bg-background/30",
               ].join(" ")}
             >
-              <p className="select-text text-[13px] leading-[1.52] text-foreground whitespace-pre-wrap break-words [text-wrap:pretty]">
+              <p
+                className="select-text text-[13px] leading-[1.52] text-foreground whitespace-pre-wrap break-words [text-wrap:pretty]"
+                dir="auto"
+              >
                 {activeText}
               </p>
             </div>

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -114,7 +114,7 @@ export function ChatInput({
     <div className="shrink-0 px-3 pb-3 pt-1">
       <div
         className={cn(
-          "flex items-center gap-2 min-h-11 pl-4 pr-1.5 rounded-full",
+          "flex items-center gap-2 min-h-11 ps-4 pe-1.5 rounded-full",
           GLASS_SURFACE,
           "border border-black/10 dark:border-white/14",
           "transition-all duration-200",
@@ -125,7 +125,7 @@ export function ChatInput({
         {isListening && (
           <>
             <RecordingIndicator />
-            <span className="text-[12px] text-foreground/80 truncate flex-1">
+            <span className="text-[12px] text-foreground/80 truncate flex-1" dir="auto">
               {partialTranscript || t("agentMode.input.listening")}
             </span>
           </>
@@ -200,6 +200,7 @@ export function ChatInput({
               onKeyDown={handleKeyDown}
               disabled={isBusy}
               autoFocus={autoFocus}
+              dir="auto"
               placeholder={placeholder ?? t("agentMode.input.typeMessage")}
               className={cn(
                 "input-inline flex-1 outline-none bg-transparent caret-primary",

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -39,11 +39,11 @@ function ToolCallStep({ toolCall }: { toolCall: ToolCallInfo }) {
     <div
       className={cn(
         "relative rounded-md mb-1 overflow-hidden",
-        "border-l-2 transition-colors duration-300",
-        isExecuting && "border-l-primary/60",
-        isCompleted && !isError && "border-l-muted-foreground/20",
-        isClipboard && "border-l-emerald-500/50",
-        isError && "border-l-destructive/50"
+        "border-s-2 transition-colors duration-300",
+        isExecuting && "border-s-primary/60",
+        isCompleted && !isError && "border-s-muted-foreground/20",
+        isClipboard && "border-s-emerald-500/50",
+        isError && "border-s-destructive/50"
       )}
     >
       {isExecuting && (
@@ -154,7 +154,9 @@ function NoteCard({
         <FileText size={12} className="text-primary/70" />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="text-[12px] font-medium text-foreground truncate">{title}</p>
+        <p className="text-[12px] font-medium text-foreground truncate" dir="auto">
+          {title}
+        </p>
         <p className="text-[10px] text-muted-foreground/50">{t("agentMode.tools.openNote")}</p>
       </div>
       <ChevronRight
@@ -193,6 +195,7 @@ export function ChatMessage({
       >
         <div
           data-chat-bubble
+          dir="auto"
           className={cn(
             "max-w-[80%] px-3 py-2 rounded-lg rounded-br-sm",
             "bg-primary/90 text-primary-foreground",
@@ -216,6 +219,7 @@ export function ChatMessage({
     >
       <div
         data-chat-bubble
+        dir="auto"
         className={cn(
           "max-w-[85%] px-3 py-2 rounded-lg rounded-bl-sm",
           "bg-surface-1 border border-border/30 text-foreground",
@@ -243,7 +247,7 @@ export function ChatMessage({
 
         {isStreaming && hasContent && (
           <span
-            className="inline-block w-[2px] h-[14px] bg-foreground/70 align-middle ml-0.5"
+            className="inline-block w-[2px] h-[14px] bg-foreground/70 align-middle ms-0.5"
             style={{ animation: "agent-cursor-blink 1s ease-in-out infinite" }}
           />
         )}

--- a/src/components/chat/ConversationItem.tsx
+++ b/src/components/chat/ConversationItem.tsx
@@ -67,7 +67,10 @@ export default function ConversationItem({
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-2">
-          <p className={cn("text-xs truncate text-foreground", isActive && "font-medium")}>
+          <p
+            className={cn("text-xs truncate text-foreground", isActive && "font-medium")}
+            dir="auto"
+          >
             {conversation.title}
           </p>
           <div className="flex items-center gap-0.5 shrink-0">
@@ -121,7 +124,7 @@ export default function ConversationItem({
           </div>
         </div>
         {conversation.preview && (
-          <p className="text-[11px] text-muted-foreground/50 line-clamp-1 mt-0.5">
+          <p className="text-[11px] text-muted-foreground/50 line-clamp-1 mt-0.5" dir="auto">
             {conversation.preview}
           </p>
         )}

--- a/src/components/notes/AddNotesToFolderDialog.tsx
+++ b/src/components/notes/AddNotesToFolderDialog.tsx
@@ -136,7 +136,7 @@ export default function AddNotesToFolderDialog({
                         <FileText size={12} className="text-foreground/20" />
                       </div>
                       <div className="flex-1 min-w-0 text-left">
-                        <p className="text-xs text-foreground/80 truncate">
+                        <p className="text-xs text-foreground/80 truncate" dir="auto">
                           {note.title || t("notes.list.untitled")}
                         </p>
                       </div>

--- a/src/components/notes/MeetingTranscriptChat.tsx
+++ b/src/components/notes/MeetingTranscriptChat.tsx
@@ -39,14 +39,14 @@ const SPEAKER_COLORS = [
 ];
 
 const SPEAKER_BORDER_COLORS = [
-  "border-l-blue-400/50",
-  "border-l-green-400/50",
-  "border-l-purple-400/50",
-  "border-l-orange-400/50",
-  "border-l-pink-400/50",
-  "border-l-cyan-400/50",
-  "border-l-yellow-400/50",
-  "border-l-red-400/50",
+  "border-s-blue-400/50",
+  "border-s-green-400/50",
+  "border-s-purple-400/50",
+  "border-s-orange-400/50",
+  "border-s-pink-400/50",
+  "border-s-cyan-400/50",
+  "border-s-yellow-400/50",
+  "border-s-red-400/50",
 ];
 
 const STICKY_SCROLL_THRESHOLD_PX = 80;
@@ -118,10 +118,11 @@ function PartialBubble({
             s.bg,
             "text-[13px] leading-relaxed italic"
           )}
+          dir="auto"
         >
           {text}
           <span
-            className={cn("inline-block w-[2px] h-[13px] align-middle ml-0.5", s.cursor)}
+            className={cn("inline-block w-[2px] h-[13px] align-middle ms-0.5", s.cursor)}
             style={{ animation: "agent-cursor-blink 800ms steps(1) infinite" }}
           />
         </div>
@@ -835,7 +836,7 @@ export function MeetingTranscriptChat({
                 "group flex flex-col",
                 selfSide ? "items-start" : "items-end",
                 !sameSpeaker && i > 0 && "mt-2",
-                selectable && (selfSide ? "pl-6" : "pr-6")
+                selectable && (selfSide ? "ps-6" : "pe-6")
               )}
               style={{ animation: "agent-message-in 200ms ease-out both" }}
             >
@@ -863,10 +864,11 @@ export function MeetingTranscriptChat({
                       : cn(
                           "bg-surface-2 border border-border/30 text-foreground",
                           sameSpeaker ? "rounded-lg rounded-tr-sm" : "rounded-lg rounded-br-sm",
-                          isSystemSpeaker && cn("border-l-2", SPEAKER_BORDER_COLORS[colorIdx])
+                          isSystemSpeaker && cn("border-s-2", SPEAKER_BORDER_COLORS[colorIdx])
                         ),
                     isSelected && "ring-2 ring-primary/60"
                   )}
+                  dir="auto"
                 >
                   {segment.text}
                 </div>

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -773,6 +773,7 @@ export default function NoteEditor({
             onKeyDown={handleTitleKeyDown}
             onPaste={handleTitlePaste}
             data-placeholder={t("notes.editor.untitled")}
+            dir="auto"
             className="text-base font-semibold text-foreground bg-transparent outline-none tracking-[-0.01em] empty:before:content-[attr(data-placeholder)] empty:before:text-foreground/15 empty:before:pointer-events-none"
             role="textbox"
             aria-label={t("notes.editor.noteTitle")}

--- a/src/components/notes/SpacesTree.tsx
+++ b/src/components/notes/SpacesTree.tsx
@@ -904,7 +904,9 @@ function NoteLeaf({
       }}
       className={MENU_ITEM_CLASS}
     >
-      <span className="truncate flex-1">{label}</span>
+      <span className="truncate flex-1" dir="auto">
+        {label}
+      </span>
       {option.isCurrent && <Check size={9} className="text-primary shrink-0" />}
     </DropdownMenuItem>
   );

--- a/src/components/notes/overview/OverviewNoteList.tsx
+++ b/src/components/notes/overview/OverviewNoteList.tsx
@@ -81,7 +81,7 @@ export function OverviewNoteList({
                   size={14}
                   className="text-foreground/30 dark:text-foreground/20 shrink-0"
                 />
-                <span className="text-[13px] text-foreground/85 truncate flex-1">
+                <span className="text-[13px] text-foreground/85 truncate flex-1" dir="auto">
                   {note.title || t("notes.list.untitled")}
                 </span>
                 {authorName && (

--- a/src/components/ui/MarkdownRenderer.tsx
+++ b/src/components/ui/MarkdownRenderer.tsx
@@ -8,7 +8,7 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
   return (
-    <div className={cn("prose prose-sm max-w-none", className)}>
+    <div className={cn("prose prose-sm max-w-none", className)} dir="auto">
       <Markdown
         components={{
           h1: ({ children }) => (
@@ -21,9 +21,9 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
             <h3 className="text-sm font-semibold mb-1.5 mt-2 first:mt-0">{children}</h3>
           ),
           p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-          ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-1">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-1">{children}</ol>,
-          li: ({ children }) => <li className="pl-1">{children}</li>,
+          ul: ({ children }) => <ul className="list-disc ps-4 mb-2 space-y-1">{children}</ul>,
+          ol: ({ children }) => <ol className="list-decimal ps-4 mb-2 space-y-1">{children}</ol>,
+          li: ({ children }) => <li className="ps-1">{children}</li>,
           a: ({ href, children }) => (
             <a
               href={href}
@@ -43,7 +43,7 @@ export function MarkdownRenderer({ content, className }: MarkdownRendererProps) 
           strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
           em: ({ children }) => <em className="italic">{children}</em>,
           blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-current/30 pl-3 italic my-2">
+            <blockquote className="border-s-2 border-current/30 ps-3 italic my-2">
               {children}
             </blockquote>
           ),

--- a/src/components/ui/RichTextEditor.tsx
+++ b/src/components/ui/RichTextEditor.tsx
@@ -58,6 +58,7 @@ export function RichTextEditor({
     editorProps: {
       attributes: {
         class: "rich-text-editor-content",
+        dir: "auto",
       },
     },
   });

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -218,7 +218,9 @@ const Toast: React.FC<
       <div className="flex items-start gap-2 flex-1 min-w-0 px-2.5 py-2">
         <div className="flex-1 min-w-0">
           {message && (
-            <div className="text-xs font-medium leading-tight text-white/90">{message}</div>
+            <div className="text-xs font-medium leading-tight text-white/90" dir="auto">
+              {message}
+            </div>
           )}
           {detail &&
             (isDestructive ? (
@@ -230,7 +232,9 @@ const Toast: React.FC<
                 )}
               >
                 <div className="flex items-start justify-between gap-1.5">
-                  <span className="select-all wrap-break-word min-w-0">{detail}</span>
+                  <span className="select-all wrap-break-word min-w-0" dir="auto">
+                    {detail}
+                  </span>
                   <button
                     onClick={handleCopyError}
                     className={cn(

--- a/src/components/ui/TranscriptionItem.tsx
+++ b/src/components/ui/TranscriptionItem.tsx
@@ -98,8 +98,8 @@ export default function TranscriptionItem({
           : isDiscarded
             ? "border-border/30 bg-muted/20 hover:bg-muted/30 opacity-80"
             : "border-border/40 dark:border-border-subtle/60 bg-card/50 dark:bg-surface-2/60 hover:bg-muted/30 dark:hover:bg-surface-2/80",
-        // Translation rows get a 2px primary accent; pl-[11px] keeps text pixel-aligned with 1px-bordered rows.
-        item.route_kind === "translation" && "border-l-2 border-l-primary/70 pl-[11px]"
+        // Translation rows get a 2px primary accent; ps-[11px] keeps text pixel-aligned with 1px-bordered rows.
+        item.route_kind === "translation" && "border-s-2 border-s-primary/70 ps-[11px]"
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
@@ -171,7 +171,10 @@ export default function TranscriptionItem({
             </span>
           </div>
         ) : (
-          <p className="flex-1 min-w-0 text-foreground text-sm leading-normal wrap-break-word whitespace-pre-wrap">
+          <p
+            className="flex-1 min-w-0 text-foreground text-sm leading-normal wrap-break-word whitespace-pre-wrap"
+            dir="auto"
+          >
             {item.text}
           </p>
         )}
@@ -323,7 +326,9 @@ export default function TranscriptionItem({
                   </Button>
                 </Tooltip>
               </div>
-              <p className="text-xs text-muted-foreground/80 leading-relaxed mt-1">{rawText}</p>
+              <p className="text-xs text-muted-foreground/80 leading-relaxed mt-1" dir="auto">
+                {rawText}
+              </p>
               {rawText === item.text && (
                 <p className="text-[10px] text-muted-foreground/50 italic mt-1">
                   {t("controlPanel.history.noAiProcessing")}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,6 +7,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
     <input
       type={type}
       data-slot="input"
+      dir="auto"
       className={cn(
         "flex h-10 w-full min-w-0 rounded border border-border/70 bg-input px-3 py-2 text-sm text-foreground shadow-none transition-colors duration-200 outline-none",
         "placeholder:text-muted-foreground/40",

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -8,6 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (
       <textarea
+        dir="auto"
         className={cn(
           "flex min-h-[80px] w-full rounded-xl border border-neutral-200 bg-white px-3.5 py-3 text-sm text-neutral-900 shadow-sm transition-colors duration-200 outline-none resize-y cursor-text",
           "placeholder:text-neutral-400",

--- a/src/config/languageRegistry.json
+++ b/src/config/languageRegistry.json
@@ -25,6 +25,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
+      "dir": "rtl",
       "instruction": "LANGUAGE CONTEXT: The user's preferred language is Arabic. The transcribed text will be in Arabic. You MUST write your entire output in Arabic while maintaining proper Arabic grammar and punctuation. Preserve any English technical terms as the user spoke them."
     },
     {
@@ -209,6 +210,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
+      "dir": "rtl",
       "instruction": "LANGUAGE CONTEXT: The user's preferred language is Hebrew. The transcribed text will be in Hebrew. You MUST write your entire output in Hebrew while maintaining proper Hebrew grammar and punctuation. Preserve any English technical terms as the user spoke them."
     },
     {
@@ -371,6 +373,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
+      "dir": "rtl",
       "instruction": "LANGUAGE CONTEXT: The user's preferred language is Persian. The transcribed text will be in Persian. You MUST write your entire output in Persian while maintaining proper Persian grammar and punctuation. Preserve any English technical terms as the user spoke them."
     },
     {
@@ -511,7 +514,8 @@
       "flag": "\uD83C\uDDF5\uD83C\uDDF0",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false
+      "assemblyai": false,
+      "dir": "rtl"
     },
     {
       "code": "vi",

--- a/src/helpers/windowConfig.js
+++ b/src/helpers/windowConfig.js
@@ -16,11 +16,7 @@ function resolveOverlayWindowType({ role, platform, linuxSession }) {
 
   // Sway asks wlroots whether an unmanaged XWayland surface wants focus.
   // "toolbar" opts in; "notification" keeps the existing text field focused.
-  if (
-    linuxSession.isSway &&
-    linuxSession.xwaylandAvailable &&
-    FOCUSLESS_OVERLAY_ROLES.has(role)
-  ) {
+  if (linuxSession.isSway && linuxSession.xwaylandAvailable && FOCUSLESS_OVERLAY_ROLES.has(role)) {
     return "notification";
   }
 

--- a/src/utils/languageSupport.ts
+++ b/src/utils/languageSupport.ts
@@ -45,4 +45,16 @@ export function getLanguageLabel(code: string | null | undefined): string {
   return entry?.label ?? code;
 }
 
+export type TextDirection = "rtl" | "ltr" | "auto";
+
+export function getLanguageDirection(language: string | null | undefined): TextDirection {
+  if (!language || language === "auto") return "auto";
+  const base = language.split("-")[0];
+  const entry =
+    registry.languages.find((l) => l.code === language) ??
+    registry.languages.find((l) => l.code === base);
+  if (entry && (entry as { dir?: string }).dir === "rtl") return "rtl";
+  return "ltr";
+}
+
 export { WHISPER_LANGUAGES, ASSEMBLYAI_UNIVERSAL3_PRO_LANGUAGES };


### PR DESCRIPTION
## What
Users writing in RTL languages (Arabic, Hebrew, Persian, Urdu) saw broken alignment in transcripts, notes, and chats.

## How
Scoped to **user-generated content only** (UI stays LTR). Containers now use `dir="auto"` so the browser picks direction per element from the text itself, and mirror-sensitive utilities were switched to **tailwind v4** logical variants (`ps-/pe-`, `ms-/me-`, `border-s-`, `rounded-bs/be/ts/te`).

- `languageRegistry.json`: `"dir": "rtl"` for `ar`, `he`, `fa`, `ur`
- `languageSupport.ts`: add `getLanguageDirection()` helper
- `input`/`textarea`: default `dir="auto"`
- `dir="auto"` on chat bubbles/input, transcript history + raw text, live preview, note title/body, markdown, meeting segments, conversation/note list titles, toasts

fixes #1402 
