### PR TITLE
fix(auth): guard nullish parameters and non-string tokens in accountScopeBinding

### DIFF
--- a/src/helpers/accountScopeBinding.js
+++ b/src/helpers/accountScopeBinding.js
@@ -15,6 +15,7 @@ const BINDING_VERSION = 1;
 const bindingFile = () => path.join(app.getPath("userData"), "account-scope-binding.json");
 
 function hashToken(token) {
+  if (typeof token !== "string" || token.length === 0) return "";
   return crypto.createHash("sha256").update(token, "utf8").digest("hex");
 }
 
@@ -22,7 +23,9 @@ function hashToken(token) {
 // arriving while a token exists is a "validated signed-out" transition and
 // must carry the current generation, so a stray early null call cannot
 // discard a valid binding.
-function evaluateScopeRequest({ accountId, expectedGeneration, token, generation }) {
+function evaluateScopeRequest(request = {}) {
+  const { accountId, expectedGeneration, token, generation } =
+    request && typeof request === "object" ? request : {};
   if (accountId !== null && (typeof accountId !== "string" || accountId.trim().length === 0)) {
     return { ok: false, code: "INVALID_ACCOUNT" };
   }
@@ -37,7 +40,8 @@ function evaluateScopeRequest({ accountId, expectedGeneration, token, generation
 
 // Pure boot decision: restore only when the persisted bearer is the exact
 // credential this binding was validated under.
-function resolveBootAccountScope({ token, binding }) {
+function resolveBootAccountScope(params = {}) {
+  const { token, binding } = params && typeof params === "object" ? params : {};
   if (typeof token !== "string" || token.length === 0) return null;
   if (!binding || binding.version !== BINDING_VERSION) return null;
   if (typeof binding.accountId !== "string" || binding.accountId.trim().length === 0) return null;

--- a/test/helpers/accountScopeBinding.test.js
+++ b/test/helpers/accountScopeBinding.test.js
@@ -130,3 +130,17 @@ test("clear removes the binding and read tolerates absence and corruption", (t) 
   assert.equal(binding.read(), null);
   binding.clear();
 });
+
+test("safely handles nullish arguments and non-string tokens", () => {
+  assert.equal(binding.resolveBootAccountScope(null), null);
+  assert.equal(binding.resolveBootAccountScope(), null);
+  assert.deepEqual(binding.evaluateScopeRequest(null), { ok: false, code: "INVALID_ACCOUNT" });
+  assert.deepEqual(binding.evaluateScopeRequest(), { ok: false, code: "INVALID_ACCOUNT" });
+  assert.equal(
+    binding.resolveBootAccountScope({
+      token: 123,
+      binding: { version: 1, accountId: "account-a", tokenHash: "abc" },
+    }),
+    null
+  );
+});


### PR DESCRIPTION
Fixes #1900

### Problem
In `src/helpers/accountScopeBinding.js`:
- `hashToken(token)` called `crypto.createHash().update(token)` without checking `typeof token === "string"`, throwing `TypeError [ERR_INVALID_ARG_TYPE]` on nullish or invalid values.
- `evaluateScopeRequest` and `resolveBootAccountScope` threw `TypeError` when called with `null` or without arguments.

### Solution
- Checked that `token` is a non-empty string in `hashToken`.
- Safely defaulted object destructuring in `evaluateScopeRequest` and `resolveBootAccountScope`.
- Added unit tests in `test/helpers/accountScopeBinding.test.js`.

### Verification
- `node --test test/helpers/accountScopeBinding.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)