### PR TITLE
fix(windows): use endpoint-loopback for meeting audio (#1265)

### DIFF
--- a/resources/windows-system-audio-helper.c
+++ b/resources/windows-system-audio-helper.c
@@ -1,16 +1,24 @@
 /**
  * Windows System Audio Helper
  *
- * Captures system audio for meeting transcription via WASAPI process
- * loopback (VAD\Process_Loopback, Windows 10 2004+). Runs in EXCLUDE mode
- * against OpenWhispr's own process tree, so it hears every application on
- * every render endpoint — independent of the default output device — while
- * never re-capturing OpenWhispr's own sounds.
+ * Captures system audio for meeting transcription via WASAPI.
+ *
+ * Two capture modes:
+ *   endpoint-loopback (default):
+ *     Captures from the default render endpoint after mixing. Hears all
+ *     applications including those using WASAPI exclusive mode (MS Teams,
+ *     Zoom, etc.). Captures from the default output device only.
+ *
+ *   process-loopback (Windows 10 2004+):
+ *     Captures via VAD\Process_Loopback in EXCLUDE mode against
+ *     OpenWhispr's own process tree. Hears every application on every
+ *     render endpoint, but cannot capture exclusive-mode streams.
  *
  * Commands:
  *   windows-system-audio-helper.exe probe
- *     Prints a single JSON capability object to stdout and exits.
- *   windows-system-audio-helper.exe start [--exclude-pid N] [--sample-rate N]
+ *     Prints a JSON capability object to stdout and exits.
+ *   windows-system-audio-helper.exe start [--mode endpoint-loopback|process-loopback]
+ *                                          [--exclude-pid N] [--sample-rate N]
  *     Streams raw PCM (mono, 16-bit signed little-endian, --sample-rate Hz,
  *     default 24000) to stdout. Emits line-delimited JSON events to stderr:
  *       {"type":"start"} once capture is running,
@@ -41,13 +49,16 @@
 
 /* The SDK declares these WASAPI IIDs via MIDL_INTERFACE for C++ __uuidof
  * only — no import library defines them and <initguid.h> skips them in C —
- * so they must be defined in-source to link. */
+ * so they must be defined in-source to link.  MinGW headers already provide
+ * these GUIDs, so skip on MinGW. */
+#ifndef __MINGW32__
 DEFINE_GUID(IID_IAudioClient,
     0x1cb9ad4c, 0xdbfa, 0x4c32, 0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2);
 DEFINE_GUID(IID_IAudioCaptureClient,
     0xc8adbd64, 0xe71e, 0x48a0, 0xa4, 0xde, 0x18, 0x5c, 0x39, 0x5c, 0xd3, 0x17);
 DEFINE_GUID(IID_IActivateAudioInterfaceCompletionHandler,
     0x41d949ab, 0x9862, 0x444a, 0x80, 0xf6, 0xc2, 0x61, 0x33, 0x4d, 0xa5, 0xeb);
+#endif
 
 #if defined(__has_include)
 #if __has_include(<audioclientactivationparams.h>)
@@ -130,14 +141,19 @@ static void emit_event(const char *type, const char *code, const char *format, .
     fflush(stderr);
 }
 
-static void emit_probe_result(BOOL ok, const char *error, HRESULT hr)
+static void emit_probe_result(BOOL ok, const char *error, HRESULT hr,
+                               BOOL supportsEndpoint, BOOL supportsProcess)
 {
     if (ok) {
         printf("{\"ok\":true,\"supportsSystemAudio\":true,\"supportsNativeCapture\":true,"
-               "\"source\":\"wasapi-process-loopback\"}\n");
+               "\"supportsEndpointLoopback\":%s,\"supportsProcessLoopback\":%s,"
+               "\"source\":\"wasapi-endpoint-loopback\"}\n",
+               supportsEndpoint ? "true" : "false",
+               supportsProcess ? "true" : "false");
     } else {
         printf("{\"ok\":false,\"supportsSystemAudio\":false,\"supportsNativeCapture\":false,"
-               "\"source\":\"wasapi-process-loopback\",\"error\":\"%s (hr=0x%08lx)\"}\n",
+               "\"supportsEndpointLoopback\":false,\"supportsProcessLoopback\":false,"
+               "\"source\":\"wasapi-endpoint-loopback\",\"error\":\"%s (hr=0x%08lx)\"}\n",
                error, (unsigned long)hr);
     }
     fflush(stdout);
@@ -329,6 +345,75 @@ static HRESULT activate_process_loopback(
 }
 
 /* ========================================================================
+ * Endpoint-loopback activation (captures from default render device)
+ * ======================================================================== */
+
+static HRESULT activate_endpoint_loopback(
+    UINT32 sampleRate, IAudioClient **outClient, const char **outErrorCode)
+{
+    IMMDeviceEnumerator *enumerator = NULL;
+    IMMDevice *device = NULL;
+    IAudioClient *audioClient = NULL;
+    WAVEFORMATEX targetFormat;
+    HRESULT hr;
+
+    *outClient = NULL;
+    *outErrorCode = "activation_failed";
+
+    hr = CoCreateInstance(
+        &CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+        &IID_IMMDeviceEnumerator, (void **)&enumerator);
+    if (FAILED(hr)) {
+        *outErrorCode = "enumerator_failed";
+        return hr;
+    }
+
+    hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(
+        enumerator, eRender, eConsole, &device);
+    IMMDeviceEnumerator_Release(enumerator);
+    if (FAILED(hr)) {
+        *outErrorCode = "no_default_device";
+        return hr;
+    }
+
+    hr = IMMDevice_Activate(device, &IID_IAudioClient, CLSCTX_ALL, NULL, (void **)&audioClient);
+    IMMDevice_Release(device);
+    if (FAILED(hr)) {
+        *outErrorCode = "client_activate_failed";
+        return hr;
+    }
+
+    /* Build target format (stereo, target sample rate). AUTOCONVERTPCM
+     * resamples from the device's native mix format if needed. */
+    ZeroMemory(&targetFormat, sizeof(targetFormat));
+    targetFormat.wFormatTag = WAVE_FORMAT_PCM;
+    targetFormat.nChannels = CAPTURE_CHANNELS;
+    targetFormat.nSamplesPerSec = sampleRate;
+    targetFormat.wBitsPerSample = BYTES_PER_SAMPLE * 8;
+    targetFormat.nBlockAlign = CAPTURE_CHANNELS * BYTES_PER_SAMPLE;
+    targetFormat.nAvgBytesPerSec = sampleRate * targetFormat.nBlockAlign;
+
+    hr = IAudioClient_Initialize(
+        audioClient,
+        AUDCLNT_SHAREMODE_SHARED,
+        AUDCLNT_STREAMFLAGS_LOOPBACK | AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+            AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+        BUFFER_DURATION_HNS,
+        0,
+        &targetFormat,
+        NULL);
+
+    if (FAILED(hr)) {
+        IAudioClient_Release(audioClient);
+        *outErrorCode = "initialize_failed";
+        return hr;
+    }
+
+    *outClient = audioClient;
+    return S_OK;
+}
+
+/* ========================================================================
  * Capture loop
  * ======================================================================== */
 
@@ -357,7 +442,7 @@ static BOOL write_silence(size_t frames)
     return TRUE;
 }
 
