### PR TITLE
fix(gpu): refresh banner after settings close

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -59,7 +59,7 @@ import WindowControls from "./WindowControls";
 
 import { getCachedPlatform } from "../utils/platform";
 import { isAccessibilitySkipped } from "../utils/permissions";
-import { eligibleGpuOffers, type GpuOffers } from "../utils/gpuBannerPolicy";
+import { useGpuBannerAvailability } from "../hooks/useGpuBannerAvailability";
 import {
   setActiveNoteId,
   setActiveFolderId,
@@ -156,10 +156,6 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
     folderId: number;
     event: any;
   } | null>(null);
-  const [gpuAccelAvailable, setGpuAccelAvailable] = useState<GpuOffers>({
-    transcription: false,
-    intelligence: null,
-  });
   const [gpuBannerDismissed, setGpuBannerDismissed] = useState(
     () => localStorage.getItem("gpuBannerDismissedUnified") === "true"
   );
@@ -220,6 +216,13 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
       };
     })
   );
+  const gpuAccelAvailable = useGpuBannerAvailability({
+    settings: gpuBannerSettings,
+    agentAllowedByPolicy,
+    dismissed: gpuBannerDismissed,
+    settingsOpen: showSettings,
+    platform,
+  });
 
   const {
     confirmDialog,
@@ -405,43 +408,6 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
     localStorage.removeItem("pendingCloudMigration");
     setShowCloudMigrationBanner(true);
   }, [authLoaded, isSignedIn, setUseLocalWhisper, setCloudTranscriptionMode]);
