### PR TITLE
fix(calendar): support pre-parsed conference_data and guard primitives in getMeetingJoinUrl

### DIFF
--- a/src/helpers/meetingJoinUrl.js
+++ b/src/helpers/meetingJoinUrl.js
@@ -37,14 +37,19 @@ function isMeetingUrl(value) {
 }
 
 export function getMeetingJoinUrl(event) {
-  if (!event) return null;
-  const hangoutLink = event.hangout_link?.trim();
+  if (!event || typeof event !== "object") return null;
+  const hangoutLink =
+    typeof event.hangout_link === "string" ? event.hangout_link.trim() : "";
   if (hangoutLink) return hangoutLink;
   if (!event.conference_data) return null;
   try {
-    const data = JSON.parse(event.conference_data);
-    const uri = data?.entryPoints
-      ?.find((ep) => ep.entryPointType === "video" && ep.uri?.trim())
+    const data =
+      typeof event.conference_data === "string"
+        ? JSON.parse(event.conference_data)
+        : event.conference_data;
+    const entryPoints = Array.isArray(data?.entryPoints) ? data.entryPoints : [];
+    const uri = entryPoints
+      .find((ep) => ep?.entryPointType === "video" && typeof ep?.uri === "string" && ep.uri.trim())
       ?.uri?.trim();
     return uri || null;
   } catch {

--- a/test/helpers/meetingJoinUrl.test.js
+++ b/test/helpers/meetingJoinUrl.test.js
@@ -165,3 +165,17 @@ test("getMeetingJoinUrl trims hangout_link and skips whitespace-only links", asy
   };
   assert.equal(getMeetingJoinUrl(eventWithWhitespaceOnly), "https://zoom.us/j/123");
 });
+
+test("getMeetingJoinUrl handles pre-parsed conference_data objects and primitive events", async () => {
+  const { getMeetingJoinUrl } = await load();
+
+  const eventWithObjectData = {
+    conference_data: {
+      entryPoints: [{ entryPointType: "video", uri: "https://zoom.us/j/123" }],
+    },
+  };
+  assert.equal(getMeetingJoinUrl(eventWithObjectData), "https://zoom.us/j/123");
+  assert.equal(getMeetingJoinUrl("not an object"), null);
+  assert.equal(getMeetingJoinUrl(123), null);
+  assert.equal(getMeetingJoinUrl(true), null);
+});


### PR DESCRIPTION
Fixes #1846

### Problem
In `src/helpers/meetingJoinUrl.js`:
1. `getMeetingJoinUrl` assumed `event.conference_data` was always a serialized JSON string. If passed an already-parsed object, `JSON.parse` failed with a SyntaxError on `"[object Object]"` and caught to `null`.
2. Primitive non-object `event` inputs were not guarded before property access.

### Solution
- Supported both JSON-serialized strings and parsed objects for `conference_data`.
- Validated that `event` is an object and guarded entry points array handling.
- Added unit tests in `test/helpers/meetingJoinUrl.test.js`.

### Verification
- `node --test test/helpers/meetingJoinUrl.test.js` (passes, 14/14 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)