### PR TITLE
fix(dictionary): coerce string boolean values in applyAutoLearnSetting

### DIFF
--- a/src/helpers/autoLearnSetting.js
+++ b/src/helpers/autoLearnSetting.js
@@ -1,9 +1,23 @@
+function coerceToBoolean(value) {
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === "false" || trimmed === "0" || trimmed === "off" || trimmed === "no" || trimmed === "") {
+      return false;
+    }
+    if (trimmed === "true" || trimmed === "1" || trimmed === "on" || trimmed === "yes") {
+      return true;
+    }
+  }
+  return Boolean(value);
+}
+
 // Pure resolver for the "auto-learn-changed" IPC sync. Coerces the raw IPC
 // value to boolean and reports whether it differs from the current state, so
 // the handler can ignore repeated same-value syncs (#1080).
 function applyAutoLearnSetting(current, incoming) {
-  const enabled = !!incoming;
-  return { changed: enabled !== !!current, enabled };
+  const enabled = coerceToBoolean(incoming);
+  const currentEnabled = coerceToBoolean(current);
+  return { changed: enabled !== currentEnabled, enabled };
 }
 
 module.exports = { applyAutoLearnSetting };

--- a/test/helpers/autoLearnSetting.test.js
+++ b/test/helpers/autoLearnSetting.test.js
@@ -39,3 +39,13 @@ test("coerces truthy/falsy incoming values to boolean", () => {
     enabled: false,
   });
 });
+
+test("correctly coerces string boolean representations", () => {
+  assert.deepEqual(applyAutoLearnSetting(false, "false"), { changed: false, enabled: false });
+  assert.deepEqual(applyAutoLearnSetting(true, "false"), { changed: true, enabled: false });
+  assert.deepEqual(applyAutoLearnSetting(false, "true"), { changed: true, enabled: true });
+  assert.deepEqual(applyAutoLearnSetting(true, "0"), { changed: true, enabled: false });
+  assert.deepEqual(applyAutoLearnSetting(false, "1"), { changed: true, enabled: true });
+  assert.deepEqual(applyAutoLearnSetting(true, "off"), { changed: true, enabled: false });
+  assert.deepEqual(applyAutoLearnSetting(false, "on"), { changed: true, enabled: true });
+});


### PR DESCRIPTION
Fixes #1921

### Problem
In `src/helpers/autoLearnSetting.js`:
- `applyAutoLearnSetting(current, incoming)` directly used `!!incoming`.
- When passed serialized string boolean values (such as `"false"`, `"0"`, or `"off"`) from IPC, query parameters, or stringified storage, `Boolean("false")` evaluated to `true`, erroneously turning on auto-learn.

### Solution
- Introduced a string-aware boolean coercion helper `coerceToBoolean` that properly interprets falsey strings (`"false"`, `"0"`, `"off"`, `"no"`, `""`) and truthy strings (`"true"`, `"1"`, `"on"`, `"yes"`).
- Applied proper coercion to both `incoming` and `current` arguments.
- Added unit tests in `test/helpers/autoLearnSetting.test.js`.

### Verification
- `node --test test/helpers/autoLearnSetting.test.js` (passes, 6/6 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)