### PR TITLE
fix(assistant): handle nullish state and optional callbacks in assistantSessionState

### DIFF
--- a/src/helpers/assistantSessionState.js
+++ b/src/helpers/assistantSessionState.js
@@ -5,7 +5,7 @@
  */
 export function closeAssistantSessionState(state) {
   return {
-    conversationId: state.conversationId ?? null,
+    conversationId: state?.conversationId ?? null,
     pendingCommand: null,
     thinking: false,
     busy: false,
@@ -13,7 +13,8 @@ export function closeAssistantSessionState(state) {
   };
 }
 
-export function resolveAssistantPanelBusy({ agentState, activeToolName, submissionInFlight }) {
+export function resolveAssistantPanelBusy(params) {
+  const { agentState, activeToolName, submissionInFlight } = params || {};
   return Boolean(
     submissionInFlight ||
     activeToolName ||
@@ -36,15 +37,15 @@ export async function restoreAssistantConversation({
   isActive = () => true,
 }) {
   try {
-    await loadConversation(conversationId);
+    await loadConversation?.(conversationId);
     if (!isActive()) return "inactive";
-    onReady();
+    onReady?.();
     return "restored";
   } catch (error) {
     if (!isActive()) return "inactive";
-    onError(error);
-    onReset();
-    onReady();
+    onError?.(error);
+    onReset?.();
+    onReady?.();
     return "reset";
   }
 }

--- a/test/helpers/assistantSessionState.test.js
+++ b/test/helpers/assistantSessionState.test.js
@@ -111,3 +111,47 @@ test("failed Assistant history resets before enabling a fresh conversation", asy
   );
   assert.deepEqual(events, ["error", "reset", "ready"]);
 });
+
+test("assistantSessionState helpers handle nullish inputs safely", async () => {
+  const {
+    closeAssistantSessionState,
+    resolveAssistantPanelBusy,
+    restoreAssistantConversation,
+  } = await import("../../src/helpers/assistantSessionState.js");
+
+  assert.deepEqual(closeAssistantSessionState(null), {
+    conversationId: null,
+    pendingCommand: null,
+    thinking: false,
+    busy: false,
+    responseReady: false,
+  });
+  assert.deepEqual(closeAssistantSessionState(undefined), {
+    conversationId: null,
+    pendingCommand: null,
+    thinking: false,
+    busy: false,
+    responseReady: false,
+  });
+
+  assert.equal(resolveAssistantPanelBusy(null), false);
+  assert.equal(resolveAssistantPanelBusy(undefined), false);
+
+  assert.equal(
+    await restoreAssistantConversation({
+      conversationId: 42,
+      loadConversation: async () => {},
+    }),
+    "restored"
+  );
+
+  assert.equal(
+    await restoreAssistantConversation({
+      conversationId: 42,
+      loadConversation: async () => {
+        throw new Error("fail");
+      },
+    }),
+    "reset"
+  );
+});


### PR DESCRIPTION
Fixes #1791

### Problem
In `src/helpers/assistantSessionState.js`:
1. `closeAssistantSessionState(state)` accessed `state.conversationId` directly, throwing a `TypeError` when called with `null` or `undefined`.
2. `resolveAssistantPanelBusy(params)` destructured properties directly from `params`, throwing a `TypeError` when `params` was `null` or `undefined`.
3. `restoreAssistantConversation` called callback functions (`onReady()`, `onError(error)`, `onReset()`) directly, throwing a `TypeError` when any callback was omitted or undefined.

### Solution
- Added optional chaining in `closeAssistantSessionState` (`state?.conversationId ?? null`).
- Defaulted `params` to `{}` in `resolveAssistantPanelBusy`.
- Used optional invocation for callbacks (`onReady?.()`, `onError?.(error)`, `onReset?.()`, `loadConversation?.()`) in `restoreAssistantConversation`.
- Added unit tests in `test/helpers/assistantSessionState.test.js`.

### Verification
- `node --test test/helpers/assistantSessionState.test.js` (passes, 7/7 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)