### PR TITLE
fix(notifications): normalize source in getNotificationTimeoutMs and sanitize timer duration

### DIFF
--- a/src/helpers/notificationTimer.js
+++ b/src/helpers/notificationTimer.js
@@ -9,7 +9,8 @@ const CALENDAR_TIMEOUT_MS = 2 * 60 * 1000;
 const MIN_RESUME_MS = 5 * 1000;
 
 function getNotificationTimeoutMs(source) {
-  return source === "calendar" ? CALENDAR_TIMEOUT_MS : DETECTION_TIMEOUT_MS;
+  const normSource = typeof source === "string" ? source.trim().toLowerCase() : "";
+  return normSource === "calendar" ? CALENDAR_TIMEOUT_MS : DETECTION_TIMEOUT_MS;
 }
 
 // Auto-dismiss countdown for the meeting notification overlay, pausable while
@@ -24,7 +25,9 @@ class NotificationDismissTimer {
 
   start(durationMs) {
     this.cancel();
-    this._arm(durationMs);
+    const validDuration =
+      Number.isFinite(durationMs) && durationMs > 0 ? durationMs : DETECTION_TIMEOUT_MS;
+    this._arm(validDuration);
   }
 
   pause() {
@@ -55,7 +58,9 @@ class NotificationDismissTimer {
     this._timer = setTimeout(() => {
       this._timer = null;
       this._deadline = null;
-      this._onTimeout();
+      if (typeof this._onTimeout === "function") {
+        this._onTimeout();
+      }
     }, durationMs);
   }
 }

--- a/test/helpers/notificationTimer.test.js
+++ b/test/helpers/notificationTimer.test.js
@@ -111,3 +111,26 @@ test("start replaces a running countdown", (t) => {
   t.mock.timers.tick(1);
   assert.equal(fired, 1);
 });
+
+test("getNotificationTimeoutMs supports case-insensitive and trimmed source names", () => {
+  assert.equal(getNotificationTimeoutMs("Calendar"), 120 * 1000);
+  assert.equal(getNotificationTimeoutMs(" CALENDAR "), 120 * 1000);
+  assert.equal(getNotificationTimeoutMs("detection"), 30 * 1000);
+  assert.equal(getNotificationTimeoutMs(null), 30 * 1000);
+  assert.equal(getNotificationTimeoutMs(undefined), 30 * 1000);
+});
+
+test("NotificationDismissTimer handles invalid duration and missing callback safely", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const noopTimer = new NotificationDismissTimer(null);
+  noopTimer.start(NaN);
+  t.mock.timers.tick(35_000);
+
+  let fired = 0;
+  const timer = new NotificationDismissTimer(() => fired++);
+  timer.start(-100);
+  t.mock.timers.tick(29_999);
+  assert.equal(fired, 0);
+  t.mock.timers.tick(1);
+  assert.equal(fired, 1);
+});


### PR DESCRIPTION
Fixes #1807

### Problem
In `src/helpers/notificationTimer.js`:
1. `getNotificationTimeoutMs(source)` used strict lowercase comparison against `"calendar"`, falling back to 30s detection timeout when `source` was capitalized or padded with whitespace (e.g. `"Calendar"`).
2. `NotificationDismissTimer.prototype.start(durationMs)` did not sanitize `durationMs`, allowing non-finite or non-positive numbers to disrupt timer scheduling.
3. `NotificationDismissTimer` threw a `TypeError` when the timer expired if `this._onTimeout` was missing or not a function.

### Solution
- Normalized `source` with `trim().toLowerCase()`.
- Sanitized `durationMs` to ensure a positive finite number before passing to `_arm`.
- Guarded callback invocation with `typeof this._onTimeout === "function"`.
- Added unit tests in `test/helpers/notificationTimer.test.js`.

### Verification
- `node --test test/helpers/notificationTimer.test.js` (passes, 10/10 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)