### PR TITLE
fix(onboarding): normalize demo and input kinds in isOnboardingInputAllowed

### DIFF
--- a/src/helpers/onboardingInputPolicy.js
+++ b/src/helpers/onboardingInputPolicy.js
@@ -2,7 +2,9 @@ const ONBOARDING_DEMO_KINDS = new Set(["dictation", "assistant"]);
 
 function isOnboardingInputAllowed(onboardingActive, demoKind, inputKind) {
   if (!onboardingActive) return true;
-  return ONBOARDING_DEMO_KINDS.has(demoKind) && demoKind === inputKind;
+  const normDemo = typeof demoKind === "string" ? demoKind.trim().toLowerCase() : "";
+  const normInput = typeof inputKind === "string" ? inputKind.trim().toLowerCase() : "";
+  return ONBOARDING_DEMO_KINDS.has(normDemo) && normDemo === normInput;
 }
 
 module.exports = { ONBOARDING_DEMO_KINDS, isOnboardingInputAllowed };

--- a/test/helpers/onboardingInputPolicy.test.js
+++ b/test/helpers/onboardingInputPolicy.test.js
@@ -27,3 +27,11 @@ test("unknown demo kinds fail closed while onboarding is active", () => {
   assert.equal(isOnboardingInputAllowed(true, "unknown", "dictation"), false);
   assert.equal(isOnboardingInputAllowed(true, undefined, "assistant"), false);
 });
+
+test("supports case-insensitive and trimmed demo and input kinds", () => {
+  assert.equal(isOnboardingInputAllowed(true, "Dictation", "dictation"), true);
+  assert.equal(isOnboardingInputAllowed(true, " DICTATION ", "dictation"), true);
+  assert.equal(isOnboardingInputAllowed(true, "Assistant", " assistant "), true);
+  assert.equal(isOnboardingInputAllowed(true, "ASSISTANT", "assistant"), true);
+  assert.equal(isOnboardingInputAllowed(true, " Dictation ", "assistant"), false);
+});


### PR DESCRIPTION
Fixes #1831

### Problem
In `src/helpers/onboardingInputPolicy.js`:
`isOnboardingInputAllowed` used strict case-sensitive checks against `ONBOARDING_DEMO_KINDS`, returning `false` during onboarding demos if `demoKind` or `inputKind` had mixed casing or whitespace (e.g. `"Dictation"`, `"Assistant"`).

### Solution
- Normalized `demoKind` and `inputKind` with `trim().toLowerCase()`.
- Added unit tests in `test/helpers/onboardingInputPolicy.test.js`.

### Verification
- `node --test test/helpers/onboardingInputPolicy.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)