### PR TITLE
fix(catalog): handle non-array summaries and nullish fields in normalizeBedrockCatalog

### DIFF
--- a/src/helpers/bedrockCatalog.js
+++ b/src/helpers/bedrockCatalog.js
@@ -4,10 +4,13 @@
 
 function profileIdByModelId(inferenceProfileSummaries) {
   const map = new Map();
-  for (const profile of inferenceProfileSummaries || []) {
+  const profiles = Array.isArray(inferenceProfileSummaries) ? inferenceProfileSummaries : [];
+  for (const profile of profiles) {
     if (!profile?.inferenceProfileId) continue;
-    for (const model of profile.models || []) {
-      const modelId = model?.modelArn?.split("/").pop();
+    const models = Array.isArray(profile.models) ? profile.models : [];
+    for (const model of models) {
+      const modelId =
+        typeof model?.modelArn === "string" ? model.modelArn.split("/").pop() : undefined;
       if (modelId && !map.has(modelId)) map.set(modelId, profile.inferenceProfileId);
     }
   }
@@ -18,22 +21,32 @@ function normalizeBedrockCatalog(modelSummaries, inferenceProfileSummaries) {
   const profiles = profileIdByModelId(inferenceProfileSummaries);
   const seen = new Set();
   const models = [];
+  const summaries = Array.isArray(modelSummaries) ? modelSummaries : [];
 
-  for (const summary of modelSummaries || []) {
-    if (!summary?.modelId) continue;
-    if (!(summary.outputModalities || []).includes("TEXT")) continue;
+  for (const summary of summaries) {
+    if (!summary?.modelId || typeof summary.modelId !== "string") continue;
+    const modalities = Array.isArray(summary.outputModalities) ? summary.outputModalities : [];
+    if (!modalities.includes("TEXT")) continue;
     const status = summary.modelLifecycle?.status;
     if (status && status !== "ACTIVE") continue;
 
-    const types = summary.inferenceTypesSupported || [];
+    const types = Array.isArray(summary.inferenceTypesSupported)
+      ? summary.inferenceTypesSupported
+      : [];
     const value = types.includes("ON_DEMAND") ? summary.modelId : profiles.get(summary.modelId);
     if (!value || seen.has(value)) continue;
     seen.add(value);
 
+    const vendor = typeof summary.providerName === "string" ? summary.providerName : "";
+    const label =
+      typeof summary.modelName === "string" && summary.modelName
+        ? summary.modelName
+        : String(summary.modelId);
+
     models.push({
       value,
-      label: summary.modelName || summary.modelId,
-      vendor: summary.providerName || "",
+      label,
+      vendor,
     });
   }
 

--- a/test/helpers/bedrockCatalog.test.js
+++ b/test/helpers/bedrockCatalog.test.js
@@ -96,3 +96,28 @@ test("sorts by vendor then label and dedupes by value", () => {
   const vendors = models.map((m) => m.vendor);
   assert.deepEqual(vendors, [...vendors].sort((a, b) => a.localeCompare(b)));
 });
+
+test("handles non-array summaries and nullish fields safely", () => {
+  assert.deepEqual(normalizeBedrockCatalog(null, null), []);
+  assert.deepEqual(normalizeBedrockCatalog(undefined, undefined), []);
+  assert.deepEqual(normalizeBedrockCatalog({}, {}), []);
+  assert.deepEqual(normalizeBedrockCatalog("invalid", "invalid"), []);
+  assert.deepEqual(
+    normalizeBedrockCatalog([
+      {
+        modelId: "test-model",
+        outputModalities: ["TEXT"],
+        inferenceTypesSupported: ["ON_DEMAND"],
+        providerName: null,
+        modelName: null,
+      },
+    ]),
+    [
+      {
+        value: "test-model",
+        label: "test-model",
+        vendor: "",
+      },
+    ]
+  );
+});


### PR DESCRIPTION
Fixes #1795

### Problem
In `src/helpers/bedrockCatalog.js`:
1. `profileIdByModelId` and `normalizeBedrockCatalog` iterated over input summaries assuming they were always arrays, throwing a `TypeError` if non-array objects or primitives were passed.
2. In `models.sort((a, b) => a.vendor.localeCompare(b.vendor) || a.label.localeCompare(b.label))`, missing or non-string `providerName` or `modelName` could lead to `TypeError: a.vendor.localeCompare is not a function`.

### Solution
- Added `Array.isArray()` guards in `profileIdByModelId` and `normalizeBedrockCatalog`.
- Guaranteed string values for `vendor` and `label` before sorting.
- Added test coverage in `test/helpers/bedrockCatalog.test.js`.

### Verification
- `node --test test/helpers/bedrockCatalog.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)