### PR TITLE
fix(dictation): guard settings and normalize cloudTranscriptionMode in needsSttConfigBeforeStart

### DIFF
--- a/src/helpers/sttConfigPolicy.js
+++ b/src/helpers/sttConfigPolicy.js
@@ -5,8 +5,12 @@
 // awaited fetch stalls on auth resolution for seconds and then changes
 // nothing (#1673).
 export function needsSttConfigBeforeStart(settings) {
-  const s = settings || {};
+  const s = settings && typeof settings === "object" ? settings : {};
   if (s.useLocalWhisper) return false;
-  if (s.cloudTranscriptionMode !== "openwhispr") return false;
+  const cloudMode =
+    typeof s.cloudTranscriptionMode === "string"
+      ? s.cloudTranscriptionMode.trim().toLowerCase()
+      : "";
+  if (cloudMode !== "openwhispr") return false;
   return !!s.isSignedIn;
 }

--- a/test/helpers/sttConfigPolicy.test.js
+++ b/test/helpers/sttConfigPolicy.test.js
@@ -62,6 +62,21 @@ describe("needsSttConfigBeforeStart", () => {
   test("missing settings fail open to a non-blocking start", async () => {
     const { needsSttConfigBeforeStart } = await loadPolicy();
     assert.equal(needsSttConfigBeforeStart(null), false);
+    assert.equal(needsSttConfigBeforeStart(undefined), false);
+    assert.equal(needsSttConfigBeforeStart(123), false);
+    assert.equal(needsSttConfigBeforeStart(""), false);
     assert.equal(needsSttConfigBeforeStart({}), false);
+  });
+
+  test("normalizes mixed-case and whitespace in cloudTranscriptionMode", async () => {
+    const { needsSttConfigBeforeStart } = await loadPolicy();
+    assert.equal(
+      needsSttConfigBeforeStart({
+        useLocalWhisper: false,
+        cloudTranscriptionMode: " OpenWhispr ",
+        isSignedIn: true,
+      }),
+      true
+    );
   });
 });


### PR DESCRIPTION
Fixes #1927

### Problem
In `src/helpers/sttConfigPolicy.js`:
- `needsSttConfigBeforeStart(settings)` used `settings || {}`, which did not safely guard against non-object primitives.
- `s.cloudTranscriptionMode !== "openwhispr"` did strict case/whitespace comparisons, causing mixed-casing or whitespace-padded provider strings (e.g., `"OpenWhispr"` or `" openwhispr "`) to bypass the config wait and proceed without streaming configuration.

### Solution
- Added a proper object check for `settings`.
- Normalized `cloudTranscriptionMode` with `.trim().toLowerCase()`.
- Added unit tests in `test/helpers/sttConfigPolicy.test.js`.

### Verification
- `node --test test/helpers/sttConfigPolicy.test.js` (passes, 6/6 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)