### PR TITLE
fix(linux): map Hyprland punctuation hotkeys to XKB keysyms

### DIFF
--- a/src/helpers/hyprlandShortcut.js
+++ b/src/helpers/hyprlandShortcut.js
@@ -38,12 +38,24 @@ const ELECTRON_TO_HYPRLAND_KEY = {
   backquote: "grave",
   "`": "grave",
   " ": "space",
+  // Punctuation must be XKB names; a literal "," is the bind delimiter.
+  ",": "comma",
+  ".": "period",
+  "/": "slash",
+  "-": "minus",
+  "=": "equal",
+  ";": "semicolon",
+  "'": "apostrophe",
+  "[": "bracketleft",
+  "]": "bracketright",
+  "\\": "backslash",
+  plus: "plus",
 };
 
 // Valid Electron-format hotkey: optional modifiers joined by +, ending with a key
 // Supports: standalone keys (F4, Space), modifier+key combos, and modifier-only combos (Control+Super)
 const VALID_HOTKEY_PATTERN =
-  /^((CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd)(\+(CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd))*(\+)?)?(F([1-9]|1[0-9]|2[0-4])|[A-Za-z0-9]|Space|Escape|Tab|Backspace|Delete|Insert|Home|End|PageUp|PageDown|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|Enter|PrintScreen|ScrollLock|Pause|Backquote|`)?$/i;
+  /^((CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd)(\+(CommandOrControl|CmdOrCtrl|Control|Ctrl|Alt|Option|Shift|Super|Meta|Win|Command|Cmd))*(\+)?)?(F([1-9]|1[0-9]|2[0-4])|[A-Za-z0-9]|Space|Escape|Tab|Backspace|Delete|Insert|Home|End|PageUp|PageDown|ArrowUp|ArrowDown|ArrowLeft|ArrowRight|Enter|PrintScreen|ScrollLock|Pause|Backquote|`|,|\.|\/|-|=|;|'|\[|\]|\\|Plus)?$/i;
 
 const BINDS_FILENAMES = {
   conf: "openwhispr-binds.conf",

--- a/test/helpers/hyprlandShortcut.test.js
+++ b/test/helpers/hyprlandShortcut.test.js
@@ -416,3 +416,26 @@ test(
     assert.equal(fs.readFileSync(confPath, "utf8"), "# keep this comment\n");
   })
 );
+
+test("punctuation accelerators validate and convert to XKB key names", () => {
+  const HyprlandShortcutManager = loadManager(() => "ok\n");
+
+  assert.equal(HyprlandShortcutManager.isValidHotkey("F8"), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+F8"), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+Super"), true);
+
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+,"), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Alt+."), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+/"), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+-"), true);
+  assert.equal(HyprlandShortcutManager.isValidHotkey("Control+Plus"), true);
+
+  assert.equal(HyprlandShortcutManager.convertToHyprlandFormat("Control+,").bindKey, "CTRL, comma");
+  assert.equal(HyprlandShortcutManager.convertToHyprlandFormat("Alt+.").bindKey, "ALT, period");
+  assert.equal(HyprlandShortcutManager.convertToHyprlandFormat("Control+/").bindKey, "CTRL, slash");
+  assert.equal(HyprlandShortcutManager.convertToHyprlandFormat("Control+-").bindKey, "CTRL, minus");
+  assert.equal(
+    HyprlandShortcutManager.convertToHyprlandFormat("Control+Plus").bindKey,
+    "CTRL, plus"
+  );
+});


### PR DESCRIPTION
## Summary

- Hyprland rejected punctuation accelerators in `isValidHotkey()`, so `registerKeybinding()` never wrote a bind.
- `convertToHyprlandFormat("Control+,")` would emit `CTRL, ,`; a literal comma is Hyprland’s bind delimiter, so the key must be the XKB name `comma`.
- Map the same unshifted punctuation set GNOME (#1658) and KDE (#1752) already handle.

Fixes #1875

## Problem

Choosing Ctrl+, (a documented valid accelerator in `hotkeyList.js`) silently fails to register on Hyprland.

## Root cause

`VALID_HOTKEY_PATTERN` only allowed a single `[A-Za-z0-9]` or named keys like Space/F8/Backquote. Punctuation and `Plus` were missing. The key map had grave/space but not comma/period/….

## Fix

- Accept that punctuation set in `VALID_HOTKEY_PATTERN`
- Map those Electron keys to XKB names in `ELECTRON_TO_HYPRLAND_KEY`

## Behavior before vs after

| Accelerator | `isValidHotkey` before | `bindKey` after |
| --- | --- | --- |
| `Control+,` | false | `CTRL, comma` |
| `Alt+.` | false | `ALT, period` |
| `Control+/` | false | `CTRL, slash` |
| `Control+-` | false | `CTRL, minus` |
| `Control+Plus` | false | `CTRL, plus` |
| `Control+F8` | true | unchanged |

## Scope & non-goals

- Only Hyprland validation + conversion + unit tests
- Does not change GNOME/KDE converters, Electron `globalShortcut`, or slot wiring (#1811)

## Tests

- `test/helpers/hyprlandShortcut.test.js` — punctuation accelerators validate and convert to XKB key names

## Validation

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/hyprlandShortcut.test.js` → PASS (16 tests)
- `npx prettier --check src/helpers/hyprlandShortcut.js test/helpers/hyprlandShortcut.test.js` → PASS