### PR TITLE
fix(linux): restore meeting prompts for later calls on Linux

### DIFF
--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -52,6 +52,35 @@ class AudioActivityDetector extends EventEmitter {
     this._externalMicActive = false;
     this._lastEmittedExternalMicReliable = false;
     this._lastEmittedExternalMicActive = false;
+    this._externalCapturePids = new Set();
+    this._promptedCapturePids = new Set();
+  }
+
+  _markPrompted() {
+    this.hasPrompted = true;
+    this._promptedCapturePids = new Set(this._externalCapturePids);
+  }
+
+  _rearmPromptForSourceChange() {
+    if (!this.hasPrompted || !this._pidScopedCapability || !this._externalCapturePids.size) return;
+    if (!this._promptedCapturePids.size) {
+      this._promptedCapturePids = new Set(this._externalCapturePids);
+      return;
+    }
+
+    const previousSourceGone = [...this._promptedCapturePids].every(
+      (pid) => !this._externalCapturePids.has(pid)
+    );
+    if (!previousSourceGone) return;
+
+    this.hasPrompted = false;
+    this._promptedCapturePids.clear();
+    debugLogger.info("Re-armed meeting prompt for a changed capture source", {}, "meeting");
+  }
+
+  _isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds) {
+    const processId = Number(sourceOutput?.properties?.["application.process.id"]);
+    return Number.isInteger(processId) && processId > 0 && !excludedProcessIds.has(processId);
   }
 
   getExternalMicState() {
@@ -151,6 +180,7 @@ class AudioActivityDetector extends EventEmitter {
 
   resetPrompt() {
     this.hasPrompted = false;
+    this._promptedCapturePids = new Set();
     this._clearSustainedTimer();
     this.audioActiveStart = null;
     debugLogger.info("Audio detection prompt reset (no cooldown)", {}, "meeting");
@@ -160,6 +190,7 @@ class AudioActivityDetector extends EventEmitter {
     this.consecutiveChecks = 0;
     this.audioActiveStart = null;
     this.hasPrompted = false;
+    this._promptedCapturePids = new Set();
     this._clearResetTimer();
   }
 
@@ -172,6 +203,7 @@ class AudioActivityDetector extends EventEmitter {
     this._activeMicPids.clear();
     this._activeSources = 0;
     this._lastKnownMicState = false;
+    this._externalCapturePids = new Set();
     this._clearCooldownReevalTimer();
     this._linuxOwnershipRequest++;
     this._linuxReconcileQueued = false;
@@ -195,6 +227,7 @@ class AudioActivityDetector extends EventEmitter {
     this._resetTimer = setTimeout(() => {
       this._resetTimer = null;
       this.hasPrompted = false;
+      this._promptedCapturePids.clear();
       debugLogger.debug("hasPrompted reset after sustained inactivity", {}, "meeting");
     }, INACTIVE_RESET_MS);
   }
@@ -451,10 +484,8 @@ class AudioActivityDetector extends EventEmitter {
 
     if (/Event\s+'new'\s+on\s+source-output/i.test(line)) {
       this._activeSources++;
-      this._onMicStateChanged(true);
     } else if (/Event\s+'remove'\s+on\s+source-output/i.test(line)) {
       this._activeSources = Math.max(0, this._activeSources - 1);
-      this._onMicStateChanged(this._activeSources > 0);
     }
 
     this._queueLinuxReconcile();
@@ -532,13 +563,17 @@ class AudioActivityDetector extends EventEmitter {
         activeMicPids.add(processId);
       }
 
+      const excludedProcessIds = this._getExcludedProcessIdSet();
       this._activeMicPids = activeMicPids;
-      this._activeSources = sourceOutputs.length;
+      this._activeSources = sourceOutputs.filter((sourceOutput) =>
+        this._isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds)
+      ).length;
       this._setPidScopedCapability(true);
       this._onMicStateChanged(this._activeSources > 0);
     } catch (err) {
       if (this._isStale(generation) || request !== this._linuxOwnershipRequest) return;
       this._setPidScopedCapability(false);
+      this._onMicStateChanged(this._activeSources > 0);
       debugLogger.warn(
         "Failed to reconcile pactl source-output ownership",
         { error: err.message },
@@ -566,6 +601,7 @@ class AudioActivityDetector extends EventEmitter {
     try {
       excludedProcessIds = this._getExcludedProcessIdSet();
     } catch (err) {
+      this._externalCapturePids = new Set();
       this._setExternalMicSnapshot(false, false, emitChange);
       debugLogger.warn(
         "Failed to resolve excluded microphone PIDs",
@@ -575,9 +611,11 @@ class AudioActivityDetector extends EventEmitter {
       return false;
     }
 
-    const externalMicActive = [...this._activeMicPids].some(
+    const externalPids = [...this._activeMicPids].filter(
       (processId) => !excludedProcessIds.has(processId)
     );
+    this._externalCapturePids = new Set(externalPids);
+    const externalMicActive = externalPids.length > 0;
     if (!this._pidScopedCapability) {
       this._setExternalMicSnapshot(false, false, emitChange);
       return externalMicActive;
@@ -612,6 +650,7 @@ class AudioActivityDetector extends EventEmitter {
   _onMicStateChanged(active) {
     if (!this._running) return;
     this._lastKnownMicState = active;
+    this._rearmPromptForSourceChange();
     this._evaluateMicState(active);
   }
 
@@ -685,7 +724,7 @@ class AudioActivityDetector extends EventEmitter {
           if (this._userRecording || this._micWarmHold || this.hasPrompted) return;
           if (this.lastDismissedAt && Date.now() - this.lastDismissedAt < COOLDOWN_MS) return;
 
-          this.hasPrompted = true;
+          this._markPrompted();
           const now = Date.now();
           const durationMs = now - this.audioActiveStart;
           debugLogger.info(
@@ -721,6 +760,7 @@ class AudioActivityDetector extends EventEmitter {
     this._checking = true;
     try {
       const active = await this._isMicActive();
+      this._rearmPromptForSourceChange();
       debugLogger.debug(
         "Mic check",
         { active, consecutiveChecks: this.consecutiveChecks },
@@ -733,7 +773,7 @@ class AudioActivityDetector extends EventEmitter {
         if (!this.audioActiveStart) this.audioActiveStart = Date.now();
 
         if (!this.hasPrompted && this.consecutiveChecks >= SUSTAINED_THRESHOLD_CHECKS) {
-          this.hasPrompted = true;
+          this._markPrompted();
           const now = Date.now();
           const durationMs = now - this.audioActiveStart;
           debugLogger.info(
@@ -800,6 +840,30 @@ class AudioActivityDetector extends EventEmitter {
   }
 
   async _checkLinux() {
+    try {
+      const { stdout } = await execAsync("pactl --format=json list source-outputs", EXEC_OPTS);
+      const sourceOutputs = JSON.parse(stdout);
+      if (!Array.isArray(sourceOutputs)) throw new Error("pactl returned a non-array response");
+
+      const excludedProcessIds = this._getExcludedProcessIdSet();
+      this._activeMicPids = new Set(
+        sourceOutputs
+          .map((sourceOutput) => Number(sourceOutput?.properties?.["application.process.id"]))
+          .filter((processId) => Number.isInteger(processId) && processId > 0)
+      );
+      this._setPidScopedCapability(true);
+      return sourceOutputs.some((sourceOutput) =>
+        this._isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds)
+      );
+    } catch (err) {
+      this._setPidScopedCapability(false);
+      debugLogger.debug(
+        "Linux mic check fell back to an unfiltered listing",
+        { error: err.message },
+        "meeting"
+      );
+    }
+
     try {
       const { stdout } = await execAsync("pactl list source-outputs short", EXEC_OPTS);
       return stdout.trim().length > 0;

--- a/src/helpers/audioActivityDetector.js
+++ b/src/helpers/audioActivityDetector.js
@@ -54,19 +54,30 @@ class AudioActivityDetector extends EventEmitter {
     this._lastEmittedExternalMicActive = false;
     this._externalCapturePids = new Set();
     this._promptedCapturePids = new Set();
+    this._captureIdleSincePrompt = false;
   }
 
   _markPrompted() {
     this.hasPrompted = true;
     this._promptedCapturePids = new Set(this._externalCapturePids);
+    this._captureIdleSincePrompt = false;
   }
 
-  _rearmPromptForSourceChange() {
+  // A later call re-arms the prompt, but only after the capture that was
+  // prompted for has actually gone quiet. A pid set that merely differs is not
+  // evidence the call ended: an app rebuilds its input unit when screen share
+  // starts, and a capture helper can die and respawn under a new pid inside a
+  // single reconcile window, so the swap is observed with no idle gap at all.
+  // Prompting again there would drop a card over a live call, which is exactly
+  // what hasPrompted exists to prevent.
+  _rearmPromptForSourceChange(active) {
+    if (!active) this._captureIdleSincePrompt = true;
     if (!this.hasPrompted || !this._pidScopedCapability || !this._externalCapturePids.size) return;
     if (!this._promptedCapturePids.size) {
       this._promptedCapturePids = new Set(this._externalCapturePids);
       return;
     }
+    if (!this._captureIdleSincePrompt) return;
 
     const previousSourceGone = [...this._promptedCapturePids].every(
       (pid) => !this._externalCapturePids.has(pid)
@@ -75,12 +86,8 @@ class AudioActivityDetector extends EventEmitter {
 
     this.hasPrompted = false;
     this._promptedCapturePids.clear();
+    this._captureIdleSincePrompt = false;
     debugLogger.info("Re-armed meeting prompt for a changed capture source", {}, "meeting");
-  }
-
-  _isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds) {
-    const processId = Number(sourceOutput?.properties?.["application.process.id"]);
-    return Number.isInteger(processId) && processId > 0 && !excludedProcessIds.has(processId);
   }
 
   getExternalMicState() {
@@ -180,7 +187,8 @@ class AudioActivityDetector extends EventEmitter {
 
   resetPrompt() {
     this.hasPrompted = false;
-    this._promptedCapturePids = new Set();
+    this._promptedCapturePids.clear();
+    this._captureIdleSincePrompt = false;
     this._clearSustainedTimer();
     this.audioActiveStart = null;
     debugLogger.info("Audio detection prompt reset (no cooldown)", {}, "meeting");
@@ -190,7 +198,8 @@ class AudioActivityDetector extends EventEmitter {
     this.consecutiveChecks = 0;
     this.audioActiveStart = null;
     this.hasPrompted = false;
-    this._promptedCapturePids = new Set();
+    this._promptedCapturePids.clear();
+    this._captureIdleSincePrompt = false;
     this._clearResetTimer();
   }
 
@@ -203,7 +212,7 @@ class AudioActivityDetector extends EventEmitter {
     this._activeMicPids.clear();
     this._activeSources = 0;
     this._lastKnownMicState = false;
-    this._externalCapturePids = new Set();
+    this._externalCapturePids.clear();
     this._clearCooldownReevalTimer();
     this._linuxOwnershipRequest++;
     this._linuxReconcileQueued = false;
@@ -563,13 +572,17 @@ class AudioActivityDetector extends EventEmitter {
         activeMicPids.add(processId);
       }
 
-      const excludedProcessIds = this._getExcludedProcessIdSet();
       this._activeMicPids = activeMicPids;
-      this._activeSources = sourceOutputs.filter((sourceOutput) =>
-        this._isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds)
-      ).length;
+      // Raw total, matching the subscribe-event counter: it is the only signal
+      // left if a later reconcile cannot parse pactl's JSON.
+      this._activeSources = sourceOutputs.length;
       this._setPidScopedCapability(true);
-      this._onMicStateChanged(this._activeSources > 0);
+      // A live listener makes the snapshot reliable unless the excluded-pid
+      // provider itself failed. It is external and can, so keep the raw total as
+      // the fallback signal rather than reporting a silent mic.
+      this._onMicStateChanged(
+        this._externalMicReliable ? this._externalMicActive : this._activeSources > 0
+      );
     } catch (err) {
       if (this._isStale(generation) || request !== this._linuxOwnershipRequest) return;
       this._setPidScopedCapability(false);
@@ -596,12 +609,22 @@ class AudioActivityDetector extends EventEmitter {
     this._updateExternalMicState();
   }
 
+  // Auto-end may only trust the ownership snapshot while a listener is pushing
+  // every transition into it. The poller cannot carry that guarantee: it samples
+  // at CHECK_INTERVAL_MS and stops outright while gated by a recording, a warm
+  // hold or a dismissal cooldown — so a snapshot taken before a meeting began
+  // would still read as "another app holds the mic" for the whole recording,
+  // and the controller's ownership mode would never release it.
+  _isOwnershipSnapshotLive() {
+    return this._listenerProcess !== null;
+  }
+
   _updateExternalMicState(emitChange = true) {
     let excludedProcessIds;
     try {
       excludedProcessIds = this._getExcludedProcessIdSet();
     } catch (err) {
-      this._externalCapturePids = new Set();
+      this._externalCapturePids.clear();
       this._setExternalMicSnapshot(false, false, emitChange);
       debugLogger.warn(
         "Failed to resolve excluded microphone PIDs",
@@ -616,7 +639,7 @@ class AudioActivityDetector extends EventEmitter {
     );
     this._externalCapturePids = new Set(externalPids);
     const externalMicActive = externalPids.length > 0;
-    if (!this._pidScopedCapability) {
+    if (!this._pidScopedCapability || !this._isOwnershipSnapshotLive()) {
       this._setExternalMicSnapshot(false, false, emitChange);
       return externalMicActive;
     }
@@ -650,7 +673,7 @@ class AudioActivityDetector extends EventEmitter {
   _onMicStateChanged(active) {
     if (!this._running) return;
     this._lastKnownMicState = active;
-    this._rearmPromptForSourceChange();
+    this._rearmPromptForSourceChange(active);
     this._evaluateMicState(active);
   }
 
@@ -760,7 +783,7 @@ class AudioActivityDetector extends EventEmitter {
     this._checking = true;
     try {
       const active = await this._isMicActive();
-      this._rearmPromptForSourceChange();
+      this._rearmPromptForSourceChange(active);
       debugLogger.debug(
         "Mic check",
         { active, consecutiveChecks: this.consecutiveChecks },
@@ -845,16 +868,21 @@ class AudioActivityDetector extends EventEmitter {
       const sourceOutputs = JSON.parse(stdout);
       if (!Array.isArray(sourceOutputs)) throw new Error("pactl returned a non-array response");
 
+      const capturePids = sourceOutputs
+        .map((sourceOutput) => Number(sourceOutput?.properties?.["application.process.id"]))
+        .filter((processId) => Number.isInteger(processId) && processId > 0);
+      // A stream without application.process.id carries no ownership
+      // information. When nothing in a non-empty listing is attributable, the
+      // unfiltered listings below still answer "is anything capturing" — far
+      // better than reporting silence and never detecting a meeting.
+      if (sourceOutputs.length > 0 && capturePids.length === 0) {
+        throw new Error("no source-output reported an application.process.id");
+      }
+
       const excludedProcessIds = this._getExcludedProcessIdSet();
-      this._activeMicPids = new Set(
-        sourceOutputs
-          .map((sourceOutput) => Number(sourceOutput?.properties?.["application.process.id"]))
-          .filter((processId) => Number.isInteger(processId) && processId > 0)
-      );
+      this._activeMicPids = new Set(capturePids);
       this._setPidScopedCapability(true);
-      return sourceOutputs.some((sourceOutput) =>
-        this._isExternalLinuxSourceOutput(sourceOutput, excludedProcessIds)
-      );
+      return capturePids.some((processId) => !excludedProcessIds.has(processId));
     } catch (err) {
       this._setPidScopedCapability(false);
       debugLogger.debug(

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -768,6 +768,11 @@ class MeetingDetectionEngine {
     });
   }
 
+  // A card can vanish without a response — a compositor kill, a load failure,
+  // onboarding taking the screen. Only this detection is released, unlike a
+  // response or an expiry which settle every pending one: clearing them all
+  // would strand _notificationQueue, whose entries the flush below looks up in
+  // activeDetections.
   handleDetectionNotificationClosed(detectionId, { flushQueued = true } = {}) {
     if (!this.activeDetections.has(detectionId)) return;
     this.activeDetections.delete(detectionId);

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -768,6 +768,17 @@ class MeetingDetectionEngine {
     });
   }
 
+  handleDetectionNotificationClosed(detectionId, { flushQueued = true } = {}) {
+    if (!this.activeDetections.has(detectionId)) return;
+    this.activeDetections.delete(detectionId);
+    debugLogger.info(
+      "Detection notification closed without a response",
+      { detectionId },
+      "meeting"
+    );
+    if (flushQueued) this._flushNotificationQueue();
+  }
+
   handleNotificationTimeout(notification = null) {
     if (notification?.kind === "auto-end") {
       this.handleAutoEndNotificationClosed(notification.sessionId);

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -69,10 +69,8 @@ class WindowManager {
     this._notificationLoadTimeout = null;
     this._notificationDismissTimer = new NotificationDismissTimer(() => {
       const notification = this._pendingNotificationData;
-      // Dismiss first: an expiring restart offer lets the engine flush the
-      // detections it was holding, and a prompt raised from that handler must
-      // not be closed by this dismissal.
-      this.dismissMeetingNotification();
+      // Let the timeout handler settle the notification after the window closes.
+      this.dismissMeetingNotification({ notifyEngine: false });
       if (this.meetingDetectionEngine) {
         this.meetingDetectionEngine.handleNotificationTimeout(notification);
       }
@@ -1500,7 +1498,7 @@ class WindowManager {
     this.hideDictationPanel();
     this.hideTranscriptionPreview();
     this.hideAgentDictationPill();
-    this.dismissMeetingNotification();
+    this.dismissMeetingNotification({ flushQueued: false });
 
     if (this._pendingUpdateNotificationData) {
       this._deferredUpdateNotificationInfo = { ...this._pendingUpdateNotificationData };
@@ -1963,10 +1961,11 @@ class WindowManager {
     // after the replacement already took over the reference and the countdown.
     win.on("closed", () => {
       if (this.notificationWindow !== win) return;
+      const closedNotification = this._pendingNotificationData;
       const closedAutoEndSessionId =
-        this._pendingNotificationData?.kind === "auto-end"
-          ? this._pendingNotificationData.sessionId
-          : null;
+        closedNotification?.kind === "auto-end" ? closedNotification.sessionId : null;
+      const closedDetectionId =
+        closedNotification?.kind === "detection" ? closedNotification.detectionId : null;
       this.notificationWindow = null;
       this._pendingNotificationData = null;
       this._notificationDismissTimer.cancel();
@@ -1980,6 +1979,8 @@ class WindowManager {
       }
       if (closedAutoEndSessionId) {
         this.meetingDetectionEngine?.handleAutoEndNotificationClosed?.(closedAutoEndSessionId);
+      } else if (closedDetectionId) {
+        this.meetingDetectionEngine?.handleDetectionNotificationClosed?.(closedDetectionId);
       }
     });
 
@@ -2083,7 +2084,8 @@ class WindowManager {
     win.showInactive();
   }
 
-  dismissMeetingNotification() {
+  dismissMeetingNotification({ notifyEngine = true, flushQueued = true } = {}) {
+    const notification = this._pendingNotificationData;
     this._pendingNotificationData = null;
     if (this._notificationReadyFallback) {
       clearTimeout(this._notificationReadyFallback);
@@ -2097,6 +2099,11 @@ class WindowManager {
     const win = this.notificationWindow;
     this.notificationWindow = null;
     if (win && !win.isDestroyed()) win.close();
+    if (notifyEngine && notification?.kind === "detection") {
+      this.meetingDetectionEngine?.handleDetectionNotificationClosed?.(notification.detectionId, {
+        flushQueued,
+      });
+    }
   }
 
   showMeetingAutoEndNotification({ sessionId, expiresAt, reason }) {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -69,7 +69,12 @@ class WindowManager {
     this._notificationLoadTimeout = null;
     this._notificationDismissTimer = new NotificationDismissTimer(() => {
       const notification = this._pendingNotificationData;
-      // Let the timeout handler settle the notification after the window closes.
+      // Dismiss first: an expiring restart offer lets the engine flush the
+      // detections it was holding, and a prompt raised from that handler must
+      // not be closed by this dismissal. The engine is not told the card closed
+      // either — handleNotificationTimeout below settles this expiry, and a
+      // close report here would flush the queue into a card that handler is
+      // about to clear.
       this.dismissMeetingNotification({ notifyEngine: false });
       if (this.meetingDetectionEngine) {
         this.meetingDetectionEngine.handleNotificationTimeout(notification);

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -231,21 +231,6 @@ test("win32: MIC_START/MIC_STOP pids are tracked across partial chunks", async (
   detector.stop();
 });
 
-test("linux: pactl source-output events drive the sustained timer", async () => {
-  const { detector, children, calls } = createDetector("linux");
-
-  await detector.start();
-  assert.equal(calls[0].command, "pactl");
-  assert.deepEqual(calls[0].args, ["subscribe"]);
-
-  children[0].stdout.emit("data", "Event 'new' on source-output #7\n");
-  assert.notEqual(detector._sustainedTimer, null);
-
-  children[0].stdout.emit("data", "Event 'remove' on source-output #7\n");
-  assert.equal(detector._sustainedTimer, null);
-  detector.stop();
-});
-
 test("a listener that dies while running falls back to polling", async () => {
   const { detector, children } = createDetector("linux");
 
@@ -953,4 +938,86 @@ test("win32: our own capture cannot cancel a real meeting already in progress", 
   assert.deepEqual([...detector._activeMicPids], [9001]);
   assert.notEqual(detector._sustainedTimer, null);
   detector.stop();
+});
+
+const RECONCILE_SPACING = 1000;
+const linuxStream = (index, processId) => ({
+  index,
+  properties: { "application.process.id": String(processId) },
+});
+const linuxStreams = (...processIds) =>
+  JSON.stringify(processIds.map((processId, index) => linuxStream(index + 1, processId)));
+
+test("linux: an owned source event cannot prompt before ownership reconciliation", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const ownership = createDeferred();
+  const { detector, children } = createDetector("linux", {
+    excludedProcessIds: () => [700],
+    execResponses: [{ stdout: "[]" }, { promise: ownership.promise }],
+  });
+  let detections = 0;
+  detector.on("sustained-audio-detected", () => detections++);
+
+  await detector.start();
+  children[0].stdout.emit("data", "Event 'new' on source-output #1\n");
+  t.mock.timers.tick(RECONCILE_SPACING + SUSTAINED_MS);
+  await flushImmediate();
+  assert.equal(detections, 0);
+
+  ownership.resolve({ stdout: linuxStreams(700), stderr: "" });
+  await flushImmediate();
+  assert.equal(detector._lastKnownMicState, false);
+  detector.stop();
+});
+
+test("linux: a later capture process re-prompts while the same process does not", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const CHROME = 17111;
+  const ZOOM = 22222;
+  const { detector, children } = createDetector("linux", {
+    excludedProcessIds: () => [700],
+    execResponses: [
+      { stdout: "[]" },
+      { stdout: linuxStreams(CHROME) },
+      { stdout: linuxStreams(CHROME) },
+      { stdout: "[]" },
+      { stdout: linuxStreams(ZOOM) },
+    ],
+  });
+  let detections = 0;
+  detector.on("sustained-audio-detected", () => detections++);
+
+  await detector.start();
+  children[0].stdout.emit("data", "Event 'new' on source-output #1\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(detections, 1);
+
+  children[0].stdout.emit("data", "Event 'change' on source-output #1\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(detections, 1);
+
+  children[0].stdout.emit("data", "Event 'remove' on source-output #1\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+
+  children[0].stdout.emit("data", "Event 'new' on source-output #2\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(detections, 2);
+  detector.stop();
+});
+
+test("linux: polling reports only external capture as mic activity", async () => {
+  const { detector } = createDetector("linux", {
+    excludedProcessIds: () => [700],
+    execResponses: [{ stdout: linuxStreams(700) }, { stdout: linuxStreams(900) }],
+  });
+
+  assert.equal(await detector._checkLinux(), false);
+  assert.equal(await detector._checkLinux(), true);
 });

--- a/test/helpers/audioActivityDetector.test.js
+++ b/test/helpers/audioActivityDetector.test.js
@@ -1021,3 +1021,76 @@ test("linux: polling reports only external capture as mic activity", async () =>
   assert.equal(await detector._checkLinux(), false);
   assert.equal(await detector._checkLinux(), true);
 });
+
+test("linux: a capture pid swapped inside one reconcile does not re-prompt", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: 10_000 });
+  const AUDIO_SERVICE = 17111;
+  const RESPAWNED_AUDIO_SERVICE = 17999;
+  const { detector, children } = createDetector("linux", {
+    excludedProcessIds: () => [700],
+    execResponses: [
+      { stdout: "[]" },
+      { stdout: linuxStreams(AUDIO_SERVICE) },
+      // The call never went quiet: one reconcile sees the old stream gone and
+      // the app's replacement capture helper already in its place.
+      { stdout: linuxStreams(RESPAWNED_AUDIO_SERVICE) },
+    ],
+  });
+  let detections = 0;
+  detector.on("sustained-audio-detected", () => detections++);
+
+  await detector.start();
+  children[0].stdout.emit("data", "Event 'new' on source-output #1\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(detections, 1);
+
+  children[0].stdout.emit("data", "Event 'change' on source-output #2\n");
+  t.mock.timers.tick(RECONCILE_SPACING);
+  await flushImmediate();
+  t.mock.timers.tick(SUSTAINED_MS);
+  assert.equal(detections, 1, "a card must not drop over a call that never ended");
+  detector.stop();
+});
+
+test("linux: polling never reports ownership as reliable", async () => {
+  const { detector } = createDetector("linux", {
+    spawnError: "spawn ENOENT",
+    excludedProcessIds: () => [700],
+    execResponses: [{ stdout: linuxStreams(900) }],
+  });
+  detector._isMicActive = undefined;
+  delete detector._isMicActive;
+
+  await detector.start();
+  await flush();
+
+  assert.equal(detector._eventDriven, false);
+  assert.equal(detector._pidScopedCapability, true, "the poll still scopes the re-arm by pid");
+  // The poller stops sampling for the whole of a recording, so a snapshot it
+  // took cannot be handed to auto-end as live ownership evidence.
+  assert.deepEqual(detector.getExternalMicState(), { reliable: false, externalMicActive: false });
+  detector.setUserRecording(true);
+  assert.deepEqual(detector.getExternalMicState(), { reliable: false, externalMicActive: false });
+  detector.stop();
+});
+
+test("linux: a listing with no attributable stream falls through to the unfiltered check", async () => {
+  const { detector, execCalls } = createDetector("linux", {
+    excludedProcessIds: () => [700],
+    execResponses: [
+      {
+        stdout: JSON.stringify([{ index: 1, properties: { "media.name": "echo-cancel source" } }]),
+      },
+      { stdout: "0\tsink\n" },
+    ],
+  });
+
+  assert.equal(await detector._checkLinux(), true);
+  assert.deepEqual(
+    execCalls.map((call) => call.command),
+    ["pactl --format=json list source-outputs", "pactl list source-outputs short"]
+  );
+  assert.equal(detector._pidScopedCapability, false);
+});

--- a/test/helpers/meetingDetectionEngine.test.js
+++ b/test/helpers/meetingDetectionEngine.test.js
@@ -91,3 +91,13 @@ test("explicitly dismissing an audio prompt still starts the mic cooldown", asyn
 
   assert.equal(audioDetector.dismissals, 1, "an explicit decline must keep its cooldown");
 });
+
+test("a detection card closed without a response allows the next prompt", () => {
+  const { engine, audioDetector, shown } = createEngine();
+
+  audioDetector.emit("sustained-audio-detected", { durationMs: 2000, detectedAt: 0 });
+  engine.handleDetectionNotificationClosed(shown[0].detectionId);
+  audioDetector.emit("sustained-audio-detected", { durationMs: 4000, detectedAt: 1 });
+
+  assert.equal(shown.length, 2);
+});

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -694,3 +694,55 @@ test("a notification raised from the timeout handler survives the dismissal that
     timers.restore();
   }
 });
+
+test("unexpected detection card closure releases that detection", async () => {
+  const manager = createNormalWindowManager();
+  const closedDetections = [];
+  manager.meetingDetectionEngine = {
+    handleDetectionNotificationClosed: (detectionId) => closedDetections.push(detectionId),
+  };
+
+  const showPromise = manager.showMeetingNotification({
+    kind: "detection",
+    detectionId: "audio:sustained-audio",
+    source: "audio",
+  });
+  const notificationWindow = createdWindows[0];
+  notificationWindow.loadDeferred.resolve();
+  await showPromise;
+
+  // A compositor window kill never reaches the renderer's response IPC.
+  notificationWindow.close();
+
+  assert.deepEqual(closedDetections, ["audio:sustained-audio"]);
+});
+
+test("an expired detection reports the timeout once, not also as a close", async () => {
+  const timers = installFakeTimers();
+  const manager = createNormalWindowManager();
+  const closedDetections = [];
+  let timeouts = 0;
+  manager.meetingDetectionEngine = {
+    handleDetectionNotificationClosed: (detectionId) => closedDetections.push(detectionId),
+    handleNotificationTimeout: () => {
+      timeouts += 1;
+    },
+  };
+
+  const showPromise = manager.showMeetingNotification({
+    kind: "detection",
+    detectionId: "audio:sustained-audio",
+    source: "audio",
+  });
+  createdWindows[0].loadDeferred.resolve();
+  await showPromise;
+
+  try {
+    timers.runDelay(30_000);
+    assert.equal(timeouts, 1, "the countdown owns this dismissal");
+    assert.deepEqual(closedDetections, [], "the close must not double-report the same card");
+  } finally {
+    manager.dismissMeetingNotification();
+    timers.restore();
+  }
+});

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -746,3 +746,23 @@ test("an expired detection reports the timeout once, not also as a close", async
     timers.restore();
   }
 });
+
+test("a detection card whose load fails releases that detection", async () => {
+  const manager = createNormalWindowManager();
+  const closedDetections = [];
+  manager.meetingDetectionEngine = {
+    handleDetectionNotificationClosed: (detectionId) => closedDetections.push(detectionId),
+  };
+
+  const showPromise = manager.showMeetingNotification({
+    kind: "detection",
+    detectionId: "audio:sustained-audio",
+    source: "audio",
+  });
+  createdWindows[0].loadDeferred.reject(new Error("load failed"));
+
+  // The card never appeared and no countdown ever started, so nothing else
+  // would ever settle this detection.
+  await assert.rejects(showPromise, /load failed/);
+  assert.deepEqual(closedDetections, ["audio:sustained-audio"]);
+});


### PR DESCRIPTION
### Summary
Fixes meeting notifications becoming stuck after the first detected call on Linux.  

Users will now receive prompts for later meetings after the previous meeting ends. Closing a notification through Hyprland also releases it correctly instead of blocking future prompts.

### Behavior
- Ignores OpenWhispr’s own microphone activity when deciding whether a meeting is still active.
- Allows a later calling application to trigger a new prompt.
- Avoids repeated prompts during the same ongoing call.
- Preserves the five-minute cooldown when the user explicitly clicks Dismiss.
- Preserves the 30-second automatic expiry without applying a cooldown.

fixes #1917 