### PR TITLE
fix(notes): format future timestamps as dates

### DIFF
--- a/src/utils/dateFormatting.ts
+++ b/src/utils/dateFormatting.ts
@@ -30,6 +30,7 @@ export function formatRelativeTime(
   const date = normalizeDbDate(dateStr);
   if (Number.isNaN(date.getTime())) return "";
   const diff = Date.now() - date.getTime();
+  if (diff < 0) return formatShortDate(dateStr);
   const minutes = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);
   const days = Math.floor(diff / 86400000);

--- a/test/utils/dateFormatting.test.js
+++ b/test/utils/dateFormatting.test.js
@@ -1,0 +1,14 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/dateFormatting.ts");
+
+test("future timestamps use a calendar date instead of the now label", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: Date.parse("2026-08-21T12:00:00.000Z") });
+  const { formatRelativeTime } = await load();
+
+  assert.notEqual(
+    formatRelativeTime("2026-08-21T14:00:00.000Z", (key) => key),
+    "notes.list.timeNow"
+  );
+});

--- a/test/utils/dateFormatting.test.js
+++ b/test/utils/dateFormatting.test.js
@@ -5,10 +5,11 @@ const load = () => import("../../src/utils/dateFormatting.ts");
 
 test("future timestamps use a calendar date instead of the now label", async (t) => {
   t.mock.timers.enable({ apis: ["Date"], now: Date.parse("2026-08-21T12:00:00.000Z") });
-  const { formatRelativeTime } = await load();
+  const { formatRelativeTime, formatShortDate } = await load();
+  const futureTimestamp = "2026-08-21T14:00:00.000Z";
 
-  assert.notEqual(
-    formatRelativeTime("2026-08-21T14:00:00.000Z", (key) => key),
-    "notes.list.timeNow"
+  assert.equal(
+    formatRelativeTime(futureTimestamp, (key) => key),
+    formatShortDate(futureTimestamp)
   );
 });


### PR DESCRIPTION
## Summary

Prevent future note timestamps from being displayed as “now”.

## Problem

`formatRelativeTime` treated every negative elapsed-minute value as less than one minute, so a timestamp two hours in the future returned the `notes.list.timeNow` label.

## Root cause

The elapsed-time thresholds did not distinguish future timestamps from timestamps that are less than one minute old.

## Solution

Return the existing short-date representation for future timestamps. Past relative-time labels and invalid-date handling remain unchanged.

## Tests

- Added deterministic coverage with a mocked clock for a timestamp two hours in the future.
- Existing date-grouping tests continue to pass.

## Validation

- `node --test test/utils/dateFormatting.test.js test/utils/dateGrouping.test.js` — PASS (5 tests).
- `npm run lint` — PASS.
- `npm run format:check` — PASS.
- `npm run typecheck` — PASS.
- `npm run i18n:check` — PASS.
- `npm run build:renderer` — PASS.

## Compatibility and risk

This changes only future timestamps; all existing past-time thresholds and the short-date formatter are preserved. No API shape or locale keys changed.

## Documentation

No documentation change is needed for this internal display correction.

## Related issues and prior work

Fixes #1767. Duplicate searches found no existing issue or pull request for future relative timestamps.
