### PR TITLE
fix(cleanup): stop granting timed-out requests a fresh 30 s budget per retry

### DIFF
--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -8,7 +8,7 @@ import {
 } from "../models/ModelRegistry";
 import { BaseReasoningService, ReasoningConfig } from "./BaseReasoningService";
 import { SecureCache } from "../utils/SecureCache";
-import { withRetry, createApiRetryStrategy, httpError } from "../utils/retry";
+import { withRetry, createApiRetryStrategy, httpError, timeoutError } from "../utils/retry";
 import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, ensureV1Suffix } from "../config/constants";
 import logger from "../utils/logger";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
@@ -384,7 +384,7 @@ class ReasoningService extends BaseReasoningService {
           if (requestGeneration !== this.requestCancellationGeneration) {
             throw httpError("Request cancelled", 499);
           }
-          throw new Error(`Request timed out after ${timeoutSeconds}s`);
+          throw timeoutError(`Request timed out after ${timeoutSeconds}s`);
         }
         throw error;
       } finally {

--- a/src/services/ai/inferenceProviders/gemini.ts
+++ b/src/services/ai/inferenceProviders/gemini.ts
@@ -1,6 +1,6 @@
 import type { InferenceProvider } from "./types";
 import { getCloudModel } from "../../../models/ModelRegistry";
-import { withRetry, createApiRetryStrategy, httpError } from "../../../utils/retry";
+import { withRetry, createApiRetryStrategy, httpError, timeoutError } from "../../../utils/retry";
 import { API_ENDPOINTS, TOKEN_LIMITS } from "../../../config/constants";
 import { getLlmRequestTimeoutSeconds } from "../../../helpers/llmRequestTimeout.js";
 import { wrapCleanupTranscript } from "../../../config/prompts";
@@ -126,7 +126,7 @@ export const geminiProvider: InferenceProvider = {
         return jsonResponse;
       } catch (error) {
         if ((error as Error).name === "AbortError") {
-          throw new Error(`Request timed out after ${timeoutSeconds}s`);
+          throw timeoutError(`Request timed out after ${timeoutSeconds}s`);
         }
         throw error;
       } finally {

--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -2,7 +2,7 @@ import type { InferenceProvider } from "./types";
 import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl } from "../../../config/constants";
 import { getOpenAiApiConfig } from "../../../models/ModelRegistry";
 import { getSettings } from "../../../stores/settingsStore";
-import { withRetry, createApiRetryStrategy, httpError } from "../../../utils/retry";
+import { withRetry, createApiRetryStrategy, httpError, timeoutError } from "../../../utils/retry";
 import logger from "../../../utils/logger";
 import { canBorrowCleanupCustomKey, resolveConfiguredOpenAIBase } from "../openaiBase";
 import {
@@ -296,7 +296,7 @@ export const openaiProvider: InferenceProvider = {
           return res.json();
         } catch (error) {
           if ((error as Error).name === "AbortError") {
-            throw new Error(`Request timed out after ${timeoutSeconds}s`);
+            throw timeoutError(`Request timed out after ${timeoutSeconds}s`);
           }
           lastError = error as Error;
           if (retryStrategy.shouldRetry(lastError)) {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -44,11 +44,29 @@ export function httpError(message: string, status: number): Error & { status: nu
   return Object.assign(new Error(message), { status });
 }
 
+// Marks a client-side abort that fired after the full per-attempt timeout.
+// Unlike a network drop, the request *was* being answered — too slowly — and
+// each retry re-spends the entire budget relearning that (#1761).
+export function timeoutError(message: string): Error & { timedOut: true } {
+  return Object.assign(new Error(message), { timedOut: true as const });
+}
+
+// The OpenAI SDK (Tinfoil path) raises its own status-less timeout class
+// instead of going through timeoutError().
+function isClientTimeout(error: any): boolean {
+  return error?.timedOut === true || error?.name === "APIConnectionTimeoutError";
+}
+
 // Specific retry strategy for API calls
 export function createApiRetryStrategy() {
   return {
     shouldRetry: (error: any) => {
-      // No HTTP status means the request never got an answer (network drop, timeout).
+      // A timeout already consumed its whole budget proving the server slow;
+      // retrying it costs another full budget per attempt (127 s measured
+      // before the raw-paste fallback in #1761). Fail over instead.
+      if (isClientTimeout(error)) return false;
+
+      // No HTTP status means the request never got an answer (network drop).
       const status = error?.status ?? error?.response?.status;
       if (typeof status !== "number") return true;
 

--- a/test/utils/retry.test.js
+++ b/test/utils/retry.test.js
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  withRetry,
+  httpError,
+  timeoutError,
+  createApiRetryStrategy,
+} = require("../../src/utils/retry.ts");
+
+// #1759-adjacent history note: the status-less-retryable rule shipped for
+// network drops (#1183). #1761 measured what it does to client-side timeouts:
+// 4 attempts x 30 s + 7 s backoff = 127 s before the raw-paste fallback.
+
+test("status-less plain errors stay retryable (network drop path, #1183)", () => {
+  const { shouldRetry } = createApiRetryStrategy();
+  assert.equal(shouldRetry(new Error("fetch failed")), true);
+  assert.equal(shouldRetry(Object.assign(new Error("refused"), { code: "ECONNREFUSED" })), true);
+});
+
+test("timeoutError-marked aborts are not retryable (#1761)", () => {
+  const { shouldRetry } = createApiRetryStrategy();
+  assert.equal(shouldRetry(timeoutError("Request timed out after 30s")), false);
+});
+
+test("OpenAI SDK timeout class name is not retryable (Tinfoil path, #1761)", () => {
+  const { shouldRetry } = createApiRetryStrategy();
+  const sdkTimeout = new Error("Request timed out.");
+  sdkTimeout.name = "APIConnectionTimeoutError";
+  assert.equal(shouldRetry(sdkTimeout), false);
+});
+
+test("HTTP status classes keep their existing retry split", () => {
+  const { shouldRetry } = createApiRetryStrategy();
+  assert.equal(shouldRetry(httpError("timeout", 408)), true);
+  assert.equal(shouldRetry(httpError("rate limited", 429)), true);
+  assert.equal(shouldRetry(httpError("bad gateway", 502)), true);
+  assert.equal(shouldRetry(httpError("bad request", 400)), false);
+  assert.equal(shouldRetry(httpError("cancelled", 499)), false);
+});
+
+test("timeoutError carries the message and the timedOut marker", () => {
+  const err = timeoutError("Request timed out after 30s");
+  assert.equal(err.message, "Request timed out after 30s");
+  assert.equal(err.timedOut, true);
+  assert.ok(err instanceof Error);
+});
+
+test("withRetry gives a timed-out attempt no second budget (#1761)", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    withRetry(
+      async () => {
+        attempts++;
+        throw timeoutError("Request timed out after 30s");
+      },
+      { ...createApiRetryStrategy(), initialDelay: 1 }
+    ),
+    /timed out/
+  );
+  assert.equal(attempts, 1);
+});
+
+test("withRetry still retries a genuine network fault to exhaustion", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    withRetry(
+      async () => {
+        attempts++;
+        throw new Error("socket hang up");
+      },
+      { ...createApiRetryStrategy(), maxRetries: 3, initialDelay: 1, maxDelay: 2 }
+    ),
+    /socket hang up/
+  );
+  // MAX_RETRIES semantics: 1 initial + 3 retries
+  assert.equal(attempts, 4);
+});
+
+test("withRetry recovers when a fault clears mid-ladder", async () => {
+  let attempts = 0;
+  const result = await withRetry(
+    async () => {
+      attempts++;
+      if (attempts < 3) throw httpError("bad gateway", 502);
+      return "ok";
+    },
+    { ...createApiRetryStrategy(), initialDelay: 1 }
+  );
+  assert.equal(result, "ok");
+  assert.equal(attempts, 3);
+});


### PR DESCRIPTION
Closes #1761.

When the cleanup endpoint is slow, each attempt burns the full 30 s timeout, gets aborted client-side, and is rethrown as a status-less Error. `createApiRetryStrategy` treats status-less as retryable (right call for network drops, #1183), so the same slow server gets probed three more times at full price: 4 x 30 s + 7 s of backoff = the 127 s the issue measured before the raw-paste fallback. During a provider incident every utterance pays that.

The distinguishing axis is elapsed cost, not error class. A fast `ECONNREFUSED` is cheap to retry. An abort that already consumed its whole budget is not: the server was answering, too slowly, and retrying re-learns that at 30 s a lesson.

## Changes

- `timeoutError()` in `src/utils/retry.ts` marks a client-side abort that fired after the full per-attempt timeout.
- `createApiRetryStrategy` refuses to retry those (and the OpenAI SDK's status-less `APIConnectionTimeoutError`, which is how the Tinfoil path reports the same thing). Worst case drops from 127 s to 30 s.
- The three rethrow sites now use the marker: `ReasoningService.ts`, `inferenceProviders/gemini.ts`, `inferenceProviders/openai.ts`.
- Everything else is untouched: genuine network faults still retry to exhaustion, 408/429/5xx keep their ladder, the 499 cancellation path is unchanged. No new settings.

## Test

- New `test/utils/retry.test.js` (8 tests): a timed-out attempt gets exactly 1 call where it used to get 4, network faults still get all 4, the HTTP status split is pinned. 4 tests fail on main, 8/8 with the fix.
- Full suite: no new failures vs main. `npm run typecheck` and lint clean.