### PR TITLE
fix(macos): resolve paste/copy key codes for non-QWERTY layouts

### DIFF
--- a/resources/macos-fast-paste.swift
+++ b/resources/macos-fast-paste.swift
@@ -1,14 +1,54 @@
 import Cocoa
+import Carbon
 
 if !AXIsProcessTrusted() {
     exit(2)
+}
+
+// Look up which key code produces a given character in the current keyboard
+// layout. Hardcoded key codes (0x09 for 'v', 0x08 for 'c') are only correct on
+// QWERTY, so Cmd+V / Cmd+C land on the wrong key on Dvorak, Colemak, etc.
+func keyCodeForCharacter(_ target: UniChar) -> CGKeyCode? {
+    guard let sourceRef = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+          let layoutDataRef = TISGetInputSourceProperty(sourceRef, kTISPropertyUnicodeKeyLayoutData) else {
+        return nil
+    }
+    let layoutData = unsafeBitCast(layoutDataRef, to: CFData.self)
+    let keyLayout = unsafeBitCast(CFDataGetBytePtr(layoutData), to: UnsafePointer<UCKeyboardLayout>.self)
+
+    for keyCode: UInt16 in 0..<128 {
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+
+        let status = UCKeyTranslate(
+            keyLayout,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            0,
+            UInt32(LMGetKbdType()),
+            UInt32(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            4,
+            &length,
+            &chars
+        )
+
+        if status == noErr && length > 0 && chars[0] == target {
+            return CGKeyCode(keyCode)
+        }
+    }
+    return nil
 }
 
 // Selection capture sends ⌘C and reports which app received it, so the caller
 // can tell a copied selection from a target that changed underneath it. With no
 // arguments this stays what the paste path expects: ⌘V, no output.
 let copyMode = CommandLine.arguments.contains("--copy")
-let virtualKey: CGKeyCode = copyMode ? 0x08 : 0x09  // kVK_ANSI_C : kVK_ANSI_V
+// 0x0063 = 'c', 0x0076 = 'v'. Fall back to the QWERTY key code for the same
+// mode if the layout lookup fails, never to the other mode's key.
+let virtualKey: CGKeyCode = keyCodeForCharacter(copyMode ? 0x0063 : 0x0076)
+    ?? (copyMode ? 0x08 : 0x09)  // kVK_ANSI_C : kVK_ANSI_V
 
 // Resolved before the keystroke is posted: this is the app that will receive it.
 let target = copyMode ? NSWorkspace.shared.frontmostApplication : nil


### PR DESCRIPTION
## Problem

`resources/macos-fast-paste.swift` hardcodes the virtual key codes it posts: `0x09` for `v` and `0x08` for `c`. Those values are positions on a QWERTY layout, not characters. On Dvorak, Colemak, and similar layouts they land on different keys, so the synthesized `⌘V` and `⌘C` are not paste and copy.

Both paths are affected:

- Auto-paste after dictation silently does nothing (or triggers whatever shortcut happens to live on that key).
- `--copy` selection capture returns `COPY_OK` because the frontmost app resolved fine, but the clipboard was never populated — so the caller believes it captured a selection that it did not.

On a Dvorak layout, `v` is at key code 47 and `c` is at key code 34.

## Fix

Look the key code up in the active keyboard layout with `UCKeyTranslate` instead of hardcoding it. `keyCodeForCharacter(_:)` walks key codes 0–127 through the current `TISCopyCurrentKeyboardLayoutInputSource()` layout and returns the one that produces the requested character.

If the lookup fails, it falls back to the QWERTY key code **for the same mode** — `0x08` in copy mode, `0x09` in paste mode. Keeping the fallback mode-aligned matters: falling back to a single constant would let a failed lookup in copy mode post `⌘V`, overwriting the user's selection instead of copying it.

No behaviour change on QWERTY: the lookup returns the same values that were previously hardcoded.

## Notes

- Adds `import Carbon` for the Text Input Services and `UCKeyTranslate` APIs.
- The `--copy` stdout contract (`COPY_OK <pid> <name>`), exit codes, and the ordering of the `AXIsProcessTrusted()` check and frontmost-app resolution are all unchanged.
- Self-contained in the one file — no build-script or caller changes.

## Testing

- `swiftc` compiles clean.
- On a non-QWERTY (Dvorak) layout, the lookup resolves `v` to key code 47 and `c` to key code 34, confirming the resolution path runs rather than silently falling back.
- Verified end to end in a local packaged build on macOS 15 (arm64): dictation auto-paste inserts text, and selection capture populates the clipboard so in-place selection edits work.