### PR TITLE
fix(i18n): guard localStorage deref against partial window stubs

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -94,7 +94,7 @@ const browserLanguage =
   typeof navigator !== "undefined" ? navigator.language || navigator.languages?.[0] : undefined;
 
 const storageLanguage =
-  typeof window !== "undefined" ? window.localStorage.getItem("uiLanguage") : undefined;
+  typeof window !== "undefined" ? window.localStorage?.getItem("uiLanguage") : undefined;
 
 const initialLanguage = normalizeUiLanguage(storageLanguage || browserLanguage || "en");
 

--- a/test/locales/i18nImports.test.js
+++ b/test/locales/i18nImports.test.js
@@ -1,0 +1,15 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+test("i18n still loads under a window stub that lacks localStorage", async (t) => {
+  installBrowserGlobals(t, { window: { localStorage: undefined } });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-i18n-import-test-",
+  });
+
+  const mod = await vite.ssrLoadModule("/i18n.ts");
+
+  assert.equal(typeof mod.normalizeUiLanguage, "function");
+  assert.ok(mod.SUPPORTED_UI_LANGUAGES.includes(mod.default.language));
+});


### PR DESCRIPTION
## Problem

`src/i18n.ts` read `window.localStorage.getItem("uiLanguage")` at module scope, guarded only by `typeof window !== "undefined"`. A test harness that defines a `window` global **without** a `localStorage` property crashes at import time with `TypeError: Cannot read properties of undefined (reading 'getItem')` — and since `settingsStore` imports `i18n.ts`, the affected import graph is wide. Same partial-stub hazard class as the recent renderer-store guards.

## Fix

Optional-chain the deref so a missing `localStorage` falls through to the browser-language/`en` fallback instead of throwing:

```ts
typeof window !== "undefined" ? window.localStorage?.getItem("uiLanguage") : undefined
```

## Test

New regression test `test/locales/i18nImports.test.js` loads `/i18n.ts` through the Vite SSR renderer harness under a window stub with `localStorage: undefined` and asserts the module still resolves a supported UI language. Written first and confirmed to fail with the exact TypeError before the fix; passes after.

Full suite under Node 24: 2980 tests, 2803 pass, 0 fail, 176 skipped (known local Electron-ABI DB skips).