### PR TITLE
fix(calendar): fail OAuth loopback immediately on state mismatch

### DIFF
--- a/src/helpers/oauthLoopbackFlow.js
+++ b/src/helpers/oauthLoopbackFlow.js
@@ -57,8 +57,17 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
     const codeVerifier = crypto.randomBytes(32).toString("base64url").slice(0, 43);
     const codeChallenge = crypto.createHash("sha256").update(codeVerifier).digest("base64url");
     const state = crypto.randomBytes(32).toString("hex");
+    let callbackClaimed = false;
 
     const server = http.createServer(async (req, res) => {
+      // Accepted requests can outlive server.close(), so only the first
+      // terminal callback may settle the flow or exchange a code.
+      if (callbackClaimed) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end("<html><body><h3>Invalid request.</h3></body></html>");
+        return;
+      }
+
       try {
         const url = new URL(req.url, `http://127.0.0.1`);
         const returnedState = url.searchParams.get("state");
@@ -66,6 +75,7 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
         const error = url.searchParams.get("error");
 
         if (error) {
+          callbackClaimed = true;
           redirect(res, { [errorParam]: error });
           cleanup();
           reject(new Error(`OAuth error: ${error}`));
@@ -76,16 +86,17 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
           res.writeHead(400, { "Content-Type": "text/html" });
           res.end("<html><body><h3>Invalid request.</h3></body></html>");
           // A real callback with a code but the wrong state is a failed
-          // attempt (stale tab, CSRF). Fail the flow now — the error=
-          // branch already does. A request with no code (favicon / bare
-          // GET) must keep waiting for the provider redirect.
+          // attempt (stale tab, CSRF). Fail the flow now. A request with no
+          // code (favicon / bare GET) must keep waiting for the redirect.
           if (code) {
+            callbackClaimed = true;
             cleanup();
             reject(new Error("OAuth state mismatch"));
           }
           return;
         }
 
+        callbackClaimed = true;
         const redirectUri = `http://127.0.0.1:${server.address().port}`;
         const result = await handleCallback(code, redirectUri, codeVerifier);
 

--- a/src/helpers/oauthLoopbackFlow.js
+++ b/src/helpers/oauthLoopbackFlow.js
@@ -75,6 +75,14 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
         if (!code || returnedState !== state) {
           res.writeHead(400, { "Content-Type": "text/html" });
           res.end("<html><body><h3>Invalid request.</h3></body></html>");
+          // A real callback with a code but the wrong state is a failed
+          // attempt (stale tab, CSRF). Fail the flow now — the error=
+          // branch already does. A request with no code (favicon / bare
+          // GET) must keep waiting for the provider redirect.
+          if (code) {
+            cleanup();
+            reject(new Error("OAuth state mismatch"));
+          }
           return;
         }
 

--- a/src/helpers/oauthLoopbackFlow.js
+++ b/src/helpers/oauthLoopbackFlow.js
@@ -104,6 +104,7 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
         cleanup();
         resolve(result);
       } catch (err) {
+        callbackClaimed = true;
         redirect(res, { [errorParam]: err.redirectCode || "server_error" });
         cleanup();
         reject(err);
@@ -124,6 +125,7 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
     });
 
     timeoutId = setTimeout(() => {
+      callbackClaimed = true;
       server.close();
       reject(new Error("OAuth flow timed out"));
     }, OAUTH_TIMEOUT_MS);

