### PR TITLE
fix(chat): normalize provider casing and guard settings in resolveChatRoute

### DIFF
--- a/src/helpers/chatRouting.js
+++ b/src/helpers/chatRouting.js
@@ -11,15 +11,18 @@ const CLOUD_CHAT_PROVIDERS = new Set([
 
 // Resolve Chat from Chat-owned settings only. In particular, this must never
 // consult Dictation Cleanup's mode or endpoint.
-export function resolveChatRoute({ provider, lanUrl, customApiKey, isEnterpriseProvider = false }) {
+export function resolveChatRoute(settings = {}) {
+  const { provider, lanUrl, customApiKey, isEnterpriseProvider = false } =
+    settings && typeof settings === "object" ? settings : {};
+
   // An explicit self-hosted URL is the caller's declared route — it wins even
   // over a stale enterprise provider id left in settings.
-  const baseUrl = lanUrl?.trim() || "";
+  const baseUrl = typeof lanUrl === "string" ? lanUrl.trim() : "";
   if (baseUrl) {
     return {
       kind: "self-hosted",
       baseUrl,
-      apiKey: customApiKey?.trim() || "",
+      apiKey: typeof customApiKey === "string" ? customApiKey.trim() : "",
     };
   }
 
@@ -27,7 +30,8 @@ export function resolveChatRoute({ provider, lanUrl, customApiKey, isEnterpriseP
     return { kind: "enterprise", baseUrl: "", apiKey: "" };
   }
 
-  if (!CLOUD_CHAT_PROVIDERS.has(provider)) {
+  const normalizedProvider = typeof provider === "string" ? provider.trim().toLowerCase() : "";
+  if (!CLOUD_CHAT_PROVIDERS.has(normalizedProvider)) {
     return { kind: "local", baseUrl: "", apiKey: "" };
   }
 

--- a/test/helpers/chatRouting.test.js
+++ b/test/helpers/chatRouting.test.js
@@ -74,3 +74,14 @@ test("blank Chat LAN URL does not activate self-hosted routing", async () => {
 
   assert.equal(route.kind, "provider");
 });
+
+test("handles nullish settings and normalizes provider casing and whitespace", async () => {
+  const { resolveChatRoute } = await load();
+
+  assert.deepEqual(resolveChatRoute(), { kind: "local", baseUrl: "", apiKey: "" });
+  assert.deepEqual(resolveChatRoute(null), { kind: "local", baseUrl: "", apiKey: "" });
+  assert.equal(resolveChatRoute({ provider: "OpenAI" }).kind, "provider");
+  assert.equal(resolveChatRoute({ provider: " Anthropic " }).kind, "provider");
+  assert.equal(resolveChatRoute({ provider: "GROQ" }).kind, "provider");
+  assert.equal(resolveChatRoute({ lanUrl: 123 }).kind, "local");
+});


### PR DESCRIPTION
Fixes #1890

### Problem
In `src/helpers/chatRouting.js`:
- `resolveChatRoute` threw `TypeError: Cannot destructure property 'provider' of 'undefined'` when called without settings or with `null`.
- `CLOUD_CHAT_PROVIDERS.has(provider)` failed for valid provider names with mixed casing or leading/trailing whitespace (e.g. `"OpenAI"`, `" Anthropic "`), causing valid cloud providers to route as `kind: "local"`.
- Non-string `lanUrl` and `customApiKey` threw `TypeError` when evaluating `?.trim()`.

### Solution
- Safely defaulted `settings` in `resolveChatRoute`.
- Normalized `provider` with `typeof provider === "string" ? provider.trim().toLowerCase() : ""`.
- Added string type checks for `lanUrl` and `customApiKey`.
- Added unit tests in `test/helpers/chatRouting.test.js`.

### Verification
- `node --test test/helpers/chatRouting.test.js` (passes, 8/8 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)