### PR TITLE
feat(calendar): widen the availability horizon from 7 to 31 days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,9 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
 - **googleCalendarManager.js**: Google Calendar sync (REST, OAuth via `googleCalendarOAuth.js`)
   - 10s socket timeout on API requests
   - Incremental sync via `syncToken`; full re-sync on 410 prunes stale events (note-linked rows retained)
-  - Sync tokens pin the `timeMin`/`timeMax` window of the full sync that created them (incremental syncs never roll it forward), so tokens are discarded after 1 day to keep the 9-day lookahead covering the availability tool's 7-day horizon
+  - Sync tokens pin the `timeMin`/`timeMax` window of the full sync that created them (incremental syncs never roll it forward), so tokens are discarded after 1 day to keep the 33-day lookahead covering the availability tool's 31-day horizon
 - **microsoftCalendarManager.js**: Microsoft Calendar sync via Graph API (OAuth via `microsoftCalendarOAuth.js`)
-  - `calendarView/delta` incremental sync over a 14-day window; delta token discarded after 7 days (Graph delta links never roll their window forward)
+  - `calendarView/delta` incremental sync over a 38-day window; delta token discarded after 7 days (Graph delta links never roll their window forward)
   - Delta can return recurring-series occurrences as bare stubs (no subject/attendees/meeting link); they're backfilled from their series master, one `GET /me/calendars/{calendarId}/events/{id}` per series (calendar-scoped: `/me/events/{id}` 404s for shared calendars). A failed backfill shortens the delta token TTL to 10 min so an early full sync retries instead of leaving untitled blocks
   - Full re-sync (410 or expired token) prunes stale events like Google
 - **appleCalendarManager.js**: Apple Calendar (EventKit) via the `macos-calendar-listener` Swift helper — macOS only, snapshot-push over stdout, no tokens ("connected" = `apple_calendars` has rows)

--- a/resources/macos-calendar-listener.swift
+++ b/resources/macos-calendar-listener.swift
@@ -23,8 +23,8 @@ import Foundation
 
 let eventStore = EKEventStore()
 let requestAccess = CommandLine.arguments.contains("--request")
-// One extra day keeps the tool's 7-day horizon covered between snapshots.
-let CACHE_LOOKAHEAD_DAYS = 8.0
+// One extra day keeps the tool's 31-day horizon covered between snapshots.
+let CACHE_LOOKAHEAD_DAYS = 32.0
 let REFRESH_INTERVAL_SECONDS = 300.0
 // Keep events that may still block availability after the maximum two-hour
 // buffer, plus one snapshot interval of safety.

--- a/src/helpers/calendarAvailability.js
+++ b/src/helpers/calendarAvailability.js
@@ -2,7 +2,7 @@
 // Vite only handles ESM source files; main-process CJS callers load it via
 // Node's require(esm) with module-syntax detection.
 const MINUTE_MS = 60 * 1000;
-export const MAX_AVAILABILITY_HORIZON_DAYS = 7;
+export const MAX_AVAILABILITY_HORIZON_DAYS = 31;
 export const PAST_START_TOLERANCE_MS = 5 * MINUTE_MS;
 export const DEFAULT_MINIMUM_SLOT_MINUTES = 30;
 export const DEFAULT_BUFFER_MINUTES = 0;

--- a/src/helpers/googleCalendarManager.js
+++ b/src/helpers/googleCalendarManager.js
@@ -11,8 +11,8 @@ const BUFFER_COVERAGE_MS = MAX_BUFFER_MINUTES * 60 * 1000;
 const ALL_DAY_TIMEZONE_PADDING_MS = 48 * 60 * 60 * 1000;
 
 // Sync tokens pin the full sync's timeMin/timeMax window, so discard them
-// after a day to keep the lookahead covering the 7-day availability horizon.
-const SYNC_LOOKAHEAD_MS = 9 * 24 * 60 * 60 * 1000;
+// after a day to keep the lookahead covering the 31-day availability horizon.
+const SYNC_LOOKAHEAD_MS = 33 * 24 * 60 * 60 * 1000;
 const SYNC_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 const GOOGLE_RESPONSE_STATUSES = new Set(["accepted", "declined", "tentative", "needsAction"]);
 

--- a/src/helpers/microsoftCalendarManager.js
+++ b/src/helpers/microsoftCalendarManager.js
@@ -12,9 +12,9 @@ const SERIES_MASTER_FIELDS =
   "subject,isAllDay,isCancelled,showAs,responseStatus,onlineMeeting,onlineMeetingUrl,location,bodyPreview,organizer,attendees";
 
 // Graph's deltaLink permanently encodes the calendarView window it was created
-// with — it never rolls forward. Sync a 14-day window and discard the token
-// after 7 days so coverage never drops below the app's 7-day lookahead.
-const DELTA_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+// with — it never rolls forward. Sync a 38-day window and discard the token
+// after 7 days so coverage never drops below the app's 31-day lookahead.
+const DELTA_WINDOW_MS = 38 * 24 * 60 * 60 * 1000;
 const DELTA_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 // A failed series-master backfill can't be retried via delta (unchanged
 // occurrences are never re-delivered); a short TTL forces an early full sync.

--- a/test/helpers/calendarAvailability.test.js
+++ b/test/helpers/calendarAvailability.test.js
@@ -55,7 +55,7 @@ test("request validation applies defaults, clamps a slightly stale start, and ca
     bufferMinutes: 0,
     maxResults: 10,
   });
