### PR TITLE
fix(auth): Unify onboarding and reauthentication display

### DIFF
--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,16 +1,15 @@
 import React, { Suspense, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import App from "./App.jsx";
-import AuthenticationStep from "./components/AuthenticationStep.tsx";
 import MeetingNotificationOverlay from "./components/MeetingNotificationOverlay.tsx";
+import ReauthenticationScreen from "./components/ReauthenticationScreen.tsx";
 import UpdateNotificationOverlay from "./components/UpdateNotificationOverlay.tsx";
-import WindowControls from "./components/WindowControls.tsx";
 import BackgroundModelDownloadTray from "./components/onboarding/BackgroundModelDownloadTray.tsx";
-import { Card, CardContent } from "./components/ui/card.tsx";
 import { LEGACY_ONBOARDING_STEP_KEY, ONBOARDING_SESSION_KEY } from "./components/onboarding/flow";
 import { useAuth } from "./hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
 import { usePolicyStore } from "./stores/policyStore";
+import { resolveSettledControlPanelWindowMode } from "./utils/controlPanelWindowMode.ts";
 import { isControlPanelWindow } from "./utils/windowContext.ts";
 
 // Either marker means the flow is mid-way: the legacy step key is kept for
@@ -111,36 +110,47 @@ function MainApp() {
   }, [authLoaded, isControlPanel, isDictationPanel, isGracePeriodOnly, isSignedIn]);
 
   useEffect(() => {
-    if (!isControlPanel) return;
+    if (!isControlPanel || !authLoaded) return;
     // Fast path: a user who already finished onboarding can never enter the
-    // compact flow, so show the control panel immediately instead of holding
-    // it hidden behind auth/policy resolution. Fresh installs and mid-flow
-    // restarts fall through to the effect below, preserving the no-flash
-    // guarantee for windows that will enter compact onboarding mode.
+    // compact flow only when their session or guest choice is still valid.
+    // Signed-out account users fall through so reauthentication can select the
+    // compact window without first flashing restored control-panel dimensions.
     const completed = localStorage.getItem("onboardingCompleted") === "true";
-    if (completed && !isOnboardingInProgress()) {
+    const authSkipped =
+      localStorage.getItem("authenticationSkipped") === "true" ||
+      localStorage.getItem("skipAuth") === "true";
+    if (completed && !isOnboardingInProgress() && (isSignedIn || authSkipped)) {
       void window.electronAPI?.setOnboardingWindowMode?.("restore");
     }
-  }, [isControlPanel]);
+  }, [authLoaded, isControlPanel, isSignedIn]);
+
+  const settledControlPanelWindowMode = resolveSettledControlPanelWindowMode({
+    isControlPanel,
+    isLoading,
+    isWaitingForPolicyStart,
+    showOnboarding,
+    needsReauth,
+  });
 
   useEffect(() => {
-    if (!isControlPanel || isLoading || isWaitingForPolicyStart || showOnboarding) return;
+    if (!settledControlPanelWindowMode) return;
     // The main process waits for this renderer decision before showing the
     // control panel, preventing a fresh install from flashing at 1200×800
-    // before the compact onboarding mode is applied.
-    void window.electronAPI?.setOnboardingWindowMode?.("restore");
-  }, [isControlPanel, isLoading, isWaitingForPolicyStart, showOnboarding]);
+    // before its route-appropriate window mode is applied.
+    void window.electronAPI?.setOnboardingWindowMode?.(settledControlPanelWindowMode);
+  }, [settledControlPanelWindowMode]);
 
   useEffect(() => {
     if (isLoading || isWaitingForPolicyStart) return;
 
     const onboardingCompleted = localStorage.getItem("onboardingCompleted") === "true";
-    const normalAppVisible = onboardingCompleted && (!isControlPanel || !showOnboarding);
+    const normalAppVisible =
+      onboardingCompleted && (!isControlPanel || (!showOnboarding && !needsReauth));
     // Main starts fail-closed. Only a renderer that has resolved the route and
     // actually committed the normal app may release global hotkeys and popup
     // surfaces; fresh installs and onboarding reloads keep them suppressed.
     void window.electronAPI?.setOnboardingActive?.(!normalAppVisible);
-  }, [isControlPanel, isLoading, isWaitingForPolicyStart, showOnboarding]);
+  }, [isControlPanel, isLoading, isWaitingForPolicyStart, needsReauth, showOnboarding]);
 
   const handleOnboardingComplete = (options) => {
     if (options?.openSettings) {
@@ -168,39 +178,14 @@ function MainApp() {
 
   if (isControlPanel && needsReauth) {
     return (
-      <div
-        className="h-screen flex flex-col bg-background"
-        style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}
-      >
-        <div
-          className="flex items-center justify-end w-full h-10 shrink-0"
-          style={{ WebkitAppRegion: "drag" }}
-        >
-          {window.electronAPI?.getPlatform?.() !== "darwin" && (
-            <div className="pr-1" style={{ WebkitAppRegion: "no-drag" }}>
-              <WindowControls />
-            </div>
-          )}
-        </div>
-        <div className="flex-1 px-6 overflow-y-auto flex items-center">
-          <div className="w-full max-w-sm mx-auto">
-            <Card className="bg-card/90 backdrop-blur-2xl border border-border/50 dark:border-white/5 shadow-lg rounded-xl overflow-hidden">
-              <CardContent className="p-6">
-                <AuthenticationStep
-                  onContinueWithoutAccount={() => {
-                    localStorage.setItem("authenticationSkipped", "true");
-                    localStorage.setItem("skipAuth", "true");
-                    setNeedsReauth(false);
-                  }}
-                  onAuthComplete={() => setNeedsReauth(false)}
-                  onNeedsVerification={() => {}}
-                  embedded
-                />
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
+      <ReauthenticationScreen
+        onContinueWithoutAccount={() => {
+          localStorage.setItem("authenticationSkipped", "true");
+          localStorage.setItem("skipAuth", "true");
+          setNeedsReauth(false);
+        }}
+        onAuthComplete={() => setNeedsReauth(false)}
+      />
     );
   }
 

--- a/src/components/CompactAuthenticationFlow.tsx
+++ b/src/components/CompactAuthenticationFlow.tsx
@@ -1,0 +1,41 @@
+import { useState, type JSX } from "react";
+import { signOut } from "../lib/auth";
+import AuthenticationStep from "./AuthenticationStep";
+import EmailVerificationStep from "./EmailVerificationStep";
+
+interface CompactAuthenticationFlowProps {
+  onContinueWithoutAccount?: () => void;
+  onAuthComplete: () => void;
+}
+
+export function CompactAuthenticationFlow({
+  onContinueWithoutAccount,
+  onAuthComplete,
+}: CompactAuthenticationFlowProps): JSX.Element {
+  const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
+
+  if (pendingVerificationEmail) {
+    return (
+      <EmailVerificationStep
+        email={pendingVerificationEmail}
+        onVerified={() => {
+          setPendingVerificationEmail(null);
+          onAuthComplete();
+        }}
+        onBack={() => {
+          // Abandoning verification leaves a live session for the wrong email;
+          // end it first or the remounted auth step auto-completes that account.
+          void signOut().then(() => setPendingVerificationEmail(null));
+        }}
+      />
+    );
+  }
+
+  return (
+    <AuthenticationStep
+      onContinueWithoutAccount={onContinueWithoutAccount}
+      onAuthComplete={onAuthComplete}
+      onNeedsVerification={setPendingVerificationEmail}
+    />
+  );
+}

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertCircle } from "lucide-react";
-import AuthenticationStep from "./AuthenticationStep";
-import EmailVerificationStep from "./EmailVerificationStep";
+import { CompactAuthenticationFlow } from "./CompactAuthenticationFlow";
 import UseCaseStep from "./onboarding/UseCaseStep";
 import { hasUseCaseIntent } from "./onboarding/useCases";
 import OnboardingShell, { OnboardingStepHeader } from "./onboarding/OnboardingShell";
@@ -16,7 +15,6 @@ import SetupChoiceStep from "./onboarding/SetupChoiceStep";
 import { ByokProviderStep, LocalModelSetupStep } from "./onboarding/ProviderSetupStep";
 import { AlertDialog } from "./ui/dialog";
 import { useAuth } from "../hooks/useAuth";
-import { signOut } from "../lib/auth";
 import { usePermissions } from "../hooks/usePermissions";
 import { useClipboard } from "../hooks/useClipboard";
 import { useSystemAudioPermission } from "../hooks/useSystemAudioPermission";
@@ -90,7 +88,6 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     clearSession,
   } = useOnboardingSession();
 