--- a/test/helpers/oauthLoopbackFlow.test.js
+++ b/test/helpers/oauthLoopbackFlow.test.js
@@ -1,0 +1,95 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const loopbackModulePath = require.resolve("../../src/helpers/oauthLoopbackFlow.js");
+const originalLoad = Module._load;
+
+function loadLoopback() {
+  delete require.cache[loopbackModulePath];
+  Module._load = function loadWithElectronMock(request, parent, isMain) {
+    if (request === "electron") {
+      return { shell: { openExternal() {} } };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    return require(loopbackModulePath);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function startFlow(handleCallback = async () => ({ ok: true })) {
+  const { runOAuthLoopbackFlow } = loadLoopback();
+  let redirectUri;
+  let state;
+  const flow = runOAuthLoopbackFlow({
+    errorParam: "gcal_error",
+    buildAuthUrl: (uri, flowState) => {
+      redirectUri = uri;
+      state = flowState;
+      return "https://example.test/auth";
+    },
+    handleCallback,
+  });
+  return { flow, getRedirectUri: () => redirectUri, getState: () => state };
+}
+
+async function waitForListen(getRedirectUri) {
+  for (let i = 0; i < 50; i++) {
+    if (getRedirectUri()) return getRedirectUri();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("loopback server did not start");
+}
+
+test("a callback with a code and the wrong state rejects immediately", async () => {
+  const { flow, getRedirectUri } = startFlow();
+  const redirectUri = await waitForListen(getRedirectUri);
+  const started = Date.now();
+  const rejected = assert.rejects(flow, /OAuth state mismatch/);
+
+  const response = await fetch(`${redirectUri}/?code=stolen&state=wrong`, {
+    redirect: "manual",
+  });
+  assert.equal(response.status, 400);
+
+  await rejected;
+  assert.ok(Date.now() - started < 5000, "must not wait for the 120s timeout");
+});
+
+test("a request with no code leaves the flow running until a real callback", async () => {
+  const { flow, getRedirectUri, getState } = startFlow(async (code) => ({ code }));
+  const redirectUri = await waitForListen(getRedirectUri);
+
+  const stray = await fetch(`${redirectUri}/favicon.ico`, { redirect: "manual" });
+  assert.equal(stray.status, 400);
+
+  const stillPending = await Promise.race([
+    flow.then(
+      () => "resolved",
+      () => "rejected"
+    ),
+    new Promise((resolve) => setTimeout(() => resolve("pending"), 200)),
+  ]);
+  assert.equal(stillPending, "pending");
+
+  const success = await fetch(`${redirectUri}/?code=ok&state=${getState()}`, {
+    redirect: "manual",
+  });
+  assert.equal(success.status, 302);
+  assert.deepEqual(await flow, { code: "ok" });
+});
+
+test("a provider error query still fails the flow immediately", async () => {
+  const { flow, getRedirectUri } = startFlow();
+  const redirectUri = await waitForListen(getRedirectUri);
+  const rejected = assert.rejects(flow, /OAuth error: access_denied/);
+
+  const response = await fetch(`${redirectUri}/?error=access_denied`, {
+    redirect: "manual",
+  });
+  assert.equal(response.status, 302);
+  await rejected;
+});

--- a/test/helpers/oauthLoopbackFlow.test.js
+++ b/test/helpers/oauthLoopbackFlow.test.js
@@ -1,5 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const http = require("node:http");
 const Module = require("node:module");
 
 const loopbackModulePath = require.resolve("../../src/helpers/oauthLoopbackFlow.js");
@@ -36,12 +37,49 @@ function startFlow(handleCallback = async () => ({ ok: true })) {
   return { flow, getRedirectUri: () => redirectUri, getState: () => state };
 }
 
+function startBlockedFlow() {
+  let callbackCount = 0;
+  let releaseHandleCallback;
+  let markCallbackStarted;
+  const callbackStarted = new Promise((resolve) => {
+    markCallbackStarted = resolve;
+  });
+  const startedFlow = startFlow(async (code) => {
+    callbackCount += 1;
+    if (callbackCount === 1) {
+      markCallbackStarted();
+      await new Promise((resolve) => {
+        releaseHandleCallback = resolve;
+      });
+    }
+    return { code };
+  });
+
+  return {
+    ...startedFlow,
+    callbackStarted,
+    getCallbackCount: () => callbackCount,
+    releaseHandleCallback: () => releaseHandleCallback?.(),
+  };
+}
+
 async function waitForListen(getRedirectUri) {
   for (let i = 0; i < 50; i++) {
     if (getRedirectUri()) return getRedirectUri();
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error("loopback server did not start");
+}
+
+function requestPath(redirectUri, path) {
+  const { hostname, port } = new URL(redirectUri);
+  return new Promise((resolve, reject) => {
+    const request = http.get({ hostname, port, path }, (response) => {
+      response.resume();
+      response.on("end", () => resolve(response.statusCode));
+    });
+    request.on("error", reject);
+  });
 }
 
 test("a callback with a code and the wrong state rejects immediately", async () => {
@@ -92,4 +130,127 @@ test("a provider error query still fails the flow immediately", async () => {
   });
   assert.equal(response.status, 302);
   await rejected;
+});
+
+test("a late state mismatch cannot reject a valid callback already in progress", async () => {
+  const {
+    flow,
+    getRedirectUri,
+    getState,
+    callbackStarted,
+    releaseHandleCallback,
+  } = startBlockedFlow();
+  const redirectUri = await waitForListen(getRedirectUri);
+  const flowOutcome = flow.then(
+    () => "resolved",
+    (error) => `rejected: ${error.message}`
+  );
+
+  const validResponsePromise = fetch(`${redirectUri}/?code=ok&state=${getState()}`, {
+    redirect: "manual",
+  });
+  await callbackStarted;
+
+  let mismatchResponse;
+  let outcomeBeforeRelease;
+  try {
+    mismatchResponse = await fetch(`${redirectUri}/?code=stale&state=wrong`, {
+      redirect: "manual",
+    });
+    outcomeBeforeRelease = await Promise.race([
+      flowOutcome,
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 200)),
+    ]);
+  } finally {
+    releaseHandleCallback();
+  }
+
+  const validResponse = await validResponsePromise;
+  assert.equal(mismatchResponse.status, 400);
+  assert.equal(outcomeBeforeRelease, "pending");
+  assert.equal(validResponse.status, 302);
+  assert.equal(await flowOutcome, "resolved");
+});
+
+test("a late malformed request cannot reject a valid callback already in progress", async () => {
+  const {
+    flow,
+    getRedirectUri,
+    getState,
+    callbackStarted,
+    releaseHandleCallback,
+  } = startBlockedFlow();
+  const redirectUri = await waitForListen(getRedirectUri);
+  const flowOutcome = flow.then(
+    () => "resolved",
+    (error) => `rejected: ${error.message}`
+  );
+
+  const validResponsePromise = fetch(`${redirectUri}/?code=ok&state=${getState()}`, {
+    redirect: "manual",
+  });
+  await callbackStarted;
+
+  let malformedStatus;
+  let outcomeBeforeRelease;
+  try {
+    malformedStatus = await requestPath(redirectUri, "//[");
+    outcomeBeforeRelease = await Promise.race([
+      flowOutcome,
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 200)),
+    ]);
+  } finally {
+    releaseHandleCallback();
+  }
+
+  const validResponse = await validResponsePromise;
+  assert.equal(malformedStatus, 400);
+  assert.equal(outcomeBeforeRelease, "pending");
+  assert.equal(validResponse.status, 302);
+  assert.equal(await flowOutcome, "resolved");
+});
+
+test("a second valid callback cannot start another token exchange", async () => {
+  const {
+    flow,
+    getRedirectUri,
+    getState,
+    callbackStarted,
+    getCallbackCount,
+    releaseHandleCallback,
+  } = startBlockedFlow();
+  const redirectUri = await waitForListen(getRedirectUri);
+  const flowOutcome = flow.then(
+    (result) => ({ status: "resolved", result }),
+    (error) => ({ status: "rejected", error: error.message })
+  );
+
+  const firstResponsePromise = fetch(`${redirectUri}/?code=first&state=${getState()}`, {
+    redirect: "manual",
+  });
+  await callbackStarted;
+
+  let duplicateResponse;
+  let outcomeBeforeRelease;
+  try {
+    duplicateResponse = await fetch(`${redirectUri}/?code=duplicate&state=${getState()}`, {
+      redirect: "manual",
+    });
+    outcomeBeforeRelease = await Promise.race([
+      flowOutcome,
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 200)),
+    ]);
+  } finally {
+    releaseHandleCallback();
+  }
+
+  const firstResponse = await firstResponsePromise;
+  assert.equal(duplicateResponse.status, 400);
+  assert.equal(outcomeBeforeRelease, "pending");
+  assert.equal(getCallbackCount(), 1);
+  assert.equal(firstResponse.status, 302);
+  assert.deepEqual(await flowOutcome, {
+    status: "resolved",
+    result: { code: "first" },
+  });
 });

