### PR TITLE
fix(dictation): initialize onboarding event ref safely

### DIFF
--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -49,7 +49,7 @@ export const useAudioRecording = (toast, options = {}) => {
   const wasRecordingRef = useRef(false);
   const wasMicUnavailableRef = useRef(false);
   const demoKindRef = useRef("dictation");
-  const onDemoEventRef = useRef(onDemoEvent);
+  const onDemoEventRef = useRef(options.onDemoEvent);
   const reportedLifecycleRef = useRef(null);
   const lastStartOptionsRef = useRef({
     voiceAgentRequested: false,

--- a/test/helpers/useAudioRecordingInitialization.test.js
+++ b/test/helpers/useAudioRecordingInitialization.test.js
@@ -1,0 +1,23 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+test("useAudioRecording accepts an onboarding event handler on its initial render", async (t) => {
+  installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-audio-recording-initialization-",
+    mockModules: {
+      "/helpers/audioManager": "export default class AudioManager {}",
+    },
+  });
+  const { useAudioRecording } = await vite.ssrLoadModule("/hooks/useAudioRecording.js");
+
+  function InitialRenderProbe() {
+    useAudioRecording(() => {}, { onDemoEvent: () => {} });
+    return React.createElement("div");
+  }
+
+  assert.doesNotThrow(() => renderToStaticMarkup(React.createElement(InitialRenderProbe)));
+});


### PR DESCRIPTION
## Summary
Fixes the recorder window crashing during its initial render.
Initializes the onboarding event ref directly from options.
Adds a regression test covering initialization with an onboarding event handler.

## Root cause
useAudioRecording referenced onDemoEvent before it was initialized by the subsequent options destructuring. In the bundled application, this caused a temporal dead zone error:
Cannot access variable before initialization
Because the error occurred during module initialization, the recorder window displayed the generic “Something went wrong” screen.