### PR TITLE
fix(auth): validate tenant string type and normalize environment in cortiAuth

### DIFF
--- a/src/helpers/cortiAuth.js
+++ b/src/helpers/cortiAuth.js
@@ -12,16 +12,21 @@ const TOKEN_FETCH_TIMEOUT_MS = 12_000;
 const tokenCache = new Map();
 
 function assertValidTarget(environment, tenant) {
-  if (!CORTI_ENVIRONMENTS.has(environment)) {
+  if (typeof environment !== "string" || !CORTI_ENVIRONMENTS.has(environment.trim().toLowerCase())) {
     throw new Error(`Invalid Corti environment: ${environment}`);
   }
-  if (!TENANT_PATTERN.test(tenant)) {
+  if (typeof tenant !== "string" || !TENANT_PATTERN.test(tenant.trim())) {
     throw new Error("Invalid Corti tenant name");
   }
 }
 
-async function getCortiToken({ environment, tenant, clientId, clientSecret }, fetchImpl) {
+async function getCortiToken(credentials = {}, fetchImpl) {
+  const { environment, tenant, clientId, clientSecret } =
+    credentials && typeof credentials === "object" ? credentials : {};
   assertValidTarget(environment, tenant);
+
+  const normalizedEnv = environment.trim().toLowerCase();
+  const normalizedTenant = tenant.trim();
 
   // The secret is part of the key (digested, never stored raw) so edited
   // credentials always re-authenticate; a key without it makes a connection
@@ -30,7 +35,7 @@ async function getCortiToken({ environment, tenant, clientId, clientSecret }, fe
     .update(clientSecret ?? "")
     .digest("hex")
     .slice(0, 16);
-  const cacheKey = `${environment}/${tenant}/${clientId}/${secretDigest}`;
+  const cacheKey = `${normalizedEnv}/${normalizedTenant}/${clientId}/${secretDigest}`;
   const cached = tokenCache.get(cacheKey);
   if (cached && Date.now() < cached.expiresAt) {
     return cached.value;
@@ -41,7 +46,7 @@ async function getCortiToken({ environment, tenant, clientId, clientSecret }, fe
   const timeoutHandle = setTimeout(() => controller.abort(), TOKEN_FETCH_TIMEOUT_MS);
   try {
     const response = await doFetch(
-      `https://auth.${environment}.corti.app/realms/${tenant}/protocol/openid-connect/token`,
+      `https://auth.${normalizedEnv}.corti.app/realms/${normalizedTenant}/protocol/openid-connect/token`,
       {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/test/helpers/cortiAuth.test.js
+++ b/test/helpers/cortiAuth.test.js
@@ -63,3 +63,27 @@ test("the token request carries an abort signal and surfaces AbortError", async 
   );
   assert.ok(seenSignal instanceof AbortSignal);
 });
+
+test("rejects invalid or nullish tenant names and normalizes environment casing", async () => {
+  await assert.rejects(
+    getCortiToken({ environment: "eu", tenant: null, clientId: "t", clientSecret: "s" }),
+    /Invalid Corti tenant name/
+  );
+  await assert.rejects(
+    getCortiToken({ environment: "eu", tenant: undefined, clientId: "t", clientSecret: "s" }),
+    /Invalid Corti tenant name/
+  );
+  await assert.rejects(
+    getCortiToken(null),
+    /Invalid Corti environment/
+  );
+
+  const { fetchImpl } = makeFetch(["token-eu"]);
+  assert.equal(
+    await getCortiToken(
+      { environment: " EU ", tenant: " acme ", clientId: "case-check", clientSecret: "s" },
+      fetchImpl
+    ),
+    "token-eu"
+  );
+});


### PR DESCRIPTION
Fixes #1882

### Problem
In `src/helpers/cortiAuth.js`:
1. `assertValidTarget` evaluated `TENANT_PATTERN.test(tenant)` without checking `typeof tenant === "string"`. In JavaScript, `RegExp.prototype.test(null)` coerces `null` to `"null"` (and `undefined` to `"undefined"`), matching the alphanumeric tenant regex and permitting invalid/nullish tenant names.
2. `assertValidTarget` was sensitive to casing/whitespace for valid Corti environment targets (e.g. `"EU"`).
3. `getCortiToken` threw `TypeError: Cannot destructure property 'environment' of 'null'` when called with nullish credentials.

### Solution
- Checked that `typeof tenant === "string"` and `typeof environment === "string"`, and normalized environment strings with `.trim().toLowerCase()`.
- Guarded credentials parameter in `getCortiToken`.
- Added unit tests in `test/helpers/cortiAuth.test.js`.

### Verification
- `node --test test/helpers/cortiAuth.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)