### PR TITLE
fix(diarization): guard nullish inputs and format non-finite timestamps in speakerMerge

### DIFF
--- a/src/helpers/speakerMerge.js
+++ b/src/helpers/speakerMerge.js
@@ -1,4 +1,7 @@
 function splitIntoSentences(text) {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return [];
+  }
   if (typeof Intl !== "undefined" && Intl.Segmenter) {
     try {
       const segmenter = new Intl.Segmenter(undefined, { granularity: "sentence" });
@@ -16,9 +19,13 @@ function splitIntoSentences(text) {
 }
 
 function formatTimestamp(seconds) {
-  const hrs = Math.floor(seconds / 3600);
-  const mins = Math.floor((seconds % 3600) / 60);
-  const secs = Math.floor(seconds % 60);
+  const totalSeconds =
+    typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? Math.floor(seconds)
+      : 0;
+  const hrs = Math.floor(totalSeconds / 3600);
+  const mins = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
   if (hrs > 0) {
     return `${hrs}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
   }
@@ -26,16 +33,17 @@ function formatTimestamp(seconds) {
 }
 
 function mergeSpeakersWithText(segments, text, durationSeconds) {
+  const safeText = typeof text === "string" ? text : "";
   if (!segments || segments.length === 0) {
-    return [{ speaker: "speaker_0", text, start: 0, end: durationSeconds || 0 }];
+    return [{ speaker: "speaker_0", text: safeText, start: 0, end: durationSeconds || 0 }];
   }
 
   // Segments arrive in stdout order, not sorted — never assume the last one ends latest.
   const maxSegmentEnd = segments.reduce((max, s) => Math.max(max, s.end || 0), 0);
 
-  const sentences = splitIntoSentences(text);
+  const sentences = splitIntoSentences(safeText);
   if (sentences.length === 0) {
-    return [{ speaker: segments[0].speaker, text, start: segments[0].start, end: maxSegmentEnd }];
+    return [{ speaker: segments[0].speaker, text: safeText, start: segments[0].start, end: maxSegmentEnd }];
   }
 
   const totalDuration = durationSeconds || maxSegmentEnd || 1;
@@ -87,6 +95,10 @@ function mergeSpeakersWithText(segments, text, durationSeconds) {
 }
 
 function formatSpeakerTranscript(mergedSegments) {
+  if (!Array.isArray(mergedSegments) || mergedSegments.length === 0) {
+    return "";
+  }
+
   const speakerMap = new Map();
   let nextIndex = 1;
 

--- a/test/helpers/speakerMerge.test.js
+++ b/test/helpers/speakerMerge.test.js
@@ -1,6 +1,11 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { mergeSpeakersWithText, formatSpeakerTranscript } = require("../../src/helpers/speakerMerge");
+const {
+  mergeSpeakersWithText,
+  formatSpeakerTranscript,
+  splitIntoSentences,
+  formatTimestamp,
+} = require("../../src/helpers/speakerMerge");
 
 test("mergeSpeakersWithText assigns sentences to speakers by time proportion", () => {
   const segments = [
@@ -170,4 +175,45 @@ test("zero duration with unsorted segments still maps proportionally against the
   const merged = mergeSpeakersWithText(segments, text, 0);
   const last = merged[merged.length - 1];
   assert.equal(last.speaker, "spk_1", "tail sentences must map to the late segment");
+});
+
+test("splitIntoSentences returns empty array for nullish, non-string, or whitespace input", () => {
+  assert.deepEqual(splitIntoSentences(null), []);
+  assert.deepEqual(splitIntoSentences(undefined), []);
+  assert.deepEqual(splitIntoSentences(""), []);
+  assert.deepEqual(splitIntoSentences("   "), []);
+  assert.deepEqual(splitIntoSentences(123), []);
+});
+
+test("formatTimestamp handles non-finite, negative, and nullish inputs safely", () => {
+  assert.equal(formatTimestamp(undefined), "0:00");
+  assert.equal(formatTimestamp(null), "0:00");
+  assert.equal(formatTimestamp(NaN), "0:00");
+  assert.equal(formatTimestamp(Infinity), "0:00");
+  assert.equal(formatTimestamp(-Infinity), "0:00");
+  assert.equal(formatTimestamp(-5), "0:00");
+  assert.equal(formatTimestamp(0), "0:00");
+  assert.equal(formatTimestamp(65), "1:05");
+  assert.equal(formatTimestamp(3665), "1:01:05");
+});
+
+test("formatSpeakerTranscript returns empty string for nullish or invalid inputs", () => {
+  assert.equal(formatSpeakerTranscript(null), "");
+  assert.equal(formatSpeakerTranscript(undefined), "");
+  assert.equal(formatSpeakerTranscript("not an array"), "");
+});
+
+test("mergeSpeakersWithText handles nullish text and segments safely", () => {
+  const resultNull = mergeSpeakersWithText(null, null, 10);
+  assert.equal(resultNull.length, 1);
+  assert.equal(resultNull[0].speaker, "speaker_0");
+  assert.equal(resultNull[0].text, "");
+  assert.equal(resultNull[0].start, 0);
+  assert.equal(resultNull[0].end, 10);
+
+  const segments = [{ start: 0, end: 10, speaker: "speaker_0" }];
+  const resultNullText = mergeSpeakersWithText(segments, null, 10);
+  assert.equal(resultNullText.length, 1);
+  assert.equal(resultNullText[0].speaker, "speaker_0");
+  assert.equal(resultNullText[0].text, "");
 });


### PR DESCRIPTION
Fixes #1779

### Problem
In `src/helpers/speakerMerge.js`:
1. `splitIntoSentences(text)` passed `text` directly to `Intl.Segmenter`, which coerces `null` or `undefined` into string values (`"null"` / `"undefined"`), causing `splitIntoSentences(null)` to return `["null"]`. In environments without `Intl.Segmenter`, calling `splitIntoSentences(null)` threw a `TypeError`.
2. `formatTimestamp(seconds)` did not sanitize non-number, non-finite, or negative inputs, returning `"NaN:NaN"` on undefined/NaN/Infinity or negative minute/second components like `"-1:-5"` on negative numbers.
3. `formatSpeakerTranscript(mergedSegments)` threw `TypeError: Cannot read properties of null (reading 'map')` when `mergedSegments` was nullish.
4. `mergeSpeakersWithText(segments, text)` produced segments with `text: null` when text was null.

### Solution
- Added explicit string and empty-string guards at the top of `splitIntoSentences`.
- Sanitized `seconds` in `formatTimestamp` so that non-finite, sub-zero, or nullish inputs safely default to 0 seconds (`"0:00"`).
- Added array guard in `formatSpeakerTranscript` to safely return `""` for nullish or empty inputs.
- Sanitized input text in `mergeSpeakersWithText` to default to `""`.
- Added comprehensive regression tests in `test/helpers/speakerMerge.test.js`.

### Verification
- `node --test test/helpers/speakerMerge.test.js` (passes, 17/17 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)