--- a/test/helpers/oauthLoopbackFlow.test.js
+++ b/test/helpers/oauthLoopbackFlow.test.js
@@ -1,6 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const http = require("node:http");
+const net = require("node:net");
 const Module = require("node:module");
 
 const loopbackModulePath = require.resolve("../../src/helpers/oauthLoopbackFlow.js");
@@ -25,16 +26,27 @@ function startFlow(handleCallback = async () => ({ ok: true })) {
   const { runOAuthLoopbackFlow } = loadLoopback();
   let redirectUri;
   let state;
-  const flow = runOAuthLoopbackFlow({
-    errorParam: "gcal_error",
-    buildAuthUrl: (uri, flowState) => {
-      redirectUri = uri;
-      state = flowState;
-      return "https://example.test/auth";
-    },
-    handleCallback,
-  });
-  return { flow, getRedirectUri: () => redirectUri, getState: () => state };
+  let server;
+  const originalCreateServer = http.createServer;
+  http.createServer = (...args) => {
+    server = originalCreateServer(...args);
+    return server;
+  };
+
+  try {
+    const flow = runOAuthLoopbackFlow({
+      errorParam: "gcal_error",
+      buildAuthUrl: (uri, flowState) => {
+        redirectUri = uri;
+        state = flowState;
+        return "https://example.test/auth";
+      },
+      handleCallback,
+    });
+    return { flow, server, getRedirectUri: () => redirectUri, getState: () => state };
+  } finally {
+    http.createServer = originalCreateServer;
+  }
 }
 
 function startBlockedFlow() {
@@ -63,6 +75,32 @@ function startBlockedFlow() {
   };
 }
 
