### PR TITLE
fix(transcription): handle nullish inputs safely in cloudChunkPolicy helpers

### DIFF
--- a/src/helpers/cloudChunkPolicy.js
+++ b/src/helpers/cloudChunkPolicy.js
@@ -53,6 +53,7 @@ const FATAL_CHUNK_CODES = new Set(["AUTH_EXPIRED", "LIMIT_REACHED"]);
 const NON_RETRYABLE_CHUNK_CODES = new Set([...FATAL_CHUNK_CODES, "NO_SPEECH_DETECTED"]);
 
 function isTransientChunkError(err) {
+  if (!err || typeof err !== "object") return true;
   if (NON_RETRYABLE_CHUNK_CODES.has(err.code)) return false;
   return !err.statusCode || err.statusCode >= 500;
 }
@@ -62,7 +63,7 @@ function isTransientChunkError(err) {
 // before the next attempt. Errors carrying a statusCode or a business code
 // prove the connection works.
 function isNetworkLevelFailure(err, { timedOut = false } = {}) {
-  return timedOut || (!err.statusCode && !err.code);
+  return timedOut || (!err?.statusCode && !err?.code);
 }
 
 // Fatal TLS alerts and HTTP/2/QUIC protocol errors poison every stream on the
@@ -99,7 +100,12 @@ function summarizeChunkResults(results) {
   let failedChunks = 0;
   let silentChunks = 0;
 
-  for (const result of results) {
+  const list =
+    Array.isArray(results) || (results && typeof results[Symbol.iterator] === "function")
+      ? results
+      : [];
+
+  for (const result of list) {
     if (result == null) {
       failedChunks++;
     } else if (result === SILENT_CHUNK) {
@@ -119,6 +125,7 @@ function summarizeChunkResults(results) {
 // marker is read by users and pasted by dictation, so it is localized like the
 // [Speaker N] labels in transcriptFormatter.
 function assembleChunkTranscript(results, segmentDurationSeconds, totalDurationSeconds) {
+  if (!Array.isArray(results)) return "";
   const pieces = [];
   for (let i = 0; i < results.length; i++) {
     if (results[i] === SILENT_CHUNK) continue;

--- a/test/helpers/cloudChunkPolicy.test.js
+++ b/test/helpers/cloudChunkPolicy.test.js
@@ -331,3 +331,22 @@ test("double-release does not mint extra capacity", async () => {
   r1();
   (await second)();
 });
+
+test("cloudChunkPolicy helpers handle nullish inputs safely", () => {
+  assert.equal(isTransientChunkError(null), true);
+  assert.equal(isTransientChunkError(undefined), true);
+  assert.equal(isNetworkLevelFailure(null), true);
+  assert.equal(isNetworkLevelFailure(undefined), true);
+  assert.deepEqual(summarizeChunkResults(null), {
+    responses: [],
+    failedChunks: 0,
+    silentChunks: 0,
+  });
+  assert.deepEqual(summarizeChunkResults(undefined), {
+    responses: [],
+    failedChunks: 0,
+    silentChunks: 0,
+  });
+  assert.equal(assembleChunkTranscript(null, 10, 100), "");
+  assert.equal(assembleChunkTranscript(undefined, 10, 100), "");
+});


### PR DESCRIPTION
Fixes #1850

### Problem
In `src/helpers/cloudChunkPolicy.js`:
1. `isTransientChunkError` and `isNetworkLevelFailure` threw `TypeError` when called with `null` or `undefined`.
2. `summarizeChunkResults` threw `TypeError: results is not iterable` on `null`.
3. `assembleChunkTranscript` threw `TypeError: Cannot read properties of null (reading 'length')` on `null`.

### Solution
- Added defensive null/type guards to `isTransientChunkError`, `isNetworkLevelFailure`, `summarizeChunkResults`, and `assembleChunkTranscript`.
- Added unit tests in `test/helpers/cloudChunkPolicy.test.js`.

### Verification
- `node --test test/helpers/cloudChunkPolicy.test.js` (passes, 30/30 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)