### PR TITLE
fix(linux): treat COSMIC Terminal as a terminal for paste

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -353,7 +353,7 @@ static const char *terminal_classes[] = {
     "terminator", "xterm", "urxvt", "rxvt", "tilix", "terminology",
     "wezterm", "foot", "st", "yakuake", "ghostty", "guake", "tilda",
     "hyper", "tabby", "sakura", "warp", "termius", "waveterm",
-    "ptyxis", "kgx", "org.gnome.console", NULL
+    "ptyxis", "kgx", "org.gnome.console", "cosmicterm", "cosmic-term", NULL
 };
 
 static int is_terminal(const char *wm_class) {

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -60,6 +60,8 @@ const LINUX_TERMINAL_CLASSES = [
   "ptyxis",
   "kgx",
   "org.gnome.console",
+  "cosmicterm",
+  "cosmic-term",
 ];
 
 // macOS reports localized app names rather than window classes, and iTerm2 has

--- a/test/helpers/linuxTerminalClasses.test.js
+++ b/test/helpers/linuxTerminalClasses.test.js
@@ -38,6 +38,12 @@ test("Ptyxis and GNOME Console window classes are terminals", () => {
   assert.equal(clipboard.isLinuxTerminalWindowClass("kgx"), true);
 });
 
+test("COSMIC Terminal window classes are terminals", () => {
+  const clipboard = new ClipboardManager();
+  assert.equal(clipboard.isLinuxTerminalWindowClass("com.system76.CosmicTerm"), true);
+  assert.equal(clipboard.isLinuxTerminalWindowClass("cosmic-term"), true);
+});
+
 test("existing terminals still match", () => {
   const clipboard = new ClipboardManager();
   assert.equal(clipboard.isLinuxTerminalWindowClass("kitty"), true);


### PR DESCRIPTION
## Summary

- Linux auto-paste uses Ctrl+Shift+V in terminals and Ctrl+V elsewhere.
- COSMIC Terminal’s app id is `com.system76.CosmicTerm` (process `cosmic-term`). Neither matches the existing `"terminal"` substring (`CosmicTerm` ≠ `terminal`).
- Add those signatures to `clipboard.js` and `linux-fast-paste.c` (lists must stay in sync).

Fixes #1876

## Problem

Dictating into COSMIC Terminal pastes with Ctrl+V, which typically inserts a control character instead of clipboard text.

## Root cause

Same gap as Ptyxis/GNOME Console (#1659): a newer terminal’s window class was never added to `LINUX_TERMINAL_CLASSES`.

## Fix

- Add `cosmicterm` (matches `com.system76.CosmicTerm`) and `cosmic-term` (process name)

## Behavior before vs after

| Window class | Before | After |
| --- | --- | --- |
| `com.system76.CosmicTerm` | not a terminal | terminal (Ctrl+Shift+V) |
| `cosmic-term` | not a terminal | terminal |
| `org.gnome.Ptyxis` | terminal | unchanged |
| `firefox` | not a terminal | unchanged |

## Scope & non-goals

- Only the two class lists and the existing terminal-class test
- Does not change paste backends, portal order, or other app classes

## Tests

- `test/helpers/linuxTerminalClasses.test.js`

## Validation

- `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/linuxTerminalClasses.test.js` → PASS (4 tests)
- `npx prettier --check src/helpers/clipboard.js test/helpers/linuxTerminalClasses.test.js` → PASS