### PR TITLE
fix(dev): support HTTPS and sanitize options in DevServerManager

### DIFF
--- a/src/helpers/devServerManager.js
+++ b/src/helpers/devServerManager.js
@@ -18,17 +18,22 @@ const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}/`;
 
 class DevServerManager {
   static async waitForDevServer(url = DEV_SERVER_URL, maxAttempts = 30, delay = 1000) {
-    for (let i = 0; i < maxAttempts; i++) {
+    const attempts = Number.isInteger(maxAttempts) && maxAttempts > 0 ? maxAttempts : 30;
+    const intervalDelay = Number.isInteger(delay) && delay >= 0 ? delay : 1000;
+
+    for (let i = 0; i < attempts; i++) {
       try {
-        const http = require("http");
         const urlObj = new URL(url);
+        const isHttps = urlObj.protocol === "https:";
+        const client = isHttps ? require("https") : require("http");
+        const defaultPort = isHttps ? 443 : 80;
 
         const result = await new Promise((resolve) => {
-          const req = http.get(
+          const req = client.get(
             {
               hostname: urlObj.hostname,
-              port: urlObj.port || 80,
-              path: urlObj.pathname,
+              port: urlObj.port || defaultPort,
+              path: urlObj.pathname + urlObj.search,
               timeout: 2000,
             },
             (res) => {
@@ -49,7 +54,7 @@ class DevServerManager {
       } catch {
         // Dev server not ready yet, continue waiting
       }
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, intervalDelay));
     }
     return false;
   }
@@ -91,3 +96,4 @@ class DevServerManager {
 module.exports = DevServerManager;
 module.exports.DEV_SERVER_PORT = DEV_SERVER_PORT;
 module.exports.DEV_SERVER_URL = DEV_SERVER_URL;
+module.exports.parseDevServerPort = parseDevServerPort;

--- a/test/helpers/devServerManager.test.js
+++ b/test/helpers/devServerManager.test.js
@@ -1,0 +1,63 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const DevServerManager = require("../../src/helpers/devServerManager.js");
+
+test("DEV_SERVER_PORT and DEV_SERVER_URL are defined and valid", () => {
+  assert.equal(typeof DevServerManager.DEV_SERVER_PORT, "number");
+  assert.ok(DevServerManager.DEV_SERVER_PORT > 0);
+  assert.ok(DevServerManager.DEV_SERVER_URL.startsWith("http://localhost:"));
+});
+
+test("parseDevServerPort validates integer port ranges", () => {
+  const originalEnv = process.env.OPENWHISPR_DEV_SERVER_PORT;
+  try {
+    delete process.env.OPENWHISPR_DEV_SERVER_PORT;
+    delete process.env.VITE_DEV_SERVER_PORT;
+    assert.equal(DevServerManager.parseDevServerPort(), 5183);
+
+    process.env.OPENWHISPR_DEV_SERVER_PORT = "8080";
+    assert.equal(DevServerManager.parseDevServerPort(), 8080);
+
+    process.env.OPENWHISPR_DEV_SERVER_PORT = "invalid";
+    assert.equal(DevServerManager.parseDevServerPort(), 5183);
+
+    process.env.OPENWHISPR_DEV_SERVER_PORT = "-1";
+    assert.equal(DevServerManager.parseDevServerPort(), 5183);
+
+    process.env.OPENWHISPR_DEV_SERVER_PORT = "70000";
+    assert.equal(DevServerManager.parseDevServerPort(), 5183);
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env.OPENWHISPR_DEV_SERVER_PORT = originalEnv;
+    } else {
+      delete process.env.OPENWHISPR_DEV_SERVER_PORT;
+    }
+  }
+});
+
+test("getAppUrl produces correct URLs in development", () => {
+  const originalEnv = process.env.NODE_ENV;
+  try {
+    process.env.NODE_ENV = "development";
+    assert.equal(DevServerManager.getAppUrl(false), DevServerManager.DEV_SERVER_URL);
+    assert.equal(
+      DevServerManager.getAppUrl(true),
+      `${DevServerManager.DEV_SERVER_URL}?panel=true`
+    );
+
+    process.env.NODE_ENV = "production";
+    assert.equal(DevServerManager.getAppUrl(false), null);
+  } finally {
+    process.env.NODE_ENV = originalEnv;
+  }
+});
+
+test("waitForDevServer handles unreachable server URLs gracefully", async () => {
+  // Probe a port where nothing is listening with 1 attempt and 10ms delay
+  const ready = await DevServerManager.waitForDevServer(
+    "http://127.0.0.1:59999/",
+    1,
+    10
+  );
+  assert.equal(ready, false);
+});


### PR DESCRIPTION
Fixes #1902

### Problem
In `src/helpers/devServerManager.js`:
- `DevServerManager.waitForDevServer` unconditionally used cleartext `http.get` and defaulted the port to `80`, failing when checking HTTPS URLs (or dev servers configured with HTTPS certificates).
- Handled invalid/negative `maxAttempts` and `delay` values without sanitization.

### Solution
- Selected the appropriate client module (`https` or `http`) based on the URL protocol and defaulted the port accordingly (443 for HTTPS, 80 for HTTP).
- Sanitized `maxAttempts` and `delay` parameters.
- Exported `parseDevServerPort` for testability.
- Added comprehensive unit tests in `test/helpers/devServerManager.test.js`.

### Verification
- `node --test test/helpers/devServerManager.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)