### PR TITLE
fix(i18n): support Chinese BCP 47 locales in resolveChineseScriptTarget

### DIFF
--- a/src/utils/chineseScript.js
+++ b/src/utils/chineseScript.js
@@ -73,12 +73,16 @@ export function isChineseText(text) {
   return SIMPLIFIED_CHINESE_VARIANT_RE.test(text) || TRADITIONAL_CHINESE_VARIANT_RE.test(text);
 }
 
+const SIMPLIFIED_LOCALES = new Set(["zh-CN", "zh-Hans", "zh-SG"]);
+const TRADITIONAL_LOCALES = new Set(["zh-TW", "zh-Hant", "zh-HK", "zh-MO"]);
+
 /**
  * Resolve the script target from preferred language + auto-detect preference.
  *
- * zh-CN / zh-TW are an explicit user assertion and always win. On auto the
- * preference applies only to text that actually looks Chinese — otherwise
- * Japanese and Korean dictation gets rewritten (会議の資料 → 会议の数据).
+ * zh-CN / zh-TW and other explicit Chinese locales are an assertion and always
+ * win. On auto (or generic zh) the preference applies only to text that
+ * actually looks Chinese — otherwise Japanese and Korean dictation gets
+ * rewritten (会議の資料 → 会议の数据).
  *
  * Omit `text` when no transcript exists yet (Whisper prompt building): without
  * it only an explicit language can be trusted, since biasing the prompt toward
@@ -90,10 +94,13 @@ export function isChineseText(text) {
  * @returns {ChineseScriptTarget | null}
  */
 export function resolveChineseScriptTarget(preferredLanguage, chineseScriptPreference, text) {
-  if (preferredLanguage === "zh-CN") return "simplified";
-  if (preferredLanguage === "zh-TW") return "traditional";
+  if (preferredLanguage && SIMPLIFIED_LOCALES.has(preferredLanguage)) return "simplified";
+  if (preferredLanguage && TRADITIONAL_LOCALES.has(preferredLanguage)) return "traditional";
 
-  if ((!preferredLanguage || preferredLanguage === "auto") && isChineseText(text)) {
+  if (
+    (!preferredLanguage || preferredLanguage === "auto" || preferredLanguage === "zh") &&
+    isChineseText(text)
+  ) {
     const preference = normalizeChineseScriptPreference(chineseScriptPreference);
     if (preference === "simplified") return "simplified";
     if (preference === "traditional") return "traditional";

--- a/test/helpers/chineseScript.test.js
+++ b/test/helpers/chineseScript.test.js
@@ -14,12 +14,18 @@ test("normalizeChineseScriptPreference defaults unknown values", async () => {
   assert.equal(normalizeChineseScriptPreference(undefined), "as-transcribed");
 });
 
-test("resolveChineseScriptTarget: zh-CN / zh-TW override auto preference", async () => {
+test("resolveChineseScriptTarget: explicit Chinese locale tags override auto preference", async () => {
   const { resolveChineseScriptTarget } = await load();
   assert.equal(resolveChineseScriptTarget("zh-CN", "traditional"), "simplified");
+  assert.equal(resolveChineseScriptTarget("zh-Hans", "traditional"), "simplified");
+  assert.equal(resolveChineseScriptTarget("zh-SG", "traditional"), "simplified");
   assert.equal(resolveChineseScriptTarget("zh-TW", "simplified"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-Hant", "simplified"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-HK", "simplified"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-MO", "simplified"), "traditional");
   assert.equal(resolveChineseScriptTarget("en", "simplified"), null);
 });
+
 
 test("isChineseText distinguishes Chinese from Japanese and Korean", async () => {
   const { isChineseText } = await load();
@@ -50,6 +56,8 @@ test("resolveChineseScriptTarget: auto applies preference only to Chinese text",
   assert.equal(resolveChineseScriptTarget("auto", "simplified", "這是中文"), "simplified");
   assert.equal(resolveChineseScriptTarget("auto", "traditional", "这是中文"), "traditional");
   assert.equal(resolveChineseScriptTarget("auto", "as-transcribed", "这是中文"), null);
+  assert.equal(resolveChineseScriptTarget("zh", "simplified", "这是中文"), "simplified");
+  assert.equal(resolveChineseScriptTarget("zh", "traditional", "这是中文"), "traditional");
   assert.equal(resolveChineseScriptTarget(undefined, "simplified", "这是中文"), "simplified");
   // Japanese, Korean and non-CJK must never be rewritten. See #975.
   assert.equal(resolveChineseScriptTarget("auto", "simplified", "会議の資料"), null);
@@ -59,13 +67,20 @@ test("resolveChineseScriptTarget: auto applies preference only to Chinese text",
   assert.equal(resolveChineseScriptTarget("auto", "simplified", "hello world"), null);
 });
 
-test("resolveChineseScriptTarget: without text only explicit zh-CN / zh-TW apply", async () => {
+test("resolveChineseScriptTarget: without text only explicit locale tags apply", async () => {
   const { resolveChineseScriptTarget } = await load();
   assert.equal(resolveChineseScriptTarget("zh-CN", "as-transcribed"), "simplified");
+  assert.equal(resolveChineseScriptTarget("zh-Hans", "as-transcribed"), "simplified");
+  assert.equal(resolveChineseScriptTarget("zh-SG", "as-transcribed"), "simplified");
   assert.equal(resolveChineseScriptTarget("zh-TW", "as-transcribed"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-Hant", "as-transcribed"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-HK", "as-transcribed"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh-MO", "as-transcribed"), "traditional");
+  assert.equal(resolveChineseScriptTarget("zh", "simplified"), null);
   assert.equal(resolveChineseScriptTarget("auto", "simplified"), null);
   assert.equal(resolveChineseScriptTarget("auto", "traditional"), null);
 });
+
 
 test("resolveCleanupLanguage keeps auto until the transcription language is known", async () => {
   const { resolveCleanupLanguage } = await load();


### PR DESCRIPTION
Fixes #1785

### Problem
In `src/utils/chineseScript.js`, `resolveChineseScriptTarget` only checked exact equality against `"zh-CN"` and `"zh-TW"`. When a user has other standard Chinese BCP 47 locale codes configured:
- Simplified: `"zh-Hans"`, `"zh-SG"`
- Traditional: `"zh-Hant"`, `"zh-HK"`, `"zh-MO"`
- Generic: `"zh"`

`resolveChineseScriptTarget` returned `null` and failed to apply the appropriate script conversion or auto script preference.

### Solution
- Added `SIMPLIFIED_LOCALES` (`zh-CN`, `zh-Hans`, `zh-SG`) and `TRADITIONAL_LOCALES` (`zh-TW`, `zh-Hant`, `zh-HK`, `zh-MO`) sets to resolve the target script deterministically.
- Allowed generic `zh` to utilize the auto-detect `chineseScriptPreference` when text contains Chinese characters.
- Added test coverage in `test/helpers/chineseScript.test.js`.

### Verification
- `node --test test/helpers/chineseScript.test.js` (passes, 13/13 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)