### PR TITLE
fix(reasoning): make streaming think filter case-insensitive and drop orphan closers

### DIFF
--- a/src/services/ai/streamingThinkFilter.ts
+++ b/src/services/ai/streamingThinkFilter.ts
@@ -1,6 +1,7 @@
 const OPEN_TAG = "<think>";
 const CLOSE_TAG = "</think>";
-const OPEN_TAGS = [OPEN_TAG] as const;
+const OPEN_RE = /<think>/gi;
+const CLOSE_RE = /<\/think>/gi;
 const THINK_TAGS = [OPEN_TAG, CLOSE_TAG] as const;
 const MAX_PARTIAL_TAG_LENGTH = CLOSE_TAG.length - 1;
 
@@ -9,19 +10,27 @@ export interface StreamingThinkFilter {
   finish: () => string;
 }
 
+function indexOfTag(re: RegExp, input: string, from: number): number {
+  re.lastIndex = from;
+  const match = re.exec(input);
+  return match ? match.index : -1;
+}
+
 function getPartialTagSuffix(value: string, tags: readonly string[]): string {
   const maxLength = Math.min(value.length, MAX_PARTIAL_TAG_LENGTH);
   for (let length = maxLength; length > 0; length -= 1) {
     const suffix = value.slice(-length);
-    if (tags.some((tag) => tag.startsWith(suffix))) return suffix;
+    if (tags.some((tag) => tag.startsWith(suffix.toLowerCase()))) return suffix;
   }
   return "";
 }
 
 // Filters <think> blocks out of streamed chat deltas, keeping state across
