### PR TITLE
fix(meetings): Add swipe dismissal to meeting reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The chat agent and the voice agent become one Voice Assistant behind a redesigne
 
 ### Meetings & speakers
 
-- **Meeting reminders swipe away like desktop notifications.** Horizontal trackpad swipes and pointer drags now dismiss meeting-detected and calendar reminder cards, while the **Keep recording** countdown remains protected.
+- **Meeting reminders swipe away like desktop notifications.** A horizontal pointer swipe now dismisses meeting-detected and calendar reminder cards, while the **Keep recording** countdown remains protected.
 - **Forgotten recordings end themselves.** When the call is over — the meeting app releases your microphone, or both audio channels go quiet, or the app exits — a 60-second countdown starts, cancellable with **Keep recording**, and the card tells you which signal fired. Remote voices still playing defer the countdown, so a quiet-but-live meeting is never cut short. (#1494)
 - **Meeting notes know who is who.** Every transcript line carries its resolved speaker name and the mic track carries your own name, a Meeting Context block names the note owner and invited participants, and the prompt is forbidden from inventing identities — so notes stop assuming you're whoever got named in conversation. (#1741)
 - **In-person meetings get speaker labels.** Recordings with everyone in the room and no call ended with zero diarized segments, because only the (silent) system-audio channel was ever diarized. Those sessions now diarize the microphone track. (#1726)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The chat agent and the voice agent become one Voice Assistant behind a redesigne
 
 ### Meetings & speakers
 
+- **Meeting reminders swipe away like desktop notifications.** Horizontal trackpad swipes and pointer drags now dismiss meeting-detected and calendar reminder cards, while the **Keep recording** countdown remains protected.
 - **Forgotten recordings end themselves.** When the call is over — the meeting app releases your microphone, or both audio channels go quiet, or the app exits — a 60-second countdown starts, cancellable with **Keep recording**, and the card tells you which signal fired. Remote voices still playing defer the countdown, so a quiet-but-live meeting is never cut short. (#1494)
 - **Meeting notes know who is who.** Every transcript line carries its resolved speaker name and the mic track carries your own name, a Meeting Context block names the note owner and invited participants, and the prompt is forbidden from inventing identities — so notes stop assuming you're whoever got named in conversation. (#1741)
 - **In-person meetings get speaker labels.** Recordings with everyone in the room and no call ended with zero diarized segments, because only the (silent) system-audio channel was ever diarized. Those sessions now diarize the microphone track. (#1726)

--- a/src/components/MeetingNotificationOverlay.tsx
+++ b/src/components/MeetingNotificationOverlay.tsx
@@ -1,41 +1,25 @@
 import {
-  useState,
-  useEffect,
   useCallback,
+  useEffect,
   useRef,
-  type CSSProperties,
+  useState,
   type PointerEvent as ReactPointerEvent,
   type ReactElement,
-  type WheelEvent as ReactWheelEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
 import type { MeetingNotificationData } from "../types/electron";
 import { MeetingNotificationCard } from "./MeetingNotificationCard";
 import {
   getMeetingNotificationPresentation,
-  getMeetingNotificationSwipeOutcome,
   initializeMeetingNotificationOverlay,
+  shouldDismissMeetingNotificationSwipe,
   subscribeMeetingAutoEndCountdown,
 } from "./meetingNotificationModel";
 
 interface PointerSwipe {
   pointerId: number;
   startX: number;
-  startY: number;
-  startedAt: number;
-  axis: "pending" | "horizontal" | "vertical";
 }
-
-interface WheelSwipe {
-  offsetX: number;
-  lastEventAt: number;
-}
-
-type SwipeExitDirection = "left" | "right";
-
-const DEFAULT_CARD_WIDTH_PX = 368;
-const SWIPE_AXIS_LOCK_PX = 6;
-const WHEEL_SWIPE_IDLE_MS = 140;
 
 export default function MeetingNotificationOverlay(): ReactElement {
   const { t } = useTranslation();
@@ -43,15 +27,7 @@ export default function MeetingNotificationOverlay(): ReactElement {
   const [isVisible, setIsVisible] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [secondsRemaining, setSecondsRemaining] = useState(0);
-  const [swipeOffsetX, setSwipeOffsetX] = useState(0);
-  const [isSwiping, setIsSwiping] = useState(false);
-  const [exitDirection, setExitDirection] = useState<SwipeExitDirection>("right");
-  const notificationRef = useRef<HTMLDivElement | null>(null);
   const pointerSwipeRef = useRef<PointerSwipe | null>(null);
-  const wheelSwipeRef = useRef<WheelSwipe | null>(null);
-  const wheelIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const gestureActiveRef = useRef(false);
-  const responseStartedRef = useRef(false);
 
   useEffect(() => {
     return initializeMeetingNotificationOverlay({
@@ -71,20 +47,11 @@ export default function MeetingNotificationOverlay(): ReactElement {
     return subscribeMeetingAutoEndCountdown(data.expiresAt, setSecondsRemaining);
   }, [data]);
 
-  useEffect(() => {
-    return () => {
-      if (wheelIdleTimerRef.current !== null) clearTimeout(wheelIdleTimerRef.current);
-    };
-  }, []);
-
   const presentation = getMeetingNotificationPresentation(data, secondsRemaining);
 
   const respond = useCallback(
-    async (action: string, direction: SwipeExitDirection = "right"): Promise<void> => {
-      if (data?.kind !== "detection" || responseStartedRef.current) return;
-      responseStartedRef.current = true;
-      setExitDirection(direction);
-      setIsSwiping(false);
+    async (action: string): Promise<void> => {
+      if (data?.kind !== "detection") return;
       setIsVisible(false);
       await new Promise<void>((resolve) => setTimeout(resolve, 200));
       window.electronAPI?.meetingNotificationRespond?.(data.detectionId, action);
@@ -92,59 +59,27 @@ export default function MeetingNotificationOverlay(): ReactElement {
     [data]
   );
 
-  const keepRecording = useCallback(() => {
+  const keepRecording = useCallback((): void => {
     if (data?.kind !== "auto-end") return;
     void window.electronAPI?.meetingAutoEndKeep?.(data.sessionId);
   }, [data]);
 
-  const handleMouseEnter = useCallback(() => {
+  const handleMouseEnter = useCallback((): void => {
     setIsHovered(true);
     window.electronAPI?.setNotificationInteractivity?.(true);
   }, []);
 
-  const handleMouseLeave = useCallback(() => {
+  const handleMouseLeave = useCallback((): void => {
     setIsHovered(false);
-    if (gestureActiveRef.current || pointerSwipeRef.current !== null) return;
+    if (pointerSwipeRef.current) return;
     window.electronAPI?.setNotificationInteractivity?.(false);
   }, []);
-
-  const finishSwipe = useCallback(
-    (horizontalDelta: number, verticalDelta: number, horizontalVelocity: number): void => {
-      if (wheelIdleTimerRef.current !== null) {
-        clearTimeout(wheelIdleTimerRef.current);
-        wheelIdleTimerRef.current = null;
-      }
-      wheelSwipeRef.current = null;
-      gestureActiveRef.current = false;
-
-      const outcome = getMeetingNotificationSwipeOutcome({
-        dismissible: presentation.dismissible,
-        horizontalDelta,
-        verticalDelta,
-        horizontalVelocity,
-        cardWidth: notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX,
-      });
-
-      if (outcome === "dismiss") {
-        void respond("dismiss", horizontalDelta < 0 ? "left" : "right");
-        return;
-      }
-
-      setIsSwiping(false);
-      setSwipeOffsetX(0);
-      if (!notificationRef.current?.matches(":hover")) {
-        window.electronAPI?.setNotificationInteractivity?.(false);
-      }
-    },
-    [presentation.dismissible, respond]
-  );
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>): void => {
       if (
         !presentation.dismissible ||
         !isVisible ||
-        responseStartedRef.current ||
         !event.isPrimary ||
         event.button !== 0 ||
         (event.target instanceof Element && event.target.closest("button"))
@@ -152,43 +87,14 @@ export default function MeetingNotificationOverlay(): ReactElement {
         return;
       }
 
-      if (wheelIdleTimerRef.current !== null) {
-        clearTimeout(wheelIdleTimerRef.current);
-        wheelIdleTimerRef.current = null;
-      }
-      wheelSwipeRef.current = null;
       pointerSwipeRef.current = {
         pointerId: event.pointerId,
         startX: event.clientX,
-        startY: event.clientY,
-        startedAt: event.timeStamp,
-        axis: "pending",
       };
       event.currentTarget.setPointerCapture(event.pointerId);
     },
     [isVisible, presentation.dismissible]
   );
-
-  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>): void => {
-    const swipe = pointerSwipeRef.current;
-    if (!swipe || swipe.pointerId !== event.pointerId) return;
-
-    const horizontalDelta = event.clientX - swipe.startX;
-    const verticalDelta = event.clientY - swipe.startY;
-    if (
-      swipe.axis === "pending" &&
-      Math.max(Math.abs(horizontalDelta), Math.abs(verticalDelta)) >= SWIPE_AXIS_LOCK_PX
-    ) {
-      swipe.axis = Math.abs(horizontalDelta) > Math.abs(verticalDelta) ? "horizontal" : "vertical";
-    }
-    if (swipe.axis !== "horizontal") return;
-
-    event.preventDefault();
-    gestureActiveRef.current = true;
-    setIsSwiping(true);
-    const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
-    setSwipeOffsetX(Math.max(-cardWidth, Math.min(cardWidth, horizontalDelta)));
-  }, []);
 
   const handlePointerUp = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>): void => {
@@ -199,69 +105,28 @@ export default function MeetingNotificationOverlay(): ReactElement {
       if (event.currentTarget.hasPointerCapture(event.pointerId)) {
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
-      const horizontalDelta = event.clientX - swipe.startX;
-      const verticalDelta = event.clientY - swipe.startY;
-      const elapsedMs = Math.max(1, event.timeStamp - swipe.startedAt);
-      finishSwipe(horizontalDelta, verticalDelta, horizontalDelta / elapsedMs);
+
+      if (
+        shouldDismissMeetingNotificationSwipe(
+          presentation.dismissible,
+          event.clientX - swipe.startX
+        )
+      ) {
+        void respond("dismiss");
+      } else if (!isHovered) {
+        window.electronAPI?.setNotificationInteractivity?.(false);
+      }
     },
-    [finishSwipe]
+    [isHovered, presentation.dismissible, respond]
   );
 
   const handlePointerCancel = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>): void => {
       if (pointerSwipeRef.current?.pointerId !== event.pointerId) return;
       pointerSwipeRef.current = null;
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-        event.currentTarget.releasePointerCapture(event.pointerId);
-      }
-      finishSwipe(0, 0, 0);
+      if (!isHovered) window.electronAPI?.setNotificationInteractivity?.(false);
     },
-    [finishSwipe]
-  );
-
-  const handleWheel = useCallback(
-    (event: ReactWheelEvent<HTMLDivElement>): void => {
-      if (
-        !presentation.dismissible ||
-        !isVisible ||
-        responseStartedRef.current ||
-        Math.abs(event.deltaX) <= Math.abs(event.deltaY)
-      ) {
-        return;
-      }
-
-      const previous = wheelSwipeRef.current;
-      const eventGapMs = previous ? event.timeStamp - previous.lastEventAt : Infinity;
-      const previousOffset = eventGapMs <= WHEEL_SWIPE_IDLE_MS ? (previous?.offsetX ?? 0) : 0;
-      const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
-      // Wheel deltas describe content scrolling, so invert them to keep the card under the finger.
-      const nextOffset = Math.max(-cardWidth, Math.min(cardWidth, previousOffset - event.deltaX));
-      const sampleDurationMs = Number.isFinite(eventGapMs) ? Math.max(1, eventGapMs) : 16;
-      const horizontalVelocity = (nextOffset - previousOffset) / sampleDurationMs;
-
-      wheelSwipeRef.current = { offsetX: nextOffset, lastEventAt: event.timeStamp };
-      gestureActiveRef.current = true;
-      setIsSwiping(true);
-      setSwipeOffsetX(nextOffset);
-
-      const outcome = getMeetingNotificationSwipeOutcome({
-        dismissible: true,
-        horizontalDelta: nextOffset,
-        verticalDelta: 0,
-        horizontalVelocity,
-        cardWidth,
-      });
-      if (outcome === "dismiss") {
-        finishSwipe(nextOffset, 0, horizontalVelocity);
-        return;
-      }
-
-      if (wheelIdleTimerRef.current !== null) clearTimeout(wheelIdleTimerRef.current);
-      wheelIdleTimerRef.current = setTimeout(() => {
-        finishSwipe(nextOffset, 0, 0);
-      }, WHEEL_SWIPE_IDLE_MS);
-    },
-    [finishSwipe, isVisible, presentation.dismissible]
+    [isHovered]
   );
 
   const title = "title" in presentation ? presentation.title : t(presentation.titleKey);
@@ -271,39 +136,32 @@ export default function MeetingNotificationOverlay(): ReactElement {
       : t(presentation.bodyKey);
   const handleAction =
     presentation.action === "keep" ? keepRecording : () => respond(presentation.action);
-  const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
-  const swipeOpacity = Math.max(0.72, 1 - Math.abs(swipeOffsetX) / cardWidth / 2);
-  const translateX = isVisible ? `${swipeOffsetX}px` : exitDirection === "left" ? "-120%" : "120%";
-  const motionStyle: CSSProperties = {
-    opacity: isVisible ? swipeOpacity : 0,
-    transform: `translateX(${translateX}) scale(${isVisible ? 1 : 0.95})`,
-    transition: isSwiping ? "none" : "transform 300ms ease-out, opacity 300ms ease-out",
-    touchAction: presentation.dismissible ? "pan-y" : "auto",
-  };
 
   return (
-    <div className="meeting-notification-window w-full h-full bg-transparent p-3">
-      <div
-        ref={notificationRef}
-        style={motionStyle}
+    <div
+      className="meeting-notification-window w-full h-full bg-transparent p-3"
+      style={{ touchAction: presentation.dismissible ? "pan-y" : "auto" }}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+    >
+      <MeetingNotificationCard
+        title={title}
+        body={body}
+        startLabel={t(presentation.actionKey)}
+        onStart={handleAction}
+        onDismiss={presentation.dismissible ? () => respond("dismiss") : undefined}
+        closeVisible={isHovered}
+        allowTitleWrap={presentation.allowTitleWrap}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerCancel}
-        onWheel={handleWheel}
-      >
-        <MeetingNotificationCard
-          title={title}
-          body={body}
-          startLabel={t(presentation.actionKey)}
-          onStart={handleAction}
-          onDismiss={presentation.dismissible ? () => respond("dismiss") : undefined}
-          closeVisible={isHovered}
-          allowTitleWrap={presentation.allowTitleWrap}
-        />
-      </div>
+        className={[
+          "transition-all duration-300 ease-out",
+          isVisible
+            ? "translate-x-0 opacity-100 scale-100"
+            : "translate-x-[120%] opacity-0 scale-95",
+        ].join(" ")}
+      />
     </div>
   );
 }

--- a/src/components/MeetingNotificationOverlay.tsx
+++ b/src/components/MeetingNotificationOverlay.tsx
@@ -1,19 +1,57 @@
-import { useState, useEffect, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type WheelEvent as ReactWheelEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
 import type { MeetingNotificationData } from "../types/electron";
 import { MeetingNotificationCard } from "./MeetingNotificationCard";
 import {
   getMeetingNotificationPresentation,
+  getMeetingNotificationSwipeOutcome,
   initializeMeetingNotificationOverlay,
   subscribeMeetingAutoEndCountdown,
 } from "./meetingNotificationModel";
 
-export default function MeetingNotificationOverlay() {
+interface PointerSwipe {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startedAt: number;
+  axis: "pending" | "horizontal" | "vertical";
+}
+
+interface WheelSwipe {
+  offsetX: number;
+  lastEventAt: number;
+}
+
+type SwipeExitDirection = "left" | "right";
+
+const DEFAULT_CARD_WIDTH_PX = 368;
+const SWIPE_AXIS_LOCK_PX = 6;
+const WHEEL_SWIPE_IDLE_MS = 140;
+
+export default function MeetingNotificationOverlay(): ReactElement {
   const { t } = useTranslation();
   const [data, setData] = useState<MeetingNotificationData | null>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [secondsRemaining, setSecondsRemaining] = useState(0);
+  const [swipeOffsetX, setSwipeOffsetX] = useState(0);
+  const [isSwiping, setIsSwiping] = useState(false);
+  const [exitDirection, setExitDirection] = useState<SwipeExitDirection>("right");
+  const notificationRef = useRef<HTMLDivElement | null>(null);
+  const pointerSwipeRef = useRef<PointerSwipe | null>(null);
+  const wheelSwipeRef = useRef<WheelSwipe | null>(null);
+  const wheelIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gestureActiveRef = useRef(false);
+  const responseStartedRef = useRef(false);
 
   useEffect(() => {
     return initializeMeetingNotificationOverlay({
@@ -33,11 +71,22 @@ export default function MeetingNotificationOverlay() {
     return subscribeMeetingAutoEndCountdown(data.expiresAt, setSecondsRemaining);
   }, [data]);
 
+  useEffect(() => {
+    return () => {
+      if (wheelIdleTimerRef.current !== null) clearTimeout(wheelIdleTimerRef.current);
+    };
+  }, []);
+
+  const presentation = getMeetingNotificationPresentation(data, secondsRemaining);
+
   const respond = useCallback(
-    async (action: string) => {
-      if (data?.kind !== "detection") return;
+    async (action: string, direction: SwipeExitDirection = "right"): Promise<void> => {
+      if (data?.kind !== "detection" || responseStartedRef.current) return;
+      responseStartedRef.current = true;
+      setExitDirection(direction);
+      setIsSwiping(false);
       setIsVisible(false);
-      await new Promise((r) => setTimeout(r, 200));
+      await new Promise<void>((resolve) => setTimeout(resolve, 200));
       window.electronAPI?.meetingNotificationRespond?.(data.detectionId, action);
     },
     [data]
@@ -55,10 +104,166 @@ export default function MeetingNotificationOverlay() {
 
   const handleMouseLeave = useCallback(() => {
     setIsHovered(false);
+    if (gestureActiveRef.current || pointerSwipeRef.current !== null) return;
     window.electronAPI?.setNotificationInteractivity?.(false);
   }, []);
 
-  const presentation = getMeetingNotificationPresentation(data, secondsRemaining);
+  const finishSwipe = useCallback(
+    (horizontalDelta: number, verticalDelta: number, horizontalVelocity: number): void => {
+      if (wheelIdleTimerRef.current !== null) {
+        clearTimeout(wheelIdleTimerRef.current);
+        wheelIdleTimerRef.current = null;
+      }
+      wheelSwipeRef.current = null;
+      gestureActiveRef.current = false;
+
+      const outcome = getMeetingNotificationSwipeOutcome({
+        dismissible: presentation.dismissible,
+        horizontalDelta,
+        verticalDelta,
+        horizontalVelocity,
+        cardWidth: notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX,
+      });
+
+      if (outcome === "dismiss") {
+        void respond("dismiss", horizontalDelta < 0 ? "left" : "right");
+        return;
+      }
+
+      setIsSwiping(false);
+      setSwipeOffsetX(0);
+      if (!notificationRef.current?.matches(":hover")) {
+        window.electronAPI?.setNotificationInteractivity?.(false);
+      }
+    },
+    [presentation.dismissible, respond]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      if (
+        !presentation.dismissible ||
+        !isVisible ||
+        responseStartedRef.current ||
+        !event.isPrimary ||
+        event.button !== 0 ||
+        (event.target instanceof Element && event.target.closest("button"))
+      ) {
+        return;
+      }
+
+      if (wheelIdleTimerRef.current !== null) {
+        clearTimeout(wheelIdleTimerRef.current);
+        wheelIdleTimerRef.current = null;
+      }
+      wheelSwipeRef.current = null;
+      pointerSwipeRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        startedAt: event.timeStamp,
+        axis: "pending",
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [isVisible, presentation.dismissible]
+  );
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>): void => {
+    const swipe = pointerSwipeRef.current;
+    if (!swipe || swipe.pointerId !== event.pointerId) return;
+
+    const horizontalDelta = event.clientX - swipe.startX;
+    const verticalDelta = event.clientY - swipe.startY;
+    if (
+      swipe.axis === "pending" &&
+      Math.max(Math.abs(horizontalDelta), Math.abs(verticalDelta)) >= SWIPE_AXIS_LOCK_PX
+    ) {
+      swipe.axis = Math.abs(horizontalDelta) > Math.abs(verticalDelta) ? "horizontal" : "vertical";
+    }
+    if (swipe.axis !== "horizontal") return;
+
+    event.preventDefault();
+    gestureActiveRef.current = true;
+    setIsSwiping(true);
+    const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
+    setSwipeOffsetX(Math.max(-cardWidth, Math.min(cardWidth, horizontalDelta)));
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      const swipe = pointerSwipeRef.current;
+      if (!swipe || swipe.pointerId !== event.pointerId) return;
+
+      pointerSwipeRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      const horizontalDelta = event.clientX - swipe.startX;
+      const verticalDelta = event.clientY - swipe.startY;
+      const elapsedMs = Math.max(1, event.timeStamp - swipe.startedAt);
+      finishSwipe(horizontalDelta, verticalDelta, horizontalDelta / elapsedMs);
+    },
+    [finishSwipe]
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>): void => {
+      if (pointerSwipeRef.current?.pointerId !== event.pointerId) return;
+      pointerSwipeRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      finishSwipe(0, 0, 0);
+    },
+    [finishSwipe]
+  );
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>): void => {
+      if (
+        !presentation.dismissible ||
+        !isVisible ||
+        responseStartedRef.current ||
+        Math.abs(event.deltaX) <= Math.abs(event.deltaY)
+      ) {
+        return;
+      }
+
+      const previous = wheelSwipeRef.current;
+      const eventGapMs = previous ? event.timeStamp - previous.lastEventAt : Infinity;
+      const previousOffset = eventGapMs <= WHEEL_SWIPE_IDLE_MS ? (previous?.offsetX ?? 0) : 0;
+      const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
+      // Wheel deltas describe content scrolling, so invert them to keep the card under the finger.
+      const nextOffset = Math.max(-cardWidth, Math.min(cardWidth, previousOffset - event.deltaX));
+      const sampleDurationMs = Number.isFinite(eventGapMs) ? Math.max(1, eventGapMs) : 16;
+      const horizontalVelocity = (nextOffset - previousOffset) / sampleDurationMs;
+
+      wheelSwipeRef.current = { offsetX: nextOffset, lastEventAt: event.timeStamp };
+      gestureActiveRef.current = true;
+      setIsSwiping(true);
+      setSwipeOffsetX(nextOffset);
+
+      const outcome = getMeetingNotificationSwipeOutcome({
+        dismissible: true,
+        horizontalDelta: nextOffset,
+        verticalDelta: 0,
+        horizontalVelocity,
+        cardWidth,
+      });
+      if (outcome === "dismiss") {
+        finishSwipe(nextOffset, 0, horizontalVelocity);
+        return;
+      }
+
+      if (wheelIdleTimerRef.current !== null) clearTimeout(wheelIdleTimerRef.current);
+      wheelIdleTimerRef.current = setTimeout(() => {
+        finishSwipe(nextOffset, 0, 0);
+      }, WHEEL_SWIPE_IDLE_MS);
+    },
+    [finishSwipe, isVisible, presentation.dismissible]
+  );
+
   const title = "title" in presentation ? presentation.title : t(presentation.titleKey);
   const body =
     "bodyValues" in presentation
@@ -66,26 +271,39 @@ export default function MeetingNotificationOverlay() {
       : t(presentation.bodyKey);
   const handleAction =
     presentation.action === "keep" ? keepRecording : () => respond(presentation.action);
+  const cardWidth = notificationRef.current?.offsetWidth ?? DEFAULT_CARD_WIDTH_PX;
+  const swipeOpacity = Math.max(0.72, 1 - Math.abs(swipeOffsetX) / cardWidth / 2);
+  const translateX = isVisible ? `${swipeOffsetX}px` : exitDirection === "left" ? "-120%" : "120%";
+  const motionStyle: CSSProperties = {
+    opacity: isVisible ? swipeOpacity : 0,
+    transform: `translateX(${translateX}) scale(${isVisible ? 1 : 0.95})`,
+    transition: isSwiping ? "none" : "transform 300ms ease-out, opacity 300ms ease-out",
+    touchAction: presentation.dismissible ? "pan-y" : "auto",
+  };
 
   return (
     <div className="meeting-notification-window w-full h-full bg-transparent p-3">
-      <MeetingNotificationCard
-        title={title}
-        body={body}
-        startLabel={t(presentation.actionKey)}
-        onStart={handleAction}
-        onDismiss={presentation.dismissible ? () => respond("dismiss") : undefined}
-        closeVisible={isHovered}
-        allowTitleWrap={presentation.allowTitleWrap}
+      <div
+        ref={notificationRef}
+        style={motionStyle}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className={[
-          "transition-all duration-300 ease-out",
-          isVisible
-            ? "translate-x-0 opacity-100 scale-100"
-            : "translate-x-[120%] opacity-0 scale-95",
-        ].join(" ")}
-      />
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onWheel={handleWheel}
+      >
+        <MeetingNotificationCard
+          title={title}
+          body={body}
+          startLabel={t(presentation.actionKey)}
+          onStart={handleAction}
+          onDismiss={presentation.dismissible ? () => respond("dismiss") : undefined}
+          closeVisible={isHovered}
+          allowTitleWrap={presentation.allowTitleWrap}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/meetingNotificationModel.ts
+++ b/src/components/meetingNotificationModel.ts
@@ -36,6 +36,37 @@ interface DetectionPresentation {
 
 export type MeetingNotificationPresentation = AutoEndPresentation | DetectionPresentation;
 
+interface MeetingNotificationSwipeSample {
+  dismissible: boolean;
+  horizontalDelta: number;
+  verticalDelta: number;
+  horizontalVelocity: number;
+  cardWidth: number;
+}
+
+export type MeetingNotificationSwipeOutcome = "dismiss" | "ignore" | "reset";
+
+const SWIPE_MAX_DISTANCE_PX = 96;
+const SWIPE_DISTANCE_RATIO = 0.25;
+const SWIPE_MIN_FLING_DISTANCE_PX = 24;
+const SWIPE_MIN_FLING_VELOCITY_PX_PER_MS = 0.75;
+
+export function getMeetingNotificationSwipeOutcome(
+  sample: MeetingNotificationSwipeSample
+): MeetingNotificationSwipeOutcome {
+  if (!sample.dismissible) return "ignore";
+  if (Math.abs(sample.verticalDelta) >= Math.abs(sample.horizontalDelta)) return "ignore";
+  const horizontalDistance = Math.abs(sample.horizontalDelta);
+  const distanceThreshold = Math.min(
+    SWIPE_MAX_DISTANCE_PX,
+    sample.cardWidth * SWIPE_DISTANCE_RATIO
+  );
+  const isFling =
+    horizontalDistance >= SWIPE_MIN_FLING_DISTANCE_PX &&
+    Math.abs(sample.horizontalVelocity) >= SWIPE_MIN_FLING_VELOCITY_PX_PER_MS;
+  return horizontalDistance >= distanceThreshold || isFling ? "dismiss" : "reset";
+}
+
 export function getMeetingNotificationPresentation(
   data: MeetingNotificationData | null,
   secondsRemaining: number

--- a/src/components/meetingNotificationModel.ts
+++ b/src/components/meetingNotificationModel.ts
@@ -36,35 +36,13 @@ interface DetectionPresentation {
 
 export type MeetingNotificationPresentation = AutoEndPresentation | DetectionPresentation;
 
-interface MeetingNotificationSwipeSample {
-  dismissible: boolean;
-  horizontalDelta: number;
-  verticalDelta: number;
-  horizontalVelocity: number;
-  cardWidth: number;
-}
+const MEETING_NOTIFICATION_SWIPE_DISTANCE_PX = 80;
 
-export type MeetingNotificationSwipeOutcome = "dismiss" | "ignore" | "reset";
-
-const SWIPE_MAX_DISTANCE_PX = 96;
-const SWIPE_DISTANCE_RATIO = 0.25;
-const SWIPE_MIN_FLING_DISTANCE_PX = 24;
-const SWIPE_MIN_FLING_VELOCITY_PX_PER_MS = 0.75;
-
-export function getMeetingNotificationSwipeOutcome(
-  sample: MeetingNotificationSwipeSample
-): MeetingNotificationSwipeOutcome {
-  if (!sample.dismissible) return "ignore";
-  if (Math.abs(sample.verticalDelta) >= Math.abs(sample.horizontalDelta)) return "ignore";
-  const horizontalDistance = Math.abs(sample.horizontalDelta);
-  const distanceThreshold = Math.min(
-    SWIPE_MAX_DISTANCE_PX,
-    sample.cardWidth * SWIPE_DISTANCE_RATIO
-  );
-  const isFling =
-    horizontalDistance >= SWIPE_MIN_FLING_DISTANCE_PX &&
-    Math.abs(sample.horizontalVelocity) >= SWIPE_MIN_FLING_VELOCITY_PX_PER_MS;
-  return horizontalDistance >= distanceThreshold || isFling ? "dismiss" : "reset";
+export function shouldDismissMeetingNotificationSwipe(
+  dismissible: boolean,
+  horizontalDistance: number
+): boolean {
+  return dismissible && Math.abs(horizontalDistance) >= MEETING_NOTIFICATION_SWIPE_DISTANCE_PX;
 }
 
 export function getMeetingNotificationPresentation(

--- a/test/helpers/meetingNotificationModel.test.js
+++ b/test/helpers/meetingNotificationModel.test.js
@@ -64,6 +64,81 @@ test("detection presentation preserves event title, join action, and dismissal",
   );
 });
 
+test("a horizontal meeting notification swipe past one quarter of the card dismisses", async () => {
+  const { getMeetingNotificationSwipeOutcome } = await load();
+
+  assert.equal(
+    getMeetingNotificationSwipeOutcome({
+      dismissible: true,
+      horizontalDelta: 100,
+      verticalDelta: 10,
+      horizontalVelocity: 0.1,
+      cardWidth: 392,
+    }),
+    "dismiss"
+  );
+});
+
+test("non-dismissible meeting notifications ignore horizontal swipes", async () => {
+  const { getMeetingNotificationSwipeOutcome } = await load();
+
+  assert.equal(
+    getMeetingNotificationSwipeOutcome({
+      dismissible: false,
+      horizontalDelta: 300,
+      verticalDelta: 0,
+      horizontalVelocity: 2,
+      cardWidth: 620,
+    }),
+    "ignore"
+  );
+});
+
+test("vertical meeting notification gestures are ignored", async () => {
+  const { getMeetingNotificationSwipeOutcome } = await load();
+
+  assert.equal(
+    getMeetingNotificationSwipeOutcome({
+      dismissible: true,
+      horizontalDelta: 80,
+      verticalDelta: 120,
+      horizontalVelocity: 1,
+      cardWidth: 392,
+    }),
+    "ignore"
+  );
+});
+
+test("a short horizontal meeting notification swipe resets", async () => {
+  const { getMeetingNotificationSwipeOutcome } = await load();
+
+  assert.equal(
+    getMeetingNotificationSwipeOutcome({
+      dismissible: true,
+      horizontalDelta: 60,
+      verticalDelta: 4,
+      horizontalVelocity: 0.2,
+      cardWidth: 392,
+    }),
+    "reset"
+  );
+});
+
+test("a short fast meeting notification flick dismisses", async () => {
+  const { getMeetingNotificationSwipeOutcome } = await load();
+
+  assert.equal(
+    getMeetingNotificationSwipeOutcome({
+      dismissible: true,
+      horizontalDelta: -30,
+      verticalDelta: 2,
+      horizontalVelocity: -0.9,
+      cardWidth: 392,
+    }),
+    "dismiss"
+  );
+});
+
 test("countdown rounds up and emits updated seconds until expiration", async () => {
   const { subscribeMeetingAutoEndCountdown } = await load();
   let now = 10_000;

--- a/test/helpers/meetingNotificationModel.test.js
+++ b/test/helpers/meetingNotificationModel.test.js
@@ -64,79 +64,18 @@ test("detection presentation preserves event title, join action, and dismissal",
   );
 });
 
-test("a horizontal meeting notification swipe past one quarter of the card dismisses", async () => {
-  const { getMeetingNotificationSwipeOutcome } = await load();
+test("a dismissible meeting notification closes after an 80px horizontal swipe", async () => {
+  const { shouldDismissMeetingNotificationSwipe } = await load();
 
-  assert.equal(
-    getMeetingNotificationSwipeOutcome({
-      dismissible: true,
-      horizontalDelta: 100,
-      verticalDelta: 10,
-      horizontalVelocity: 0.1,
-      cardWidth: 392,
-    }),
-    "dismiss"
-  );
+  assert.equal(shouldDismissMeetingNotificationSwipe(true, 80), true);
+  assert.equal(shouldDismissMeetingNotificationSwipe(true, -80), true);
+  assert.equal(shouldDismissMeetingNotificationSwipe(true, 79), false);
 });
 
 test("non-dismissible meeting notifications ignore horizontal swipes", async () => {
-  const { getMeetingNotificationSwipeOutcome } = await load();
+  const { shouldDismissMeetingNotificationSwipe } = await load();
 
-  assert.equal(
-    getMeetingNotificationSwipeOutcome({
-      dismissible: false,
-      horizontalDelta: 300,
-      verticalDelta: 0,
-      horizontalVelocity: 2,
-      cardWidth: 620,
-    }),
-    "ignore"
-  );
-});
-
-test("vertical meeting notification gestures are ignored", async () => {
-  const { getMeetingNotificationSwipeOutcome } = await load();
-
-  assert.equal(
-    getMeetingNotificationSwipeOutcome({
-      dismissible: true,
-      horizontalDelta: 80,
-      verticalDelta: 120,
-      horizontalVelocity: 1,
-      cardWidth: 392,
-    }),
-    "ignore"
-  );
-});
-
-test("a short horizontal meeting notification swipe resets", async () => {
-  const { getMeetingNotificationSwipeOutcome } = await load();
-
-  assert.equal(
-    getMeetingNotificationSwipeOutcome({
-      dismissible: true,
-      horizontalDelta: 60,
-      verticalDelta: 4,
-      horizontalVelocity: 0.2,
-      cardWidth: 392,
-    }),
-    "reset"
-  );
-});
-
-test("a short fast meeting notification flick dismisses", async () => {
-  const { getMeetingNotificationSwipeOutcome } = await load();
-
-  assert.equal(
-    getMeetingNotificationSwipeOutcome({
-      dismissible: true,
-      horizontalDelta: -30,
-      verticalDelta: 2,
-      horizontalVelocity: -0.9,
-      cardWidth: 392,
-    }),
-    "dismiss"
-  );
+  assert.equal(shouldDismissMeetingNotificationSwipe(false, 200), false);
 });
 
 test("countdown rounds up and emits updated seconds until expiration", async () => {


### PR DESCRIPTION
## Summary

- Allow horizontal pointer swipes to dismiss meeting detection and calendar reminder cards.
- Reuse the existing notification dismissal and slide-out behavior with an 80 px threshold in either direction.
- Ignore swipes that begin on notification action buttons.
- Keep the “Keep recording” auto-end countdown non-dismissible.

## Verification

- Full test suite: 3,040 passed, 0 failed, 185 skipped, 1 todo.
- TypeScript type check passed.
- Targeted ESLint and Prettier checks passed.