### PR TITLE
fix(dock): handle nullish and missing parameters in resolveDockVisibility

### DIFF
--- a/src/helpers/dockPolicy.js
+++ b/src/helpers/dockPolicy.js
@@ -10,7 +10,8 @@
 
 // Whether the Dock icon should be visible right now.
 // Returns null off macOS, where there is no Dock to act on.
-export function resolveDockVisibility({ platform, controlPanelVisible }) {
+export function resolveDockVisibility(params = {}) {
+  const { platform, controlPanelVisible } = params || {};
   if (platform !== "darwin") return null;
   return !!controlPanelVisible;
 }

--- a/test/helpers/dockPolicy.test.js
+++ b/test/helpers/dockPolicy.test.js
@@ -27,3 +27,12 @@ test("there is no Dock to act on outside macOS", async () => {
     assert.equal(resolveDockVisibility({ platform, controlPanelVisible: true }), null);
   }
 });
+
+test("handles nullish and missing parameter safely", async () => {
+  const { resolveDockVisibility } = await load();
+
+  assert.equal(resolveDockVisibility(), null);
+  assert.equal(resolveDockVisibility(null), null);
+  assert.equal(resolveDockVisibility(undefined), null);
+  assert.equal(resolveDockVisibility({}), null);
+});


### PR DESCRIPTION
Fixes #1817

### Problem
In `src/helpers/dockPolicy.js`:
`resolveDockVisibility({ platform, controlPanelVisible })` threw `TypeError: Cannot destructure property 'platform' of 'undefined' / 'null'` when called without arguments or when passed `null`/`undefined`.

### Solution
- Defaulted parameters with `params || {}` before destructuring.
- Added unit tests in `test/helpers/dockPolicy.test.js`.

### Verification
- `node --test test/helpers/dockPolicy.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)