### PR TITLE
fix(cli): enforce request body byte limit

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -30,9 +30,14 @@ async function findAvailablePort() {
 function readJsonBody(req) {
   return new Promise((resolve, reject) => {
     let raw = "";
+    // Count wire bytes per chunk: string concatenation decodes each Buffer
+    // chunk, so measuring the decoded string would rescan the whole body on
+    // every chunk and miscount sequences split across chunk boundaries.
+    let receivedBytes = 0;
     req.on("data", (chunk) => {
       raw += chunk;
-      if (Buffer.byteLength(raw, "utf8") > MAX_REQUEST_BODY_BYTES) {
+      receivedBytes += Buffer.byteLength(chunk);
+      if (receivedBytes > MAX_REQUEST_BODY_BYTES) {
         reject(new Error("Request body too large"));
         req.destroy();
       }

--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -32,7 +32,7 @@ function readJsonBody(req) {
     let raw = "";
     req.on("data", (chunk) => {
       raw += chunk;
-      if (raw.length > MAX_REQUEST_BODY_BYTES) {
+      if (Buffer.byteLength(raw, "utf8") > MAX_REQUEST_BODY_BYTES) {
         reject(new Error("Request body too large"));
         req.destroy();
       }

--- a/test/helpers/cliBridgeRequestBody.test.js
+++ b/test/helpers/cliBridgeRequestBody.test.js
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const CliBridge = require("../../src/helpers/cliBridge.js");
+
+function makeRequest(body) {
+  const request = new EventEmitter();
+  request.method = "POST";
+  request.url = "/v1/notes/create";
+  request.headers = { authorization: "Bearer test-token" };
+  request.socket = { remoteAddress: "127.0.0.1" };
+  request.destroyed = false;
+  request.destroy = () => {
+    request.destroyed = true;
+  };
+  setImmediate(() => {
+    request.emit("data", body);
+    request.emit("end");
+  });
+  return request;
+}
+
+function makeResponse() {
+  return {
+    headersSent: false,
+    statusCode: null,
+    payload: "",
+    writeHead(statusCode) {
+      this.statusCode = statusCode;
+      this.headersSent = true;
+    },
+    end(body = "") {
+      this.payload = body;
+    },
+  };
+}
+
+test("CLI request body limit counts UTF-8 bytes, not JavaScript characters", async () => {
+  let saveCalls = 0;
+  const bridge = new CliBridge({
+    databaseManager: {
+      saveNote() {
+        saveCalls += 1;
+        return { success: true, note: { id: 1 } };
+      },
+    },
+    _asyncVectorUpsert() {},
+    _asyncMirrorWrite() {},
+  });
+  bridge.token = "test-token";
+  bridge.port = 8200;
+
+  const body = JSON.stringify({ content: "😀".repeat(300_000) });
+  assert.ok(body.length < 1 * 1024 * 1024);
+  assert.ok(Buffer.byteLength(body, "utf8") > 1 * 1024 * 1024);
+
+  const request = makeRequest(body);
+  const response = makeResponse();
+  await bridge._handleRequest(request, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.payload), {
+    error: { code: "validation_error", message: "Request body too large" },
+  });
+  assert.equal(request.destroyed, true);
+  assert.equal(saveCalls, 0);
+});


### PR DESCRIPTION
## Summary

The CLI bridge advertises a 1 MiB request body limit, but the guard compared JavaScript character count instead of UTF-8 byte count. Multibyte payloads could therefore exceed the intended limit before parsing and dispatch.

This changes the check to `Buffer.byteLength(raw, "utf8")` and adds a regression test proving a sub-1 MiB character-count payload whose encoded bytes exceed 1 MiB is rejected with HTTP 400 before the database mutation runs.

## Validation

- `NODE_OPTIONS='--import=tsx' node --test test/helpers/cliBridgeRequestBody.test.js`
- `npm run typecheck`
- `npm run i18n:check`
- `npm run build:renderer`
- `git diff --check`
- `npm run format:check` reaches an existing upstream Prettier failure in `src/components/notes/floatingChatLayout.ts`; ESLint passes.
