### PR TITLE
fix(speaker-count): validate primitive type in normalizeStoredSpeakerCount

### DIFF
--- a/src/helpers/speakerCount.js
+++ b/src/helpers/speakerCount.js
@@ -4,6 +4,7 @@ const { MAX_SPEAKER_COUNT } = require("../constants/speakerDetection.json");
 // 1 is meaningless. Cloud sync persists whatever the server sends, so invalid
 // values arrive as data rather than as programmer error and must degrade to null.
 function normalizeStoredSpeakerCount(value) {
+  if (typeof value !== "number" && typeof value !== "string") return null;
   const count = Number(value);
   if (!Number.isInteger(count) || count < 1) return null;
   return Math.min(count, MAX_SPEAKER_COUNT);

--- a/test/helpers/speakerCount.test.js
+++ b/test/helpers/speakerCount.test.js
@@ -7,6 +7,7 @@ const { MAX_SPEAKER_COUNT } = require("../../src/constants/speakerDetection.json
 test("keeps a usable stored count", () => {
   assert.equal(normalizeStoredSpeakerCount(1), 1);
   assert.equal(normalizeStoredSpeakerCount(3), 3);
+  assert.equal(normalizeStoredSpeakerCount("3"), 3);
   assert.equal(normalizeStoredSpeakerCount(MAX_SPEAKER_COUNT), MAX_SPEAKER_COUNT);
 });
 
@@ -15,7 +16,22 @@ test("clamps above the supported maximum", () => {
 });
 
 test("rejects values the cloud can persist but the app cannot use", () => {
-  for (const value of [0, -1, 1.5, NaN, Infinity, -Infinity, null, undefined, "", {}]) {
+  for (const value of [
+    0,
+    -1,
+    1.5,
+    NaN,
+    Infinity,
+    -Infinity,
+    null,
+    undefined,
+    "",
+    {},
+    true,
+    false,
+    [],
+    ["2"],
+  ]) {
     assert.equal(
       normalizeStoredSpeakerCount(value),
       null,


### PR DESCRIPTION
Fixes #1833

### Problem
In `src/helpers/speakerCount.js`:
`normalizeStoredSpeakerCount` converted inputs directly with `Number(value)`, causing boolean `true` to evaluate to `1` and array `["2"]` to evaluate to `2` instead of rejecting non-numeric types as `null`.

### Solution
- Restricted `normalizeStoredSpeakerCount` to only numbers and strings (`typeof value === "number" || typeof value === "string"`) before numeric conversion.
- Added unit tests in `test/helpers/speakerCount.test.js`.

### Verification
- `node --test test/helpers/speakerCount.test.js` (passes, 3/3 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)