### PR TITLE
fix(assistant): normalize requestId and add input guards in AgentStreamRequestRegistry

### DIFF
--- a/src/helpers/agentStreamRequestRegistry.js
+++ b/src/helpers/agentStreamRequestRegistry.js
@@ -11,38 +11,44 @@ class AgentStreamRequestRegistry {
       throw new TypeError("requestId must be a non-empty string");
     }
 
+    const normalizedRequestId = requestId.trim();
     let senderRequests = this.requestsBySender.get(senderId);
     if (!senderRequests) {
       senderRequests = new Map();
       this.requestsBySender.set(senderId, senderRequests);
     }
 
-    senderRequests.get(requestId)?.abort();
+    senderRequests.get(normalizedRequestId)?.abort();
     const controller = new AbortController();
-    senderRequests.set(requestId, controller);
+    senderRequests.set(normalizedRequestId, controller);
     return controller;
   }
 
   cancel(senderId, requestId) {
+    if (!Number.isInteger(senderId) || typeof requestId !== "string") return false;
+    const normalizedRequestId = requestId.trim();
     const senderRequests = this.requestsBySender.get(senderId);
-    const controller = senderRequests?.get(requestId);
+    const controller = senderRequests?.get(normalizedRequestId);
     if (!controller) return false;
 
     controller.abort();
-    senderRequests.delete(requestId);
+    senderRequests.delete(normalizedRequestId);
     if (senderRequests.size === 0) this.requestsBySender.delete(senderId);
     return true;
   }
 
   complete(senderId, requestId, controller) {
+    if (!Number.isInteger(senderId) || typeof requestId !== "string") return;
+    const normalizedRequestId = requestId.trim();
     const senderRequests = this.requestsBySender.get(senderId);
-    if (senderRequests?.get(requestId) !== controller) return;
+    if (senderRequests?.get(normalizedRequestId) !== controller) return;
 
-    senderRequests.delete(requestId);
+    senderRequests.delete(normalizedRequestId);
     if (senderRequests.size === 0) this.requestsBySender.delete(senderId);
   }
 
   cancelSender(senderId) {
+    if (!Number.isInteger(senderId)) return 0;
     const senderRequests = this.requestsBySender.get(senderId);
     if (!senderRequests) return 0;
 

--- a/test/helpers/agentStreamRequestRegistry.test.js
+++ b/test/helpers/agentStreamRequestRegistry.test.js
@@ -53,3 +53,20 @@ test("sender teardown cancels only that sender and reports the cancelled count",
   assert.equal(otherSender.signal.aborted, false);
   assert.equal(registry.cancelSender(10), 0);
 });
+
+test("normalizes requestId whitespace across begin and cancel", () => {
+  const registry = new AgentStreamRequestRegistry();
+  const controller = registry.begin(10, "  request-spaced  ");
+
+  assert.equal(registry.cancel(10, "request-spaced"), true);
+  assert.equal(controller.signal.aborted, true);
+});
+
+test("handles invalid arguments safely in cancel, complete, and cancelSender", () => {
+  const registry = new AgentStreamRequestRegistry();
+
+  assert.equal(registry.cancel(null, "req"), false);
+  assert.equal(registry.cancel(10, null), false);
+  assert.equal(registry.cancelSender(null), 0);
+  assert.doesNotThrow(() => registry.complete(null, null, null));
+});


### PR DESCRIPTION
Fixes #1919

### Problem
In `src/helpers/agentStreamRequestRegistry.js`:
- `begin(senderId, requestId)` validated that `requestId.trim()` was non-empty, but stored the untrimmed string. If a request was registered with surrounding whitespace and cancelled without it (or vice versa), the controller lookup missed and the active stream failed to abort.
- `cancel`, `complete`, and `cancelSender` did not guard against invalid types (e.g. non-integer `senderId` or non-string `requestId`).

### Solution
- Normalized `requestId` with `.trim()` consistently across `begin`, `cancel`, and `complete`.
- Added input type guards for `senderId` and `requestId` across registry methods.
- Added unit tests in `test/helpers/agentStreamRequestRegistry.test.js`.

### Verification
- `node --test test/helpers/agentStreamRequestRegistry.test.js` (passes, 7/7 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)