### PR TITLE
fix(stores): Survive imports under partial browser window stubs

### DIFF
--- a/src/stores/enterpriseIdentityStore.ts
+++ b/src/stores/enterpriseIdentityStore.ts
@@ -34,6 +34,7 @@ interface EnterpriseIdentityState {
 let requestSequence = 0;
 let inFlightKey: string | null = null;
 let inFlightPromise: Promise<void> | null = null;
+let lifecycleListenersReady = false;
 
 export const useEnterpriseIdentityStore = create<EnterpriseIdentityState>((set, get) => ({
   accountId: null,
@@ -45,6 +46,7 @@ export const useEnterpriseIdentityStore = create<EnterpriseIdentityState>((set, 
   failClosed: false,
 
   refresh: (accountId, workspaceId, authGeneration, forceRefresh = false) => {
+    ensureLifecycleListeners();
     const key = `${accountId}:${workspaceId}:${authGeneration}:${forceRefresh ? "force" : "normal"}`;
     if (inFlightKey === key && inFlightPromise) return inFlightPromise;
     const sequence = ++requestSequence;
@@ -146,7 +148,13 @@ function refreshCurrentManagedIdentity(): void {
   void state.refresh(state.accountId, state.workspaceId, state.authGeneration, true);
 }
 
-if (typeof window !== "undefined") {
+// Bound on first refresh() rather than at module load: the listeners no-op
+// until an identity is resolved, and test harnesses import this store with
+// partial window stubs that lack setInterval (same pattern as
+// ensurePolicyLifecycleListeners in policyStore).
+function ensureLifecycleListeners(): void {
+  if (lifecycleListenersReady || typeof window === "undefined") return;
+  lifecycleListenersReady = true;
   window.addEventListener("focus", refreshCurrentManagedIdentity);
   window.setInterval(refreshCurrentManagedIdentity, 5 * 60 * 1000);
   window.electronAPI?.onManagedEnterpriseConfigChanged?.((snapshot) => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -54,7 +54,10 @@ import { getManagedScopeResolution } from "./enterpriseIdentityStore";
 
 let _ReasoningService: typeof import("../services/ReasoningService").default | null = null;
 
-const isBrowser = typeof window !== "undefined";
+// Requires localStorage as well as window: the module-scope migrations below
+// dereference the bare localStorage global, and test harnesses import this
+// store with partial window stubs that don't define it.
+const isBrowser = typeof window !== "undefined" && typeof localStorage !== "undefined";
 
 export const TRANSCRIPTION_POLICY_PROVIDER_IDS = [
   ...modelRegistryData.transcriptionProviders.map((provider) => provider.id),

--- a/test/stores/enterpriseIdentityStoreImports.test.js
+++ b/test/stores/enterpriseIdentityStoreImports.test.js
@@ -1,0 +1,41 @@
+// Test harnesses install partial browser stubs (see
+// test/helpers/harness/browserGlobals.js): a `window` with addEventListener but
+// no setInterval and no electronAPI, and not every environment defines a bare
+// `localStorage` global. Stores must survive being imported into such an
+// environment — module-scope wiring that assumes a full browser window broke CI
+// on 2026-08-25 when policyRules briefly pulled enterpriseIdentityStore into the
+// import graph of harness-based tests ("window.setInterval is not a function").
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Deliberately partial: no setInterval, no dispatchEvent, no electronAPI, and
+// localStorage exists only as a window property, never as a bare global.
+const windowStub = {
+  addEventListener() {},
+  removeEventListener() {},
+  localStorage: {
+    getItem: () => null,
+    setItem() {},
+    removeItem() {},
+  },
+  location: { origin: "https://harness.openwhispr.test" },
+};
+
+Object.defineProperty(globalThis, "window", {
+  value: windowStub,
+  configurable: true,
+  writable: true,
+});
+
+test("enterpriseIdentityStore imports under a partial window stub", async () => {
+  const store = await import("../../src/stores/enterpriseIdentityStore.ts");
+  assert.equal(typeof store.useEnterpriseIdentityStore.getState, "function");
+  assert.equal(store.useEnterpriseIdentityStore.getState().status, "idle");
+});
+
+test("settingsStore imports without a bare localStorage global", async () => {
+  assert.equal(typeof localStorage, "undefined");
+  const store = await import("../../src/stores/settingsStore.ts");
+  assert.equal(typeof store.useSettingsStore.getState, "function");
+});


### PR DESCRIPTION
## Problem

`enterpriseIdentityStore.ts` ran side effects at module scope, guarded only by `typeof window !== "undefined"`: it registered a `focus` listener, a 5-minute `window.setInterval` refresh, and the `onManagedEnterpriseConfigChanged` IPC subscription at import time.

Test harnesses install **partial** window stubs (`test/helpers/harness/browserGlobals.js` provides `addEventListener` but no `setInterval` and no `electronAPI`), so any harness-based test whose import graph reached the store crashed at import with:

```
TypeError: window.setInterval is not a function
```

This actually broke CI on 2026-08-25 when `policyRules.ts` briefly gained a transitive import of the store (worked around at the time by cutting the import in df2ef27c). This PR fixes the store itself so the next accidental import can't take CI down.

`settingsStore.ts` had the sibling hazard: its nine module-scope migrations dereference the bare `localStorage` global behind the same window-only `isBrowser` guard, so an environment with `window` but no `localStorage` global threw `ReferenceError: localStorage is not defined` at import.

## Changes

- **`enterpriseIdentityStore.ts`** — moved the focus/interval/IPC wiring out of module scope into `ensureLifecycleListeners()`, bound lazily on the first `refresh()` call. This mirrors the existing `ensurePolicyLifecycleListeners()` pattern in `policyStore.ts`. Behavior is unchanged: all three listeners no-op until an identity is resolved, and only `refresh()` ever resolves one.
- **`settingsStore.ts`** — `isBrowser` now requires `typeof localStorage !== "undefined"` in addition to `window`. No renderer behavior change (both always exist there); partial environments fall back to defaults instead of throwing.
- **`test/stores/enterpriseIdentityStoreImports.test.js`** — new regression test that imports both stores under a deliberately partial window stub (no `setInterval`, no `electronAPI`, `localStorage` only as a window property, never a bare global).

## Verification

Test-first: both regression tests were written before the fixes and observed failing with the exact production failure modes —

- `enterpriseIdentityStore` import: `TypeError: window.setInterval is not a function` (the CI error)
- `settingsStore` import (after the first fix landed): `ReferenceError: localStorage is not defined` in `migrateMicrophoneSelectionMode`

After the fixes, on Node 24:

- [x] New regression test passes (2/2)
- [x] Full suite: **2981 tests, 0 failures** (176 skips are the known local DB-ABI skips, 1 todo)
- [x] `npm run typecheck` clean
- [x] ESLint and Prettier clean on all touched files
- [x] Existing store consumers unaffected: `managedEnterpriseRouting.test.js` and `dictationTranslationInference.test.js` seed state via `setState` and never call `refresh()`, so they don't depend on the wiring

## Out of scope

`src/i18n.ts` has the same class of hazard (`window.localStorage.getItem` at module scope behind a window-only check). It survives the current harness stub, so it's being hardened separately rather than expanding this diff.
