### PR TITLE
fix(meeting): handle nullish inputs in partitionPendingMicFinals and isWithinRetractWindow

### DIFF
--- a/src/helpers/meetingMicHoldback.js
+++ b/src/helpers/meetingMicHoldback.js
@@ -15,13 +15,13 @@ const partitionPendingMicFinals = ({ pending, now, force = false, isDuplicate })
   const duplicates = [];
   const releases = [];
 
-  for (const entry of pending) {
+  for (const entry of pending || []) {
     if (!force && entry.releaseAt > now) {
       deferred.push(entry);
       continue;
     }
 
-    if (isDuplicate(entry)) {
+    if (typeof isDuplicate === "function" && isDuplicate(entry)) {
       duplicates.push(entry);
       continue;
     }
@@ -43,12 +43,22 @@ const partitionPendingMicFinals = ({ pending, now, force = false, isDuplicate })
  * `holdback` away from the capture timestamp.
  */
 const isWithinRetractWindow = ({ candidate, systemTimestamp, windowMs }) => {
+  if (
+    !candidate ||
+    !Number.isFinite(candidate.timestamp) ||
+    !Number.isFinite(systemTimestamp) ||
+    !Number.isFinite(windowMs)
+  ) {
+    return false;
+  }
+
   if (Math.abs(candidate.timestamp - systemTimestamp) <= windowMs) {
     return true;
   }
 
   return (
     candidate.committedAt != null &&
+    Number.isFinite(candidate.committedAt) &&
     systemTimestamp >= candidate.timestamp &&
     Math.abs(candidate.committedAt - systemTimestamp) <= windowMs
   );

--- a/test/helpers/meetingMicHoldback.test.js
+++ b/test/helpers/meetingMicHoldback.test.js
@@ -461,3 +461,44 @@ test("partitionOverlappingPendingMicFinals splits pending finals by system overl
     { text: "c", relaxed: false },
   ]);
 });
+
+test("partitionPendingMicFinals and isWithinRetractWindow handle nullish inputs safely", () => {
+  assert.deepEqual(partitionPendingMicFinals({ pending: null, now: NOW }), {
+    deferred: [],
+    duplicates: [],
+    releases: [],
+  });
+  assert.deepEqual(partitionPendingMicFinals({ pending: undefined, now: NOW }), {
+    deferred: [],
+    duplicates: [],
+    releases: [],
+  });
+  assert.deepEqual(
+    partitionPendingMicFinals({
+      pending: [entry({ releaseAt: NOW - 100 })],
+      now: NOW,
+    }),
+    {
+      deferred: [],
+      duplicates: [],
+      releases: [entry({ releaseAt: NOW - 100 })],
+    }
+  );
+
+  assert.equal(
+    isWithinRetractWindow({ candidate: null, systemTimestamp: NOW, windowMs: 1000 }),
+    false
+  );
+  assert.equal(
+    isWithinRetractWindow({ candidate: undefined, systemTimestamp: NOW, windowMs: 1000 }),
+    false
+  );
+  assert.equal(
+    isWithinRetractWindow({
+      candidate: entry({ timestamp: null }),
+      systemTimestamp: NOW,
+      windowMs: 1000,
+    }),
+    false
+  );
+});


### PR DESCRIPTION
Fixes #1793

### Problem
In `src/helpers/meetingMicHoldback.js`:
1. `partitionPendingMicFinals` iterated over `pending` without checking for nullish values, throwing a `TypeError: pending is not iterable`.
2. When `isDuplicate` was omitted or not a function, calling `isDuplicate(entry)` threw a `TypeError`.
3. `isWithinRetractWindow` accessed `candidate.timestamp` directly without checking whether `candidate` was nullish or whether timestamps and windows were valid finite numbers, throwing a `TypeError`.

### Solution
- Defaulted `pending` to `[]` in `partitionPendingMicFinals` and added a `typeof isDuplicate === "function"` check.
- Added nullish and `Number.isFinite` checks in `isWithinRetractWindow`.
- Added unit tests in `test/helpers/meetingMicHoldback.test.js`.

### Verification
- `node --test test/helpers/meetingMicHoldback.test.js` (passes, 25/25 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)