### PR TITLE
fix(dictionary): accept Set/iterable snapshots and guard non-string words (#1880)

### DIFF
--- a/src/helpers/agentNameDictionary.js
+++ b/src/helpers/agentNameDictionary.js
@@ -1,4 +1,5 @@
-function findStoredWord(words, word) {
+export function findStoredWord(words, word) {
+  if (typeof word !== "string") return undefined;
   const needle = word.toLowerCase();
   return words.find((w) => typeof w === "string" && w.trim().toLowerCase() === needle);
 }
@@ -17,7 +18,12 @@ function findStoredWord(words, word) {
  * @returns {{ add: string[], remove: string[] }}
  */
 export function agentNameDictionaryChanges(dictionary, newName, oldName) {
-  const words = Array.isArray(dictionary) ? dictionary : [];
+  const words =
+    dictionary != null &&
+    typeof dictionary !== "string" &&
+    typeof dictionary[Symbol.iterator] === "function"
+      ? [...dictionary]
+      : [];
   const trimmedNew = typeof newName === "string" ? newName.trim() : "";
   const trimmedOld = typeof oldName === "string" ? oldName.trim() : "";
   const storedNew = trimmedNew ? findStoredWord(words, trimmedNew) : undefined;

--- a/test/helpers/agentNameDictionary.test.js
+++ b/test/helpers/agentNameDictionary.test.js
@@ -113,3 +113,62 @@ test("removes previous agent name when oldName contains surrounding whitespace",
     }
   );
 });
+
+test("accepts a Set dictionary and asks for no changes when the name is present", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(agentNameDictionaryChanges(new Set(["OpenWhispr", "Alice"]), "OpenWhispr"), {
+    add: [],
+    remove: [],
+  });
+});
+
+test("swaps the previous agent name when the dictionary is a Set", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(
+    agentNameDictionaryChanges(new Set(["OpenWhispr", "Alice"]), "Jarvis", "OpenWhispr"),
+    {
+      add: ["Jarvis"],
+      remove: ["OpenWhispr"],
+    }
+  );
+});
+
+test("accepts any iterable dictionary, not just arrays", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  const dictionary = new Map([
+    ["OpenWhispr", 1],
+    ["Alice", 2],
+  ]).keys();
+  assert.deepEqual(agentNameDictionaryChanges(dictionary, "OpenWhispr", "Alice"), {
+    add: [],
+    remove: ["Alice"],
+  });
+});
+
+test("degrades a non-iterable dictionary to an empty one without throwing", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(agentNameDictionaryChanges({ 0: "OpenWhispr" }, "Jarvis"), {
+    add: ["Jarvis"],
+    remove: [],
+  });
+});
+
+test("does not throw when the dictionary contains non-string elements", async () => {
+  const { agentNameDictionaryChanges } = await load();
+  assert.deepEqual(agentNameDictionaryChanges(new Set(["OpenWhispr", 42, null]), "OpenWhispr"), {
+    add: [],
+    remove: [],
+  });
+});
+
+test("findStoredWord returns undefined for a non-string word", async () => {
+  const { findStoredWord } = await load();
+  assert.equal(findStoredWord(["OpenWhispr"], 42), undefined);
+  assert.equal(findStoredWord(["OpenWhispr"], null), undefined);
+  assert.equal(findStoredWord(["OpenWhispr"], undefined), undefined);
+});
+
+test("findStoredWord matches a stored string word", async () => {
+  const { findStoredWord } = await load();
+  assert.equal(findStoredWord(["OpenWhispr", "Alice"], "openwhispr"), "OpenWhispr");
+});


### PR DESCRIPTION
## Summary
Fixes #1880. `agentNameDictionaryChanges` only accepted `string[]`, so a `Set` or other iterable dictionary snapshot silently degraded to `[]` and wrongly suggested adding the name. `findStoredWord` also threw `TypeError: word.toLowerCase is not a function` on a non-string word.

- `agentNameDictionaryChanges` now coerces arrays, `Set`s, and other iterables to a word list (strings and non-iterables degrade to `[]` without throwing).
- `findStoredWord` guards against non-string `word` (returns `undefined`).
- Added unit tests for `Set`, `Map`-key iterator, non-iterable, and non-string-element inputs, plus a `findStoredWord` non-string guard.

## Verification
- `node --import tsx --test "test/helpers/agentNameDictionary.test.js"` → 21 passing
- `npm run quality-check` → passes (format + typecheck)
- `npm run i18n:check` → passes

This supersedes the failing PR #1881 with an equivalent fix that is prettier-clean.

🤖 Generated with [OpenCode](https://opencode.ai)