-  const [pendingVerificationEmail, setPendingVerificationEmail] = useState<string | null>(null);
   const [dictationHotkey, setDictationHotkey] = useState(
     () => parseHotkeyList(settings.dictationKey)[0] || getDefaultHotkey()
   );
@@ -571,37 +568,19 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
       case "auth":
         return (
           <div className="min-h-full w-full">
-            {pendingVerificationEmail ? (
-              <EmailVerificationStep
-                email={pendingVerificationEmail}
-                onVerified={() => {
-                  setPendingVerificationEmail(null);
-                  setAuthPath("account");
-                  goTo(session.setupMode === "cloud" ? "setup-choice" : "permissions");
-                }}
-                onBack={() => {
-                  // Abandoning verification leaves a live session for the
-                  // wrong email; end it first or the remounted auth step
-                  // auto-completes with that account (signOut never rejects).
-                  void signOut().then(() => setPendingVerificationEmail(null));
-                }}
-              />
-            ) : (
-              <AuthenticationStep
-                onContinueWithoutAccount={() => {
-                  // Guests continue onto their route's permissions step — jumping
-                  // straight to setup-choice would skip the permission grants and
-                  // hotkey the guest route exists to guarantee (see flow.ts).
-                  setAuthPath("guest");
-                  goTo("permissions");
-                }}
-                onAuthComplete={() => {
-                  setAuthPath("account");
-                  goTo(session.setupMode === "cloud" ? "setup-choice" : "permissions");
-                }}
-                onNeedsVerification={setPendingVerificationEmail}
-              />
-            )}
+            <CompactAuthenticationFlow
+              onContinueWithoutAccount={() => {
+                // Guests continue onto their route's permissions step — jumping
+                // straight to setup-choice would skip the permission grants and
+                // hotkey the guest route exists to guarantee (see flow.ts).
+                setAuthPath("guest");
+                goTo("permissions");
+              }}
+              onAuthComplete={() => {
+                setAuthPath("account");
+                goTo(session.setupMode === "cloud" ? "setup-choice" : "permissions");
+              }}
+            />
           </div>
         );
 

