### PR TITLE
fix(windows): block untrusted file navigation

### DIFF
--- a/src/helpers/navigationGuard.js
+++ b/src/helpers/navigationGuard.js
@@ -1,3 +1,5 @@
+// will-navigate also fires for renderer-initiated location.reload() with the
+// window's own URL (appUrl), so that URL must stay allowed.
 function isAllowedAppNavigation(url, appUrl) {
   if (url.startsWith("devtools://")) return true;
   if (!appUrl) return false;
@@ -5,10 +7,20 @@ function isAllowedAppNavigation(url, appUrl) {
   try {
     const candidate = new URL(url);
     const app = new URL(appUrl);
-    return candidate.origin === app.origin && candidate.pathname === app.pathname;
+    // file:// URLs all share the opaque "null" origin, so protocol and
+    // pathname carry the comparison there.
+    return (
+      candidate.origin === app.origin &&
+      candidate.protocol === app.protocol &&
+      candidate.pathname === app.pathname
+    );
   } catch {
     return false;
   }
 }
 
-module.exports = { isAllowedAppNavigation };
+function isExternalBrowserUrl(url) {
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
+module.exports = { isAllowedAppNavigation, isExternalBrowserUrl };

--- a/src/helpers/navigationGuard.js
+++ b/src/helpers/navigationGuard.js
@@ -1,0 +1,14 @@
+function isAllowedAppNavigation(url, appUrl) {
+  if (url.startsWith("devtools://")) return true;
+  if (!appUrl) return false;
+
+  try {
+    const candidate = new URL(url);
+    const app = new URL(appUrl);
+    return candidate.origin === app.origin && candidate.pathname === app.pathname;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { isAllowedAppNavigation };

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -6,7 +6,8 @@ const DragManager = require("./dragManager");
 const MainWindowPlacementCoordinator = require("./mainWindowPlacementCoordinator");
 const MenuManager = require("./menuManager");
 const DevServerManager = require("./devServerManager");
-const { isAllowedAppNavigation } = require("./navigationGuard");
+const { isAllowedAppNavigation, isExternalBrowserUrl } = require("./navigationGuard");
+const { pathToFileURL } = require("url");
 const dockManager = require("./dockManager");
 const { i18nMain } = require("./i18nMain");
 const { NotificationDismissTimer, getNotificationTimeoutMs } = require("./notificationTimer");
@@ -20,7 +21,6 @@ const {
 const { DEV_SERVER_PORT } = DevServerManager;
 const AUTO_END_NOTIFICATION_LOAD_TIMEOUT_MS = 10_000;
 const DRAG_MOVE_TOLERANCE_PX = 2;
-
 const {
   MAIN_WINDOW_CONFIG,
   CONTROL_PANEL_CONFIG,
@@ -1091,14 +1091,21 @@ class WindowManager {
     this._onboardingWindowState = null;
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
-      const appUrl = DevServerManager.getAppUrl(true);
+      // getAppUrl() is null in packaged builds; exactly one of the two is set.
+      const appUrl =
+        DevServerManager.getAppUrl(true) ??
+        pathToFileURL(DevServerManager.getAppFilePath(true).path).href;
 
       if (isAllowedAppNavigation(url, appUrl)) {
         return;
       }
 
       event.preventDefault();
-      this.openExternalUrl(url);
+      if (isExternalBrowserUrl(url)) {
+        this.openExternalUrl(url);
+      } else {
+        debugLogger.debug("Blocked untrusted navigation", { url }, "window");
+      }
     });
 
     this.controlPanelWindow.webContents.setWindowOpenHandler(({ url }) => {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -6,6 +6,7 @@ const DragManager = require("./dragManager");
 const MainWindowPlacementCoordinator = require("./mainWindowPlacementCoordinator");
 const MenuManager = require("./menuManager");
 const DevServerManager = require("./devServerManager");
+const { isAllowedAppNavigation } = require("./navigationGuard");
 const dockManager = require("./dockManager");
 const { i18nMain } = require("./i18nMain");
 const { NotificationDismissTimer, getNotificationTimeoutMs } = require("./notificationTimer");
@@ -19,6 +20,7 @@ const {
 const { DEV_SERVER_PORT } = DevServerManager;
 const AUTO_END_NOTIFICATION_LOAD_TIMEOUT_MS = 10_000;
 const DRAG_MOVE_TOLERANCE_PX = 2;
+
 const {
   MAIN_WINDOW_CONFIG,
   CONTROL_PANEL_CONFIG,
@@ -1090,13 +1092,8 @@ class WindowManager {
 
     this.controlPanelWindow.webContents.on("will-navigate", (event, url) => {
       const appUrl = DevServerManager.getAppUrl(true);
-      const controlPanelUrl = appUrl.startsWith("http") ? appUrl : `file://${appUrl}`;
 
-      if (
-        url.startsWith(controlPanelUrl) ||
-        url.startsWith("file://") ||
-        url.startsWith("devtools://")
-      ) {
+      if (isAllowedAppNavigation(url, appUrl)) {
         return;
       }
 

--- a/test/helpers/windowManagerNavigation.test.js
+++ b/test/helpers/windowManagerNavigation.test.js
@@ -1,16 +1,60 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { isAllowedAppNavigation } = require("../../src/helpers/navigationGuard.js");
+const {
+  isAllowedAppNavigation,
+  isExternalBrowserUrl,
+} = require("../../src/helpers/navigationGuard.js");
 
-test("navigation guard rejects arbitrary file URLs in a packaged app", () => {
+const PACKAGED_APP_URL =
+  "file:///Applications/OpenWhispr.app/Contents/Resources/app.asar/src/dist/index.html";
+
+test("packaged app: the window's own reload is allowed regardless of query or hash", () => {
+  // location.reload() fires will-navigate with the window's own URL —
+  // sign-out, restart-onboarding, account deletion, and the ErrorBoundary
+  // reload all break if this is blocked.
+  assert.equal(isAllowedAppNavigation(`${PACKAGED_APP_URL}?panel=true`, PACKAGED_APP_URL), true);
+  assert.equal(isAllowedAppNavigation(PACKAGED_APP_URL, PACKAGED_APP_URL), true);
+  assert.equal(
+    isAllowedAppNavigation(`${PACKAGED_APP_URL}?panel=true#settings`, PACKAGED_APP_URL),
+    true
+  );
+});
+
+test("packaged app: Windows-style file URLs compare on the encoded pathname", () => {
+  const winAppUrl = "file:///C:/Program%20Files/OpenWhispr/resources/app.asar/src/dist/index.html";
+  assert.equal(isAllowedAppNavigation(`${winAppUrl}?panel=true`, winAppUrl), true);
+});
+
+test("packaged app: foreign file URLs are blocked", () => {
+  assert.equal(isAllowedAppNavigation("file:///etc/passwd", PACKAGED_APP_URL), false);
+  assert.equal(isAllowedAppNavigation("file:///Users/test/secret.txt", PACKAGED_APP_URL), false);
+});
+
+test("packaged app: remote and unparseable URLs are blocked", () => {
+  assert.equal(isAllowedAppNavigation("https://example.com/", PACKAGED_APP_URL), false);
+  assert.equal(isAllowedAppNavigation("http://localhost:5183/", PACKAGED_APP_URL), false);
+  assert.equal(isAllowedAppNavigation("not a url", PACKAGED_APP_URL), false);
+});
+
+test("a null appUrl blocks everything except devtools without throwing", () => {
   assert.equal(isAllowedAppNavigation("file:///etc/passwd", null), false);
-  assert.equal(isAllowedAppNavigation("file:///Users/test/secret.txt", null), false);
+  assert.equal(isAllowedAppNavigation("https://example.com/", undefined), false);
+  assert.equal(isAllowedAppNavigation("devtools://devtools/bundled/inspector.html", null), true);
 });
 
 test("navigation guard keeps the development app route and devtools available", () => {
   const appUrl = "http://localhost:5183/?panel=true";
   assert.equal(isAllowedAppNavigation("http://localhost:5183/", appUrl), true);
+  assert.equal(isAllowedAppNavigation("http://localhost:5183/?panel=true", appUrl), true);
   assert.equal(isAllowedAppNavigation("http://localhost:5183/other", appUrl), false);
   assert.equal(isAllowedAppNavigation("devtools://devtools/bundled/inspector.html", null), true);
+});
+
+test("only http(s) targets are handed to the external browser", () => {
+  assert.equal(isExternalBrowserUrl("https://example.com/docs"), true);
+  assert.equal(isExternalBrowserUrl("http://example.com/"), true);
+  assert.equal(isExternalBrowserUrl("file:///etc/passwd"), false);
+  assert.equal(isExternalBrowserUrl("about:blank"), false);
+  assert.equal(isExternalBrowserUrl("devtools://devtools/bundled/inspector.html"), false);
 });

--- a/test/helpers/windowManagerNavigation.test.js
+++ b/test/helpers/windowManagerNavigation.test.js
@@ -1,0 +1,16 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isAllowedAppNavigation } = require("../../src/helpers/navigationGuard.js");
+
+test("navigation guard rejects arbitrary file URLs in a packaged app", () => {
+  assert.equal(isAllowedAppNavigation("file:///etc/passwd", null), false);
+  assert.equal(isAllowedAppNavigation("file:///Users/test/secret.txt", null), false);
+});
+
+test("navigation guard keeps the development app route and devtools available", () => {
+  const appUrl = "http://localhost:5183/?panel=true";
+  assert.equal(isAllowedAppNavigation("http://localhost:5183/", appUrl), true);
+  assert.equal(isAllowedAppNavigation("http://localhost:5183/other", appUrl), false);
+  assert.equal(isAllowedAppNavigation("devtools://devtools/bundled/inspector.html", null), true);
+});


### PR DESCRIPTION
## Summary

The control-panel navigation guard treated every `file://` URL as trusted. In packaged builds, `DevServerManager.getAppUrl(true)` returns `null`, so the old handler also dereferenced that value while installing the guard.

This adds a small navigation policy helper that keeps the development app route and DevTools available, rejects arbitrary file URLs, and safely handles the packaged-app null URL. The regression tests cover both the packaged file-navigation boundary and development behavior.

## Validation

- `NODE_OPTIONS='--import=tsx' node --test test/helpers/windowManagerNavigation.test.js`
- `npm run typecheck`
- `npm run i18n:check`
- `npm run build:renderer`
- `git diff --check`
- `npm run format:check` reaches an existing upstream Prettier failure in `src/components/notes/floatingChatLayout.ts`; ESLint passes.
