### PR TITLE
fix(paste): skip trailing space after CJK text in append smart spacing

### DIFF
--- a/src/helpers/smartSpacing.js
+++ b/src/helpers/smartSpacing.js
@@ -21,8 +21,17 @@ function applyPrepend(text, precedingChar) {
   return " " + text;
 }
 
+// Unspaced scripts (Han, kana) and CJK punctuation (Symbols and Punctuation,
+// Fullwidth/Halfwidth Forms, Vertical Forms, Compatibility Forms): a trailing
+// ASCII space after "你好" or "です。" violates East Asian typography and
+// accumulates as "你好 世界" gaps across consecutive dictations. Hangul is
+// excluded on purpose — Korean separates words with spaces.
+const ENDS_WITH_CJK =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\u3000-\u303f\uff00-\uff65\ufe10-\ufe1f\ufe30-\ufe4f]$/u;
+
 function applyAppend(text) {
   if (/\s$/.test(text)) return text;
+  if (ENDS_WITH_CJK.test(text)) return text;
   return text + " ";
 }
 

--- a/test/helpers/smartSpacing.test.js
+++ b/test/helpers/smartSpacing.test.js
@@ -98,6 +98,39 @@ test("append: handles empty transcript", () => {
   assert.equal(append(""), "");
 });
 
+test("append: no trailing space after CJK ideographs", () => {
+  assert.equal(append("你好"), "你好");
+  assert.equal(append("日本語"), "日本語");
+});
+
+test("append: no trailing space after kana", () => {
+  assert.equal(append("こんにちは"), "こんにちは");
+  assert.equal(append("カタカナ"), "カタカナ");
+});
+
+test("append: no trailing space after full-width punctuation", () => {
+  assert.equal(append("你好。"), "你好。");
+  assert.equal(append("すごい！"), "すごい！");
+  assert.equal(append("何？"), "何？");
+  assert.equal(append("はい、"), "はい、");
+  assert.equal(append("「引用」"), "「引用」");
+  assert.equal(append("（括弧）"), "（括弧）");
+});
+
+test("append: no trailing space after halfwidth CJK punctuation and vertical forms", () => {
+  assert.equal(append("ﾃｽﾄ｡"), "ﾃｽﾄ｡");
+  assert.equal(append("你好︒"), "你好︒");
+});
+
+test("append: last character decides for mixed-script text", () => {
+  assert.equal(append("hello 你好"), "hello 你好");
+  assert.equal(append("你好 hello"), "你好 hello ");
+});
+
+test("append: keeps trailing space after Hangul (Korean uses word spacing)", () => {
+  assert.equal(append("안녕하세요"), "안녕하세요 ");
+});
+
 test("returns text unchanged for unknown mode", () => {
   assert.equal(applySmartSpacing({ text: "hello", mode: "noop" }), "hello");
 });


### PR DESCRIPTION
## Summary

Append-mode smart spacing — the only path used in production (the paste hot path in `ipcHandlers.js`; prepend is intentionally skipped there) — unconditionally appended an ASCII space after every dictation. CJK output pasted as `你好 ` and consecutive dictations accumulated `你好 世界` gaps, violating East Asian typography.

`applyAppend` now skips the trailing space when the text ends with Han, kana, or CJK punctuation (CJK Symbols and Punctuation, Fullwidth/Halfwidth Forms, Vertical Forms, Compatibility Forms). Script properties (`\p{Script=Han}` etc.) cover astral-plane ideographs too.

**Hangul deliberately keeps the trailing space**: modern Korean separates words with ASCII spaces, so suppressing it would break Korean dictation the same way this bug breaks Chinese. A test pins that choice.

Context: #1788 attempted this fix but only touched `applyPrepend`, which is dead code in production — it was closed unmerged.

## Changes

- `src/helpers/smartSpacing.js`: new `ENDS_WITH_CJK` regex; `applyAppend` returns the text unchanged when it matches
- `test/helpers/smartSpacing.test.js`: 6 new cases — ideographs, kana, full-width punctuation, halfwidth/vertical forms, mixed-script last-char rule, Hangul keeps its space

## Testing

- `node --test test/helpers/smartSpacing.test.js`: 26 pass / 0 fail (Node 24)
- `prettier --check` clean on both files

## Follow-up (not in this PR)

`applyPrepend` still has no CJK awareness. It is unused in production today, but needs the mirror-image treatment if prepend mode is ever revived.