--- a/src/components/ReauthenticationScreen.tsx
+++ b/src/components/ReauthenticationScreen.tsx
@@ -1,0 +1,24 @@
+import type { JSX } from "react";
+import { CompactAuthenticationFlow } from "./CompactAuthenticationFlow";
+import OnboardingShell from "./onboarding/OnboardingShell";
+
+interface ReauthenticationScreenProps {
+  onContinueWithoutAccount: () => void;
+  onAuthComplete: () => void;
+}
+
+export default function ReauthenticationScreen({
+  onContinueWithoutAccount,
+  onAuthComplete,
+}: ReauthenticationScreenProps): JSX.Element {
+  return (
+    <OnboardingShell compact stepKey="reauthentication">
+      <div className="min-h-full w-full">
+        <CompactAuthenticationFlow
+          onContinueWithoutAccount={onContinueWithoutAccount}
+          onAuthComplete={onAuthComplete}
+        />
+      </div>
+    </OnboardingShell>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -830,7 +830,7 @@ h1 {
 }
 
 /* Scoped to .onboarding-canvas because AuthenticationStep also renders outside
-   onboarding (SignInDialog, AppRouter's re-auth card), where the --onboarding-*
+   onboarding (SignInDialog), where the --onboarding-*
    tokens are undefined and these !important rules would paint invisible inputs.
    Outside the canvas the Input component's default skin wins instead. */
 .onboarding-canvas .onboarding-light-input,

--- a/src/utils/controlPanelWindowMode.ts
+++ b/src/utils/controlPanelWindowMode.ts
@@ -1,0 +1,24 @@
+export type ControlPanelWindowMode = "compact" | "restore";
+
+export interface SettledControlPanelWindowState {
+  isControlPanel: boolean;
+  isLoading: boolean;
+  isWaitingForPolicyStart: boolean;
+  showOnboarding: boolean;
+  needsReauth: boolean;
+}
+
+export function resolveSettledControlPanelWindowMode(
+  state: SettledControlPanelWindowState
+): ControlPanelWindowMode | null {
+  if (
+    !state.isControlPanel ||
+    state.isLoading ||
+    state.isWaitingForPolicyStart ||
+    state.showOnboarding
+  ) {
+    return null;
+  }
+
+  return state.needsReauth ? "compact" : "restore";
+}

--- a/test/components/compactAuthenticationFlow.test.js
+++ b/test/components/compactAuthenticationFlow.test.js
@@ -1,0 +1,130 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+const noop = () => {};
+
+test("returning-user authentication renders the complete compact onboarding surface", async (t) => {
+  installBrowserGlobals(t, {
+    window: { electronAPI: { getPlatform: () => "linux" } },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-compact-reauthentication-",
+    noExternal: ["react-i18next"],
+    mockModules: {
+      "react-i18next": `
+        export function useTranslation() {
+          return { t(key) { return key; } };
+        }
+      `,
+      "onboarding-hero-dither.webp": `export default "hero-light.webp";`,
+      "onboarding-hero-dither-dark.webp": `export default "hero-dark.webp";`,
+      "onboarding-bg-light.svg": `export default "background-light.svg";`,
+      "onboarding-bg-dark.svg": `export default "background-dark.svg";`,
+      "/config/constants": `export const OPENWHISPR_API_URL = "";`,
+      "/hooks/useAuth": `
+        export function useAuth() {
+          return { isLoaded: true, isSignedIn: false, user: null };
+        }
+      `,
+      "/lib/auth": `
+        export const AUTH_URL = "https://auth.openwhispr.test";
+        export const authClient = {};
+        export async function signInWithSocial() { return {}; }
+        export async function signInWithSSO() { return {}; }
+        export async function signOut() {}
+        export function updateLastSignInTime() {}
+      `,
+      "/utils/logger": `export default { error() {} };`,
+      "/utils/platform": `
+        export function getPlatform() { return "linux"; }
+        export function getCachedPlatform() { return "linux"; }
+      `,
+    },
+  });
+  const { default: ReauthenticationScreen } = await vite.ssrLoadModule(
+    "/components/ReauthenticationScreen.tsx"
+  );
+
+  const markup = renderToStaticMarkup(
+    React.createElement(ReauthenticationScreen, {
+      onAuthComplete: noop,
+      onContinueWithoutAccount: noop,
+    })
+  );
+
+  assert.match(markup, /<main class="onboarding-canvas[^"]*compact/);
+  assert.match(markup, /onboarding-compact-hero/);
+  assert.match(markup, /auth\.welcomeTitle/);
+  assert.match(markup, /auth\.emailStep\.continueWithoutAccount/);
+  assert.match(markup, /auth\.legal\.terms/);
+  assert.match(markup, /auth\.legal\.privacy/);
+  assert.doesNotMatch(markup, /onboarding-embedded-auth/);
+});
+
+test("verification success completes auth and backing out signs out before returning", async (t) => {
+  globalThis.__compactAuthTestState = { pendingEmail: null, signOutCount: 0 };
+  t.after(() => {
+    delete globalThis.__compactAuthTestState;
+  });
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-compact-authentication-state-",
+    noExternal: ["react"],
+    mockModules: {
+      react: `
+        export function useState() {
+          const state = globalThis.__compactAuthTestState;
+          return [state.pendingEmail, (value) => { state.pendingEmail = value; }];
+        }
+      `,
+      "/jsx-dev-runtime": `
+        export const Fragment = Symbol.for("react.fragment");
+        export function jsxDEV(type, props, key) { return { type, props, key }; }
+      `,
+      "/AuthenticationStep": `
+        export default function AuthenticationStep() { return null; }
+      `,
+      "/EmailVerificationStep": `
+        export default function EmailVerificationStep() { return null; }
+      `,
+      "/lib/auth": `
+        export async function signOut() {
+          globalThis.__compactAuthTestState.signOutCount += 1;
+        }
+      `,
+    },
+  });
+  const { CompactAuthenticationFlow } = await vite.ssrLoadModule(
+    "/components/CompactAuthenticationFlow.tsx"
+  );
+  let authCompleteCount = 0;
+  const props = {
+    onAuthComplete: () => {
+      authCompleteCount += 1;
+    },
+    onContinueWithoutAccount: noop,
+  };
+
+  const authStep = CompactAuthenticationFlow(props);
+  assert.equal(authStep.type.name, "AuthenticationStep");
+  assert.equal(authStep.props.onAuthComplete, props.onAuthComplete);
+  assert.equal(authStep.props.onContinueWithoutAccount, props.onContinueWithoutAccount);
+
+  authStep.props.onNeedsVerification("person@example.com");
+  const verificationStep = CompactAuthenticationFlow(props);
+  assert.equal(verificationStep.type.name, "EmailVerificationStep");
+  assert.equal(verificationStep.props.email, "person@example.com");
+
+  verificationStep.props.onBack();
+  await Promise.resolve();
+  assert.equal(globalThis.__compactAuthTestState.signOutCount, 1);
+  assert.equal(CompactAuthenticationFlow(props).type.name, "AuthenticationStep");
+
+  authStep.props.onNeedsVerification("person@example.com");
+  CompactAuthenticationFlow(props).props.onVerified();
+  assert.equal(authCompleteCount, 1);
+  assert.equal(CompactAuthenticationFlow(props).type.name, "AuthenticationStep");
+});

