### PR TITLE
fix(notes): keep note content visible above the floating chat panel

### DIFF
--- a/src/components/notes/EmbeddedChat.tsx
+++ b/src/components/notes/EmbeddedChat.tsx
@@ -22,6 +22,8 @@ interface EmbeddedChatProps {
   activeConversationId?: number | null;
   onSwitchConversation?: (id: number) => void;
   onNewChat?: () => void;
+  /** Floating panel ref; NoteEditor reserves scroll space with it. */
+  floatingPanelRef?: React.Ref<HTMLDivElement>;
 }
 
 function EmptyState() {
@@ -46,6 +48,7 @@ export default function EmbeddedChat({
   activeConversationId,
   onSwitchConversation,
   onNewChat,
+  floatingPanelRef,
 }: EmbeddedChatProps) {
   const { t } = useTranslation();
 
@@ -143,6 +146,7 @@ export default function EmbeddedChat({
   if (mode === "floating") {
     return (
       <div
+        ref={floatingPanelRef}
         className={cn(
           "absolute bottom-4 left-5 right-5 z-20 mx-auto max-w-[600px]",
           "max-h-[calc(100%-2rem)] min-h-50",

--- a/src/components/notes/EmbeddedChat.tsx
+++ b/src/components/notes/EmbeddedChat.tsx
@@ -8,6 +8,7 @@ import type { Message, AgentState } from "../chat/types";
 import { setActiveNoteId, setActiveFolderId } from "../../stores/noteStore";
 import type { ContainerConversationItem } from "../../hooks/useContainerChat";
 import { ConversationPicker } from "./ConversationPicker";
+import { FLOATING_CHAT_MAX_HEIGHT_CSS } from "./floatingChatLayout";
 
 export type EmbeddedChatMode = "hidden" | "floating" | "sidebar";
 
@@ -147,9 +148,10 @@ export default function EmbeddedChat({
     return (
       <div
         ref={floatingPanelRef}
+        style={{ maxHeight: FLOATING_CHAT_MAX_HEIGHT_CSS }}
         className={cn(
           "absolute bottom-4 left-5 right-5 z-20 mx-auto max-w-[600px]",
-          "max-h-[calc(100%-2rem)] min-h-50",
+          "min-h-50",
           "flex flex-col",
           "bg-background/95 dark:bg-surface-2/95",
           "border border-black/15 dark:border-white/18",

--- a/src/components/notes/MeetingTranscriptChat.tsx
+++ b/src/components/notes/MeetingTranscriptChat.tsx
@@ -774,7 +774,7 @@ export function MeetingTranscriptChat({
       )}
       <div
         ref={scrollRef}
-        className="flex-1 min-h-0 overflow-y-auto px-4 pt-2 pb-24 flex flex-col gap-1.5 agent-chat-scroll"
+        className="flex-1 min-h-0 overflow-y-auto px-4 pt-2 flex flex-col gap-1.5 agent-chat-scroll pb-[var(--floating-inset,96px)]"
       >
         {segments.map((segment, i) => {
           const selfSide = isSelfSide(segment);

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -716,6 +716,47 @@ export default function NoteEditor({
     prevRecordingRef.current = isRecording;
   }, [isRecording, scheduleUiUpdate]);
 
+  // Reserve scroll space for the floating chat panel; +32 = bottom-4 + gap.
+  const contentScrollRef = useRef<HTMLDivElement>(null);
+
+  // Pin the active view's scroller to its content bottom: always on open,
+  // on resize only if already near it (padding isn't content).
+  const pinActiveScroller = useCallback((root: HTMLDivElement | null, force = false) => {
+    if (!root) return;
+    const candidates = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))].filter(
+      (el) => el.scrollHeight - el.clientHeight > 2
+    );
+    if (!candidates.length) return;
+    const scroller = candidates.reduce((a, b) =>
+      b.scrollHeight - b.clientHeight > a.scrollHeight - a.clientHeight ? b : a
+    );
+    const pad = parseFloat(getComputedStyle(scroller).paddingBottom) || 0;
+    const distToContent = scroller.scrollHeight - pad - scroller.scrollTop - scroller.clientHeight;
+    if (force || distToContent < 80) {
+      scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
+    }
+  }, []);
+
+  const floatingChatPanelRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      const container = el?.parentElement;
+      if (!el || !container) return;
+      const applyInset = (force = false) => {
+        container.style.setProperty("--floating-inset", `${el.offsetHeight + 32}px`);
+        if (force) requestAnimationFrame(() => pinActiveScroller(contentScrollRef.current, true));
+        else pinActiveScroller(contentScrollRef.current);
+      };
+      applyInset(true);
+      const observer = new ResizeObserver(() => applyInset());
+      observer.observe(el);
+      return () => {
+        observer.disconnect();
+        container.style.removeProperty("--floating-inset");
+      };
+    },
+    [pinActiveScroller]
+  );
+
   const handleContentChange = useCallback(
     (newValue: string) => {
       onContentChange(note.id, newValue);
@@ -1150,7 +1191,7 @@ export default function NoteEditor({
         )}
 
         <div className="flex-1 relative min-h-0">
-          <div className="h-full overflow-y-auto">
+          <div ref={contentScrollRef} className="h-full overflow-y-auto">
             {viewMode === "transcript" && (hasChatSegments || isRecording) ? (
               isRecording ? (
                 <LiveMeetingTranscriptChat
@@ -1245,6 +1286,7 @@ export default function NoteEditor({
           {chatMode === "floating" && (
             <EmbeddedChat
               mode="floating"
+              floatingPanelRef={floatingChatPanelRef}
               onModeChange={setChatMode}
               messages={embeddedChat.messages}
               agentState={embeddedChat.agentState}

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -69,6 +69,7 @@ import {
 } from "../../utils/transcriptSpeakerState";
 import NoteParticipants from "./NoteParticipants";
 import type { CalendarAttendee } from "../../types/calendar";
+import { observeFloatingChatLayout } from "./floatingChatLayout";
 
 const CHIP_BUTTON_CLASS =
   "inline-flex items-center gap-1.5 text-[11px] px-1.5 py-0.5 rounded-md border border-border/70 dark:border-white/25 text-foreground/50 dark:text-foreground/35 hover:text-foreground/60 hover:border-border/60 hover:bg-foreground/3 dark:hover:text-foreground/40 dark:hover:border-white/10 dark:hover:bg-white/3 transition-all duration-150 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring/30";
@@ -716,45 +717,32 @@ export default function NoteEditor({
     prevRecordingRef.current = isRecording;
   }, [isRecording, scheduleUiUpdate]);
 
-  // Reserve scroll space for the floating chat panel; +32 = bottom-4 + gap.
   const contentScrollRef = useRef<HTMLDivElement>(null);
 
-  // Pin the active view's scroller to its content bottom: always on open,
-  // on resize only if already near it (padding isn't content).
-  const pinActiveScroller = useCallback((root: HTMLDivElement | null, force = false) => {
-    if (!root) return;
+  const getActiveScroller = useCallback((root: HTMLDivElement): HTMLElement | null => {
     const candidates = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))].filter(
       (el) => el.scrollHeight - el.clientHeight > 2
     );
-    if (!candidates.length) return;
-    const scroller = candidates.reduce((a, b) =>
+    if (!candidates.length) return null;
+    return candidates.reduce((a, b) =>
       b.scrollHeight - b.clientHeight > a.scrollHeight - a.clientHeight ? b : a
     );
-    const pad = parseFloat(getComputedStyle(scroller).paddingBottom) || 0;
-    const distToContent = scroller.scrollHeight - pad - scroller.scrollTop - scroller.clientHeight;
-    if (force || distToContent < 80) {
-      scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
-    }
   }, []);
 
   const floatingChatPanelRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      const container = el?.parentElement;
-      if (!el || !container) return;
-      const applyInset = (force = false) => {
-        container.style.setProperty("--floating-inset", `${el.offsetHeight + 32}px`);
-        if (force) requestAnimationFrame(() => pinActiveScroller(contentScrollRef.current, true));
-        else pinActiveScroller(contentScrollRef.current);
-      };
-      applyInset(true);
-      const observer = new ResizeObserver(() => applyInset());
-      observer.observe(el);
-      return () => {
-        observer.disconnect();
-        container.style.removeProperty("--floating-inset");
-      };
+    (panel: HTMLDivElement | null): (() => void) | undefined => {
+      const container = panel?.parentElement;
+      const contentRoot = contentScrollRef.current;
+      if (!panel || !container || !contentRoot) return undefined;
+
+      return observeFloatingChatLayout({
+        panel,
+        container,
+        contentRoot,
+        getActiveScroller: (): HTMLElement | null => getActiveScroller(contentRoot),
+      });
     },
-    [pinActiveScroller]
+    [getActiveScroller]
   );
 
   const handleContentChange = useCallback(

--- a/src/components/notes/floatingChatLayout.ts
+++ b/src/components/notes/floatingChatLayout.ts
@@ -1,0 +1,94 @@
+export const FLOATING_CHAT_INSET_EXTRA_PX = 32;
+export const FLOATING_CHAT_MIN_VISIBLE_CONTENT_PX = 80;
+export const FLOATING_CHAT_MAX_HEIGHT_CSS = "calc(100% - 7rem)";
+
+const SCROLL_BOTTOM_THRESHOLD_PX = 80;
+
+export interface ScrollMetrics {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+interface ResizeObserverHandle {
+  observe: (element: Element) => void;
+  disconnect: () => void;
+}
+
+interface FloatingChatLayoutOptions {
+  panel: HTMLElement;
+  container: HTMLElement;
+  contentRoot: HTMLElement;
+  getActiveScroller: () => HTMLElement | null;
+}
+
+interface FloatingChatLayoutDependencies {
+  createResizeObserver?: (callback: () => void) => ResizeObserverHandle;
+  requestFrame?: (callback: () => void) => number;
+  cancelFrame?: (frameId: number) => void;
+}
+
+export function isNearScrollBottom(metrics: ScrollMetrics): boolean {
+  const distanceToBottom = metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+  return distanceToBottom <= SCROLL_BOTTOM_THRESHOLD_PX;
+}
+
+export function observeFloatingChatLayout(
+  { panel, container, contentRoot, getActiveScroller }: FloatingChatLayoutOptions,
+  dependencies: FloatingChatLayoutDependencies = {}
+): () => void {
+  const createResizeObserver =
+    dependencies.createResizeObserver ?? ((callback): ResizeObserverHandle => new ResizeObserver(callback));
+  const requestFrame =
+    dependencies.requestFrame ?? ((callback): number => requestAnimationFrame(callback));
+  const cancelFrame = dependencies.cancelFrame ?? ((frameId): void => cancelAnimationFrame(frameId));
+  let followsBottom = true;
+  let frameId: number | null = null;
+  let forcePinPending = false;
+
+  const pinActiveScroller = (): void => {
+    const scroller = getActiveScroller();
+    if (!scroller) return;
+    scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
+    followsBottom = true;
+  };
+
+  const schedulePin = (force: boolean): void => {
+    forcePinPending ||= force;
+    if (!forcePinPending && !followsBottom) return;
+    if (frameId !== null) cancelFrame(frameId);
+    frameId = requestFrame((): void => {
+      frameId = null;
+      const shouldForce = forcePinPending;
+      forcePinPending = false;
+      if (shouldForce || followsBottom) pinActiveScroller();
+    });
+  };
+
+  const applyInset = (force = false): void => {
+    container.style.setProperty(
+      "--floating-inset",
+      `${panel.offsetHeight + FLOATING_CHAT_INSET_EXTRA_PX}px`
+    );
+    schedulePin(force);
+  };
+
+  const updateFollowState = (): void => {
+    const scroller = getActiveScroller();
+    followsBottom = scroller !== null && isNearScrollBottom(scroller);
+  };
+
+  contentRoot.addEventListener("scroll", updateFollowState, true);
+  applyInset(true);
+
+  const observer = createResizeObserver((): void => applyInset());
+  observer.observe(panel);
+  observer.observe(contentRoot);
+
+  return (): void => {
+    observer.disconnect();
+    contentRoot.removeEventListener("scroll", updateFollowState, true);
+    if (frameId !== null) cancelFrame(frameId);
+    container.style.removeProperty("--floating-inset");
+  };
+}

--- a/src/components/ui/RichTextEditor.tsx
+++ b/src/components/ui/RichTextEditor.tsx
@@ -120,7 +120,12 @@ export function RichTextEditor({
     <div className={cn("relative w-full h-full", className)} onClick={handleClick}>
       <EditorContent
         editor={editor}
-        className={cn("h-full overflow-y-auto", disabled && "pointer-events-none opacity-70")}
+        className={cn(
+          "h-full overflow-y-auto",
+          disabled && "pointer-events-none opacity-70",
+          // Reserved by an ancestor via --floating-inset; 0 elsewhere.
+          "pb-[var(--floating-inset,0px)]"
+        )}
       />
     </div>
   );

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -33,6 +33,15 @@ export function useStickToBottom<T extends HTMLElement>(
       const bottom = node.scrollHeight - node.clientHeight;
       if (bottom > 0 && Math.abs(node.scrollTop - bottom) > 1) node.scrollTop = bottom;
     }
+    // Re-pin when content height settles late; re-attached per dep since the
+    // content element can swap (empty state → list).
+    const content = node.firstElementChild;
+    if (!content) return;
+    const ro = new ResizeObserver(() => {
+      if (pinnedRef.current) node.scrollTop = node.scrollHeight - node.clientHeight;
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
   }, [dep, resetToTop]);
 
   const handleScroll = useCallback(() => {

--- a/test/components/floatingChatLayout.test.js
+++ b/test/components/floatingChatLayout.test.js
@@ -1,0 +1,140 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/components/notes/floatingChatLayout.ts");
+
+function createElement(overrides = {}) {
+  const listeners = new Map();
+  const styleValues = new Map();
+
+  return {
+    scrollHeight: 0,
+    scrollTop: 0,
+    clientHeight: 0,
+    offsetHeight: 0,
+    style: {
+      setProperty(name, value) {
+        styleValues.set(name, value);
+      },
+      removeProperty(name) {
+        styleValues.delete(name);
+      },
+      getPropertyValue(name) {
+        return styleValues.get(name) ?? "";
+      },
+    },
+    addEventListener(name, listener) {
+      listeners.set(name, listener);
+    },
+    removeEventListener(name, listener) {
+      if (listeners.get(name) === listener) listeners.delete(name);
+    },
+    dispatch(name) {
+      listeners.get(name)?.();
+    },
+    hasListener(name) {
+      return listeners.has(name);
+    },
+    ...overrides,
+  };
+}
+
+test("near-bottom detection uses the real scroll range", async () => {
+  const { isNearScrollBottom } = await load();
+
+  assert.equal(
+    isNearScrollBottom({ scrollHeight: 1232, scrollTop: 700, clientHeight: 300 }),
+    false,
+    "232px of remaining padded scroll range is not near the bottom"
+  );
+  assert.equal(
+    isNearScrollBottom({ scrollHeight: 1232, scrollTop: 852, clientHeight: 300 }),
+    true,
+    "80px from the scroll bottom remains pinned"
+  );
+});
+
+test("viewport resizes preserve pinned content without yanking a reader", async () => {
+  const { observeFloatingChatLayout } = await load();
+  const panel = createElement({ offsetHeight: 200 });
+  const container = createElement();
+  const contentRoot = createElement();
+  const scroller = createElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
+  const observedElements = [];
+  const scheduledFrames = new Map();
+  let resizeCallback;
+  let nextFrameId = 0;
+  let observerDisconnected = false;
+
+  const cleanup = observeFloatingChatLayout(
+    {
+      panel,
+      container,
+      contentRoot,
+      getActiveScroller: () => scroller,
+    },
+    {
+      createResizeObserver(callback) {
+        resizeCallback = callback;
+        return {
+          observe(element) {
+            observedElements.push(element);
+          },
+          disconnect() {
+            observerDisconnected = true;
+          },
+        };
+      },
+      requestFrame(callback) {
+        const frameId = ++nextFrameId;
+        scheduledFrames.set(frameId, () => {
+          scheduledFrames.delete(frameId);
+          callback();
+        });
+        return frameId;
+      },
+      cancelFrame(frameId) {
+        scheduledFrames.delete(frameId);
+      },
+    }
+  );
+
+  assert.deepEqual(observedElements, [panel, contentRoot]);
+  assert.equal(container.style.getPropertyValue("--floating-inset"), "232px");
+
+  scheduledFrames.get(nextFrameId)();
+  scroller.clientHeight = 150;
+  resizeCallback();
+  scheduledFrames.get(nextFrameId)();
+  assert.equal(scroller.scrollTop, 850, "a pinned scroller follows a viewport shrink");
+
+  scroller.scrollTop = 600;
+  contentRoot.dispatch("scroll");
+  panel.offsetHeight = 240;
+  resizeCallback();
+  assert.equal(scheduledFrames.size, 0, "a reader away from the bottom is not scheduled to move");
+  assert.equal(scroller.scrollTop, 600);
+
+  scroller.scrollTop = 850;
+  contentRoot.dispatch("scroll");
+  resizeCallback();
+  assert.equal(scheduledFrames.size, 1);
+
+  cleanup();
+  assert.equal(observerDisconnected, true);
+  assert.equal(contentRoot.hasListener("scroll"), false);
+  assert.equal(scheduledFrames.size, 0);
+  assert.equal(container.style.getPropertyValue("--floating-inset"), "");
+});
+
+test("the panel cap leaves the promised note content visible", async () => {
+  const {
+    FLOATING_CHAT_INSET_EXTRA_PX,
+    FLOATING_CHAT_MAX_HEIGHT_CSS,
+    FLOATING_CHAT_MIN_VISIBLE_CONTENT_PX,
+  } = await load();
+
+  assert.equal(FLOATING_CHAT_INSET_EXTRA_PX, 32);
+  assert.equal(FLOATING_CHAT_MIN_VISIBLE_CONTENT_PX, 80);
+  assert.equal(FLOATING_CHAT_MAX_HEIGHT_CSS, "calc(100% - 7rem)");
+});


### PR DESCRIPTION
## Summary
Opening the floating chat panel covered the bottom of the note/transcript, forcing a manual scroll to see the latest content. This reserves scroll space for the panel and auto-reveals the content bottom on open/close.

## Changes
- Reserve panel space via an inherited `--floating-inset` CSS variable written by a callback ref + ResizeObserver — no React re renders on panel resize (NoteEditor)
- On open, force-pin the active view's scroller to its content bottom; on panel resize mid-session, re-pin only if already near the bottom so reading position isn't yanked (NoteEditor)
- Transcript scroller uses `pb-[var(--floating-inset,96px)]`: closed keeps the original 96px bottom-bar clearance, open reserves only panel height + gap (MeetingTranscriptChat); editor views use the same var with a 0px fallback (RichTextEditor)
- Cleanup removes the var instead of zeroing it so fallbacks apply on close; the browser clamp returns the scroll to the natural bottom
- Fold the chat auto-scroll ResizeObserver into the existing layout effect in `useStickToBottom` (re-pins when streamed content height settles late)

## Testing
I have tested it locally and it's working fine
<img width="2091" height="628" alt="image" src="https://github.com/user-attachments/assets/04b7997a-f260-4fcb-9a34-8974886b1d32" />