-// chunks, including tags split between deltas. Depth is a counter because
-// the first </think> in a nested block only closes the inner block. finish()
-// preserves a trailing tag-like fragment only when it was outside reasoning.
+// chunks, including tags split between deltas. Tags match case-insensitively
+// and an orphan </think> outside a block is dropped (its surrounding text is
+// kept), mirroring stripThinkingTags. Depth is a counter because the first
+// </think> in a nested block only closes the inner block. finish() preserves
+// a trailing tag-like fragment only when it was outside reasoning.
 export function createStreamingThinkFilter(): StreamingThinkFilter {
   let depth = 0;
   let pending = "";
@@ -33,22 +42,28 @@ export function createStreamingThinkFilter(): StreamingThinkFilter {
     let cursor = 0;
 
     while (cursor < input.length) {
-      const open = input.indexOf(OPEN_TAG, cursor);
+      const open = indexOfTag(OPEN_RE, input, cursor);
 
       if (depth === 0) {
-        if (open === -1) {
+        const close = indexOfTag(CLOSE_RE, input, cursor);
+        const next = open === -1 || (close !== -1 && close < open) ? close : open;
+        if (next === -1) {
           const remaining = input.slice(cursor);
-          pending = getPartialTagSuffix(remaining, OPEN_TAGS);
+          pending = getPartialTagSuffix(remaining, THINK_TAGS);
           visible += remaining.slice(0, remaining.length - pending.length);
           break;
         }
-        visible += input.slice(cursor, open);
-        depth = 1;
-        cursor = open + OPEN_TAG.length;
+        visible += input.slice(cursor, next);
+        if (next === open) {
+          depth = 1;
+          cursor = open + OPEN_TAG.length;
+        } else {
+          cursor = close + CLOSE_TAG.length;
+        }
         continue;
       }
 
-      const close = input.indexOf(CLOSE_TAG, cursor);
+      const close = indexOfTag(CLOSE_RE, input, cursor);
       if (close !== -1 && (open === -1 || close < open)) {
         depth -= 1;
         cursor = close + CLOSE_TAG.length;

--- a/test/services/streamingThinkFilter.test.js
+++ b/test/services/streamingThinkFilter.test.js
@@ -56,10 +56,30 @@ test("an unterminated block suppresses everything after it", async () => {
   assert.equal(filter.finish(), "");
 });
 
-test("a stray close tag with no open block passes through", async () => {
+test("a stray close tag with no open block is dropped, keeping the text (#1861)", async () => {
   const { createStreamingThinkFilter } = await load();
   const filter = createStreamingThinkFilter();
-  assert.equal(filter("plain</think>text"), "plain</think>text");
+  assert.equal(filter("plain</think>text"), "plaintext");
+});
+
+test("a stray close tag split across chunks is dropped", async () => {
+  const { createStreamingThinkFilter } = await load();
+  const filter = createStreamingThinkFilter();
+  assert.equal(filterAll(filter, ["plain</th", "ink>text"]), "plaintext");
+});
+
+test("strips mixed-case and uppercase think blocks (#1861)", async () => {
+  const { createStreamingThinkFilter } = await load();
+  assert.equal(createStreamingThinkFilter()("<Think>reasoning</Think>Answer"), "Answer");
+  assert.equal(createStreamingThinkFilter()("<THINK>reasoning</THINK>Answer"), "Answer");
+  assert.equal(createStreamingThinkFilter()("plain</Think>text"), "plaintext");
+});
+
+test("an uppercase unterminated block suppresses everything after it", async () => {
+  const { createStreamingThinkFilter } = await load();
+  const filter = createStreamingThinkFilter();
+  assert.equal(filterAll(filter, ["Answer<THINK>never", " closes"]), "Answer");
+  assert.equal(filter.finish(), "");
 });
 
 test("resumes normal output after a closed nested block", async () => {
@@ -85,10 +105,32 @@ test("strips nested think blocks at every two-chunk boundary", async () => {
   }
 });
 
+test("strips mixed-case nested think blocks at every two-chunk boundary", async () => {
+  const { createStreamingThinkFilter } = await load();
+  const input = "<Think>a<THINK>b</think>c</THINK>Answer";
+
+  for (let split = 1; split < input.length; split += 1) {
+    const filter = createStreamingThinkFilter();
+    assert.equal(
+      filterAll(filter, [input.slice(0, split), input.slice(split)]),
+      "Answer",
+      `split at character ${split}`
+    );
+  }
+});
+
 test("buffers a possible opening tag and flushes it when the stream ends", async () => {
   const { createStreamingThinkFilter } = await load();
   const filter = createStreamingThinkFilter();
 
   assert.equal(filter("Answer<thi"), "Answer");
   assert.equal(filter.finish(), "<thi");
+});
+
+test("buffers a possible close tag and flushes it when the stream ends", async () => {
+  const { createStreamingThinkFilter } = await load();
+  const filter = createStreamingThinkFilter();
+
+  assert.equal(filter("text</thi"), "text");
+  assert.equal(filter.finish(), "</thi");
 });


### PR DESCRIPTION
Fixes #1861

### Problem
`createStreamingThinkFilter` matched only exact lowercase `<think>` / `</think>` via `indexOf`, and passed orphan closing tags through. #1802 fixed both on the non-streaming path (`stripThinkingTags`); the streaming path serves the same local/LAN providers, so a `<Think>` block (arbitrary LAN fine-tunes) or an orphan `</think>` (R1-style templates with the opener in the prompt) still leaked reasoning text into streamed output.

### Solution
- Tag search now uses case-insensitive regexes through a small `indexOfTag` helper. Searching the original string (rather than a lowercased copy) keeps indices exact for characters whose lowercase form changes length (e.g. `İ`).
- At depth 0, an orphan `</think>` is dropped and the surrounding text kept, mirroring `stripThinkingTags`.
- Partial-tag buffering at chunk boundaries now covers both tags case-insensitively, so a split `</th` + `ink>` orphan is still caught; a trailing fragment that never completes is flushed verbatim by `finish()` as before.

One deliberate test flip: the pin that a stray closer passes through untouched predates #1802 and now contradicts the non-streaming behavior; it's updated to expect the tag dropped with text preserved.

### Verification
- `test/services/streamingThinkFilter.test.js` (17 tests incl. mixed-case every-boundary split sweeps) and `test/helpers/stripThinking.test.js`: 27/27 pass; `test/services/reasoningServiceStreamingThink.test.js` end-to-end suite: 19/19 pass.
- Differential fuzz vs `stripThinkingTags`: ~240k chunk-split cases (curated adversarial corpus + 4k random inputs + Unicode edge cases: `İ`, Kelvin sign, combining marks, surrogate splits) — zero divergences, and output is invariant across all chunkings of the same input.
- Differential vs the previous implementation on lowercase-only input: the orphan-closer drop is the only behavior change; everything else is byte-identical.
- Prettier, ESLint, and typecheck clean (the only typecheck error locally is the pre-existing stale `canvas-confetti` install, identical on `main`).