--- a/test/components/controlPanelWindowMode.test.js
+++ b/test/components/controlPanelWindowMode.test.js
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const load = () => import("../../src/utils/controlPanelWindowMode.ts");
+
+const settledState = {
+  isControlPanel: true,
+  isLoading: false,
+  isWaitingForPolicyStart: false,
+  showOnboarding: false,
+  needsReauth: false,
+};
+
+test("returning-user authentication selects the compact window", async () => {
+  const { resolveSettledControlPanelWindowMode } = await load();
+
+  assert.equal(
+    resolveSettledControlPanelWindowMode({ ...settledState, needsReauth: true }),
+    "compact"
+  );
+});
+
+test("normal control-panel content restores the saved window", async () => {
+  const { resolveSettledControlPanelWindowMode } = await load();
+
+  assert.equal(resolveSettledControlPanelWindowMode(settledState), "restore");
+});
+
+test("unsettled and onboarding routes leave window sizing to their owners", async () => {
+  const { resolveSettledControlPanelWindowMode } = await load();
+
+  assert.equal(
+    resolveSettledControlPanelWindowMode({ ...settledState, isControlPanel: false }),
+    null
+  );
+  assert.equal(resolveSettledControlPanelWindowMode({ ...settledState, isLoading: true }), null);
+  assert.equal(
+    resolveSettledControlPanelWindowMode({ ...settledState, isWaitingForPolicyStart: true }),
+    null
+  );
+  assert.equal(
+    resolveSettledControlPanelWindowMode({ ...settledState, showOnboarding: true }),
+    null
+  );
+});


### PR DESCRIPTION
## Summary

Make the returning-user sign-in/up screen match the compact authentication
experience shown during initial onboarding.

## Root cause

Initial onboarding used the complete compact authentication shell, while
normal sign-out rendered an embedded authentication form inside a separate
generic card. The reauthentication route also restored the larger control
panel window before rendering.

## Changes

- Extract the authentication and email-verification state into a shared flow
- Use the shared flow for both onboarding and returning-user authentication
- Render reauthentication inside the canonical compact onboarding shell
- Keep the window compact while reauthentication is active
- Restore the previous control-panel window state afterward
- Suppress normal app surfaces and global input while reauthentication is active
- Preserve guest continuation and completed-onboarding state
- Add regression coverage for the compact display, verification flow, and
  window-mode lifecycle

## Testing

- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run i18n:check`
- [x] `npm run build:renderer`
- [x] `npm test` — 2,882 tests, 0 failures