### PR TITLE
fix(calendar): skip non-web video entry points

### DIFF
--- a/src/helpers/meetingJoinUrl.js
+++ b/src/helpers/meetingJoinUrl.js
@@ -44,7 +44,15 @@ export function getMeetingJoinUrl(event) {
   try {
     const data = JSON.parse(event.conference_data);
     const uri = data?.entryPoints
-      ?.find((ep) => ep.entryPointType === "video" && ep.uri?.trim())
+      ?.find((ep) => {
+        const candidate = ep?.uri?.trim();
+        if (ep?.entryPointType !== "video" || !candidate) return false;
+        try {
+          return ["http:", "https:"].includes(new URL(candidate).protocol);
+        } catch {
+          return false;
+        }
+      })
       ?.uri?.trim();
     return uri || null;
   } catch {

--- a/test/helpers/meetingJoinUrl.test.js
+++ b/test/helpers/meetingJoinUrl.test.js
@@ -27,6 +27,20 @@ test("falls back to the video entry point in conference_data", async () => {
   assert.equal(getMeetingJoinUrl(event), "https://zoom.us/j/123");
 });
 
+test("skips non-HTTP video entry points when a later web link is available", async () => {
+  const { getMeetingJoinUrl } = await load();
+  const event = {
+    conference_data: JSON.stringify({
+      entryPoints: [
+        { entryPointType: "video", uri: "tel:+15551234567" },
+        { entryPointType: "video", uri: "https://meet.google.com/abc-defg-hij" },
+      ],
+    }),
+  };
+
+  assert.equal(getMeetingJoinUrl(event), "https://meet.google.com/abc-defg-hij");
+});
+
 test("returns null without a video entry point", async () => {
   const { getMeetingJoinUrl } = await load();
   const event = {


### PR DESCRIPTION
## Summary

Fix calendar conference-link selection when a non-web `video` entry point appears before a usable web meeting URL.

## Problem

`getMeetingJoinUrl` returned the first non-empty `video` URI from `conference_data`, including `tel:` or other non-web schemes. That value is used as a calendar join URL and passed to the desktop join action.

## Root cause

The conference entry-point filter checked only `entryPointType` and URI presence. It did not validate the URI or continue to later entry points when the first URI was not an HTTP(S) URL.

## Solution

Select the first syntactically valid HTTP(S) video URI. Provider-mapped `hangout_link` behavior is unchanged.

## Tests

- Added a regression test proving a `tel:` video entry is skipped in favor of a later HTTPS meeting link.
- Existing meeting-link tests continue to cover normal, malformed, empty, and vendor-specific cases.

## Validation

- `node --test test/helpers/meetingJoinUrl.test.js` — PASS (14 tests).
- `npm run lint` — PASS.
- `npm run format:check` — PASS.
- `npm run typecheck` — PASS.
- `npm run i18n:check` — PASS.
- `npm run build:renderer` — PASS.
- `npm test` — environment/pre-existing failure in this isolated checkout: 1,289 passed, 1,156 failed, 171 skipped, 1 todo. Failures include repository-wide TypeScript/ESM loader mismatches and Electron-dependent tests; the initial run also lacked Electron's postinstall binary because dependencies were installed with `npm ci --ignore-scripts`. The changed-file standalone test passes.

## Compatibility and risk

This narrows only `conference_data` video entry points to web URLs, matching their use as desktop web meeting join links. No provider mappings, public API shapes, or supported vendor paths changed.

## Documentation

No documentation change is needed for this internal normalization.

## Related issues and prior work

Fixes #1765. This is distinct from prior calendar fixes for whitespace handling, vendor path extraction, and time-block reminder eligibility.