-
-  useEffect(() => {
-    if (platform === "darwin" || gpuBannerDismissed) return;
-    const offers = eligibleGpuOffers({ ...gpuBannerSettings, agentAllowedByPolicy });
-    // A run that loses its settings mid-probe must not publish: switching to a
-    // cloud mode resolves with no IPC at all, so an older local-mode run would
-    // otherwise land last and re-raise the banner for the rest of the session.
-    let cancelled = false;
-    const detect = async () => {
-      const results: GpuOffers = { transcription: false, intelligence: null };
-      if (offers.transcription) {
-        try {
-          const status = await window.electronAPI?.getCudaWhisperStatus?.();
-          if (status?.gpuInfo.hasNvidiaGpu && status.gpuInfo.cudaSupported) {
-            if (!status.downloaded) results.transcription = true;
-          } else {
-            const vulkan = await window.electronAPI?.getVulkanWhisperStatus?.();
-            if (vulkan?.vulkan.available && !vulkan.downloaded) results.transcription = true;
-          }
-        } catch {}
-      }
-      if (offers.intelligence) {
-        try {
-          const [gpu, vulkan] = await Promise.all([
-            window.electronAPI?.detectVulkanGpu?.(),
-            window.electronAPI?.getLlamaVulkanStatus?.(),
-          ]);
-          if (gpu?.available && !vulkan?.downloaded) results.intelligence = offers.intelligence;
-        } catch {}
-      }
-      if (!cancelled) setGpuAccelAvailable(results);
-    };
-    detect();
-    return () => {
-      cancelled = true;
-    };
-  }, [gpuBannerSettings, agentAllowedByPolicy, gpuBannerDismissed]);
 
   useEffect(() => {
     const drain = async () => {

--- a/src/hooks/useGpuBannerAvailability.ts
+++ b/src/hooks/useGpuBannerAvailability.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { eligibleGpuOffers, type GpuOfferInputs, type GpuOffers } from "../utils/gpuBannerPolicy";
+import type { Platform } from "../utils/platform";
+
+type GpuBannerSettings = Omit<GpuOfferInputs, "agentAllowedByPolicy">;
+
+interface UseGpuBannerAvailabilityOptions {
+  settings: GpuBannerSettings;
+  agentAllowedByPolicy: boolean;
+  dismissed: boolean;
+  settingsOpen: boolean;
+  platform: Platform;
+}
+
+const EMPTY_GPU_OFFERS: GpuOffers = {
+  transcription: false,
+  intelligence: null,
+};
+
+export function useGpuBannerAvailability({
+  settings,
+  agentAllowedByPolicy,
+  dismissed,
+  settingsOpen,
+  platform,
+}: UseGpuBannerAvailabilityOptions): GpuOffers {
+  const [availability, setAvailability] = useState<GpuOffers>(EMPTY_GPU_OFFERS);
+
+  useEffect(() => {
+    if (platform === "darwin" || dismissed || settingsOpen) return;
+
+    const offers = eligibleGpuOffers({ ...settings, agentAllowedByPolicy });
+    // A run that loses its settings mid-probe must not publish: switching to a
+    // cloud mode resolves with no IPC at all, so an older local-mode run would
+    // otherwise land last and re-raise the banner for the rest of the session.
+    let cancelled = false;
+    const detect = async () => {
+      const results: GpuOffers = { ...EMPTY_GPU_OFFERS };
+      if (offers.transcription) {
+        try {
+          const status = await window.electronAPI?.getCudaWhisperStatus?.();
+          if (status?.gpuInfo.hasNvidiaGpu && status.gpuInfo.cudaSupported) {
+            if (!status.downloaded) results.transcription = true;
+          } else {
+            const vulkan = await window.electronAPI?.getVulkanWhisperStatus?.();
+            if (vulkan?.vulkan.available && !vulkan.downloaded) results.transcription = true;
+          }
+        } catch {}
+      }
+      if (offers.intelligence) {
+        try {
+          const [gpu, vulkan] = await Promise.all([
+            window.electronAPI?.detectVulkanGpu?.(),
+            window.electronAPI?.getLlamaVulkanStatus?.(),
+          ]);
+          if (gpu?.available && !vulkan?.downloaded) results.intelligence = offers.intelligence;
+        } catch {}
+      }
+      if (!cancelled) setAvailability(results);
+    };
+    detect();
+    return () => {
+      cancelled = true;
+    };
+  }, [settings, agentAllowedByPolicy, dismissed, settingsOpen, platform]);
+
+  return availability;
+}

--- a/test/helpers/liveTranscriptHoldLifecycle.test.js
+++ b/test/helpers/liveTranscriptHoldLifecycle.test.js
@@ -2,66 +2,13 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const React = require("react");
 const { createRoot } = require("react-dom/client");
-const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+const {
+  createRendererServer,
+  installBrowserGlobals,
+  installHookDom,
+} = require("../lib/rendererTestHarness");
 
 const FINAL_HIDE_MS = 4000;
-
-function installHookDom(t) {
-  const originalDocument = globalThis.document;
-  const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
-  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
-  const noop = () => {};
-
-  class Element {}
-  class HTMLElement extends Element {}
-  class HTMLIFrameElement extends HTMLElement {}
-
-  const document = {
-    nodeType: 9,
-    activeElement: null,
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-  const container = {
-    nodeType: 1,
-    nodeName: "DIV",
-    tagName: "DIV",
-    namespaceURI: "http://www.w3.org/1999/xhtml",
-    ownerDocument: document,
-    addEventListener: noop,
-    removeEventListener: noop,
-    appendChild: noop,
-    removeChild: noop,
-    insertBefore: noop,
-  };
-  Object.assign(globalThis.window, {
-    Element,
-    HTMLElement,
-    HTMLIFrameElement,
-    document,
-    getSelection: () => null,
-  });
-  document.defaultView = globalThis.window;
-  document.documentElement = container;
-  globalThis.document = document;
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-  globalThis.requestAnimationFrame = () => 1;
-  globalThis.cancelAnimationFrame = noop;
-
-  t.after(() => {
-    if (originalDocument === undefined) delete globalThis.document;
-    else globalThis.document = originalDocument;
-    if (originalActEnvironment === undefined) delete globalThis.IS_REACT_ACT_ENVIRONMENT;
-    else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
-    if (originalRequestAnimationFrame === undefined) delete globalThis.requestAnimationFrame;
-    else globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-    if (originalCancelAnimationFrame === undefined) delete globalThis.cancelAnimationFrame;
-    else globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-  });
-
-  return container;
-}
 
 function capturePanelTimers(t) {
   const originalSetTimeout = globalThis.setTimeout;

--- a/test/hooks/gpuBannerAvailability.test.js
+++ b/test/hooks/gpuBannerAvailability.test.js
@@ -1,0 +1,127 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const React = require("react");
+const { createRoot } = require("react-dom/client");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+function installHookDom(t) {
+  const originalDocument = globalThis.document;
+  const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  const noop = () => {};
+
+  class Element {}
+  class HTMLElement extends Element {}
+  class HTMLIFrameElement extends HTMLElement {}
+
+  const document = {
+    nodeType: 9,
+    activeElement: null,
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  const container = {
+    nodeType: 1,
+    nodeName: "DIV",
+    tagName: "DIV",
+    namespaceURI: "http://www.w3.org/1999/xhtml",
+    ownerDocument: document,
+    addEventListener: noop,
+    removeEventListener: noop,
+    appendChild: noop,
+    removeChild: noop,
+    insertBefore: noop,
+  };
+  Object.assign(globalThis.window, {
+    Element,
+    HTMLElement,
+    HTMLIFrameElement,
+    document,
+    getSelection: () => null,
+  });
+  document.defaultView = globalThis.window;
+  document.documentElement = container;
+  globalThis.document = document;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+  t.after(() => {
+    if (originalDocument === undefined) delete globalThis.document;
+    else globalThis.document = originalDocument;
+    if (originalActEnvironment === undefined) delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+    else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
+  });
+
+  return container;
+}
+
+test("closing settings refreshes a stale transcription GPU offer", async (t) => {
+  let root = null;
+  t.after(async () => {
+    if (root) await React.act(async () => root.unmount());
+  });
+  let cudaDownloaded = false;
+  let cudaProbeCount = 0;
+  installBrowserGlobals(t, {
+    window: {
+      electronAPI: {
+        async getCudaWhisperStatus() {
+          cudaProbeCount += 1;
+          return {
+            downloaded: cudaDownloaded,
+            gpuInfo: { hasNvidiaGpu: true, cudaSupported: true },
+          };
+        },
+      },
+    },
+  });
+  const container = installHookDom(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-gpu-banner-availability-test-",
+  });
+  const { useGpuBannerAvailability } = await vite.ssrLoadModule(
+    "/hooks/useGpuBannerAvailability.ts"
+  );
+
+  const settings = {
+    useLocalWhisper: true,
+    localTranscriptionProvider: "whisper",
+    useCleanupModel: false,
+    cleanupMode: "openwhispr",
+    useDictationAgent: false,
+    dictationAgentMode: "openwhispr",
+  };
+  let props = {
+    settings,
+    agentAllowedByPolicy: true,
+    dismissed: false,
+    settingsOpen: false,
+    platform: "win32",
+  };
+  let availability;
+  function Harness() {
+    availability = useGpuBannerAvailability(props);
+    return null;
+  }
+
+  root = createRoot(container);
+  const render = async () => {
+    await React.act(async () => {
+      root.render(React.createElement(Harness));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  await render();
+  assert.equal(cudaProbeCount, 1);
+  assert.equal(availability.transcription, true);
+
+  props = { ...props, settingsOpen: true };
+  await render();
+  cudaDownloaded = true;
+  assert.equal(cudaProbeCount, 1, "opening settings should not perform a redundant probe");
+
+  props = { ...props, settingsOpen: false };
+  await render();
+  assert.equal(cudaProbeCount, 2);
+  assert.equal(availability.transcription, false);
+});

--- a/test/hooks/gpuBannerAvailability.test.js
+++ b/test/hooks/gpuBannerAvailability.test.js
@@ -2,56 +2,11 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const React = require("react");
 const { createRoot } = require("react-dom/client");
-const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
-
-function installHookDom(t) {
-  const originalDocument = globalThis.document;
-  const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
-  const noop = () => {};
-
-  class Element {}
-  class HTMLElement extends Element {}
-  class HTMLIFrameElement extends HTMLElement {}
-
-  const document = {
-    nodeType: 9,
-    activeElement: null,
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-  const container = {
-    nodeType: 1,
-    nodeName: "DIV",
-    tagName: "DIV",
-    namespaceURI: "http://www.w3.org/1999/xhtml",
-    ownerDocument: document,
-    addEventListener: noop,
-    removeEventListener: noop,
-    appendChild: noop,
-    removeChild: noop,
-    insertBefore: noop,
-  };
-  Object.assign(globalThis.window, {
-    Element,
-    HTMLElement,
-    HTMLIFrameElement,
-    document,
-    getSelection: () => null,
-  });
-  document.defaultView = globalThis.window;
-  document.documentElement = container;
-  globalThis.document = document;
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-
-  t.after(() => {
-    if (originalDocument === undefined) delete globalThis.document;
-    else globalThis.document = originalDocument;
-    if (originalActEnvironment === undefined) delete globalThis.IS_REACT_ACT_ENVIRONMENT;
-    else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
-  });
-
-  return container;
-}
+const {
+  createRendererServer,
+  installBrowserGlobals,
+  installHookDom,
+} = require("../lib/rendererTestHarness");
 
 test("closing settings refreshes a stale transcription GPU offer", async (t) => {
   let root = null;

--- a/test/lib/rendererTestHarness.js
+++ b/test/lib/rendererTestHarness.js
@@ -35,6 +35,66 @@ function installBrowserGlobals(t, { initialStorage = {}, window: windowProps = {
   return { window: globalThis.window, storage };
 }
 
+// Minimal fake DOM for mounting hook harnesses with react-dom's createRoot:
+// just enough node structure for React to attach a root — no layout, no real
+// events. Call installBrowserGlobals first; this assigns onto globalThis.window.
+function installHookDom(t) {
+  const originalDocument = globalThis.document;
+  const originalActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const noop = () => {};
+
+  class Element {}
+  class HTMLElement extends Element {}
+  class HTMLIFrameElement extends HTMLElement {}
+
+  const document = {
+    nodeType: 9,
+    activeElement: null,
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  const container = {
+    nodeType: 1,
+    nodeName: "DIV",
+    tagName: "DIV",
+    namespaceURI: "http://www.w3.org/1999/xhtml",
+    ownerDocument: document,
+    addEventListener: noop,
+    removeEventListener: noop,
+    appendChild: noop,
+    removeChild: noop,
+    insertBefore: noop,
+  };
+  Object.assign(globalThis.window, {
+    Element,
+    HTMLElement,
+    HTMLIFrameElement,
+    document,
+    getSelection: () => null,
+  });
+  document.defaultView = globalThis.window;
+  document.documentElement = container;
+  globalThis.document = document;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  globalThis.requestAnimationFrame = () => 1;
+  globalThis.cancelAnimationFrame = noop;
+
+  t.after(() => {
+    if (originalDocument === undefined) delete globalThis.document;
+    else globalThis.document = originalDocument;
+    if (originalActEnvironment === undefined) delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+    else globalThis.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment;
+    if (originalRequestAnimationFrame === undefined) delete globalThis.requestAnimationFrame;
+    else globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    if (originalCancelAnimationFrame === undefined) delete globalThis.cancelAnimationFrame;
+    else globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  return container;
+}
+
 // mockModules maps an import-path suffix (e.g. "/utils/logger") to the ESM
 // source served in its place.
 async function createRendererServer(
@@ -76,4 +136,4 @@ async function createRendererServer(
   return vite;
 }
 
-module.exports = { createRendererServer, installBrowserGlobals };
+module.exports = { createRendererServer, installBrowserGlobals, installHookDom };


### PR DESCRIPTION
## Summary

- refresh the home-screen GPU offer after Settings closes
- keep the existing CUDA, Vulkan, and intelligence detection behavior in a focused hook
- add renderer lifecycle coverage for install success followed by closing Settings

Fixes #1778

## Root cause

ControlPanel cached the GPU offer, but its detection effect did not observe the Settings modal state. A successful GPU pack installation only updated local state inside TranscriptionModelPicker, and the main process did not publish a completion event. Closing Settings therefore left the home banner on its previous result until another eligible setting changed or the app restarted.

The fix pauses the home probe while Settings is open and re-runs the existing probe when Settings closes. It does not change GPU installation, persistence, provider selection, or translations.

## Validation

- Node 24.19.0: focused GPU lifecycle and policy tests (11/11 passed)
- Regression mutation check: removing the Settings-close dependency makes the new test fail with one probe instead of two
- TypeScript typecheck
- Full repository ESLint
- Prettier check for changed files
- Renderer production build on Windows

## Full-suite note

The full Windows test run reaches an existing failure in test/helpers/assemblyAiStreaming.test.js because its Electron mock leaves electron.app undefined for debugLogger. The same failure reproduces on an unchanged main worktree at fa11ddc, so this PR does not modify that unrelated area. The real GPU-pack download flow was not repeated; the regression test exercises the renderer lifecycle with mocked Electron status responses.