### PR TITLE
fix(notes): handle nullish and non-iterable placeholders in isRegenerableNoteTitle

### DIFF
--- a/src/helpers/regenerableNoteTitle.js
+++ b/src/helpers/regenerableNoteTitle.js
@@ -9,7 +9,12 @@ export function isRegenerableNoteTitle(title, placeholders = [], calendarEventNa
   if (trimmed === "") return true;
 
   const set = new Set(BUILTIN_PLACEHOLDERS);
-  for (const p of placeholders) {
+  const placeholderList =
+    Array.isArray(placeholders) ||
+    (placeholders && typeof placeholders[Symbol.iterator] === "function")
+      ? placeholders
+      : [];
+  for (const p of placeholderList) {
     if (typeof p === "string" && p.trim()) set.add(p.trim().toLowerCase());
   }
   if (set.has(trimmed.toLowerCase())) return true;

--- a/test/helpers/regenerableNoteTitle.test.js
+++ b/test/helpers/regenerableNoteTitle.test.js
@@ -36,3 +36,12 @@ test("a manually-typed title is preserved (not regenerable)", async () => {
   // even if a calendar event exists, a title that differs from it is user-set
   assert.equal(isRegenerableNoteTitle("My own title", LABELS, "Weekly Team Sync"), false);
 });
+
+test("handles nullish and non-iterable placeholders safely", async () => {
+  const { isRegenerableNoteTitle } = await load();
+  assert.equal(isRegenerableNoteTitle("My Note", null), false);
+  assert.equal(isRegenerableNoteTitle("My Note", undefined), false);
+  assert.equal(isRegenerableNoteTitle("My Note", {}), false);
+  assert.equal(isRegenerableNoteTitle("My Note", 123), false);
+  assert.equal(isRegenerableNoteTitle("Untitled Note", null), true);
+});


### PR DESCRIPTION
Fixes #1815

### Problem
In `src/helpers/regenerableNoteTitle.js`:
`isRegenerableNoteTitle` defaulted `placeholders = []`, which only triggers when `placeholders === undefined`. If passed `null` or a non-iterable value, iterating with `for (const p of placeholders)` threw `TypeError: placeholders is not iterable`.

### Solution
- Fall back to `[]` if `placeholders` is `null` or not iterable before iterating.
- Added unit tests in `test/helpers/regenerableNoteTitle.test.js`.

### Verification
- `node --test test/helpers/regenerableNoteTitle.test.js` (passes, 6/6 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)