### PR TITLE
fix(audio): default now to current timestamp and validate finite numbers in isMicWarm

### DIFF
--- a/src/helpers/micWarmState.js
+++ b/src/helpers/micWarmState.js
@@ -9,8 +9,19 @@ export const WARMUP_ACQUIRE_TIMEOUT_MS = 15000;
 
 // True only when the mic was warmed within the TTL. A negative elapsed (clock
 // jumped backwards) returns false so we err on the side of re-warming.
-export const isMicWarm = (lastWarmedAt, now, ttlMs = MIC_WARM_TTL_MS) => {
-  if (typeof lastWarmedAt !== "number" || lastWarmedAt <= 0) return false;
-  const elapsed = now - lastWarmedAt;
-  return elapsed >= 0 && elapsed < ttlMs;
+export const isMicWarm = (lastWarmedAt, now = Date.now(), ttlMs = MIC_WARM_TTL_MS) => {
+  if (typeof lastWarmedAt !== "number" || !Number.isFinite(lastWarmedAt) || lastWarmedAt <= 0) {
+    return false;
+  }
+  const currentNow =
+    typeof now === "number" && Number.isFinite(now)
+      ? now
+      : now === undefined
+        ? Date.now()
+        : NaN;
+  const currentTtl =
+    typeof ttlMs === "number" && Number.isFinite(ttlMs) ? ttlMs : (ttlMs === undefined ? MIC_WARM_TTL_MS : NaN);
+  if (!Number.isFinite(currentNow) || !Number.isFinite(currentTtl)) return false;
+  const elapsed = currentNow - lastWarmedAt;
+  return elapsed >= 0 && elapsed < currentTtl;
 };

--- a/test/helpers/micWarmState.test.js
+++ b/test/helpers/micWarmState.test.js
@@ -54,3 +54,13 @@ test("honors a custom ttlMs argument", () => {
   assert.equal(isMicWarm(1000, 2000, 1000), false);
   assert.equal(isMicWarm(1000, 2001, 1000), false);
 });
+
+test("defaults now to current timestamp and handles non-finite inputs", () => {
+  const now = Date.now();
+  assert.equal(isMicWarm(now), true);
+  assert.equal(isMicWarm(now - 1000), true);
+  assert.equal(isMicWarm(now - 10000), false);
+  assert.equal(isMicWarm(1000, NaN), false);
+  assert.equal(isMicWarm(1000, Infinity), false);
+  assert.equal(isMicWarm(1000, 2000, NaN), false);
+});


### PR DESCRIPTION
Fixes #1852

### Problem
In `src/helpers/micWarmState.js`:
When `isMicWarm(lastWarmedAt)` was called without providing the `now` parameter, `now` was `undefined`, producing `NaN` for elapsed calculation and always returning `false` regardless of when the microphone was warmed.

### Solution
- Defaulted `now` to `Date.now()`.
- Validated that timestamps and TTL values are finite numbers.
- Added unit tests in `test/helpers/micWarmState.test.js`.

### Verification
- `node --test test/helpers/micWarmState.test.js` (passes, 11/11 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)