### PR TITLE
fix(dictionary): support Set and iterable snapshots in agentNameDictionaryChanges

### DIFF
--- a/src/helpers/agentNameDictionary.js
+++ b/src/helpers/agentNameDictionary.js
@@ -1,5 +1,6 @@
 function findStoredWord(words, word) {
-  const needle = word.toLowerCase();
+  if (typeof word !== "string" || !Array.isArray(words)) return undefined;
+  const needle = word.trim().toLowerCase();
   return words.find((w) => typeof w === "string" && w.trim().toLowerCase() === needle);
 }
 
@@ -11,13 +12,17 @@ function findStoredWord(words, word) {
  * table, so a caller holding a stale snapshot deletes everything it omitted
  * (#1295); a delta can only touch the words it names.
  *
- * @param {string[]} dictionary current dictionary snapshot
+ * @param {Iterable<string>|string[]} dictionary current dictionary snapshot
  * @param {string} newName
  * @param {string} [oldName]
  * @returns {{ add: string[], remove: string[] }}
  */
 export function agentNameDictionaryChanges(dictionary, newName, oldName) {
-  const words = Array.isArray(dictionary) ? dictionary : [];
+  const words = Array.isArray(dictionary)
+    ? dictionary
+    : dictionary && typeof dictionary[Symbol.iterator] === "function" && typeof dictionary !== "string"
+      ? Array.from(dictionary)
+      : [];
   const trimmedNew = typeof newName === "string" ? newName.trim() : "";
   const trimmedOld = typeof oldName === "string" ? oldName.trim() : "";
   const storedNew = trimmedNew ? findStoredWord(words, trimmedNew) : undefined;

--- a/test/helpers/agentNameDictionary.test.js
+++ b/test/helpers/agentNameDictionary.test.js
@@ -113,3 +113,19 @@ test("removes previous agent name when oldName contains surrounding whitespace",
     }
   );
 });
+
+test("supports Set and iterable dictionary inputs", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(
+    agentNameDictionaryChanges(new Set(["OpenWhispr", "Alice"]), "OpenWhispr"),
+    { add: [], remove: [] }
+  );
+  assert.deepEqual(
+    agentNameDictionaryChanges(new Set(["OpenWhispr", "Alice"]), "Jarvis", "OpenWhispr"),
+    { add: ["Jarvis"], remove: ["OpenWhispr"] }
+  );
+  assert.deepEqual(agentNameDictionaryChanges(null, "Jarvis"), {
+    add: ["Jarvis"],
+    remove: [],
+  });
+});


### PR DESCRIPTION
Fixes #1880

### Problem
In `src/helpers/agentNameDictionary.js`:
- `agentNameDictionaryChanges` strictly checked `Array.isArray(dictionary)`, ignoring non-array iterables (such as `Set`), which resulted in calculating redundant add deltas.
- `findStoredWord` called `word.toLowerCase()` unconditionally, throwing `TypeError` if `word` was not a string.

### Solution
- Supported Sets and generic iterables via `Array.from`.
- Added defensive type check for `word` in `findStoredWord`.
- Added unit tests in `test/helpers/agentNameDictionary.test.js`.

### Verification
- `node --test test/helpers/agentNameDictionary.test.js` (passes, 15/15 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)