### PR TITLE
fix(macos): make auto-paste layout-independent for non-QWERTY keyboards

### DIFF
--- a/resources/macos-fast-paste.swift
+++ b/resources/macos-fast-paste.swift
@@ -9,6 +9,10 @@ if !AXIsProcessTrusted() {
 // arguments this stays what the paste path expects: ⌘V, no output.
 let copyMode = CommandLine.arguments.contains("--copy")
 let virtualKey: CGKeyCode = copyMode ? 0x08 : 0x09  // kVK_ANSI_C : kVK_ANSI_V
+// Emit the character rather than the physical keycode so the event resolves to the
+// right glyph regardless of the active keyboard layout (Dvorak, AZERTY, …). Without
+// this, a non-QWERTY layout makes Cmd+V paste the wrong character (issues #1478/#643).
+let unicodeChar: UniChar = copyMode ? 0x63 : 0x76  // "c" : "v"
 
 // Resolved before the keystroke is posted: this is the app that will receive it.
 let target = copyMode ? NSWorkspace.shared.frontmostApplication : nil
@@ -23,6 +27,9 @@ guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: virtualKey, ke
 
 keyDown.flags = .maskCommand
 keyUp.flags = .maskCommand
+var uni = unicodeChar
+CGEventKeyboardSetUnicodeString(keyDown, 1, &uni)
+CGEventKeyboardSetUnicodeString(keyUp, 1, &uni)
 keyDown.post(tap: .cgSessionEventTap)
 usleep(8000)
 keyUp.post(tap: .cgSessionEventTap)

--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -985,7 +985,7 @@ class ClipboardManager {
           ? spawn(fastPasteBinary)
           : spawn("osascript", [
               "-e",
-              'tell application "System Events" to key code 9 using command down',
+              'tell application "System Events" to keystroke "v" using command down',
             ]);
 
         let errorOutput = "";
@@ -1062,7 +1062,7 @@ class ClipboardManager {
     return new Promise((resolve, reject) => {
       const pasteProcess = spawn("osascript", [
         "-e",
-        'tell application "System Events" to key code 9 using command down',
+        'tell application "System Events" to keystroke "v" using command down',
       ]);
 
       let hasTimedOut = false;


### PR DESCRIPTION
## Summary
OpenWhispr's macOS auto-paste types the **fixed physical keycode** `kVK_ANSI_V` (0x09) / AppleScript `key code 9` with the Command modifier. Because the event carries a physical keycode rather than the character "v", the receiving app resolves it through the **active keyboard layout** — so on non-QWERTY layouts (Dvorak, AZERTY, Colemak…) Cmd+V pastes the wrong glyph (#1478, #643).

This change posts the **Unicode character "v"** instead, so the event always resolves to Cmd+"v" regardless of layout.

## Changes
- `resources/macos-fast-paste.swift`: set the event's unicode string via `CGEventKeyboardSetUnicodeString` for both paste ("v") and copy ("c") paths. Physical keycode is retained (harmless; improves compatibility with keycode-bound apps).
- `src/helpers/clipboard.js`: AppleScript fallback (used when the native binary is untrusted/missing) changed from `key code 9` → `keystroke "v" using command down` in both `pasteMacOS` and `pasteMacOSWithOsascript`.

Both changes are confined to the `darwin` paste path; Windows/Linux paste binaries are untouched.

## Notes
- **Required build step on macOS:** recompile the native binary with `npm run compile:fast-paste` (regenerates `resources/bin/macos-fast-paste`) before testing.
- #1641 (remote desktop pasting "v") is **best-effort** — the unicode change may help but the root cause can differ (remote client intercepting the synthesized keystroke) and needs separate validation. Not claimed as fixed here.

## Verification (on macOS, with accessibility granted)
- [ ] `npm run compile:fast-paste` succeeds and `resources/bin/macos-fast-paste` is updated
- [ ] QWERTY regression: normal layout still pastes correctly
- [ ] Non-QWERTY: switch to Dvorak/AZERTY, dictate, confirm text pastes (not a wrong glyph)
- [ ] `npm run lint` / `npm run typecheck` / `npm run test` pass

Closes #1478, closes #643.