### PR TITLE
fix(audio): guard evaluateFinishedRecording against null and non-object parameters

### DIFF
--- a/src/helpers/recordingValidation.js
+++ b/src/helpers/recordingValidation.js
@@ -3,7 +3,9 @@ import { isEmptyRecording } from "./recordingGuard.js";
 // Decide whether a finished MediaRecorder session carries real audio before we
 // hand it to the transcription backend. A fast tap can flush only the container
 // header, or deliver no chunks at all, which crashes FFmpeg. See issue #871.
-export function evaluateFinishedRecording({ blobSize, receivedAudioData } = {}) {
+export function evaluateFinishedRecording(params = {}) {
+  const { blobSize, receivedAudioData } =
+    params && typeof params === "object" ? params : {};
   if (!receivedAudioData) {
     return { usable: false, reason: "no-audio-data" };
   }

--- a/test/helpers/recordingValidation.test.js
+++ b/test/helpers/recordingValidation.test.js
@@ -43,10 +43,14 @@ test("rejects 255 bytes (just under the threshold)", async () => {
   });
 });
 
-test("treats missing / undefined args as unusable (defensive, does not throw)", async () => {
+test("treats missing / undefined / null args as unusable (defensive, does not throw)", async () => {
   const { evaluateFinishedRecording } = await load();
   assert.deepEqual(evaluateFinishedRecording(), { usable: false, reason: "no-audio-data" });
+  assert.deepEqual(evaluateFinishedRecording(null), { usable: false, reason: "no-audio-data" });
+  assert.deepEqual(evaluateFinishedRecording(undefined), { usable: false, reason: "no-audio-data" });
   assert.deepEqual(evaluateFinishedRecording({}), { usable: false, reason: "no-audio-data" });
+  assert.deepEqual(evaluateFinishedRecording("invalid"), { usable: false, reason: "no-audio-data" });
+  assert.deepEqual(evaluateFinishedRecording(123), { usable: false, reason: "no-audio-data" });
   assert.deepEqual(evaluateFinishedRecording({ receivedAudioData: true }), {
     usable: false,
     reason: "empty-container",


### PR DESCRIPTION
Fixes #1839

### Problem
In `src/helpers/recordingValidation.js`:
`evaluateFinishedRecording({ blobSize, receivedAudioData } = {})` threw `TypeError: Cannot destructure property 'blobSize' of 'null' as it is null` when passed `null`.

### Solution
- Handled `null` and non-object parameters safely using `params && typeof params === "object" ? params : {}`.
- Added unit tests in `test/helpers/recordingValidation.test.js`.

### Verification
- `node --test test/helpers/recordingValidation.test.js` (passes, 10/10 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)