+function startFlowWithControlledTimeout(handleCallback) {
+  const originalSetTimeout = global.setTimeout;
+  let runFlowTimeout;
+
+  global.setTimeout = (callback, delay, ...args) => {
+    if (delay === 120000) {
+      runFlowTimeout = () => callback(...args);
+      return originalSetTimeout(() => {}, 0);
+    }
+    return originalSetTimeout(callback, delay, ...args);
+  };
+
+  try {
+    const startedFlow = startFlow(handleCallback);
+    return {
+      ...startedFlow,
+      triggerTimeout: () => {
+        if (!runFlowTimeout) throw new Error("OAuth timeout was not scheduled");
+        runFlowTimeout();
+      },
+    };
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+}
+
 async function waitForListen(getRedirectUri) {
   for (let i = 0; i < 50; i++) {
     if (getRedirectUri()) return getRedirectUri();
@@ -74,12 +112,85 @@ async function waitForListen(getRedirectUri) {
 function requestPath(redirectUri, path) {
   const { hostname, port } = new URL(redirectUri);
   return new Promise((resolve, reject) => {
-    const request = http.get({ hostname, port, path }, (response) => {
-      response.resume();
-      response.on("end", () => resolve(response.statusCode));
-    });
+    const request = http.get(
+      { hostname, port, path, agent: false, headers: { Connection: "close" } },
+      (response) => {
+        response.resume();
+        response.on("end", () => resolve(response.statusCode));
+      }
+    );
     request.on("error", reject);
   });
+}
+
+async function parkPartialRequest(redirectUri, server) {
+  const { hostname, port } = new URL(redirectUri);
+  let response = "";
+  let responseStatus;
+  let responseSettled = false;
+  let resolveStatus;
+  let rejectStatus;
+  const status = new Promise((resolve, reject) => {
+    resolveStatus = resolve;
+    rejectStatus = reject;
+  });
+  const requestStarted = new Promise((resolve) => {
+    server.once("connection", (acceptedSocket) => {
+      acceptedSocket.once("data", resolve);
+    });
+  });
+  const socket = net.createConnection({ host: hostname, port });
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk) => {
+    response += chunk;
+    const match = /^HTTP\/1\.1 (\d{3})/.exec(response);
+    if (match) {
+      responseStatus = Number(match[1]);
+    }
+  });
+  socket.on("end", () => {
+    if (responseStatus && !responseSettled) {
+      responseSettled = true;
+      resolveStatus(responseStatus);
+    }
+  });
+  socket.on("error", (error) => {
+    if (!responseSettled) {
+      responseSettled = true;
+      rejectStatus(error);
+    }
+  });
+  socket.on("close", () => {
+    if (!responseSettled) {
+      responseSettled = true;
+      rejectStatus(new Error("parked request closed without a response"));
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    const handleConnect = () => {
+      socket.off("error", handleError);
+      resolve();
+    };
+    const handleError = (error) => {
+      socket.off("connect", handleConnect);
+      reject(error);
+    };
+    socket.once("connect", handleConnect);
+    socket.once("error", handleError);
+  });
+  socket.write("GET /");
+  await requestStarted;
+
+  return {
+    complete: (path) => {
+      socket.end(
+        `${path} HTTP/1.1\r\nHost: ${hostname}:${port}\r\nConnection: close\r\n\r\n`
+      );
+      return status;
+    },
+    destroy: () => socket.destroy(),
+  };
 }
 
 test("a callback with a code and the wrong state rejects immediately", async () => {
@@ -253,4 +364,50 @@ test("a second valid callback cannot start another token exchange", async () => 
     status: "resolved",
     result: { code: "first" },
   });
+});
+
+test("an accepted callback cannot run after a malformed request rejects the flow", async () => {
+  let callbackCount = 0;
+  const { flow, server, getRedirectUri, getState } = startFlow(async () => {
+    callbackCount += 1;
+    return { ok: true };
+  });
+  const redirectUri = await waitForListen(getRedirectUri);
+  const parkedRequest = await parkPartialRequest(redirectUri, server);
+  const rejected = assert.rejects(flow, /Invalid URL/);
+
+  try {
+    assert.equal(await requestPath(redirectUri, "//["), 302);
+    await rejected;
+
+    const lateStatus = await parkedRequest.complete(`?code=late&state=${getState()}`);
+    assert.equal(lateStatus, 400);
+    assert.equal(callbackCount, 0);
+  } finally {
+    parkedRequest.destroy();
+  }
+});
+
+test("an accepted callback cannot run after the flow times out", async () => {
+  let callbackCount = 0;
+  const { flow, server, getRedirectUri, getState, triggerTimeout } = startFlowWithControlledTimeout(
+    async () => {
+      callbackCount += 1;
+      return { ok: true };
+    }
+  );
+  const redirectUri = await waitForListen(getRedirectUri);
+  const parkedRequest = await parkPartialRequest(redirectUri, server);
+  const rejected = assert.rejects(flow, /OAuth flow timed out/);
+
+  try {
+    triggerTimeout();
+    await rejected;
+
+    const lateStatus = await parkedRequest.complete(`?code=late&state=${getState()}`);
+    assert.equal(lateStatus, 400);
+    assert.equal(callbackCount, 0);
+  } finally {
+    parkedRequest.destroy();
+  }
 });


### PR DESCRIPTION
## Summary

- Calendar connect (Google/Microsoft) uses an ephemeral `127.0.0.1` PKCE loopback server.
- A callback that includes `code` but the wrong `state` already returned HTTP 400; the promise kept waiting until the 120s timeout.
- Reject those attempts immediately, matching the existing `error=` branch. Requests with no `code` (favicon / bare GET) still only get 400 and keep waiting.

Fixes #1750

## Problem

After a stale-tab or CSRF-mismatched redirect, the browser shows "Invalid request" while the app stays on "connecting" for two minutes.

## Root cause

`runOAuthLoopbackFlow` treated `!code || returnedState !== state` as a 400 and returned without `cleanup()` or `reject()`. Only `error=` and the timeout closed the server.

## Fix

If a `code` is present and `state` does not match, call `cleanup()` and reject with `OAuth state mismatch`. Leave no-code requests as 400-and-wait so a favicon fetch cannot abort a real login.

## Behavior before vs after

| Callback | Before | After |
| --- | --- | --- |
| `?code=…&state=wrong` | 400, hang 120s | 400, reject immediately |
| `/favicon.ico` (no code) | 400, keep waiting | unchanged |
| `?error=access_denied` | reject immediately | unchanged |
| matching `code` + `state` | success | unchanged |

## Scope & non-goals

- Only `oauthLoopbackFlow.js` and a new unit test.
- Does not change token exchange, PKCE generation, or hosted callback HTML.

## Tests

- `test/helpers/oauthLoopbackFlow.test.js` (mocked `electron.shell`)

## Validation

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/oauthLoopbackFlow.test.js` → PASS (3 tests)
- `npx prettier --check src/helpers/oauthLoopbackFlow.js test/helpers/oauthLoopbackFlow.test.js` → PASS