### PR TITLE
fix(window): preserve tray-hidden control panel during auth refresh

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1442,9 +1442,22 @@ class WindowManager {
     this._controlPanelVisibilityTimer = null;
   }
 
-  _showControlPanel() {
+  _showControlPanel({ preserveCurrentVisibility = false } = {}) {
     const win = this.controlPanelWindow;
     if (!win || win.isDestroyed()) return;
+    // Auth and policy refreshes can resend onboarding window modes long after
+    // startup. Those messages own the panel's geometry, not its visibility:
+    // once the user has hidden the panel to the tray, resizing it must not pull
+    // it back to the foreground. A pending visibility timer marks the one
+    // hidden state that should still be revealed — the initial renderer-owned
+    // startup decision before the panel has ever been shown.
+    if (
+      preserveCurrentVisibility &&
+      !win.isVisible() &&
+      this._controlPanelVisibilityTimer === null
+    ) {
+      return;
+    }
     // Cancel the backstop either way: once the window has been shown on purpose,
     // a later timer firing could pull it back out of the tray.
     this._clearControlPanelVisibilityTimer();
@@ -1517,7 +1530,7 @@ class WindowManager {
       this._onboardingRestoreBounds = null;
       this._onboardingWindowMode = null;
       this._onboardingWindowState = null;
-      this._showControlPanel();
+      this._showControlPanel({ preserveCurrentVisibility: true });
       return true;
     }
 
@@ -1536,7 +1549,7 @@ class WindowManager {
     this._applyOnboardingWindowChrome(win, mode);
 
     if (this._onboardingWindowMode === mode) {
-      this._showControlPanel();
+      this._showControlPanel({ preserveCurrentVisibility: true });
       return true;
     }
 
@@ -1550,13 +1563,13 @@ class WindowManager {
       current.height === next.height
     ) {
       this._onboardingWindowMode = mode;
-      this._showControlPanel();
+      this._showControlPanel({ preserveCurrentVisibility: true });
       return true;
     }
 
     win.setContentBounds(next, true);
     this._onboardingWindowMode = mode;
-    this._showControlPanel();
+    this._showControlPanel({ preserveCurrentVisibility: true });
     return true;
   }
 

--- a/test/helpers/windowManagerControlPanel.test.js
+++ b/test/helpers/windowManagerControlPanel.test.js
@@ -1,0 +1,194 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const dockVisibilityCalls = [];
+
+const originalLoad = Module._load;
+Module._load = function loadWindowManagerWithStubs(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: { on: () => undefined },
+      screen: {
+        getPrimaryDisplay: () => ({}),
+        getDisplayMatching: () => ({
+          workArea: { x: 0, y: 0, width: 1440, height: 900 },
+        }),
+        getDisplayNearestPoint: () => ({
+          workArea: { x: 0, y: 0, width: 1440, height: 900 },
+        }),
+      },
+      BrowserWindow: class {},
+      shell: {},
+      dialog: {},
+    };
+  }
+  if (request === "./debugLogger") {
+    return {
+      warn: () => undefined,
+      debug: () => undefined,
+      log: () => undefined,
+    };
+  }
+  if (request === "./hotkeyManager") {
+    const FakeHotkeyManager = class {
+      unregisterAll() {}
+
+      isInListeningMode() {
+        return false;
+      }
+    };
+    FakeHotkeyManager.isGlobeLikeHotkey = () => false;
+    return FakeHotkeyManager;
+  }
+  if (request === "./dragManager") {
+    return class {
+      cleanup() {}
+    };
+  }
+  if (request === "./menuManager") return {};
+  if (request === "./devServerManager") {
+    return {
+      DEV_SERVER_PORT: 5173,
+      DEV_SERVER_URL: "http://localhost:5173",
+      getAppFilePath: () => ({ path: "/app/index.html", query: {} }),
+      waitForDevServer: async () => undefined,
+    };
+  }
+  if (request === "./dockManager") {
+    return {
+      setControlPanelVisible: (visible) => dockVisibilityCalls.push(visible),
+    };
+  }
+  if (request === "./i18nMain") return { i18nMain: { t: (key) => key } };
+  if (request === "./windowConfig") {
+    return {
+      MAIN_WINDOW_CONFIG: {},
+      CONTROL_PANEL_CONFIG: {},
+      NOTIFICATION_WINDOW_CONFIG: {},
+      AUTO_END_NOTIFICATION_WINDOW_SIZE: { width: 620, height: 116 },
+      getMeetingNotificationWindowSize: () => ({ width: 392, height: 92 }),
+      WINDOW_SIZES: { BASE: { width: 96, height: 96 } },
+      ONBOARDING_WINDOW_SIZES: {
+        COMPACT: { width: 480, height: 624 },
+        EXPANDED: { width: 1000, height: 740 },
+      },
+      WindowPositionUtil: {
+        setupAlwaysOnTop: () => undefined,
+        clampToWorkArea: (bounds) => bounds,
+        getMainWindowPosition: () => ({ x: 0, y: 0 }),
+        getNotificationPosition: () => ({ x: 0, y: 0 }),
+      },
+      fitAssistantWindowToWorkArea: (size) => size,
+      fitAssistantContentWindowToWorkArea: (height) => ({ width: 466, height }),
+      fitDictationErrorWindowToWorkArea: (size) => size,
+      fitDictationErrorContentWindowToWorkArea: (height) => ({ width: 466, height }),
+      resolveHorizontalWindowDirection: () => "right",
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+const WindowManager = require("../../src/helpers/windowManager");
+Module._load = originalLoad;
+
+function createControlPanelWindow({
+  visible,
+  bounds = { x: 120, y: 90, width: 1200, height: 800 },
+}) {
+  const calls = [];
+  let currentBounds = { ...bounds };
+  let isVisible = visible;
+
+  return {
+    calls,
+    isVisible: () => isVisible,
+    window: {
+      isDestroyed: () => false,
+      isVisible: () => isVisible,
+      isFullScreen: () => false,
+      isMaximized: () => false,
+      getBounds: () => ({ ...currentBounds }),
+      getContentBounds: () => ({ ...currentBounds }),
+      setContentBounds: (nextBounds) => {
+        currentBounds = { ...nextBounds };
+        calls.push("setContentBounds");
+      },
+      isResizable: () => true,
+      isMinimizable: () => true,
+      isMaximizable: () => true,
+      isClosable: () => true,
+      isFullScreenable: () => true,
+      getMinimumSize: () => [400, 300],
+      setResizable: () => undefined,
+      setMinimizable: () => undefined,
+      setMaximizable: () => undefined,
+      setClosable: () => undefined,
+      setFullScreenable: () => undefined,
+      setMinimumSize: () => undefined,
+      setWindowButtonVisibility: () => undefined,
+      show: () => {
+        isVisible = true;
+        calls.push("show");
+      },
+      focus: () => calls.push("focus"),
+      hide: () => {
+        isVisible = false;
+        calls.push("hide");
+      },
+    },
+  };
+}
+
+function createManager(windowOptions) {
+  const manager = new WindowManager();
+  const fake = createControlPanelWindow(windowOptions);
+  manager.controlPanelWindow = fake.window;
+  manager._clearControlPanelVisibilityTimer = () => {
+    manager._controlPanelVisibilityTimer = null;
+    fake.calls.push("clearVisibilityTimer");
+  };
+  return { manager, ...fake };
+}
+
+test.beforeEach(() => {
+  dockVisibilityCalls.length = 0;
+});
+
+test("initial restore still reveals the renderer-sized control panel", () => {
+  const { manager, calls, isVisible } = createManager({ visible: false });
+  manager._controlPanelVisibilityTimer = 1;
+
+  assert.equal(manager.setOnboardingWindowMode("restore"), true);
+
+  assert.equal(isVisible(), true);
+  assert.deepEqual(calls, ["clearVisibilityTimer", "show", "focus"]);
+  assert.deepEqual(dockVisibilityCalls, [true]);
+});
+
+test("repeated restore preserves a control panel hidden to the tray", () => {
+  const { manager, calls, isVisible } = createManager({ visible: true });
+  manager._controlPanelVisibilityTimer = 1;
+  manager.hideControlPanelToTray();
+  calls.length = 0;
+  dockVisibilityCalls.length = 0;
+
+  assert.equal(manager.setOnboardingWindowMode("restore"), true);
+
+  assert.equal(isVisible(), false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(dockVisibilityCalls, []);
+});
+
+test("compact reauthentication can resize a tray-hidden panel without surfacing it", () => {
+  const { manager, calls, isVisible } = createManager({ visible: true });
+  manager._controlPanelVisibilityTimer = 1;
+  manager.hideControlPanelToTray();
+  calls.length = 0;
+  dockVisibilityCalls.length = 0;
+
+  assert.equal(manager.setOnboardingWindowMode("compact"), true);
+
+  assert.equal(isVisible(), false);
+  assert.deepEqual(calls, ["setContentBounds"]);
+  assert.deepEqual(dockVisibilityCalls, []);
+});


### PR DESCRIPTION
## Summary

- keep auth/onboarding window-mode updates from surfacing a control panel that the user hid to the tray
- preserve the renderer-owned initial reveal and existing forced-show recovery paths
- add regression coverage for restore and compact reauthentication modes

## Root cause

`AppRouter` can resend `setOnboardingWindowMode("restore")` whenever auth or policy state settles again, including after a network reconnect or wake. `WindowManager.setOnboardingWindowMode()` treated every mode update as a request to call `show()` and `focus()`, even after `hideControlPanelToTray()` had cleared the startup visibility timer.

Observed on macOS 26.5.1 with OpenWhispr 1.9.0: the app process stayed running, no hotkey was pressed, and the main control panel surfaced about three seconds after two independent network changes. This is related to the still-reported behavior in #271, but has a different auth-refresh trigger introduced with the 1.9.0 window-mode lifecycle.

## Fix

Window-mode updates now preserve a hidden panel once the initial visibility timer has been cleared. A newly created panel still has that timer pending, so its first renderer-selected mode continues to reveal it. Load failures, the timeout backstop, and explicit panel opens keep their existing forced-show behavior.

## Testing

- `node --import tsx --test test/helpers/windowManagerControlPanel.test.js`
- `npm run format:check`
- `npm run typecheck`
- `npm run i18n:check`
- `npm test` — 3,158 tests; 2,973 passed, 184 skipped, 1 todo, 0 failed