### PR TITLE
fix(dictionary): split bulk import text on carriage return line breaks

### DIFF
--- a/src/helpers/dictionaryImport.js
+++ b/src/helpers/dictionaryImport.js
@@ -7,7 +7,7 @@
  */
 export function parseDictionaryImportText(text) {
   return String(text ?? "")
-    .split(/[,\n]/)
+    .split(/[,\r\n]/)
     .map((w) => w.trim())
     .filter(Boolean);
 }

--- a/test/helpers/dictionaryImportFormat.test.js
+++ b/test/helpers/dictionaryImportFormat.test.js
@@ -21,3 +21,15 @@ test("import accepts mixed commas and new lines and skips blanks", async () => {
     "Carol",
   ]);
 });
+
+test("import accepts carriage return and CRLF line endings", async () => {
+  const { parseDictionaryImportText } = await load();
+  assert.deepEqual(parseDictionaryImportText("Alice\rBob\rCarol"), ["Alice", "Bob", "Carol"]);
+  assert.deepEqual(parseDictionaryImportText("Alice\r\nBob\r\nCarol"), ["Alice", "Bob", "Carol"]);
+  assert.deepEqual(parseDictionaryImportText("Alice,\r\n Bob\r\n\r\nCarol,\rDave"), [
+    "Alice",
+    "Bob",
+    "Carol",
+    "Dave",
+  ]);
+});


### PR DESCRIPTION
Fixes #1781

### Problem
In `src/helpers/dictionaryImport.js`, `parseDictionaryImportText` used `.split(/[,\n]/)` to parse bulk-imported dictionary words.

When pasted text used carriage return line endings without line feeds (`\r`), such as from clipboard sources or older format pastes (e.g. `"Alice\rBob\rCarol"`), `/[,\n]/` failed to split the words. As a result, the entire text was kept as a single corrupted entry containing embedded `\r` characters.

### Solution
- Updated the regex split pattern to `/[,\r\n]/` so that carriage return line breaks (`\r`), line feeds (`\n`), CRLF sequences (`\r\n`), and commas all split words cleanly.
- Added regression tests in `test/helpers/dictionaryImportFormat.test.js` covering `\r`, `\r\n`, and mixed delimiters.

### Verification
- `node --test test/helpers/dictionaryImportFormat.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)