### PR TITLE
fix(audio): validate settings and finite duration in shouldSaveDiscardedRecording

### DIFF
--- a/src/helpers/discardedRecording.js
+++ b/src/helpers/discardedRecording.js
@@ -8,7 +8,10 @@ import {
 export const MIN_DISCARDED_DURATION_SECONDS = 1;
 
 export function shouldSaveDiscardedRecording(settings, durationSeconds, policyState = null) {
-  if (!settings) return false;
+  if (!settings || typeof settings !== "object") return false;
+  if (!Number.isFinite(durationSeconds) || durationSeconds < MIN_DISCARDED_DURATION_SECONDS) {
+    return false;
+  }
   const dataRetentionEnabled = policyState
     ? effectiveLocalHistoryEnabled(policyState, settings.dataRetentionEnabled)
     : settings.dataRetentionEnabled;
@@ -18,6 +21,5 @@ export function shouldSaveDiscardedRecording(settings, durationSeconds, policySt
   if (!settings.saveDiscardedTranscriptions) return false;
   if (!dataRetentionEnabled) return false;
   if (!(audioRetentionDays > 0)) return false;
-  if (!(durationSeconds >= MIN_DISCARDED_DURATION_SECONDS)) return false;
   return true;
 }

--- a/test/helpers/discardedRecording.test.js
+++ b/test/helpers/discardedRecording.test.js
@@ -15,12 +15,16 @@ test("saves when all gates pass and duration >= threshold", async () => {
   assert.equal(shouldSaveDiscardedRecording(base, MIN_DISCARDED_DURATION_SECONDS), true);
 });
 
-test("does not save below the minimum duration", async () => {
+test("does not save below the minimum duration or with non-finite duration", async () => {
   const { shouldSaveDiscardedRecording } = await load();
   assert.equal(shouldSaveDiscardedRecording(base, 0.5), false);
   assert.equal(shouldSaveDiscardedRecording(base, 0), false);
+  assert.equal(shouldSaveDiscardedRecording(base, -5), false);
   assert.equal(shouldSaveDiscardedRecording(base, null), false);
   assert.equal(shouldSaveDiscardedRecording(base, NaN), false);
+  assert.equal(shouldSaveDiscardedRecording(base, Infinity), false);
+  assert.equal(shouldSaveDiscardedRecording(base, -Infinity), false);
+  assert.equal(shouldSaveDiscardedRecording(base, "10"), false);
 });
 
 test("respects each gate", async () => {
@@ -33,10 +37,12 @@ test("respects each gate", async () => {
   assert.equal(shouldSaveDiscardedRecording({ ...base, audioRetentionDays: 0 }, 3), false);
 });
 
-test("handles missing settings", async () => {
+test("handles missing or non-object settings", async () => {
   const { shouldSaveDiscardedRecording } = await load();
   assert.equal(shouldSaveDiscardedRecording(null, 3), false);
   assert.equal(shouldSaveDiscardedRecording(undefined, 3), false);
+  assert.equal(shouldSaveDiscardedRecording("invalid", 3), false);
+  assert.equal(shouldSaveDiscardedRecording(123, 3), false);
 });
 
 test("uses the policy-effective history setting without changing raw settings", async () => {


### PR DESCRIPTION
Fixes #1805

### Problem
In `src/helpers/discardedRecording.js`:
1. `shouldSaveDiscardedRecording` checked `durationSeconds >= MIN_DISCARDED_DURATION_SECONDS`, which allowed `Infinity` to improperly evaluate to `true`.
2. When `settings` was passed as a non-object primitive, it wasn't validated upfront.

### Solution
- Added `if (!settings || typeof settings !== "object") return false;` upfront.
- Required `Number.isFinite(durationSeconds) && durationSeconds >= MIN_DISCARDED_DURATION_SECONDS`.
- Added unit tests in `test/helpers/discardedRecording.test.js`.

### Verification
- `node --test test/helpers/discardedRecording.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)