### PR TITLE
fix(auth): check existing emails before sign-up

### DIFF
--- a/src/components/AuthenticationStep.tsx
+++ b/src/components/AuthenticationStep.tsx
@@ -236,9 +236,9 @@ export default function AuthenticationStep({
       const data = await discoverEmailAuth(email, AUTH_URL);
       if (data.sso?.available) {
         const discovery = {
-          required: data.sso.required === true,
+          required: data.sso.required,
           domain: data.sso.domain || email.trim().split("@")[1] || "your organization",
-          exists: data.exists === true,
+          exists: data.exists,
         };
         setSsoDiscovery(discovery);
         if (discovery.required) await startSSOSignIn(email);

--- a/src/components/AuthenticationStep.tsx
+++ b/src/components/AuthenticationStep.tsx
@@ -9,7 +9,7 @@ import {
   updateLastSignInTime,
   type SocialProvider,
 } from "../lib/auth";
-import { OPENWHISPR_API_URL } from "../config/constants";
+import { discoverEmailAuth } from "../lib/emailAuthDiscovery";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { AlertCircle, ArrowRight, Building2, Check, Loader2, ChevronLeft } from "lucide-react";
@@ -32,6 +32,11 @@ type SsoDiscovery = {
   domain: string;
   exists: boolean;
 };
+
+const EXISTING_ACCOUNT_ERROR_CODES = new Set([
+  "USER_ALREADY_EXISTS",
+  "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL",
+]);
 
 function ProviderTile({
   label,
@@ -228,25 +233,7 @@ export default function AuthenticationStep({
     setError(null);
 
     try {
-      if (!OPENWHISPR_API_URL) {
-        setAuthMode("sign-up");
-        return;
-      }
-
-      const response = await fetch(`${OPENWHISPR_API_URL}/api/check-user`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: email.trim() }),
-      });
-
-      if (!response.ok) {
-        throw new Error(t("auth.errors.failedUserCheck"));
-      }
-
-      const data = (await response.json().catch(() => ({}))) as {
-        exists?: boolean;
-        sso?: { available?: boolean; required?: boolean; domain?: string };
-      };
+      const data = await discoverEmailAuth(email, AUTH_URL);
       if (data.sso?.available) {
         const discovery = {
           required: data.sso.required === true,
@@ -298,6 +285,7 @@ export default function AuthenticationStep({
           if (result.error) {
             needsVerificationRef.current = false;
             if (
+              EXISTING_ACCOUNT_ERROR_CODES.has(result.error.code || "") ||
               errorMessageIncludes(result.error.message, ["already exists", "already registered"])
             ) {
               setAuthMode("sign-in");

--- a/src/components/AuthenticationStep.tsx
+++ b/src/components/AuthenticationStep.tsx
@@ -234,6 +234,12 @@ export default function AuthenticationStep({
 
     try {
       const data = await discoverEmailAuth(email, AUTH_URL);
+      if (!data) {
+        // No discovery endpoint on this auth server — default to sign-up; an
+        // existing email is still caught by the duplicate check at sign-up.
+        setAuthMode("sign-up");
+        return;
+      }
       if (data.sso?.available) {
         const discovery = {
           required: data.sso.required,

--- a/src/lib/emailAuthDiscovery.ts
+++ b/src/lib/emailAuthDiscovery.ts
@@ -14,32 +14,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseEmailAuthDiscovery(value: unknown): EmailAuthDiscovery {
+  // Only `exists` is load-bearing (it routes between sign-in and sign-up), so
+  // only it is validated strictly. The sso block is advisory: a missing or
+  // malformed one falls back to the plain email flow instead of blocking auth.
   if (!isRecord(value) || typeof value.exists !== "boolean") {
     throw new Error(INVALID_DISCOVERY_RESPONSE);
   }
 
-  if (value.sso === undefined) {
+  const sso = value.sso;
+  if (!isRecord(sso) || sso.available !== true) {
     return { exists: value.exists };
   }
-
-  const sso = value.sso;
-  if (
-    !isRecord(sso) ||
-    typeof sso.available !== "boolean" ||
-    typeof sso.required !== "boolean" ||
-    (sso.domain !== undefined && typeof sso.domain !== "string")
-  ) {
-    throw new Error(INVALID_DISCOVERY_RESPONSE);
-  }
-
-  const domain = typeof sso.domain === "string" ? sso.domain : undefined;
 
   return {
     exists: value.exists,
     sso: {
-      available: sso.available,
-      required: sso.required,
-      ...(domain === undefined ? {} : { domain }),
+      available: true,
+      required: sso.required === true,
+      ...(typeof sso.domain === "string" ? { domain: sso.domain } : {}),
     },
   };
 }
@@ -47,12 +39,18 @@ function parseEmailAuthDiscovery(value: unknown): EmailAuthDiscovery {
 export async function discoverEmailAuth(
   email: string,
   authUrl: string
-): Promise<EmailAuthDiscovery> {
+): Promise<EmailAuthDiscovery | null> {
   const response = await fetch(`${authUrl}/api/check-user`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: email.trim() }),
   });
+
+  // A self-hosted auth server may not implement /api/check-user; report that
+  // as "discovery unavailable" so the caller can fall back instead of erroring.
+  if (response.status === 404) {
+    return null;
+  }
 
   if (!response.ok) {
     throw new Error(`Email account discovery failed with status ${response.status}`);

--- a/src/lib/emailAuthDiscovery.ts
+++ b/src/lib/emailAuthDiscovery.ts
@@ -48,7 +48,7 @@ export async function discoverEmailAuth(
   email: string,
   authUrl: string
 ): Promise<EmailAuthDiscovery> {
-  const response = await fetch(new URL("/api/check-user", authUrl), {
+  const response = await fetch(`${authUrl}/api/check-user`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: email.trim() }),

--- a/src/lib/emailAuthDiscovery.ts
+++ b/src/lib/emailAuthDiscovery.ts
@@ -1,0 +1,69 @@
+export interface EmailAuthDiscovery {
+  exists: boolean;
+  sso?: {
+    available: boolean;
+    required: boolean;
+    domain?: string;
+  };
+}
+
+const INVALID_DISCOVERY_RESPONSE = "Email account discovery returned an invalid response";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseEmailAuthDiscovery(value: unknown): EmailAuthDiscovery {
+  if (!isRecord(value) || typeof value.exists !== "boolean") {
+    throw new Error(INVALID_DISCOVERY_RESPONSE);
+  }
+
+  if (value.sso === undefined) {
+    return { exists: value.exists };
+  }
+
+  const sso = value.sso;
+  if (
+    !isRecord(sso) ||
+    typeof sso.available !== "boolean" ||
+    typeof sso.required !== "boolean" ||
+    (sso.domain !== undefined && typeof sso.domain !== "string")
+  ) {
+    throw new Error(INVALID_DISCOVERY_RESPONSE);
+  }
+
+  const domain = typeof sso.domain === "string" ? sso.domain : undefined;
+
+  return {
+    exists: value.exists,
+    sso: {
+      available: sso.available,
+      required: sso.required,
+      ...(domain === undefined ? {} : { domain }),
+    },
+  };
+}
+
+export async function discoverEmailAuth(
+  email: string,
+  authUrl: string
+): Promise<EmailAuthDiscovery> {
+  const response = await fetch(new URL("/api/check-user", authUrl), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: email.trim() }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Email account discovery failed with status ${response.status}`);
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error(INVALID_DISCOVERY_RESPONSE);
+  }
+
+  return parseEmailAuthDiscovery(data);
+}

--- a/test/components/authenticationStep.test.js
+++ b/test/components/authenticationStep.test.js
@@ -1,0 +1,195 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+const AUTH_MODE_INDEX = 0;
+const EMAIL_INDEX = 1;
+const PASSWORD_INDEX = 2;
+const FULL_NAME_INDEX = 3;
+const SSO_DISCOVERY_INDEX = 8;
+const ERROR_INDEX = 9;
+
+function createHarness(values = {}) {
+  return {
+    cursor: 0,
+    refCursor: 0,
+    values,
+    refs: {},
+    discoveryCalls: [],
+    discoveryResult: { exists: false },
+    discoveryError: null,
+    signupResult: {},
+  };
+}
+
+function findElement(node, predicate) {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElement(child, predicate);
+      if (match) return match;
+    }
+    return null;
+  }
+  if (!node || typeof node !== "object") return null;
+  if (predicate(node)) return node;
+  return findElement(node.props?.children, predicate);
+}
+
+async function settleAsyncHandler() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("email authentication discovers accounts before choosing sign-in or sign-up", async (t) => {
+  installBrowserGlobals(t, { window: { electronAPI: {} } });
+  t.after(() => {
+    delete globalThis.__authenticationStepHarness;
+  });
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-authentication-step-",
+    noExternal: ["react", "react-i18next", "lucide-react"],
+    mockModules: {
+      react: `
+        export default {};
+        export function useState(initialValue) {
+          const harness = globalThis.__authenticationStepHarness;
+          const index = harness.cursor++;
+          if (!(index in harness.values)) {
+            harness.values[index] = typeof initialValue === "function" ? initialValue() : initialValue;
+          }
+          return [harness.values[index], (nextValue) => {
+            harness.values[index] = typeof nextValue === "function"
+              ? nextValue(harness.values[index])
+              : nextValue;
+          }];
+        }
+        export function useCallback(callback) { return callback; }
+        export function useEffect() {}
+        export function useRef(initialValue) {
+          const harness = globalThis.__authenticationStepHarness;
+          const index = harness.refCursor++;
+          if (!(index in harness.refs)) harness.refs[index] = { current: initialValue };
+          return harness.refs[index];
+        }
+      `,
+      "/jsx-dev-runtime": `
+        export const Fragment = Symbol.for("react.fragment");
+        export function jsxDEV(type, props, key) { return { type, props, key }; }
+      `,
+      "react-i18next": `
+        export function useTranslation() {
+          return { t(key) { return key; } };
+        }
+      `,
+      "/hooks/useAuth": `
+        export function useAuth() {
+          return { isLoaded: true, isSignedIn: false, user: null };
+        }
+      `,
+      "/lib/auth": `
+        export const AUTH_URL = "https://auth.example.test";
+        export const authClient = {
+          signUp: {
+            async email(payload) {
+              const harness = globalThis.__authenticationStepHarness;
+              harness.signupPayload = payload;
+              return harness.signupResult;
+            },
+          },
+          signIn: { async email() { return {}; } },
+        };
+        export async function signInWithSocial() { return {}; }
+        export async function signInWithSSO() { return {}; }
+        export function updateLastSignInTime() {}
+      `,
+      "/lib/emailAuthDiscovery": `
+        export async function discoverEmailAuth(email, authUrl) {
+          const harness = globalThis.__authenticationStepHarness;
+          harness.discoveryCalls.push({ email, authUrl });
+          if (harness.discoveryError) throw harness.discoveryError;
+          return harness.discoveryResult;
+        }
+      `,
+      "/utils/logger": `export default { error() {} };`,
+      "/utils/platform": `export function getCachedPlatform() { return "linux"; }`,
+      "/ForgotPasswordView": `export default function ForgotPasswordView() { return null; }`,
+      "/OnboardingShell": `
+        export function CompactOnboardingFrame(props) { return props.children; }
+      `,
+      "/ui/button": `export function Button() { return null; }`,
+      "/ui/input": `export function Input() { return null; }`,
+      "lucide-react": `
+        const Icon = () => null;
+        export { Icon as AlertCircle, Icon as ArrowRight, Icon as Building2, Icon as Check,
+          Icon as Loader2, Icon as ChevronLeft };
+      `,
+    },
+  });
+  const { default: AuthenticationStep } = await vite.ssrLoadModule(
+    "/components/AuthenticationStep.tsx"
+  );
+  const props = { onAuthComplete() {}, onNeedsVerification() {} };
+
+  const render = (harness) => {
+    globalThis.__authenticationStepHarness = harness;
+    harness.cursor = 0;
+    harness.refCursor = 0;
+    return AuthenticationStep(props);
+  };
+  const submitEmail = async (harness) => {
+    const form = findElement(render(harness), (node) => node.type === "form");
+    assert.ok(form, "email form should render");
+    form.props.onSubmit({ preventDefault() {} });
+    await settleAsyncHandler();
+  };
+
+  const existingAccount = createHarness({ [EMAIL_INDEX]: "returning@example.com" });
+  existingAccount.discoveryResult = { exists: true };
+  await submitEmail(existingAccount);
+  assert.equal(existingAccount.values[AUTH_MODE_INDEX], "sign-in");
+  assert.deepEqual(existingAccount.discoveryCalls, [
+    { email: "returning@example.com", authUrl: "https://auth.example.test" },
+  ]);
+
+  const newAccount = createHarness({ [EMAIL_INDEX]: "new@example.com" });
+  await submitEmail(newAccount);
+  assert.equal(newAccount.values[AUTH_MODE_INDEX], "sign-up");
+
+  const unavailableDiscovery = createHarness({ [EMAIL_INDEX]: "user@example.com" });
+  unavailableDiscovery.discoveryError = new Error("offline");
+  await submitEmail(unavailableDiscovery);
+  assert.equal(unavailableDiscovery.values[AUTH_MODE_INDEX], null);
+  assert.equal(unavailableDiscovery.values[ERROR_INDEX], "auth.errors.failedUserCheck");
+
+  const ssoAccount = createHarness({ [EMAIL_INDEX]: "user@example.com" });
+  ssoAccount.discoveryResult = {
+    exists: true,
+    sso: { available: true, required: false, domain: "example.com" },
+  };
+  await submitEmail(ssoAccount);
+  assert.equal(ssoAccount.values[AUTH_MODE_INDEX], null);
+  assert.deepEqual(ssoAccount.values[SSO_DISCOVERY_INDEX], {
+    exists: true,
+    required: false,
+    domain: "example.com",
+  });
+
+  const duplicateRace = createHarness({
+    [AUTH_MODE_INDEX]: "sign-up",
+    [EMAIL_INDEX]: "returning@example.com",
+    [PASSWORD_INDEX]: "password123",
+    [FULL_NAME_INDEX]: "Returning User",
+  });
+  duplicateRace.signupResult = {
+    error: {
+      code: "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL",
+      message: "A localized duplicate-account response",
+    },
+  };
+  const signupForm = findElement(render(duplicateRace), (node) => node.type === "form");
+  assert.ok(signupForm, "sign-up form should render");
+  await signupForm.props.onSubmit({ preventDefault() {} });
+  assert.equal(duplicateRace.values[AUTH_MODE_INDEX], "sign-in");
+  assert.equal(duplicateRace.values[PASSWORD_INDEX], "");
+  assert.equal(duplicateRace.values[ERROR_INDEX], "auth.errors.accountExistsSignIn");
+});

--- a/test/components/authenticationStep.test.js
+++ b/test/components/authenticationStep.test.js
@@ -155,6 +155,12 @@ test("email authentication discovers accounts before choosing sign-in or sign-up
   await submitEmail(newAccount);
   assert.equal(newAccount.values[AUTH_MODE_INDEX], "sign-up");
 
+  const missingEndpoint = createHarness({ [EMAIL_INDEX]: "user@selfhosted.example" });
+  missingEndpoint.discoveryResult = null;
+  await submitEmail(missingEndpoint);
+  assert.equal(missingEndpoint.values[AUTH_MODE_INDEX], "sign-up");
+  assert.equal(missingEndpoint.values[ERROR_INDEX], null);
+
   const unavailableDiscovery = createHarness({ [EMAIL_INDEX]: "user@example.com" });
   unavailableDiscovery.discoveryError = new Error("offline");
   await submitEmail(unavailableDiscovery);

--- a/test/lib/emailAuthDiscovery.test.js
+++ b/test/lib/emailAuthDiscovery.test.js
@@ -11,7 +11,7 @@ function installFetch(t, implementation) {
   });
 }
 
-test("email discovery uses the auth origin and preserves SSO routing", async (t) => {
+test("email discovery preserves the auth base URL and SSO routing", async (t) => {
   let request;
   installFetch(t, async (input, init) => {
     request = { input, init };
@@ -28,7 +28,7 @@ test("email discovery uses the auth origin and preserves SSO routing", async (t)
     "https://auth.example.test/custom/path"
   );
 
-  assert.equal(String(request.input), "https://auth.example.test/api/check-user");
+  assert.equal(String(request.input), "https://auth.example.test/custom/path/api/check-user");
   assert.equal(request.init.method, "POST");
   assert.deepEqual(JSON.parse(request.init.body), { email: "returning@example.com" });
   assert.deepEqual(result, {

--- a/test/lib/emailAuthDiscovery.test.js
+++ b/test/lib/emailAuthDiscovery.test.js
@@ -58,9 +58,10 @@ test("email discovery treats the sso block as advisory", async (t) => {
     [{ exists: false, sso: { available: false } }, { exists: false }],
     [{ exists: true, sso: null }, { exists: true }],
   ];
-  installFetch(t, async () => new Response(JSON.stringify(lenientCases[0][0])));
-  for (const [payload, expected] of lenientCases) {
-    global.fetch = async () => new Response(JSON.stringify(payload));
+  let payload;
+  installFetch(t, async () => new Response(JSON.stringify(payload)));
+  for (const [response, expected] of lenientCases) {
+    payload = response;
     assert.deepEqual(
       await discoverEmailAuth("user@example.com", "https://auth.example.test"),
       expected

--- a/test/lib/emailAuthDiscovery.test.js
+++ b/test/lib/emailAuthDiscovery.test.js
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { discoverEmailAuth } = require("../../src/lib/emailAuthDiscovery.ts");
+
+function installFetch(t, implementation) {
+  const previousFetch = global.fetch;
+  global.fetch = implementation;
+  t.after(() => {
+    global.fetch = previousFetch;
+  });
+}
+
+test("email discovery uses the auth origin and preserves SSO routing", async (t) => {
+  let request;
+  installFetch(t, async (input, init) => {
+    request = { input, init };
+    return new Response(
+      JSON.stringify({
+        exists: true,
+        sso: { available: true, required: false, domain: "example.com" },
+      })
+    );
+  });
+
+  const result = await discoverEmailAuth(
+    "  returning@example.com  ",
+    "https://auth.example.test/custom/path"
+  );
+
+  assert.equal(String(request.input), "https://auth.example.test/api/check-user");
+  assert.equal(request.init.method, "POST");
+  assert.deepEqual(JSON.parse(request.init.body), { email: "returning@example.com" });
+  assert.deepEqual(result, {
+    exists: true,
+    sso: { available: true, required: false, domain: "example.com" },
+  });
+});
+
+test("email discovery accepts the legacy response without SSO metadata", async (t) => {
+  installFetch(t, async () => new Response(JSON.stringify({ exists: false })));
+
+  assert.deepEqual(await discoverEmailAuth("new@example.com", "https://auth.example.test"), {
+    exists: false,
+  });
+});
+
+test("email discovery rejects failed and malformed responses", async (t) => {
+  installFetch(t, async () => new Response("service unavailable", { status: 503 }));
+  await assert.rejects(discoverEmailAuth("user@example.com", "https://auth.example.test"), {
+    message: "Email account discovery failed with status 503",
+  });
+
+  const invalidPayloads = [
+    {},
+    { exists: "yes" },
+    { exists: true, sso: null },
+    { exists: true, sso: { available: true, required: "no" } },
+  ];
+  for (const payload of invalidPayloads) {
+    global.fetch = async () => new Response(JSON.stringify(payload));
+    await assert.rejects(discoverEmailAuth("user@example.com", "https://auth.example.test"), {
+      message: "Email account discovery returned an invalid response",
+    });
+  }
+
+  global.fetch = async () => new Response("not json");
+  await assert.rejects(discoverEmailAuth("user@example.com", "https://auth.example.test"), {
+    message: "Email account discovery returned an invalid response",
+  });
+});

--- a/test/lib/emailAuthDiscovery.test.js
+++ b/test/lib/emailAuthDiscovery.test.js
@@ -45,18 +45,42 @@ test("email discovery accepts the legacy response without SSO metadata", async (
   });
 });
 
+test("email discovery treats the sso block as advisory", async (t) => {
+  const lenientCases = [
+    [
+      { exists: true, sso: { available: true } },
+      { exists: true, sso: { available: true, required: false } },
+    ],
+    [
+      { exists: true, sso: { available: true, required: "no", domain: 42 } },
+      { exists: true, sso: { available: true, required: false } },
+    ],
+    [{ exists: false, sso: { available: false } }, { exists: false }],
+    [{ exists: true, sso: null }, { exists: true }],
+  ];
+  installFetch(t, async () => new Response(JSON.stringify(lenientCases[0][0])));
+  for (const [payload, expected] of lenientCases) {
+    global.fetch = async () => new Response(JSON.stringify(payload));
+    assert.deepEqual(
+      await discoverEmailAuth("user@example.com", "https://auth.example.test"),
+      expected
+    );
+  }
+});
+
+test("email discovery reports a missing endpoint as unavailable", async (t) => {
+  installFetch(t, async () => new Response("not found", { status: 404 }));
+
+  assert.equal(await discoverEmailAuth("user@example.com", "https://auth.example.test"), null);
+});
+
 test("email discovery rejects failed and malformed responses", async (t) => {
   installFetch(t, async () => new Response("service unavailable", { status: 503 }));
   await assert.rejects(discoverEmailAuth("user@example.com", "https://auth.example.test"), {
     message: "Email account discovery failed with status 503",
   });
 
-  const invalidPayloads = [
-    {},
-    { exists: "yes" },
-    { exists: true, sso: null },
-    { exists: true, sso: { available: true, required: "no" } },
-  ];
+  const invalidPayloads = [{}, { exists: "yes" }];
   for (const payload of invalidPayloads) {
     global.fetch = async () => new Response(JSON.stringify(payload));
     await assert.rejects(discoverEmailAuth("user@example.com", "https://auth.example.test"), {


### PR DESCRIPTION
## Summary

- route email account discovery through the configured auth service instead of the optional cloud API
- validate discovery responses and keep users on the email step when discovery fails or is malformed
- preserve SSO discovery and handle duplicate-account sign-up races using Better Auth error codes
- add request-level and component-level regression coverage for existing, new, SSO, failure, and duplicate-race flows

## Testing

- `npm test` — 3,030 tests, 0 failures
- `npm run quality-check`
- `npm run build:renderer`
- exercised `discoverEmailAuth` against `https://auth.openwhispr.com/api/check-user` with a non-existent `.invalid` probe address
- launched the Electron development app with `npm run dev`
