### PR TITLE
fix(paste): handle multi-char whitespace and CJK punctuation in smart spacing

### DIFF
--- a/src/helpers/smartSpacing.js
+++ b/src/helpers/smartSpacing.js
@@ -2,8 +2,52 @@
 // "prepend" mode needs the char before the cursor (read via Accessibility on
 // macOS); "append" mode is the platform-agnostic fallback.
 
-const OPENING_CHARS = new Set([" ", "\t", "\n", "\r", "(", "[", "{", "<", '"', "'", "`", "“", "‘"]);
-const LEADING_PUNCTUATION = new Set([",", ".", "!", "?", ";", ":", ")", "]", "}", "%", "”", "’"]);
+const OPENING_CHARS = new Set([
+  " ",
+  "\t",
+  "\n",
+  "\r",
+  "(",
+  "[",
+  "{",
+  "<",
+  '"',
+  "'",
+  "`",
+  "“",
+  "‘",
+  "（",
+  "【",
+  "《",
+  "「",
+  "『",
+]);
+const LEADING_PUNCTUATION = new Set([
+  ",",
+  ".",
+  "!",
+  "?",
+  ";",
+  ":",
+  ")",
+  "]",
+  "}",
+  "%",
+  "”",
+  "’",
+  "，",
+  "。",
+  "！",
+  "？",
+  "；",
+  "：",
+  "）",
+  "】",
+  "》",
+  "」",
+  "』",
+  "、",
+]);
 
 function applySmartSpacing({ text, mode, precedingChar }) {
   if (typeof text !== "string" || text.length === 0) return text;
@@ -15,7 +59,11 @@ function applySmartSpacing({ text, mode, precedingChar }) {
 function applyPrepend(text, precedingChar) {
   if (precedingChar == null || precedingChar === "") return text;
   if (/^\s/.test(text)) return text;
-  if (OPENING_CHARS.has(precedingChar)) return text;
+  const lastChar =
+    typeof precedingChar === "string" && precedingChar.length > 0
+      ? precedingChar[precedingChar.length - 1]
+      : precedingChar;
+  if (OPENING_CHARS.has(lastChar) || /\s/.test(lastChar)) return text;
   // Don't separate prior text from closing punctuation: "Hello" + ", world".
   if (LEADING_PUNCTUATION.has(text[0])) return text;
   return " " + text;

--- a/test/helpers/smartSpacing.test.js
+++ b/test/helpers/smartSpacing.test.js
@@ -59,6 +59,30 @@ test("prepend: no space when transcript starts with closing punctuation", () => 
   assert.equal(prepend("; semicolon", "o"), "; semicolon");
   assert.equal(prepend(": colon", "o"), ": colon");
   assert.equal(prepend(") close paren", "o"), ") close paren");
+  assert.equal(prepend("，世界", "好"), "，世界");
+  assert.equal(prepend("。句号", "好"), "。句号");
+  assert.equal(prepend("！感叹", "好"), "！感叹");
+  assert.equal(prepend("？问号", "好"), "？问号");
+  assert.equal(prepend("；分号", "好"), "；分号");
+  assert.equal(prepend("：冒号", "好"), "：冒号");
+  assert.equal(prepend("）右括号", "好"), "）右括号");
+  assert.equal(prepend("】右方括号", "好"), "】右方括号");
+  assert.equal(prepend("》右书名号", "好"), "》右书名号");
+  assert.equal(prepend("、顿号", "好"), "、顿号");
+});
+
+test("prepend: no space after multi-char whitespace or CRLF newlines", () => {
+  assert.equal(prepend("hello", "\r\n"), "hello");
+  assert.equal(prepend("hello", "  "), "hello");
+  assert.equal(prepend("hello", "\t\t"), "hello");
+});
+
+test("prepend: no space after full-width CJK opening brackets", () => {
+  assert.equal(prepend("内容", "（"), "内容");
+  assert.equal(prepend("内容", "【"), "内容");
+  assert.equal(prepend("内容", "《"), "内容");
+  assert.equal(prepend("内容", "「"), "内容");
+  assert.equal(prepend("内容", "『"), "内容");
 });
 
 test("prepend: adds space when preceding char is sentence punctuation (no space yet)", () => {


### PR DESCRIPTION
Fixes #1787

### Problem
In `src/helpers/smartSpacing.js`:
1. `applyPrepend` checked `OPENING_CHARS.has(precedingChar)` with the full string. When the cursor was preceded by multi-character whitespace (e.g. Windows CRLF `\r\n` line breaks or multiple trailing spaces), `OPENING_CHARS.has("\r\n")` returned `false`, improperly inserting a leading space at the start of a newline or after whitespace.
2. `OPENING_CHARS` and `LEADING_PUNCTUATION` lacked full-width CJK punctuation marks (`，`, `。`, `！`, `？`, `；`, `：`, `）`, `】`, `》`, `」`, `』`, `、`, `（`, `【`, `《`, `「`, `『`), causing unwanted spaces to be added before or after full-width punctuation.

### Solution
- Updated `applyPrepend` to check the trailing character of `precedingChar` against `OPENING_CHARS` and whitespace (`/\s/`).
- Added full-width CJK brackets and quotes to `OPENING_CHARS` and closing/delimiter punctuation to `LEADING_PUNCTUATION`.
- Added unit tests in `test/helpers/smartSpacing.test.js` covering CRLF, multi-space, and full-width CJK punctuation cases.

### Verification
- `node --test test/helpers/smartSpacing.test.js` (passes, 22/22 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)