### PR TITLE
fix(vad): guard unknown field limits and normalize context in whisperVadConfig

### DIFF
--- a/src/helpers/whisperVadConfig.js
+++ b/src/helpers/whisperVadConfig.js
@@ -6,8 +6,10 @@ const VAD_LIMITS = Object.freeze(LIMITS);
 function clampVadField(key, value) {
   const fallback = DEFAULTS[key];
   const n = value === null || value === undefined || value === "" ? fallback : Number(value);
-  if (!Number.isFinite(n)) return fallback;
-  const { min, max, round } = LIMITS[key];
+  if (!Number.isFinite(n)) return fallback !== undefined ? fallback : value;
+  const limit = LIMITS[key];
+  if (!limit) return n;
+  const { min, max, round } = limit;
   const clamped = Math.min(max, Math.max(min, n));
   return round ? Math.round(clamped) : clamped;
 }
@@ -26,9 +28,14 @@ function resolveContextSileroEnabled(settings = {}, context = "dictation") {
   // leave Whisper decoding near-silence seeded with the dictionary prompt, which
   // replaces the transcript with dictionary words (#1454). Long-form contexts
   // (notes, meetings) keep VAD to skip extended silence.
-  if (context === "dictation") return settings?.dictationSileroEnabled === true;
-  if (context === "noteRecording") return settings?.noteRecordingSileroEnabled !== false;
-  if (context === "meeting") return settings?.meetingSileroEnabled !== false;
+  const normalizedContext =
+    typeof context === "string" ? context.trim().toLowerCase() : "dictation";
+
+  if (normalizedContext === "dictation") return settings?.dictationSileroEnabled === true;
+  if (normalizedContext === "noterecording" || normalizedContext === "note_recording") {
+    return settings?.noteRecordingSileroEnabled !== false;
+  }
+  if (normalizedContext === "meeting") return settings?.meetingSileroEnabled !== false;
   return true;
 }
 

--- a/test/helpers/whisperVadConfig.test.js
+++ b/test/helpers/whisperVadConfig.test.js
@@ -47,3 +47,20 @@ test("resolveContextSileroEnabled defaults dictation off, other contexts on", as
   assert.equal(resolveContextSileroEnabled({}, "noteRecording"), true);
   assert.equal(resolveContextSileroEnabled({}, "meeting"), true);
 });
+
+test("clampVadField handles unknown keys safely without throwing", async () => {
+  const { clampVadField } = await import("../../src/helpers/whisperVadConfig.js");
+  assert.equal(clampVadField("unknownField", 42), 42);
+  assert.equal(clampVadField(null, 42), 42);
+});
+
+test("resolveContextSileroEnabled normalizes casing and whitespace in context", async () => {
+  const { resolveContextSileroEnabled } = await import("../../src/helpers/whisperVadConfig.js");
+  assert.equal(resolveContextSileroEnabled({}, " DICTATION "), false);
+  assert.equal(resolveContextSileroEnabled({}, "NoteRecording"), true);
+  assert.equal(resolveContextSileroEnabled({}, " MEETING "), true);
+  assert.equal(
+    resolveContextSileroEnabled({ dictationSileroEnabled: true }, "Dictation"),
+    true
+  );
+});


### PR DESCRIPTION
Fixes #1925

### Problem
In `src/helpers/whisperVadConfig.js`:
- `clampVadField(key, value)` unconditionally indexed `LIMITS[key]`, throwing `TypeError: Cannot destructure property 'min' of 'LIMITS[key]'` if an unlisted or custom configuration field was passed.
- `resolveContextSileroEnabled(settings, context)` compared against literal `"dictation"`, `"noteRecording"`, and `"meeting"`, failing to recognize mixed-case or whitespace-padded context strings.

### Solution
- Checked for existence of `LIMITS[key]` before destructuring min/max limits.
- Normalized context string with `.trim().toLowerCase()`.
- Added unit tests in `test/helpers/whisperVadConfig.test.js`.

### Verification
- `node --test test/helpers/whisperVadConfig.test.js` (passes, 5/5 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)