### PR TITLE
fix(notes): keep markdown mirror paths inside base

### DIFF
--- a/src/helpers/markdownMirror.js
+++ b/src/helpers/markdownMirror.js
@@ -1,16 +1,23 @@
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
+
+const ENCODED_FOLDER_PREFIX = "__ow-";
+const WINDOWS_RESERVED_FOLDER = /^(con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i;
 
 class MarkdownMirror {
   constructor() {
     this._basePath = null;
+    this._baseRealPath = null;
   }
 
   init(basePath) {
     this._basePath = basePath;
+    this._baseRealPath = null;
     try {
       fs.mkdirSync(basePath, { recursive: true });
+      this._baseRealPath = fs.realpathSync(basePath);
       debugLogger.debug("Markdown mirror initialized", { basePath }, "note-files");
     } catch (err) {
       debugLogger.error("Failed to init markdown mirror", { error: err.message }, "note-files");
@@ -23,8 +30,71 @@ class MarkdownMirror {
 
   _safeFolderName(folderName) {
     const raw = String(folderName || "Personal");
-    const safe = raw.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-");
-    return safe === "." || safe === ".." ? "-" : safe || "Personal";
+    const requiresEncoding =
+      raw === "." ||
+      raw === ".." ||
+      raw.startsWith(" ") ||
+      /[ .]$/.test(raw) ||
+      /[<>:"/\\|?*\u0000-\u001f]/.test(raw) ||
+      WINDOWS_RESERVED_FOLDER.test(raw) ||
+      raw.toLowerCase().startsWith(ENCODED_FOLDER_PREFIX);
+    if (!requiresEncoding) return raw;
+
+    const digest = crypto.createHash("sha256").update(raw, "utf8").digest("hex");
+    return `${ENCODED_FOLDER_PREFIX}${digest}`;
+  }
+
+  _isInsideBase(candidatePath) {
+    if (!this._baseRealPath) return false;
+    const relative = path.relative(this._baseRealPath, candidatePath);
+    return (
+      relative !== "" &&
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative)
+    );
+  }
+
+  _folderCandidatePath(folderName) {
+    if (!this._baseRealPath) return null;
+    return path.join(this._baseRealPath, this._safeFolderName(folderName));
+  }
+
+  _displayPath(canonicalPath) {
+    const relative = path.relative(this._baseRealPath, canonicalPath);
+    return path.join(this._basePath, relative);
+  }
+
+  _resolveExistingFolderPath(candidatePath) {
+    const stats = fs.lstatSync(candidatePath);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error("Markdown mirror folder is not a regular directory");
+    }
+
+    const realPath = fs.realpathSync(candidatePath);
+    if (!this._isInsideBase(realPath)) {
+      throw new Error("Markdown mirror folder resolves outside the configured directory");
+    }
+    return realPath;
+  }
+
+  _resolveFolderPath(folderName, { create = false } = {}) {
+    const candidatePath = this._folderCandidatePath(folderName);
+    if (!candidatePath) return null;
+
+    if (!fs.existsSync(candidatePath)) {
+      if (!create) return null;
+      fs.mkdirSync(candidatePath, { recursive: true });
+    }
+    return this._resolveExistingFolderPath(candidatePath);
+  }
+
+  _assertWritableFilePath(filePath) {
+    if (!fs.existsSync(filePath)) return;
+    const stats = fs.lstatSync(filePath);
+    if (stats.isSymbolicLink() || !stats.isFile()) {
+      throw new Error("Markdown mirror file is not a regular file");
+    }
   }
 
   _slugify(title) {
@@ -72,17 +142,17 @@ class MarkdownMirror {
   }
 
   writeNote(note, folderName) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
-      const dirName = this._safeFolderName(folderName);
-      const dirPath = path.join(this._basePath, dirName);
-      fs.mkdirSync(dirPath, { recursive: true });
+      const dirPath = this._resolveFolderPath(folderName, { create: true });
+      if (!dirPath) return;
 
       // Remove stale files (title changed or note moved to different folder)
       const glob = this._globNoteFiles(note.id);
       const slug = this._slugify(note.title);
       const newFileName = `${note.id}-${slug}.md`;
       const newFilePath = path.join(dirPath, newFileName);
+      this._assertWritableFilePath(newFilePath);
       for (const existing of glob) {
         if (existing !== newFilePath) {
           try {
@@ -104,18 +174,18 @@ class MarkdownMirror {
   }
 
   writeTranscript(note, folderName, speakerMappings) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
       const segments = JSON.parse(note.transcript || "[]");
       if (!segments.length) return;
 
-      const dirName = this._safeFolderName(folderName);
-      const dirPath = path.join(this._basePath, dirName);
-      fs.mkdirSync(dirPath, { recursive: true });
+      const dirPath = this._resolveFolderPath(folderName, { create: true });
+      if (!dirPath) return;
 
       const slug = this._slugify(note.title);
       const newFileName = `${note.id}-${slug}-transcript.md`;
       const newFilePath = path.join(dirPath, newFileName);
+      this._assertWritableFilePath(newFilePath);
 
       const stale = this._globTranscriptFiles(note.id);
       for (const existing of stale) {
@@ -138,7 +208,7 @@ class MarkdownMirror {
   }
 
   deleteNote(noteId) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
       const files = [...this._globNoteFiles(noteId), ...this._globTranscriptFiles(noteId)];
       for (const f of files) {
@@ -161,11 +231,9 @@ class MarkdownMirror {
   }
 
   ensureFolder(folderName) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
-      fs.mkdirSync(path.join(this._basePath, this._safeFolderName(folderName)), {
-        recursive: true,
-      });
+      this._resolveFolderPath(folderName, { create: true });
     } catch (err) {
       debugLogger.error(
         "Failed to ensure folder",
@@ -176,13 +244,14 @@ class MarkdownMirror {
   }
 
   renameFolder(oldName, newName) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
-      const oldPath = path.join(this._basePath, this._safeFolderName(oldName));
-      const newPath = path.join(this._basePath, this._safeFolderName(newName));
-      if (fs.existsSync(oldPath)) {
-        fs.renameSync(oldPath, newPath);
-      }
+      const oldPath = this._resolveFolderPath(oldName);
+      if (!oldPath) return;
+      const newPath = this._folderCandidatePath(newName);
+      if (!newPath || oldPath === newPath) return;
+      if (fs.existsSync(newPath)) this._resolveExistingFolderPath(newPath);
+      fs.renameSync(oldPath, newPath);
     } catch (err) {
       debugLogger.error(
         "Failed to rename folder",
@@ -193,12 +262,10 @@ class MarkdownMirror {
   }
 
   deleteFolder(folderName) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
-      const dir = path.join(this._basePath, this._safeFolderName(folderName));
-      if (fs.existsSync(dir)) {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
+      const dirPath = this._resolveFolderPath(folderName);
+      if (dirPath) fs.rmSync(dirPath, { recursive: true, force: true });
     } catch (err) {
       debugLogger.error(
         "Failed to delete folder",
@@ -209,7 +276,7 @@ class MarkdownMirror {
   }
 
   rebuildAll(notes, folderMap, speakerMappingsMap) {
-    if (!this._basePath) return;
+    if (!this._baseRealPath) return;
     try {
       for (const note of notes) {
         const folderName = folderMap[note.folder_id] || "Personal";
@@ -225,15 +292,19 @@ class MarkdownMirror {
   }
 
   getNotePath(noteId) {
-    if (!this._basePath) return null;
+    if (!this._baseRealPath) return null;
     const files = this._globNoteFiles(noteId);
-    return files.length > 0 ? files[0] : null;
+    return files.length > 0 ? this._displayPath(files[0]) : null;
   }
 
   getFolderPath(folderName) {
-    if (!this._basePath) return null;
-    const dirPath = path.join(this._basePath, this._safeFolderName(folderName));
-    return fs.existsSync(dirPath) ? dirPath : null;
+    if (!this._baseRealPath) return null;
+    try {
+      const canonicalPath = this._resolveFolderPath(folderName);
+      return canonicalPath ? this._displayPath(canonicalPath) : null;
+    } catch {
+      return null;
+    }
   }
 
   // Note markdown opens with the frontmatter this mirror writes; transcript
@@ -242,6 +313,8 @@ class MarkdownMirror {
   _isNoteMarkdownFile(filePath) {
     let fd;
     try {
+      const stats = fs.lstatSync(filePath);
+      if (stats.isSymbolicLink() || !stats.isFile()) return false;
       fd = fs.openSync(filePath, "r");
       const marker = Buffer.alloc(8);
       const bytesRead = fs.readSync(fd, marker, 0, marker.length, 0);
@@ -254,14 +327,19 @@ class MarkdownMirror {
   }
 
   _globNoteFiles(noteId) {
-    if (!this._basePath) return [];
+    if (!this._baseRealPath) return [];
     const results = [];
     try {
       const prefix = `${noteId}-`;
-      const dirs = fs.readdirSync(this._basePath, { withFileTypes: true });
+      const dirs = fs.readdirSync(this._baseRealPath, { withFileTypes: true });
       for (const dir of dirs) {
-        if (!dir.isDirectory()) continue;
-        const dirPath = path.join(this._basePath, dir.name);
+        if (!dir.isDirectory() || dir.isSymbolicLink()) continue;
+        let dirPath;
+        try {
+          dirPath = this._resolveExistingFolderPath(path.join(this._baseRealPath, dir.name));
+        } catch {
+          continue;
+        }
         const files = fs.readdirSync(dirPath);
         for (const file of files) {
           const filePath = path.join(dirPath, file);
@@ -279,18 +357,29 @@ class MarkdownMirror {
   }
 
   _globTranscriptFiles(noteId) {
-    if (!this._basePath) return [];
+    if (!this._baseRealPath) return [];
     const results = [];
     try {
       const prefix = `${noteId}-`;
-      const dirs = fs.readdirSync(this._basePath, { withFileTypes: true });
+      const dirs = fs.readdirSync(this._baseRealPath, { withFileTypes: true });
       for (const dir of dirs) {
-        if (!dir.isDirectory()) continue;
-        const dirPath = path.join(this._basePath, dir.name);
+        if (!dir.isDirectory() || dir.isSymbolicLink()) continue;
+        let dirPath;
+        try {
+          dirPath = this._resolveExistingFolderPath(path.join(this._baseRealPath, dir.name));
+        } catch {
+          continue;
+        }
         const files = fs.readdirSync(dirPath);
         for (const file of files) {
           const filePath = path.join(dirPath, file);
+          let isRegularFile = false;
+          try {
+            const stats = fs.lstatSync(filePath);
+            isRegularFile = stats.isFile() && !stats.isSymbolicLink();
+          } catch {}
           if (
+            isRegularFile &&
             file.startsWith(prefix) &&
             (file.endsWith("-transcript.txt") ||
               (file.endsWith("-transcript.md") && !this._isNoteMarkdownFile(filePath)))

--- a/src/helpers/markdownMirror.js
+++ b/src/helpers/markdownMirror.js
@@ -21,6 +21,12 @@ class MarkdownMirror {
     return this._basePath;
   }
 
+  _safeFolderName(folderName) {
+    const raw = String(folderName || "Personal");
+    const safe = raw.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-");
+    return safe === "." || safe === ".." ? "-" : safe || "Personal";
+  }
+
   _slugify(title) {
     return (title || "Untitled")
       .replace(/[/\\?%*:|"<>]/g, "-")
@@ -68,7 +74,7 @@ class MarkdownMirror {
   writeNote(note, folderName) {
     if (!this._basePath) return;
     try {
-      const dirName = folderName || "Personal";
+      const dirName = this._safeFolderName(folderName);
       const dirPath = path.join(this._basePath, dirName);
       fs.mkdirSync(dirPath, { recursive: true });
 
@@ -85,7 +91,7 @@ class MarkdownMirror {
         }
       }
 
-      const frontmatter = this._buildFrontmatter(note, dirName);
+      const frontmatter = this._buildFrontmatter(note, folderName || "Personal");
       const body = note.enhanced_content || note.content || "";
       fs.writeFileSync(newFilePath, `${frontmatter}\n\n${body}`, "utf-8");
     } catch (err) {
@@ -103,7 +109,7 @@ class MarkdownMirror {
       const segments = JSON.parse(note.transcript || "[]");
       if (!segments.length) return;
 
-      const dirName = folderName || "Personal";
+      const dirName = this._safeFolderName(folderName);
       const dirPath = path.join(this._basePath, dirName);
       fs.mkdirSync(dirPath, { recursive: true });
 
@@ -157,7 +163,9 @@ class MarkdownMirror {
   ensureFolder(folderName) {
     if (!this._basePath) return;
     try {
-      fs.mkdirSync(path.join(this._basePath, folderName), { recursive: true });
+      fs.mkdirSync(path.join(this._basePath, this._safeFolderName(folderName)), {
+        recursive: true,
+      });
     } catch (err) {
       debugLogger.error(
         "Failed to ensure folder",
@@ -170,8 +178,8 @@ class MarkdownMirror {
   renameFolder(oldName, newName) {
     if (!this._basePath) return;
     try {
-      const oldPath = path.join(this._basePath, oldName);
-      const newPath = path.join(this._basePath, newName);
+      const oldPath = path.join(this._basePath, this._safeFolderName(oldName));
+      const newPath = path.join(this._basePath, this._safeFolderName(newName));
       if (fs.existsSync(oldPath)) {
         fs.renameSync(oldPath, newPath);
       }
@@ -187,7 +195,7 @@ class MarkdownMirror {
   deleteFolder(folderName) {
     if (!this._basePath) return;
     try {
-      const dir = path.join(this._basePath, folderName);
+      const dir = path.join(this._basePath, this._safeFolderName(folderName));
       if (fs.existsSync(dir)) {
         fs.rmSync(dir, { recursive: true, force: true });
       }
@@ -224,7 +232,7 @@ class MarkdownMirror {
 
   getFolderPath(folderName) {
     if (!this._basePath) return null;
-    const dirPath = path.join(this._basePath, folderName);
+    const dirPath = path.join(this._basePath, this._safeFolderName(folderName));
     return fs.existsSync(dirPath) ? dirPath : null;
   }
 

--- a/test/helpers/markdownMirror.test.js
+++ b/test/helpers/markdownMirror.test.js
@@ -48,6 +48,18 @@ test("a note title ending in transcript keeps both mirrored files", (t) => {
   assert.equal(markdownMirror.getNotePath(note.id), notePath);
 });
 
+test("folder names cannot escape the configured mirror directory", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+
+  markdownMirror.init(basePath);
+  markdownMirror.writeNote({ id: 13, title: "Safe note", content: "Body" }, "../outside");
+
+  const escapedPath = path.resolve(basePath, "..", "outside", "13-safe-note.md");
+  assert.equal(fs.existsSync(escapedPath), false);
+  assert.equal(fs.existsSync(path.join(basePath, "..-outside", "13-safe-note.md")), true);
+});
+
 test("renaming a mirrored note cleans up both stale files and reveals the note", (t) => {
   const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
   t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));

--- a/test/helpers/markdownMirror.test.js
+++ b/test/helpers/markdownMirror.test.js
@@ -56,8 +56,121 @@ test("folder names cannot escape the configured mirror directory", (t) => {
   markdownMirror.writeNote({ id: 13, title: "Safe note", content: "Body" }, "../outside");
 
   const escapedPath = path.resolve(basePath, "..", "outside", "13-safe-note.md");
+  const notePath = markdownMirror.getNotePath(13);
   assert.equal(fs.existsSync(escapedPath), false);
-  assert.equal(fs.existsSync(path.join(basePath, "..-outside", "13-safe-note.md")), true);
+  assert.ok(notePath);
+  assert.equal(path.relative(basePath, notePath).startsWith(`..${path.sep}`), false);
+  assert.equal(readFrontmatter(fs.readFileSync(notePath, "utf8")).folder, "../outside");
+});
+
+test("unsafe folder names do not collide with portable folder names", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+
+  markdownMirror.init(basePath);
+  markdownMirror.writeNote({ id: 14, title: "Nested", content: "Unsafe folder" }, "team/docs");
+  markdownMirror.writeNote({ id: 15, title: "Flat", content: "Portable folder" }, "team-docs");
+
+  const unsafeFolderPath = markdownMirror.getFolderPath("team/docs");
+  const portableFolderPath = markdownMirror.getFolderPath("team-docs");
+  assert.ok(unsafeFolderPath);
+  assert.ok(portableFolderPath);
+  assert.notEqual(unsafeFolderPath, portableFolderPath);
+  assert.equal(portableFolderPath, path.join(basePath, "team-docs"));
+
+  markdownMirror.deleteFolder("team/docs");
+
+  assert.equal(fs.existsSync(unsafeFolderPath), false);
+  assert.equal(fs.existsSync(path.join(portableFolderPath, "15-flat.md")), true);
+});
+
+test("encoded folder keys cannot collide with logical folder names", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+
+  markdownMirror.init(basePath);
+  markdownMirror.ensureFolder("team/docs");
+  const encodedName = path.basename(markdownMirror.getFolderPath("team/docs"));
+  markdownMirror.ensureFolder(encodedName);
+
+  assert.notEqual(
+    markdownMirror.getFolderPath("team/docs"),
+    markdownMirror.getFolderPath(encodedName)
+  );
+});
+
+test("writes reject a symlinked folder that resolves outside the mirror", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  const outsidePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-outside-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(outsidePath, { recursive: true, force: true }));
+  fs.symlinkSync(outsidePath, path.join(basePath, "linked"), "dir");
+
+  markdownMirror.init(basePath);
+  markdownMirror.writeNote({ id: 16, title: "Escaped", content: "Body" }, "linked");
+
+  assert.equal(fs.existsSync(path.join(outsidePath, "16-escaped.md")), false);
+  assert.equal(markdownMirror.getFolderPath("linked"), null);
+});
+
+test("writes reject a symlinked note file without changing its target", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  const outsidePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-outside-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(outsidePath, { recursive: true, force: true }));
+  const outsideFile = path.join(outsidePath, "outside.md");
+  fs.writeFileSync(outsideFile, "unchanged", "utf8");
+
+  markdownMirror.init(basePath);
+  markdownMirror.ensureFolder("Personal");
+  fs.symlinkSync(outsideFile, path.join(basePath, "Personal", "17-linked.md"), "file");
+  markdownMirror.writeNote({ id: 17, title: "Linked", content: "Replacement" }, "Personal");
+
+  assert.equal(fs.readFileSync(outsideFile, "utf8"), "unchanged");
+  assert.equal(markdownMirror.getNotePath(17), null);
+});
+
+test("Windows-reserved and trailing-character folder names use distinct portable keys", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+  const folderNames = ["CON", "NUL.txt", "folder.", "folder "];
+
+  markdownMirror.init(basePath);
+  folderNames.forEach((folderName, index) => {
+    markdownMirror.ensureFolder(folderName);
+    markdownMirror.writeNote(
+      { id: 20 + index, title: `Note ${index}`, content: folderName },
+      folderName
+    );
+  });
+
+  const diskNames = folderNames.map((folderName) => {
+    const folderPath = markdownMirror.getFolderPath(folderName);
+    assert.ok(folderPath);
+    return path.basename(folderPath);
+  });
+  assert.equal(new Set(diskNames).size, folderNames.length);
+  for (const diskName of diskNames) {
+    assert.doesNotMatch(diskName, /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i);
+    assert.doesNotMatch(diskName, /[ .]$/);
+  }
+});
+
+test("portable folders still support the normal ensure, rename, and delete journey", (t) => {
+  const basePath = fs.mkdtempSync(path.join(os.tmpdir(), "openwhispr-markdown-mirror-"));
+  t.after(() => fs.rmSync(basePath, { recursive: true, force: true }));
+
+  markdownMirror.init(basePath);
+  markdownMirror.ensureFolder("Research");
+  markdownMirror.writeNote({ id: 30, title: "Sources", content: "Body" }, "Research");
+  markdownMirror.renameFolder("Research", "Archive");
+
+  assert.equal(markdownMirror.getFolderPath("Research"), null);
+  assert.equal(markdownMirror.getFolderPath("Archive"), path.join(basePath, "Archive"));
+  assert.equal(fs.existsSync(path.join(basePath, "Archive", "30-sources.md")), true);
+
+  markdownMirror.deleteFolder("Archive");
+  assert.equal(markdownMirror.getFolderPath("Archive"), null);
 });
 
 test("renaming a mirrored note cleans up both stale files and reveals the note", (t) => {


### PR DESCRIPTION
Fixes #1771

## Summary

- keep markdown mirror filesystem paths inside the configured mirror directory
- sanitize folder names at every mirror filesystem boundary
- retain the original folder name in note frontmatter
- add a temporary-directory traversal regression test

## Problem

`MarkdownMirror` passed user-controlled folder names directly to `path.join`. A folder named `../outside` caused note files to be written outside the configured mirror root. The same boundary affected transcript writes and folder operations.

## Fix

Centralize folder-name sanitization and use it for note/transcript writes, folder creation, rename, deletion, and folder lookup. The logical folder name remains in frontmatter; only its filesystem component is made safe.

## Validation

- `node --test test/helpers/markdownMirror.test.js` — 6 passed
- `npm run format:check` — passed
- `npm run typecheck` — passed
- `npm run i18n:check` — passed
- `npm run build:renderer` — passed
- `git diff --check` — passed
- `npm test` — pre-existing environment/loader failures on clean upstream baseline: 2,894 tests, 1,769 passed, 1,117 failed, 7 skipped; failures were unrelated module-export and renderer/native test failures

No generated files, dependencies, or unrelated paths were changed.