-  assert.equal(MAX_AVAILABILITY_HORIZON_DAYS, 7);
+  assert.equal(MAX_AVAILABILITY_HORIZON_DAYS, 31);
 });
 
 test("request validation rejects unknown fields, invalid bounds, stale starts, and excessive horizons", () => {
@@ -81,18 +81,18 @@ test("request validation rejects unknown fields, invalid bounds, stale starts, a
       validateCalendarAvailabilityRequest(
         {
           ...base,
-          end: new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1000 + 1).toISOString(),
+          end: new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000 + 1).toISOString(),
         },
         NOW
       ),
-    /7 local calendar days/
+    /31 local calendar days/
   );
   assert.throws(
     () =>
       validateCalendarAvailabilityRequest(
         {
           ...base,
-          end: new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          end: new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000).toISOString(),
           bufferMinutes: 1,
         },
         NOW
@@ -115,12 +115,12 @@ test("request validation rejects unknown fields, invalid bounds, stale starts, a
   }
 });
 
-test("request horizon spans seven local calendar days across fall-back DST", () => {
+test("request horizon spans 31 local calendar days across fall-back DST", () => {
   const originalTimezone = process.env.TZ;
   process.env.TZ = "America/New_York";
   try {
     const localNow = new Date("2026-10-30T09:00:00-04:00");
-    const endAtLocalHorizon = "2026-11-06T09:00:00-05:00";
+    const endAtLocalHorizon = "2026-11-30T09:00:00-05:00";
     const normalized = validateCalendarAvailabilityRequest(
       {
         start: localNow.toISOString(),
@@ -129,18 +129,18 @@ test("request horizon spans seven local calendar days across fall-back DST", () 
       localNow
     );
 
-    assert.equal(normalized.end, "2026-11-06T14:00:00.000Z");
-    assert.equal(Date.parse(normalized.end) - localNow.getTime(), 169 * 60 * 60 * 1000);
+    assert.equal(normalized.end, "2026-11-30T14:00:00.000Z");
+    assert.equal(Date.parse(normalized.end) - localNow.getTime(), 745 * 60 * 60 * 1000);
     assert.throws(
       () =>
         validateCalendarAvailabilityRequest(
           {
             start: localNow.toISOString(),
-            end: "2026-11-06T09:00:00.001-05:00",
+            end: "2026-11-30T09:00:00.001-05:00",
           },
           localNow
         ),
-      /7 local calendar days/
+      /31 local calendar days/
     );
     assert.throws(
       () =>

--- a/test/helpers/calendarAvailabilityService.test.js
+++ b/test/helpers/calendarAvailabilityService.test.js
@@ -52,7 +52,7 @@ test("calculates privacy-safe availability from connected provider caches", () =
     { start: "2026-08-25T10:15:00.000Z", end: "2026-08-25T12:00:00.000Z", durationMinutes: 105 },
   ]);
   assert.equal(result.isEntireRangeFree, false);
-  assert.deepEqual(result.coverage, { source: "local-calendar-cache", lookaheadDays: 7 });
+  assert.deepEqual(result.coverage, { source: "local-calendar-cache", lookaheadDays: 31 });
   // The seeded title, attendee email, and meeting link all contain "private".
   assert.doesNotMatch(JSON.stringify(result), /private/i);
 });

--- a/test/services/calendarAvailabilityTool.test.js
+++ b/test/services/calendarAvailabilityTool.test.js
@@ -28,7 +28,7 @@ function availability(overrides = {}) {
     ],
     hasMore: false,
     isEntireRangeFree: false,
-    coverage: { source: "local-calendar-cache", lookaheadDays: 7 },
+    coverage: { source: "local-calendar-cache", lookaheadDays: 31 },
     ...overrides,
   };
 }
@@ -151,7 +151,7 @@ test("forwards valid options and strips all event-identifying response fields", 
       ],
       hasMore: false,
       isEntireRangeFree: false,
-      coverage: { source: "local-calendar-cache", lookaheadDays: 7 },
+      coverage: { source: "local-calendar-cache", lookaheadDays: 31 },
     },
     displayText: "Found 1 available time slot",
   });


### PR DESCRIPTION
## What

Follow-up to #1821. The availability tool rejects any range past 7 local calendar days, so requests like *"suggest times Wed–Thu next week"* — which can land up to 13 days out — fail with a horizon error. This raises `MAX_AVAILABILITY_HORIZON_DAYS` to 31 and widens each provider's cache window to keep the horizon covered.

## Changes

23 insertions / 23 deletions — constants, their comments, and the tests that pin them:

| Provider | Window | Coverage floor |
|---|---|---|
| Google | full-sync lookahead 9d → **33d** | 32d (1-day token TTL — the wider window self-applies within a day, no migration) |
| Microsoft | Graph delta window 14d → **38d** | 31d (existing 7-day token TTL) |
| Apple | EventKit snapshot lookahead 8d → **32d** | 31d (+1d between snapshots) |

The tool description, the `end plus buffer` validation error, and the horizon bound all derive from the constant, so they update automatically. The fall-back DST boundary test now pins the 31-day edge (745 wall-clock hours across the November transition).

## Validation

- All 47 calendar availability/provider/database/tool tests pass, including the updated horizon-boundary and DST cases
- Full suite: 3019 pass, 0 fail
- TypeScript typecheck, full ESLint, and the Swift calendar listener compiles