### PR TITLE
fix(settings): guard getLlmRequestTimeoutSeconds against null and non-object parameters

### DIFF
--- a/src/helpers/llmRequestTimeout.js
+++ b/src/helpers/llmRequestTimeout.js
@@ -1,6 +1,7 @@
 const LLM_REQUEST_TIMEOUT_SECONDS = 30;
 const LLM_STREAMING_TIMEOUT_SECONDS = 60;
 
-export function getLlmRequestTimeoutSeconds({ streaming = false } = {}) {
+export function getLlmRequestTimeoutSeconds(params = {}) {
+  const { streaming = false } = params && typeof params === "object" ? params : {};
   return streaming ? LLM_STREAMING_TIMEOUT_SECONDS : LLM_REQUEST_TIMEOUT_SECONDS;
 }

--- a/test/helpers/llmRequestTimeout.test.js
+++ b/test/helpers/llmRequestTimeout.test.js
@@ -16,3 +16,12 @@ test("streaming LLM requests keep their fixed 60-second timeout", async () => {
   assert.equal(typeof getLlmRequestTimeoutSeconds, "function");
   assert.equal(getLlmRequestTimeoutSeconds({ streaming: true }), 60);
 });
+
+test("handles nullish and invalid parameters safely", async () => {
+  const { getLlmRequestTimeoutSeconds } = await load();
+
+  assert.equal(getLlmRequestTimeoutSeconds(null), 30);
+  assert.equal(getLlmRequestTimeoutSeconds(undefined), 30);
+  assert.equal(getLlmRequestTimeoutSeconds("invalid"), 30);
+  assert.equal(getLlmRequestTimeoutSeconds(123), 30);
+});


### PR DESCRIPTION
Fixes #1848

### Problem
In `src/helpers/llmRequestTimeout.js`:
`getLlmRequestTimeoutSeconds({ streaming = false } = {})` threw `TypeError: Cannot destructure property 'streaming' of 'null' as it is null` when passed `null`.

### Solution
- Guarded destructuring with `params && typeof params === "object" ? params : {}`.
- Added unit tests in `test/helpers/llmRequestTimeout.test.js`.

### Verification
- `node --test test/helpers/llmRequestTimeout.test.js` (passes, 3/3 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)