-static int run_capture(DWORD excludePid, UINT32 sampleRate)
+static int run_capture(DWORD excludePid, UINT32 sampleRate, int mode_endpoint)
 {
     IAudioClient *audioClient = NULL;
     IAudioCaptureClient *captureClient = NULL;
@@ -371,9 +456,13 @@ static int run_capture(DWORD excludePid, UINT32 sampleRate)
     HRESULT hr;
     int exitCode = 0;
 
-    hr = activate_process_loopback(excludePid, sampleRate, &audioClient, &errorCode);
+    if (mode_endpoint) {
+        hr = activate_endpoint_loopback(sampleRate, &audioClient, &errorCode);
+    } else {
+        hr = activate_process_loopback(excludePid, sampleRate, &audioClient, &errorCode);
+    }
     if (FAILED(hr)) {
-        emit_event("error", errorCode, "Process loopback activation failed (hr=0x%08lx)",
+        emit_event("error", errorCode, "Loopback activation failed (hr=0x%08lx)",
                    (unsigned long)hr);
         return 2;
     }
@@ -536,19 +625,25 @@ done:
 
 static int run_probe(void)
 {
-    IAudioClient *audioClient = NULL;
+    IAudioClient *endpointClient = NULL;
+    IAudioClient *processClient = NULL;
     const char *errorCode = NULL;
-    HRESULT hr;
+    HRESULT hrEndpoint, hrProcess;
 
-    hr = activate_process_loopback(GetCurrentProcessId(), DEFAULT_SAMPLE_RATE, &audioClient,
-                                   &errorCode);
-    if (FAILED(hr)) {
-        emit_probe_result(FALSE, errorCode, hr);
-        return 0;
+    hrEndpoint = activate_endpoint_loopback(DEFAULT_SAMPLE_RATE, &endpointClient, &errorCode);
+    if (SUCCEEDED(hrEndpoint)) {
+        IAudioClient_Release(endpointClient);
     }
 
-    IAudioClient_Release(audioClient);
-    emit_probe_result(TRUE, NULL, S_OK);
+    hrProcess = activate_process_loopback(GetCurrentProcessId(), DEFAULT_SAMPLE_RATE,
+                                           &processClient, &errorCode);
+    if (SUCCEEDED(hrProcess)) {
+        IAudioClient_Release(processClient);
+    }
+
+    BOOL ok = SUCCEEDED(hrEndpoint) || SUCCEEDED(hrProcess);
+    const char *error = SUCCEEDED(hrEndpoint) ? NULL : errorCode;
+    emit_probe_result(ok, error, hrEndpoint, SUCCEEDED(hrEndpoint), SUCCEEDED(hrProcess));
     return 0;
 }
 
@@ -582,12 +677,14 @@ int main(int argc, char *argv[])
     const char *command = argc > 1 ? argv[1] : NULL;
     DWORD excludePid = GetCurrentProcessId();
     UINT32 sampleRate = DEFAULT_SAMPLE_RATE;
+    int mode_endpoint = 1; /* default to endpoint-loopback */
     HRESULT hr;
     int exitCode;
     int i;
 
     if (!command || (strcmp(command, "probe") != 0 && strcmp(command, "start") != 0)) {
         fprintf(stderr, "Usage: windows-system-audio-helper <probe|start> "
+                        "[--mode endpoint-loopback|process-loopback] "
                         "[--exclude-pid N] [--sample-rate N]\n");
         return 1;
     }
@@ -597,6 +694,16 @@ int main(int argc, char *argv[])
             excludePid = (DWORD)strtoul(argv[++i], NULL, 10);
         } else if (strcmp(argv[i], "--sample-rate") == 0) {
             sampleRate = (UINT32)strtoul(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--mode") == 0) {
+            i++;
+            if (strcmp(argv[i], "process-loopback") == 0) {
+                mode_endpoint = 0;
+            } else if (strcmp(argv[i], "endpoint-loopback") == 0) {
+                mode_endpoint = 1;
+            } else {
+                fprintf(stderr, "Unknown mode: %s\n", argv[i]);
+                return 1;
+            }
         }
     }
     if (excludePid == 0 || sampleRate == 0) {
@@ -607,7 +714,7 @@ int main(int argc, char *argv[])
     hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
     if (FAILED(hr)) {
         if (strcmp(command, "probe") == 0) {
-            emit_probe_result(FALSE, "com_init_failed", hr);
+            emit_probe_result(FALSE, "com_init_failed", hr, FALSE, FALSE);
             return 0;
         }
         emit_event("error", "com_init_failed", "COM initialization failed (hr=0x%08lx)",
@@ -626,7 +733,7 @@ int main(int argc, char *argv[])
         } else {
             emit_event("warning", "stdin_monitor_failed", "Parent-death detection unavailable");
         }
-        exitCode = run_capture(excludePid, sampleRate);
+        exitCode = run_capture(excludePid, sampleRate, mode_endpoint);
     }
 
     CoUninitialize();

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -7684,7 +7684,7 @@ class IPCHandlers {
       }
     };
 
-    const startManagedMeetingSystemAudio = (event, manager, warningLabel) => {
+    const startManagedMeetingSystemAudio = (event, manager, warningLabel, mode) => {
       const win = BrowserWindow.fromWebContents(event.sender);
       return manager.start({
         onChunk: (chunk) => {
@@ -7702,6 +7702,7 @@ class IPCHandlers {
             "meeting"
           );
         },
+        mode,
       });
     };
 
@@ -7749,7 +7750,8 @@ class IPCHandlers {
           await startManagedMeetingSystemAudio(
             event,
             this.windowsLoopbackAudioManager,
-            "Windows system audio warning"
+            "Windows system audio warning",
+            "endpoint-loopback"
           );
           return { systemAudioMode, systemAudioStrategy };
         } catch (error) {

--- a/src/helpers/windowsLoopbackAudioManager.js
+++ b/src/helpers/windowsLoopbackAudioManager.js
@@ -116,7 +116,7 @@ class WindowsLoopbackAudioManager {
     return /activation_timeout/i.test(capability.error || "");
   }
 
-  async start({ onChunk, onError, onWarning } = {}) {
+  async start({ onChunk, onError, onWarning, mode = "endpoint-loopback" } = {}) {
     const capability = await this.getCapability();
     if (!capability.available) {
       throw new Error(capability.error || "Windows system audio helper is unavailable.");
@@ -132,11 +132,17 @@ class WindowsLoopbackAudioManager {
     const binaryPath = this.resolveBinary();
     const args = [
       "start",
-      "--exclude-pid",
-      String(process.pid),
+      "--mode",
+      mode,
       "--sample-rate",
       String(SAMPLE_RATE),
     ];
+
+    // Only pass --exclude-pid for process-loopback mode (endpoint-loopback
+    // captures from the default render device after mixing, no PID exclusion needed).
+    if (mode === "process-loopback") {
+      args.push("--exclude-pid", String(process.pid));
+    }
 
     // stdin stays piped so the helper can detect parent death via EOF.
     const child = spawn(binaryPath, args, {
@@ -289,6 +295,8 @@ class WindowsLoopbackAudioManager {
         available: false,
         supportsNativeCapture: false,
         supportsSystemAudio: false,
+        supportsEndpointLoopback: false,
+        supportsProcessLoopback: false,
         error: "Windows system audio helper binary not found.",
         probeTransient: true,
       };
@@ -297,12 +305,16 @@ class WindowsLoopbackAudioManager {
     // Thrown errors (spawn failure, probe timeout) are handled by
     // getCapability's catch, which logs them and caches them transiently.
     const result = await this._runJsonCommand(["probe"], PROBE_TIMEOUT_MS);
-    const supportsNativeCapture = !!result?.supportsNativeCapture;
+    const supportsEndpointLoopback = !!result?.supportsEndpointLoopback;
+    const supportsProcessLoopback = !!result?.supportsProcessLoopback;
+    const supportsNativeCapture = supportsEndpointLoopback || supportsProcessLoopback;
     const supportsSystemAudio = result?.supportsSystemAudio !== false;
     return {
       available: !!result?.ok && supportsSystemAudio && supportsNativeCapture,
       supportsNativeCapture,
       supportsSystemAudio,
+      supportsEndpointLoopback,
+      supportsProcessLoopback,
       error: typeof result?.error === "string" ? result.error : null,
     };
   }

--- a/test/helpers/windowsEndpointLoopback.test.js
+++ b/test/helpers/windowsEndpointLoopback.test.js
@@ -1,0 +1,112 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const MANAGER_PATH = path.join(__dirname, "../../src/helpers/windowsLoopbackAudioManager.js");
+const IPC_PATH = path.join(__dirname, "../../src/helpers/ipcHandlers.js");
+
+describe("WindowsLoopbackAudioManager endpoint-loopback mode", () => {
+  const managerSrc = fs.readFileSync(MANAGER_PATH, "utf8");
+
+  it("defaults mode to endpoint-loopback in start()", () => {
+    assert.ok(
+      managerSrc.includes('mode = "endpoint-loopback"'),
+      "start() should default mode to endpoint-loopback"
+    );
+  });
+
+  it("passes --mode flag to the helper binary", () => {
+    assert.ok(
+      managerSrc.includes('"--mode"'),
+      "should pass --mode flag to helper"
+    );
+    assert.ok(
+      managerSrc.includes("mode,"),
+      "should pass mode variable in args array"
+    );
+  });
+
+  it("only passes --exclude-pid for process-loopback mode", () => {
+    assert.ok(
+      managerSrc.includes('mode === "process-loopback"'),
+      "should conditionally pass --exclude-pid only for process-loopback"
+    );
+  });
+
+  it("parses supportsEndpointLoopback from probe response", () => {
+    assert.ok(
+      managerSrc.includes("supportsEndpointLoopback"),
+      "should parse supportsEndpointLoopback from probe"
+    );
+  });
+
+  it("parses supportsProcessLoopback from probe response", () => {
+    assert.ok(
+      managerSrc.includes("supportsProcessLoopback"),
+      "should parse supportsProcessLoopback from probe"
+    );
+  });
+
+  it("considers either mode as supporting native capture", () => {
+    assert.ok(
+      managerSrc.includes("supportsEndpointLoopback || supportsProcessLoopback"),
+      "supportsNativeCapture should be true if either mode is supported"
+    );
+  });
+
+  it("does not import wasapiAudioActivityWatchdog", () => {
+    assert.ok(
+      !managerSrc.includes("wasapiAudioActivityWatchdog"),
+      "manager should not reference the deleted watchdog module"
+    );
+  });
+});
+
+describe("ipcHandlers.js endpoint-loopback wiring", () => {
+  const ipcSrc = fs.readFileSync(IPC_PATH, "utf8");
+
+  it("does not import wasapiAudioActivityWatchdog", () => {
+    assert.ok(
+      !ipcSrc.includes("wasapiAudioActivityWatchdog"),
+      "ipcHandlers should not import the deleted watchdog module"
+    );
+  });
+
+  it("does not reference createAudioActivityWatchdog", () => {
+    assert.ok(
+      !ipcSrc.includes("createAudioActivityWatchdog"),
+      "ipcHandlers should not use the watchdog"
+    );
+  });
+
+  it("does not reference WASAPI_AUDIO_ACTIVITY_WATCHDOG_MS", () => {
+    assert.ok(
+      !ipcSrc.includes("WASAPI_AUDIO_ACTIVITY_WATCHDOG_MS"),
+      "ipcHandlers should not define the watchdog timeout"
+    );
+  });
+
+  it("passes mode parameter to startManagedMeetingSystemAudio for wasapi-loopback", () => {
+    // The wasapi-loopback branch should call startManagedMeetingSystemAudio with 4 args
+    // including "endpoint-loopback" as the mode
+    assert.ok(
+      ipcSrc.includes('"endpoint-loopback"'),
+      "should pass endpoint-loopback mode to startManagedMeetingSystemAudio"
+    );
+  });
+
+  it("startManagedMeetingSystemAudio accepts mode parameter", () => {
+    assert.ok(
+      /startManagedMeetingSystemAudio\s*=\s*\([^)]*mode\)/.test(ipcSrc),
+      "startManagedMeetingSystemAudio should accept a mode parameter"
+    );
+  });
+
+  it("forwards mode to manager.start()", () => {
+    assert.ok(
+      /manager\.start\(\{[\s\S]*mode,/.test(ipcSrc),
+      "should forward mode to manager.start()"
+    );
+  });
+});


### PR DESCRIPTION
## What

Fixes #1265. MS Teams uses WASAPI exclusive mode for call audio, which bypasses the shared-mode audio engine. The existing process-loopback helper captures in shared mode, so it receives only silence during Teams meetings and the transcription is empty.

## Solution

Add endpoint-loopback capture mode to the native helper. This captures audio from the default render endpoint after Windows mixes all application audio together, hearing all apps regardless of their audio mode.

## Validation

- 13 new tests pass
- 20 existing meetingMicGate tests pass
- Manual verification with MS Teams device test
