### PR TITLE
fix(uploads): normalize provider names and clamp verbose segment timestamps

### DIFF
--- a/src/helpers/uploadTimestamps.js
+++ b/src/helpers/uploadTimestamps.js
@@ -5,16 +5,13 @@
 // 400 on unknown fields) must keep the plain-text request untouched — a
 // missing timestamp is a degraded export, never a failed upload.
 function timestampRequestFields(provider, model) {
-  const normProvider = typeof provider === "string" ? provider.trim().toLowerCase() : "";
-  const normModel = typeof model === "string" ? model.trim().toLowerCase() : "";
-
-  if (normProvider === "openai" && normModel === "whisper-1") {
+  if (provider === "openai" && model === "whisper-1") {
     return { response_format: "verbose_json" };
   }
-  if (normProvider === "groq") {
+  if (provider === "groq") {
     return { response_format: "verbose_json" };
   }
-  if (normProvider === "mistral") {
+  if (provider === "mistral") {
     return { timestamp_granularities: "segment" };
   }
   return null;

--- a/src/helpers/uploadTimestamps.js
+++ b/src/helpers/uploadTimestamps.js
@@ -5,13 +5,16 @@
 // 400 on unknown fields) must keep the plain-text request untouched — a
 // missing timestamp is a degraded export, never a failed upload.
 function timestampRequestFields(provider, model) {
-  if (provider === "openai" && model === "whisper-1") {
+  const normProvider = typeof provider === "string" ? provider.trim().toLowerCase() : "";
+  const normModel = typeof model === "string" ? model.trim().toLowerCase() : "";
+
+  if (normProvider === "openai" && normModel === "whisper-1") {
     return { response_format: "verbose_json" };
   }
-  if (provider === "groq") {
+  if (normProvider === "groq") {
     return { response_format: "verbose_json" };
   }
-  if (provider === "mistral") {
+  if (normProvider === "mistral") {
     return { timestamp_granularities: "segment" };
   }
   return null;
@@ -28,10 +31,13 @@ function mapVerboseSegments(responseData) {
   for (const seg of segments) {
     const text = typeof seg?.text === "string" ? seg.text.trim() : "";
     if (!text || !Number.isFinite(seg.start)) continue;
+    const start = Math.max(0, seg.start);
+    const rawEnd = Number.isFinite(seg.end) ? seg.end : start;
+    const end = Math.max(start, rawEnd);
     mapped.push({
       text,
-      start: seg.start,
-      end: Number.isFinite(seg.end) ? seg.end : seg.start,
+      start,
+      end,
     });
   }
   return mapped.length ? mapped : null;

--- a/test/helpers/uploadTimestamps.test.js
+++ b/test/helpers/uploadTimestamps.test.js
@@ -67,18 +67,6 @@ test("malformed verbose segments are dropped, never thrown", () => {
   ]);
 });
 
-test("timestamp fields support case-insensitive and trimmed provider names", () => {
-  assert.deepEqual(timestampRequestFields("OpenAI", "whisper-1"), {
-    response_format: "verbose_json",
-  });
-  assert.deepEqual(timestampRequestFields(" GROQ ", "whisper-large-v3"), {
-    response_format: "verbose_json",
-  });
-  assert.deepEqual(timestampRequestFields("Mistral", "voxtral-mini-latest"), {
-    timestamp_granularities: "segment",
-  });
-});
-
 test("verbose segments clamp negative start timestamps and inverted end timestamps", () => {
   const mapped = mapVerboseSegments({
     segments: [

--- a/test/helpers/uploadTimestamps.test.js
+++ b/test/helpers/uploadTimestamps.test.js
@@ -67,6 +67,32 @@ test("malformed verbose segments are dropped, never thrown", () => {
   ]);
 });
 
+test("timestamp fields support case-insensitive and trimmed provider names", () => {
+  assert.deepEqual(timestampRequestFields("OpenAI", "whisper-1"), {
+    response_format: "verbose_json",
+  });
+  assert.deepEqual(timestampRequestFields(" GROQ ", "whisper-large-v3"), {
+    response_format: "verbose_json",
+  });
+  assert.deepEqual(timestampRequestFields("Mistral", "voxtral-mini-latest"), {
+    timestamp_granularities: "segment",
+  });
+});
+
+test("verbose segments clamp negative start timestamps and inverted end timestamps", () => {
+  const mapped = mapVerboseSegments({
+    segments: [
+      { start: -2.5, end: 3, text: "negative start clamped" },
+      { start: 6, end: 2, text: "inverted end clamped" },
+    ],
+  });
+
+  assert.deepEqual(mapped, [
+    { text: "negative start clamped", start: 0, end: 3 },
+    { text: "inverted end clamped", start: 6, end: 6 },
+  ]);
+});
+
 test("responses without usable segments map to null", () => {
   assert.equal(mapVerboseSegments({ text: "plain json response" }), null);
   assert.equal(mapVerboseSegments({ segments: "not-an-array" }), null);


### PR DESCRIPTION
Fixes #1799

### Problem
In `src/helpers/uploadTimestamps.js`:
1. `timestampRequestFields` used case-sensitive comparisons, failing when provider names had leading/trailing whitespace or mixed casing (e.g. `"OpenAI"`, `"Groq"`, `"Mistral"`).
2. `mapVerboseSegments` did not bound negative start timestamps (`start < 0`) and allowed inverted segment ranges where `end < start`.

### Solution
- Normalized `provider` and `model` with `trim().toLowerCase()` in `timestampRequestFields`.
- Clamped `start` to `Math.max(0, seg.start)` and guaranteed `end = Math.max(start, rawEnd)` in `mapVerboseSegments`.
- Added unit tests in `test/helpers/uploadTimestamps.test.js`.

### Verification
- `node --test test/helpers/uploadTimestamps.test.js` (passes, 6/6 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)