### PR TITLE
fix(updater): handle null and non-object prefs in appUpdatesEnabled

### DIFF
--- a/src/helpers/updateCheckPolicy.js
+++ b/src/helpers/updateCheckPolicy.js
@@ -3,7 +3,9 @@
 // firewalled machines never surface a connection error dialog (#1605).
 // Only an explicit false disables — missing prefs (renderer sync not arrived
 // yet) keep check-by-default behavior.
-function appUpdatesEnabled({ notificationsEnabled, notifyUpdates } = {}) {
+function appUpdatesEnabled(prefs = {}) {
+  const { notificationsEnabled, notifyUpdates } =
+    prefs && typeof prefs === "object" ? prefs : {};
   return notificationsEnabled !== false && notifyUpdates !== false;
 }
 

--- a/test/helpers/updateCheckPolicy.test.js
+++ b/test/helpers/updateCheckPolicy.test.js
@@ -25,6 +25,9 @@ test("checks stay enabled by default before renderer prefs arrive", async () => 
   // Same tri-state convention as the other notification prefs: only an
   // explicit false disables; missing prefs keep check-by-default behavior.
   assert.equal(appUpdatesEnabled(undefined), true);
+  assert.equal(appUpdatesEnabled(null), true);
   assert.equal(appUpdatesEnabled({}), true);
+  assert.equal(appUpdatesEnabled("invalid"), true);
+  assert.equal(appUpdatesEnabled(123), true);
   assert.equal(appUpdatesEnabled({ notificationsEnabled: true, notifyUpdates: true }), true);
 });


### PR DESCRIPTION
Fixes #1827

### Problem
In `src/helpers/updateCheckPolicy.js`:
`appUpdatesEnabled({ notificationsEnabled, notifyUpdates } = {})` threw `TypeError: Cannot destructure property 'notificationsEnabled' of 'null' as it is null` when passed `null`.

### Solution
- Defaulted parameters safely to handle `null` and non-object values before destructuring.
- Added unit tests in `test/helpers/updateCheckPolicy.test.js`.

### Verification
- `node --test test/helpers/updateCheckPolicy.test.js` (passes, 3/3 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)