### PR TITLE
fix(notes): preserve transcript scroll during resize

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -12,12 +12,23 @@ interface ChatMessagesProps {
 export function ChatMessages({ messages, emptyState, onOpenNote }: ChatMessagesProps) {
   // Follow the stream only while the user is at the bottom; scrolling up to
   // re-read must not be yanked back down by the next token.
-  const { scrollRef, handleScroll } = useStickToBottom<HTMLDivElement>(messages);
+  const {
+    scrollRef,
+    handleScroll,
+    handleWheel,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  } = useStickToBottom<HTMLDivElement>(messages);
 
   return (
     <div
       ref={scrollRef}
       onScroll={handleScroll}
+      onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
       className={cn("flex-1 overflow-y-auto agent-chat-scroll", "px-3 py-2")}
     >
       {messages.length === 0 ? (

--- a/src/components/dictation/LiveTranscriptPanel.tsx
+++ b/src/components/dictation/LiveTranscriptPanel.tsx
@@ -31,9 +31,14 @@ export function LiveTranscriptPanel({
   onHoldChange,
 }: LiveTranscriptPanelProps) {
   const { t } = useTranslation();
-  const { scrollRef, handleScroll } = useStickToBottom<HTMLDivElement>(text, {
-    resetToTop: !text,
-  });
+  const {
+    scrollRef,
+    handleScroll,
+    handleWheel,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  } = useStickToBottom<HTMLDivElement>(text, { resetToTop: !text });
   const { copied, copy: handleCopy } = useCopyFeedback(text, { resetMs: COPIED_RESET_MS });
   const shouldShimmer = Boolean(text) && (phase === "live" || phase === "cleanup" || processing);
   const shimmerParts = useMemo(
@@ -46,6 +51,10 @@ export function LiveTranscriptPanel({
       <main
         ref={scrollRef}
         onScroll={handleScroll}
+        onWheel={handleWheel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
         onMouseEnter={() => onHoldChange?.(true)}
         onMouseLeave={() => onHoldChange?.(false)}
         data-panel-scroll-region

--- a/src/components/notes/MeetingTranscriptChat.tsx
+++ b/src/components/notes/MeetingTranscriptChat.tsx
@@ -1,7 +1,8 @@
-import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Check, Loader2, ShieldCheck, Sparkles, Users, X } from "lucide-react";
+import { useStickToBottom } from "../../hooks/useStickToBottom";
 import { Popover, PopoverTrigger, PopoverContent } from "../ui/popover";
 import { Toggle } from "../ui/toggle";
 import { cn } from "../lib/utils";
@@ -50,7 +51,6 @@ const SPEAKER_BORDER_COLORS = [
   "border-l-red-400/50",
 ];
 
-const STICKY_SCROLL_THRESHOLD_PX = 80;
 // One unlabelled line of transcript; measureElement corrects each row on mount.
 const ESTIMATED_ROW_PX = 56;
 // Renders a screenful before the scroll element has been measured, instead of
@@ -754,8 +754,14 @@ export function MeetingTranscriptChat({
   onToggleSelect,
 }: MeetingTranscriptChatProps) {
   const { t } = useTranslation();
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const shouldStickToBottomRef = useRef(true);
+  const {
+    scrollRef,
+    handleScroll,
+    handleWheel,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  } = useStickToBottom<HTMLDivElement>(segments);
 
   // Rows are keyed by segment id, not index: segments are inserted by timestamp
   // and retracted mid-list, which would misalign an index-keyed size cache.
@@ -768,25 +774,6 @@ export function MeetingTranscriptChat({
     overscan: 8,
   });
   const totalSize = virtualizer.getTotalSize();
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const updateStickyScroll = () => {
-      shouldStickToBottomRef.current =
-        el.scrollHeight - el.scrollTop - el.clientHeight < STICKY_SCROLL_THRESHOLD_PX;
-    };
-
-    updateStickyScroll();
-    el.addEventListener("scroll", updateStickyScroll);
-    return () => el.removeEventListener("scroll", updateStickyScroll);
-  }, []);
-
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (!el || !shouldStickToBottomRef.current) return;
-    el.scrollTop = el.scrollHeight;
-  }, [segments, micPartial, systemPartial, totalSize]);
 
   const hasContent = segments.length > 0 || micPartial || systemPartial;
   const systemPartialSpeakerLabel =
@@ -952,74 +939,81 @@ export function MeetingTranscriptChat({
       )}
       <div
         ref={scrollRef}
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
         className="flex-1 min-h-0 overflow-y-auto px-4 pt-2 agent-chat-scroll pb-[var(--floating-inset,96px)]"
       >
-        <div style={{ height: totalSize, width: "100%", position: "relative" }}>
-          {virtualizer.getVirtualItems().map((virtualItem) => {
-            const i = virtualItem.index;
-            const segment = segments[i];
-            const selfSide = isSelfSide(segment);
-            const isSystemSpeaker = !!segment.speaker && !selfSide;
-            const { key, activeName } = rowMeta[i];
-            return (
-              <div
-                key={segment.id}
-                data-index={i}
-                ref={virtualizer.measureElement}
-                className="pb-1.5"
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-              >
-                <SegmentRow
-                  segment={segment}
-                  selfSide={selfSide}
-                  sameSpeaker={i > 0 && rowMeta[i - 1].key === key}
-                  isFirst={i === 0}
-                  isNewest={i === segments.length - 1}
-                  colorIdx={isSystemSpeaker ? (colorByKey.get(key) ?? 0) : 0}
-                  isSelected={selectedSegmentIds?.has(segment.id) ?? false}
-                  activeName={activeName}
-                  matchedProfile={activeName ? profilesByName.get(activeName) : undefined}
-                  speakerProfiles={speakerProfiles}
-                  participants={participants}
-                  onMapSpeaker={onMapSpeaker}
-                  onConfirmSuggestion={onConfirmSuggestion}
-                  onDismissSuggestion={onDismissSuggestion}
-                  onAttachSpeakerEmail={onAttachSpeakerEmail}
-                  onToggleSelect={onToggleSelect}
-                  t={t}
-                />
-              </div>
-            );
-          })}
-        </div>
+        <div>
+          <div style={{ height: totalSize, width: "100%", position: "relative" }}>
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const i = virtualItem.index;
+              const segment = segments[i];
+              const selfSide = isSelfSide(segment);
+              const isSystemSpeaker = !!segment.speaker && !selfSide;
+              const { key, activeName } = rowMeta[i];
+              return (
+                <div
+                  key={segment.id}
+                  data-index={i}
+                  ref={virtualizer.measureElement}
+                  className="pb-1.5"
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <SegmentRow
+                    segment={segment}
+                    selfSide={selfSide}
+                    sameSpeaker={i > 0 && rowMeta[i - 1].key === key}
+                    isFirst={i === 0}
+                    isNewest={i === segments.length - 1}
+                    colorIdx={isSystemSpeaker ? (colorByKey.get(key) ?? 0) : 0}
+                    isSelected={selectedSegmentIds?.has(segment.id) ?? false}
+                    activeName={activeName}
+                    matchedProfile={activeName ? profilesByName.get(activeName) : undefined}
+                    speakerProfiles={speakerProfiles}
+                    participants={participants}
+                    onMapSpeaker={onMapSpeaker}
+                    onConfirmSuggestion={onConfirmSuggestion}
+                    onDismissSuggestion={onDismissSuggestion}
+                    onAttachSpeakerEmail={onAttachSpeakerEmail}
+                    onToggleSelect={onToggleSelect}
+                    t={t}
+                  />
+                </div>
+              );
+            })}
+          </div>
 
-        <div className="flex flex-col gap-1.5">
-          {[
-            { text: micPartial, source: "mic" as const, speakerLabel: undefined },
-            {
-              text: systemPartial,
-              source: "system" as const,
-              speakerLabel: systemPartialSpeakerLabel,
-            },
-          ].map(
-            ({ text, source, speakerLabel }) =>
-              text && (
-                <PartialBubble
-                  key={source}
-                  text={text}
-                  source={source}
-                  speakerLabel={speakerLabel}
-                  speakerState={source === "system" ? systemPartialSpeakerState : undefined}
-                  t={t}
-                />
-              )
-          )}
+          <div className="flex flex-col gap-1.5">
+            {[
+              { text: micPartial, source: "mic" as const, speakerLabel: undefined },
+              {
+                text: systemPartial,
+                source: "system" as const,
+                speakerLabel: systemPartialSpeakerLabel,
+              },
+            ].map(
+              ({ text, source, speakerLabel }) =>
+                text && (
+                  <PartialBubble
+                    key={source}
+                    text={text}
+                    source={source}
+                    speakerLabel={speakerLabel}
+                    speakerState={source === "system" ? systemPartialSpeakerState : undefined}
+                    t={t}
+                  />
+                )
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/notes/MeetingTranscriptChat.tsx
+++ b/src/components/notes/MeetingTranscriptChat.tsx
@@ -754,6 +754,12 @@ export function MeetingTranscriptChat({
   onToggleSelect,
 }: MeetingTranscriptChatProps) {
   const { t } = useTranslation();
+  const hasContent = segments.length > 0 || Boolean(micPartial) || Boolean(systemPartial);
+  // The scroller mounts only once content exists, and a recording opens with
+  // partials before its first final segment — the follow effect must re-run on
+  // that mount too, or it runs against a null node and never attaches its
+  // resize observer.
+  const followDep = useMemo(() => ({ segments, hasContent }), [segments, hasContent]);
   const {
     scrollRef,
     handleScroll,
@@ -761,7 +767,7 @@ export function MeetingTranscriptChat({
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
-  } = useStickToBottom<HTMLDivElement>(segments);
+  } = useStickToBottom<HTMLDivElement>(followDep);
 
   // Rows are keyed by segment id, not index: segments are inserted by timestamp
   // and retracted mid-list, which would misalign an index-keyed size cache.
@@ -775,7 +781,6 @@ export function MeetingTranscriptChat({
   });
   const totalSize = virtualizer.getTotalSize();
 
-  const hasContent = segments.length > 0 || micPartial || systemPartial;
   const systemPartialSpeakerLabel =
     systemPartialSpeakerName ||
     (systemPartialSpeakerId

--- a/src/components/notes/floatingChatLayout.ts
+++ b/src/components/notes/floatingChatLayout.ts
@@ -1,14 +1,16 @@
+import {
+  createScrollFollowController,
+  getScrollBottomDistance,
+  type ScrollMetrics,
+} from "../../utils/scrollFollowState";
+
 export const FLOATING_CHAT_INSET_EXTRA_PX = 32;
 export const FLOATING_CHAT_MIN_VISIBLE_CONTENT_PX = 80;
 export const FLOATING_CHAT_MAX_HEIGHT_CSS = "calc(100% - 7rem)";
 
 const SCROLL_BOTTOM_THRESHOLD_PX = 80;
 
-export interface ScrollMetrics {
-  scrollHeight: number;
-  scrollTop: number;
-  clientHeight: number;
-}
+export type { ScrollMetrics };
 
 interface ResizeObserverHandle {
   observe: (element: Element) => void;
@@ -29,8 +31,7 @@ interface FloatingChatLayoutDependencies {
 }
 
 export function isNearScrollBottom(metrics: ScrollMetrics): boolean {
-  const distanceToBottom = metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
-  return distanceToBottom <= SCROLL_BOTTOM_THRESHOLD_PX;
+  return getScrollBottomDistance(metrics) <= SCROLL_BOTTOM_THRESHOLD_PX;
 }
 
 export function observeFloatingChatLayout(
@@ -44,26 +45,29 @@ export function observeFloatingChatLayout(
     dependencies.requestFrame ?? ((callback): number => requestAnimationFrame(callback));
   const cancelFrame =
     dependencies.cancelFrame ?? ((frameId): void => cancelAnimationFrame(frameId));
-  let followsBottom = true;
+  const follower = createScrollFollowController({
+    nearBottomThreshold: SCROLL_BOTTOM_THRESHOLD_PX,
+  });
   let frameId: number | null = null;
   let forcePinPending = false;
+  let touchY: number | null = null;
 
   const pinActiveScroller = (): void => {
     const scroller = getActiveScroller();
     if (!scroller) return;
     scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
-    followsBottom = true;
+    follower.follow();
   };
 
   const schedulePin = (force: boolean): void => {
     forcePinPending ||= force;
-    if (!forcePinPending && !followsBottom) return;
+    if (!forcePinPending && !follower.isFollowing()) return;
     if (frameId !== null) cancelFrame(frameId);
     frameId = requestFrame((): void => {
       frameId = null;
       const shouldForce = forcePinPending;
       forcePinPending = false;
-      if (shouldForce || followsBottom) pinActiveScroller();
+      if (shouldForce || follower.isFollowing()) pinActiveScroller();
     });
   };
 
@@ -77,10 +81,44 @@ export function observeFloatingChatLayout(
 
   const updateFollowState = (): void => {
     const scroller = getActiveScroller();
-    followsBottom = scroller !== null && isNearScrollBottom(scroller);
+    if (scroller) follower.update(scroller);
+  };
+
+  const stopFollowing = (): void => {
+    const scroller = getActiveScroller();
+    if (!scroller || scroller.scrollHeight - scroller.clientHeight <= 1) return;
+    follower.leaveBottom();
+    forcePinPending = false;
+    if (frameId !== null) {
+      cancelFrame(frameId);
+      frameId = null;
+    }
+  };
+
+  const handleWheel = (event: WheelEvent): void => {
+    if (event.deltaY < 0) stopFollowing();
+  };
+
+  const handleTouchStart = (event: TouchEvent): void => {
+    touchY = event.touches[0]?.clientY ?? null;
+  };
+
+  const handleTouchMove = (event: TouchEvent): void => {
+    const nextY = event.touches[0]?.clientY;
+    if (nextY == null) return;
+    if (touchY != null && nextY > touchY) stopFollowing();
+    touchY = nextY;
+  };
+
+  const handleTouchEnd = (): void => {
+    touchY = null;
   };
 
   contentRoot.addEventListener("scroll", updateFollowState, true);
+  contentRoot.addEventListener("wheel", handleWheel, { capture: true, passive: true });
+  contentRoot.addEventListener("touchstart", handleTouchStart, { capture: true, passive: true });
+  contentRoot.addEventListener("touchmove", handleTouchMove, { capture: true, passive: true });
+  contentRoot.addEventListener("touchend", handleTouchEnd, { capture: true, passive: true });
   applyInset(true);
 
   const observer = createResizeObserver((): void => applyInset());
@@ -90,6 +128,10 @@ export function observeFloatingChatLayout(
   return (): void => {
     observer.disconnect();
     contentRoot.removeEventListener("scroll", updateFollowState, true);
+    contentRoot.removeEventListener("wheel", handleWheel, true);
+    contentRoot.removeEventListener("touchstart", handleTouchStart, true);
+    contentRoot.removeEventListener("touchmove", handleTouchMove, true);
+    contentRoot.removeEventListener("touchend", handleTouchEnd, true);
     if (frameId !== null) cancelFrame(frameId);
     container.style.removeProperty("--floating-inset");
   };

--- a/src/components/notes/floatingChatLayout.ts
+++ b/src/components/notes/floatingChatLayout.ts
@@ -84,9 +84,16 @@ export function observeFloatingChatLayout(
     if (scroller) follower.update(scroller);
   };
 
-  const stopFollowing = (): void => {
+  // The capture listeners on the content root also see gestures over chrome
+  // that never scrolls the active scroller (consent strip, recording header).
+  // A wheel there moves nothing, so no scroll event could ever rejoin follow
+  // mode — only a gesture aimed at the scroller itself counts as leaving.
+  const stopFollowing = (target: EventTarget | null): void => {
     const scroller = getActiveScroller();
     if (!scroller || scroller.scrollHeight - scroller.clientHeight <= 1) return;
+    // Cast, not `instanceof Node`: this module runs under node:test, which has
+    // no DOM globals; wheel/touch targets are always nodes in the renderer.
+    if (target == null || !scroller.contains(target as Node)) return;
     follower.leaveBottom();
     forcePinPending = false;
     if (frameId !== null) {
@@ -96,7 +103,7 @@ export function observeFloatingChatLayout(
   };
 
   const handleWheel = (event: WheelEvent): void => {
-    if (event.deltaY < 0) stopFollowing();
+    if (event.deltaY < 0) stopFollowing(event.target);
   };
 
   const handleTouchStart = (event: TouchEvent): void => {
@@ -106,7 +113,7 @@ export function observeFloatingChatLayout(
   const handleTouchMove = (event: TouchEvent): void => {
     const nextY = event.touches[0]?.clientY;
     if (nextY == null) return;
-    if (touchY != null && nextY > touchY) stopFollowing();
+    if (touchY != null && nextY > touchY) stopFollowing(event.target);
     touchY = nextY;
   };
 

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -1,7 +1,18 @@
-import { useCallback, useLayoutEffect, useRef, type RefObject } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  type RefObject,
+  type TouchEvent,
+  type WheelEvent,
+} from "react";
+import {
+  createScrollFollowController,
+  type ScrollFollowController,
+} from "../utils/scrollFollowState";
 
-// Within this distance of the bottom the user counts as "following" the
-// stream; programmatic scrolls re-run the handler and therefore re-pin.
+// Passive scrolls within this distance still follow the stream. Explicit
+// upward input stays detached until the reader reaches the true bottom.
 const PIN_THRESHOLD_PX = 40;
 
 interface StickToBottomOptions {
@@ -9,46 +20,100 @@ interface StickToBottomOptions {
   resetToTop?: boolean;
 }
 
+interface StickToBottomResult<T extends HTMLElement> {
+  scrollRef: RefObject<T | null>;
+  handleScroll: () => void;
+  handleWheel: (event: WheelEvent<T>) => void;
+  handleTouchStart: (event: TouchEvent<T>) => void;
+  handleTouchMove: (event: TouchEvent<T>) => void;
+  handleTouchEnd: () => void;
+}
+
+function pinToBottom(node: HTMLElement): void {
+  const bottom = node.scrollHeight - node.clientHeight;
+  if (bottom > 0 && Math.abs(node.scrollTop - bottom) > 1) node.scrollTop = bottom;
+}
+
 /**
  * Keeps a scroller pinned to its bottom while content (`dep`) grows, but never
- * yanks a user back down after they scroll up to re-read. Attach `scrollRef`
- * and `onScroll` to the scrolling element.
+ * yanks a user back down after they scroll up to re-read. Attach the returned
+ * ref and event handlers to the scrolling element.
  */
 export function useStickToBottom<T extends HTMLElement>(
   dep: unknown,
   { resetToTop = false }: StickToBottomOptions = {}
-): { scrollRef: RefObject<T | null>; handleScroll: () => void } {
+): StickToBottomResult<T> {
   const scrollRef = useRef<T>(null);
-  const pinnedRef = useRef(true);
+  const followerRef = useRef<ScrollFollowController | null>(null);
+  const touchYRef = useRef<number | null>(null);
+  if (!followerRef.current) {
+    followerRef.current = createScrollFollowController({
+      nearBottomThreshold: PIN_THRESHOLD_PX,
+    });
+  }
 
   useLayoutEffect(() => {
     const node = scrollRef.current;
     if (!node) return;
     if (resetToTop) {
-      pinnedRef.current = true;
+      followerRef.current?.follow();
       node.scrollTop = 0;
       return;
     }
-    if (pinnedRef.current) {
-      const bottom = node.scrollHeight - node.clientHeight;
-      if (bottom > 0 && Math.abs(node.scrollTop - bottom) > 1) node.scrollTop = bottom;
-    }
-    // Re-pin when content height settles late; re-attached per dep since the
-    // content element can swap (empty state → list).
+    if (followerRef.current?.isFollowing()) pinToBottom(node);
+
     const content = node.firstElementChild;
-    if (!content) return;
     const ro = new ResizeObserver(() => {
-      if (pinnedRef.current) node.scrollTop = node.scrollHeight - node.clientHeight;
+      if (followerRef.current?.isFollowing()) pinToBottom(node);
     });
-    ro.observe(content);
+    ro.observe(node);
+    if (content) ro.observe(content);
     return () => ro.disconnect();
   }, [dep, resetToTop]);
 
   const handleScroll = useCallback(() => {
     const node = scrollRef.current;
     if (!node) return;
-    pinnedRef.current = node.scrollHeight - node.scrollTop - node.clientHeight < PIN_THRESHOLD_PX;
+    followerRef.current?.update(node);
   }, []);
 
-  return { scrollRef, handleScroll };
+  const handleWheel = useCallback((event: WheelEvent<T>) => {
+    const node = scrollRef.current;
+    if (event.deltaY < 0 && node && node.scrollHeight - node.clientHeight > 1) {
+      followerRef.current?.leaveBottom();
+    }
+  }, []);
+
+  const handleTouchStart = useCallback((event: TouchEvent<T>) => {
+    touchYRef.current = event.touches[0]?.clientY ?? null;
+  }, []);
+
+  const handleTouchMove = useCallback((event: TouchEvent<T>) => {
+    const nextY = event.touches[0]?.clientY;
+    const previousY = touchYRef.current;
+    if (nextY == null) return;
+    const node = scrollRef.current;
+    if (
+      previousY != null &&
+      nextY > previousY &&
+      node &&
+      node.scrollHeight - node.clientHeight > 1
+    ) {
+      followerRef.current?.leaveBottom();
+    }
+    touchYRef.current = nextY;
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    touchYRef.current = null;
+  }, []);
+
+  return {
+    scrollRef,
+    handleScroll,
+    handleWheel,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  };
 }

--- a/src/hooks/useStickToBottom.ts
+++ b/src/hooks/useStickToBottom.ts
@@ -34,6 +34,15 @@ function pinToBottom(node: HTMLElement): void {
   if (bottom > 0 && Math.abs(node.scrollTop - bottom) > 1) node.scrollTop = bottom;
 }
 
+// Portaled descendants (e.g. a popover opened from a row) bubble synthetic
+// events through the React tree while their DOM target lives outside the
+// scroller; wheeling there scrolls another surface, not the stream.
+function isReaderGesture(node: HTMLElement, target: EventTarget | null): boolean {
+  return (
+    node.scrollHeight - node.clientHeight > 1 && target instanceof Node && node.contains(target)
+  );
+}
+
 /**
  * Keeps a scroller pinned to its bottom while content (`dep`) grows, but never
  * yanks a user back down after they scroll up to re-read. Attach the returned
@@ -79,7 +88,7 @@ export function useStickToBottom<T extends HTMLElement>(
 
   const handleWheel = useCallback((event: WheelEvent<T>) => {
     const node = scrollRef.current;
-    if (event.deltaY < 0 && node && node.scrollHeight - node.clientHeight > 1) {
+    if (event.deltaY < 0 && node && isReaderGesture(node, event.target)) {
       followerRef.current?.leaveBottom();
     }
   }, []);
@@ -93,12 +102,7 @@ export function useStickToBottom<T extends HTMLElement>(
     const previousY = touchYRef.current;
     if (nextY == null) return;
     const node = scrollRef.current;
-    if (
-      previousY != null &&
-      nextY > previousY &&
-      node &&
-      node.scrollHeight - node.clientHeight > 1
-    ) {
+    if (previousY != null && nextY > previousY && node && isReaderGesture(node, event.target)) {
       followerRef.current?.leaveBottom();
     }
     touchYRef.current = nextY;

--- a/src/utils/scrollFollowState.ts
+++ b/src/utils/scrollFollowState.ts
@@ -1,0 +1,60 @@
+export interface ScrollMetrics {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+interface ScrollFollowOptions {
+  nearBottomThreshold: number;
+  rejoinThreshold?: number;
+}
+
+export interface ScrollFollowController {
+  isFollowing: () => boolean;
+  leaveBottom: () => void;
+  update: (metrics: ScrollMetrics) => boolean;
+  follow: () => void;
+}
+
+export function getScrollBottomDistance(metrics: ScrollMetrics): number {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+}
+
+export function createScrollFollowController({
+  nearBottomThreshold,
+  rejoinThreshold = 1,
+}: ScrollFollowOptions): ScrollFollowController {
+  let following = true;
+  let readerLeftBottom = false;
+  let readerMovedAway = false;
+
+  return {
+    isFollowing: () => following,
+    leaveBottom: () => {
+      readerLeftBottom = true;
+      readerMovedAway = false;
+      following = false;
+    },
+    update: (metrics) => {
+      const distanceToBottom = getScrollBottomDistance(metrics);
+      if (readerLeftBottom) {
+        if (distanceToBottom > rejoinThreshold) {
+          readerMovedAway = true;
+        } else if (readerMovedAway) {
+          readerLeftBottom = false;
+          readerMovedAway = false;
+          following = true;
+        }
+        return following;
+      }
+
+      following = distanceToBottom <= nearBottomThreshold;
+      return following;
+    },
+    follow: () => {
+      readerLeftBottom = false;
+      readerMovedAway = false;
+      following = true;
+    },
+  };
+}

--- a/test/components/floatingChatLayout.test.js
+++ b/test/components/floatingChatLayout.test.js
@@ -29,8 +29,8 @@ function createElement(overrides = {}) {
     removeEventListener(name, listener) {
       if (listeners.get(name) === listener) listeners.delete(name);
     },
-    dispatch(name) {
-      listeners.get(name)?.();
+    dispatch(name, event) {
+      listeners.get(name)?.(event);
     },
     hasListener(name) {
       return listeners.has(name);
@@ -137,4 +137,60 @@ test("the panel cap leaves the promised note content visible", async () => {
   assert.equal(FLOATING_CHAT_INSET_EXTRA_PX, 32);
   assert.equal(FLOATING_CHAT_MIN_VISIBLE_CONTENT_PX, 80);
   assert.equal(FLOATING_CHAT_MAX_HEIGHT_CSS, "calc(100% - 7rem)");
+});
+
+test("upward wheel intent cancels resize pinning until the reader returns to bottom", async () => {
+  const { observeFloatingChatLayout } = await load();
+  const panel = createElement({ offsetHeight: 200 });
+  const container = createElement();
+  const contentRoot = createElement();
+  const scroller = createElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
+  const scheduledFrames = new Map();
+  let resizeCallback;
+  let nextFrameId = 0;
+
+  const cleanup = observeFloatingChatLayout(
+    {
+      panel,
+      container,
+      contentRoot,
+      getActiveScroller: () => scroller,
+    },
+    {
+      createResizeObserver(callback) {
+        resizeCallback = callback;
+        return { observe() {}, disconnect() {} };
+      },
+      requestFrame(callback) {
+        const frameId = ++nextFrameId;
+        scheduledFrames.set(frameId, () => {
+          scheduledFrames.delete(frameId);
+          callback();
+        });
+        return frameId;
+      },
+      cancelFrame(frameId) {
+        scheduledFrames.delete(frameId);
+      },
+    }
+  );
+
+  scheduledFrames.get(nextFrameId)();
+  resizeCallback();
+  assert.equal(scheduledFrames.size, 1, "a followed resize schedules a bottom correction");
+
+  contentRoot.dispatch("wheel", { deltaY: -8 });
+  assert.equal(scheduledFrames.size, 0, "upward intent cancels the pending correction");
+
+  scroller.scrollTop = 680;
+  contentRoot.dispatch("scroll");
+  resizeCallback();
+  assert.equal(scheduledFrames.size, 0, "resizes do not re-pin a reader away from bottom");
+
+  scroller.scrollTop = 700;
+  contentRoot.dispatch("scroll");
+  resizeCallback();
+  assert.equal(scheduledFrames.size, 1, "reaching the true bottom restores follow mode");
+
+  cleanup();
 });

--- a/test/components/floatingChatLayout.test.js
+++ b/test/components/floatingChatLayout.test.js
@@ -139,17 +139,14 @@ test("the panel cap leaves the promised note content visible", async () => {
   assert.equal(FLOATING_CHAT_MAX_HEIGHT_CSS, "calc(100% - 7rem)");
 });
 
-test("upward wheel intent cancels resize pinning until the reader returns to bottom", async () => {
-  const { observeFloatingChatLayout } = await load();
+function createLayoutHarness(observeFloatingChatLayout, { scroller }) {
   const panel = createElement({ offsetHeight: 200 });
   const container = createElement();
   const contentRoot = createElement();
-  const scroller = createElement({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 });
   const scheduledFrames = new Map();
-  let resizeCallback;
-  let nextFrameId = 0;
+  const harness = { panel, container, contentRoot, scheduledFrames, nextFrameId: 0 };
 
-  const cleanup = observeFloatingChatLayout(
+  harness.cleanup = observeFloatingChatLayout(
     {
       panel,
       container,
@@ -158,11 +155,11 @@ test("upward wheel intent cancels resize pinning until the reader returns to bot
     },
     {
       createResizeObserver(callback) {
-        resizeCallback = callback;
+        harness.resizeCallback = callback;
         return { observe() {}, disconnect() {} };
       },
       requestFrame(callback) {
-        const frameId = ++nextFrameId;
+        const frameId = ++harness.nextFrameId;
         scheduledFrames.set(frameId, () => {
           scheduledFrames.delete(frameId);
           callback();
@@ -175,11 +172,26 @@ test("upward wheel intent cancels resize pinning until the reader returns to bot
     }
   );
 
+  return harness;
+}
+
+test("upward wheel intent cancels resize pinning until the reader returns to bottom", async () => {
+  const { observeFloatingChatLayout } = await load();
+  const transcriptRow = { name: "transcript-row" };
+  const scroller = createElement({
+    scrollHeight: 1000,
+    scrollTop: 700,
+    clientHeight: 300,
+    contains: (target) => target === transcriptRow,
+  });
+  const { contentRoot, scheduledFrames, resizeCallback, nextFrameId, cleanup } =
+    createLayoutHarness(observeFloatingChatLayout, { scroller });
+
   scheduledFrames.get(nextFrameId)();
   resizeCallback();
   assert.equal(scheduledFrames.size, 1, "a followed resize schedules a bottom correction");
 
-  contentRoot.dispatch("wheel", { deltaY: -8 });
+  contentRoot.dispatch("wheel", { deltaY: -8, target: transcriptRow });
   assert.equal(scheduledFrames.size, 0, "upward intent cancels the pending correction");
 
   scroller.scrollTop = 680;
@@ -193,4 +205,34 @@ test("upward wheel intent cancels resize pinning until the reader returns to bot
   assert.equal(scheduledFrames.size, 1, "reaching the true bottom restores follow mode");
 
   cleanup();
+});
+
+test("upward wheel over chrome outside the scroller keeps following", async () => {
+  const { observeFloatingChatLayout } = await load();
+  const recordingHeader = { name: "recording-header" };
+  const scroller = createElement({
+    scrollHeight: 1000,
+    scrollTop: 700,
+    clientHeight: 300,
+    contains: () => false,
+  });
+  const harness = createLayoutHarness(observeFloatingChatLayout, { scroller });
+  const { contentRoot, scheduledFrames } = harness;
+
+  scheduledFrames.get(harness.nextFrameId)();
+  harness.resizeCallback();
+  assert.equal(scheduledFrames.size, 1, "a followed resize schedules a bottom correction");
+
+  // The wheel moves nothing (its target never scrolls the active scroller), so
+  // no scroll event could ever rejoin — detaching here would wedge follow off.
+  contentRoot.dispatch("wheel", { deltaY: -8, target: recordingHeader });
+  assert.equal(scheduledFrames.size, 1, "a wheel aimed at chrome is not reader intent");
+
+  scheduledFrames.get(harness.nextFrameId)();
+  assert.equal(scroller.scrollTop, 700, "the pending correction still pins the bottom");
+
+  harness.resizeCallback();
+  assert.equal(scheduledFrames.size, 1, "later resizes keep following");
+
+  harness.cleanup();
 });

--- a/test/helpers/scrollFollowState.test.js
+++ b/test/helpers/scrollFollowState.test.js
@@ -31,3 +31,29 @@ test("resize measurements cannot re-pin after explicit upward scroll intent", as
     "follow mode returns only at the true bottom"
   );
 });
+
+test("a pin echo at the bottom right after leaveBottom does not restore follow", async () => {
+  const { createScrollFollowController } = await load();
+  const follower = createScrollFollowController({ nearBottomThreshold: 80 });
+
+  // A programmatic pin issued before the wheel landed still fires its scroll
+  // event after leaveBottom — at the bottom. Rejoining here would let the next
+  // resize yank the reader, which is the exact race this controller exists for.
+  follower.leaveBottom();
+  assert.equal(
+    follower.update({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 }),
+    false,
+    "a bottom scroll echoing a pre-detach pin stays detached"
+  );
+
+  assert.equal(
+    follower.update({ scrollHeight: 1000, scrollTop: 500, clientHeight: 300 }),
+    false,
+    "the reader genuinely moving away stays detached"
+  );
+  assert.equal(
+    follower.update({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 }),
+    true,
+    "only the reader's own return to the bottom rejoins"
+  );
+});

--- a/test/helpers/scrollFollowState.test.js
+++ b/test/helpers/scrollFollowState.test.js
@@ -1,0 +1,33 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/scrollFollowState.ts");
+
+test("resize measurements cannot re-pin after explicit upward scroll intent", async () => {
+  const { createScrollFollowController } = await load();
+  const follower = createScrollFollowController({ nearBottomThreshold: 80 });
+
+  assert.equal(
+    follower.update({ scrollHeight: 1000, scrollTop: 680, clientHeight: 300 }),
+    true,
+    "the initial near-bottom position follows live content"
+  );
+
+  follower.leaveBottom();
+  assert.equal(
+    follower.update({ scrollHeight: 1020, scrollTop: 680, clientHeight: 300 }),
+    false,
+    "a resize-driven height change preserves the reader's upward intent"
+  );
+  assert.equal(
+    follower.update({ scrollHeight: 990, scrollTop: 680, clientHeight: 300 }),
+    false,
+    "being back inside the old near-bottom threshold does not re-pin"
+  );
+
+  assert.equal(
+    follower.update({ scrollHeight: 980, scrollTop: 680, clientHeight: 300 }),
+    true,
+    "follow mode returns only at the true bottom"
+  );
+});


### PR DESCRIPTION
## Summary

- stop transcript and floating-chat resize observers from overriding explicit upward scroll intent
- share the follow-bottom state machine across live transcript/chat scrollers
- keep automatic live-follow enabled while the reader is at the bottom, and restore it only after returning to the true bottom
- add regression coverage for the resize-plus-upward-scroll race

## Root cause

The virtualized meeting transcript remeasures row heights while the Notes window or pane is resized. Each `totalSize` change reran a layout effect that wrote `scrollTop = scrollHeight` while the reader was still inside the near-bottom threshold. Repeated measurements could therefore reset small upward scroll deltas before they escaped the threshold, leaving the transcript apparently pinned.

The optional floating chat layout had a second resize-driven bottom correction with the same race.

## Test plan

- `node --import tsx --test test/helpers/scrollFollowState.test.js test/components/floatingChatLayout.test.js test/components/meetingTranscriptChat.test.js` — 11 passed
- `npm run typecheck` — passed
- focused renderer/test ESLint — 0 errors
- Prettier check for all changed files — passed
- `npm test` — 3,077 passed, 0 failed, 185 skipped, 1 existing todo

## Manual QA

1. Open a note with a long live transcript.
2. Resize the Notes/Transcript area continuously.
3. Scroll upward and stop in the middle while transcript updates continue.
4. Confirm resize measurements and new partials do not move the reader.
5. Scroll to the true bottom and confirm automatic live-follow resumes.
