### PR TITLE
fix(chat): handle nullish messages and malformed elements in conversationChunker

### DIFF
--- a/src/helpers/conversationChunker.js
+++ b/src/helpers/conversationChunker.js
@@ -2,7 +2,10 @@ const CHUNK_SIZE = 5;
 const CHUNK_OVERLAP = 2;
 
 function chunkConversation(title, messages) {
-  const relevant = messages.filter((m) => m.role !== "system");
+  const messageList = Array.isArray(messages) ? messages : [];
+  const relevant = messageList.filter(
+    (m) => m && typeof m === "object" && m.role !== "system"
+  );
   if (relevant.length === 0) return [];
 
   if (relevant.length <= CHUNK_SIZE) {
@@ -19,8 +22,17 @@ function chunkConversation(title, messages) {
 }
 
 function formatChunkText(title, messages) {
-  const body = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
-  return `${title}\n${body}`.slice(0, 1500);
+  const safeTitle = typeof title === "string" ? title.trim() : "";
+  const messageList = Array.isArray(messages) ? messages : [];
+  const body = messageList
+    .map((m) => {
+      const role = typeof m?.role === "string" ? m.role : "user";
+      const content = typeof m?.content === "string" ? m.content : "";
+      return `${role}: ${content}`;
+    })
+    .join("\n");
+  const header = safeTitle ? `${safeTitle}\n` : "";
+  return `${header}${body}`.slice(0, 1500);
 }
 
 module.exports = { chunkConversation };

--- a/test/helpers/conversationChunker.test.js
+++ b/test/helpers/conversationChunker.test.js
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { chunkConversation } = require("../../src/helpers/conversationChunker");
+
+test("returns empty array for empty or missing messages", () => {
+  assert.deepEqual(chunkConversation("Title", []), []);
+  assert.deepEqual(chunkConversation("Title", null), []);
+  assert.deepEqual(chunkConversation("Title", undefined), []);
+  assert.deepEqual(chunkConversation("Title", "not an array"), []);
+});
+
+test("filters out system messages and formats chunks", () => {
+  const messages = [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "Hello" },
+    { role: "assistant", content: "Hi there!" },
+  ];
+
+  const chunks = chunkConversation("General Chat", messages);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].chunkIndex, 0);
+  assert.equal(chunks[0].text, "General Chat\nuser: Hello\nassistant: Hi there!");
+});
+
+test("splits large conversations with overlap", () => {
+  const messages = [];
+  for (let i = 0; i < 10; i++) {
+    messages.push({ role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i}` });
+  }
+
+  const chunks = chunkConversation("Long Chat", messages);
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks[0].chunkIndex, 0);
+  assert.equal(chunks[1].chunkIndex, 1);
+});
+
+test("handles nullish title and malformed message elements safely", () => {
+  const messages = [
+    null,
+    { role: "user", content: "Valid message" },
+    { content: "Missing role" },
+    { role: "assistant" },
+  ];
+
+  const chunks = chunkConversation(null, messages);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].text, "user: Valid message\nuser: Missing role\nassistant: ");
+});


### PR DESCRIPTION
Fixes #1837

### Problem
In `src/helpers/conversationChunker.js`:
1. `chunkConversation` called `messages.filter(...)` without ensuring `messages` was an array, throwing `TypeError: Cannot read properties of null (reading 'filter')` when called with `null` or `undefined`.
2. `formatChunkText` emitted `"null\n..."` if `title` was nullish and `"undefined: undefined"` if message items were missing role/content properties.

### Solution
- Array-coerced and filtered nullish/non-object message items in `chunkConversation`.
- Safely sanitized `title` and formatted messages with safe defaults in `formatChunkText`.
- Added complete test suite in `test/helpers/conversationChunker.test.js`.

### Verification
- `node --test test/helpers/conversationChunker.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)