### PR TITLE
fix(transcription): handle nullish params and normalize cloudTranscriptionMode in resolveStreamingFallbackTarget

### DIFF
--- a/src/helpers/transcriptionFallback.js
+++ b/src/helpers/transcriptionFallback.js
@@ -1,11 +1,10 @@
 // Where a streaming session's batch fallback goes. "skip" keeps a signed-out
 // cloud user's audio from being diverted to a leftover BYOK provider.
-export function resolveStreamingFallbackTarget({
-  useLocalWhisper,
-  cloudTranscriptionMode,
-  isSignedIn,
-}) {
-  const isCloudMode = !useLocalWhisper && cloudTranscriptionMode === "openwhispr";
+export function resolveStreamingFallbackTarget(params = {}) {
+  const { useLocalWhisper, cloudTranscriptionMode, isSignedIn } = params || {};
+  const normMode =
+    typeof cloudTranscriptionMode === "string" ? cloudTranscriptionMode.trim().toLowerCase() : "";
+  const isCloudMode = !useLocalWhisper && normMode === "openwhispr";
   if (isCloudMode) return isSignedIn ? "cloud" : "skip";
   return "byok";
 }

--- a/test/helpers/transcriptionFallback.test.js
+++ b/test/helpers/transcriptionFallback.test.js
@@ -38,3 +38,26 @@ test("BYOK mode falls back to the user's own provider", async () => {
     "byok"
   );
 });
+
+test("handles nullish parameters and case-insensitive cloudTranscriptionMode", async () => {
+  const { resolveStreamingFallbackTarget } = await load();
+  assert.equal(resolveStreamingFallbackTarget(), "byok");
+  assert.equal(resolveStreamingFallbackTarget(null), "byok");
+  assert.equal(resolveStreamingFallbackTarget(undefined), "byok");
+  assert.equal(
+    resolveStreamingFallbackTarget({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: "OpenWhispr",
+      isSignedIn: true,
+    }),
+    "cloud"
+  );
+  assert.equal(
+    resolveStreamingFallbackTarget({
+      useLocalWhisper: false,
+      cloudTranscriptionMode: " OPENWHISPR ",
+      isSignedIn: false,
+    }),
+    "skip"
+  );
+});


### PR DESCRIPTION
Fixes #1829

### Problem
In `src/helpers/transcriptionFallback.js`:
1. `resolveStreamingFallbackTarget` threw `TypeError: Cannot destructure property 'useLocalWhisper' of 'undefined' / 'null'` when called without arguments or passed `null`/`undefined`.
2. `cloudTranscriptionMode === "openwhispr"` did not normalize casing or whitespace, treating `"OpenWhispr"` as non-cloud and returning `"byok"`.

### Solution
- Defaulted parameters with `params || {}` before destructuring.
- Normalized `cloudTranscriptionMode` with `trim().toLowerCase()`.
- Added unit tests in `test/helpers/transcriptionFallback.test.js`.

### Verification
- `node --test test/helpers/transcriptionFallback.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)