### PR TITLE
fix(startup): handle nullish loginItemSettings and argv in autoStartPolicy

### DIFF
--- a/src/helpers/autoStartPolicy.js
+++ b/src/helpers/autoStartPolicy.js
@@ -15,18 +15,19 @@ function getLoginItemArgs(platform) {
 
 // For the platforms setLoginItemSettings covers: win32 and darwin.
 function resolveAutoStartState({ platform, loginItemSettings }) {
+  const settings = loginItemSettings || {};
   if (platform === "win32") {
     // openAtLogin only checks whether the Run entry matches this executable and
     // args; it ignores Explorer's StartupApproved key, which is what Task Manager
     // writes when a user disables a startup app. Only this field covers both.
-    return { enabled: !!loginItemSettings.executableWillLaunchAtLogin, requiresApproval: false };
+    return { enabled: !!settings.executableWillLaunchAtLogin, requiresApproval: false };
   }
   return {
-    enabled: !!loginItemSettings.openAtLogin,
+    enabled: !!settings.openAtLogin,
     // macOS 13+ routes login items through SMAppService, which can register an
     // item and still leave it awaiting approval in System Settings. Unsurfaced,
     // that just looks like a toggle that will not stick.
-    requiresApproval: loginItemSettings.status === "requires-approval",
+    requiresApproval: settings.status === "requires-approval",
   };
 }
 
@@ -36,13 +37,14 @@ function resolveAutoStartState({ platform, loginItemSettings }) {
 // entry rather than adding a second one.
 function needsHiddenFlagMigration({ platform, loginItemSettings }) {
   if (platform !== "win32") return false;
-  return !!loginItemSettings.executableWillLaunchAtLogin && !loginItemSettings.openAtLogin;
+  const settings = loginItemSettings || {};
+  return !!settings.executableWillLaunchAtLogin && !settings.openAtLogin;
 }
 
 // Whether the session started this process rather than the user.
 function wasLaunchedHidden({ platform, argv, loginItemSettings }) {
-  if (platform === "darwin") return !!loginItemSettings.wasOpenedAtLogin;
-  return argv.includes(HIDDEN_LAUNCH_FLAG);
+  if (platform === "darwin") return !!loginItemSettings?.wasOpenedAtLogin;
+  return Array.isArray(argv) && argv.includes(HIDDEN_LAUNCH_FLAG);
 }
 
 module.exports = {

--- a/test/helpers/autoStartPolicy.test.js
+++ b/test/helpers/autoStartPolicy.test.js
@@ -148,3 +148,18 @@ test("macOS detects a login launch from wasOpenedAtLogin, not from argv", () => 
     false
   );
 });
+
+test("autoStartPolicy helpers handle nullish inputs safely", () => {
+  assert.deepEqual(resolveAutoStartState({ platform: "darwin", loginItemSettings: null }), {
+    enabled: false,
+    requiresApproval: false,
+  });
+  assert.deepEqual(resolveAutoStartState({ platform: "win32", loginItemSettings: undefined }), {
+    enabled: false,
+    requiresApproval: false,
+  });
+  assert.equal(needsHiddenFlagMigration({ platform: "win32", loginItemSettings: null }), false);
+  assert.equal(wasLaunchedHidden({ platform: "darwin", loginItemSettings: null }), false);
+  assert.equal(wasLaunchedHidden({ platform: "linux", argv: null }), false);
+  assert.equal(wasLaunchedHidden({ platform: "win32", argv: undefined }), false);
+});


### PR DESCRIPTION
Fixes #1789

### Problem
In `src/helpers/autoStartPolicy.js`:
1. `resolveAutoStartState` and `needsHiddenFlagMigration` accessed properties on `loginItemSettings` directly without checking for nullish values, throwing a `TypeError` if `loginItemSettings` was `null` or `undefined`.
2. `wasLaunchedHidden` did not check `loginItemSettings` before accessing `wasOpenedAtLogin` on macOS, and did not check if `argv` was a valid array before calling `.includes()`.

### Solution
- Defaulted `loginItemSettings` to `{}` across `resolveAutoStartState` and `needsHiddenFlagMigration`.
- Used optional chaining and `Array.isArray` checks in `wasLaunchedHidden`.
- Added unit tests in `test/helpers/autoStartPolicy.test.js`.

### Verification
- `node --test test/helpers/autoStartPolicy.test.js` (passes, 15/15 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)