### PR TITLE
fix(build): add JSON import attributes so the packaged ESM loader can load the registry

### DIFF
--- a/src/locales/prompts.ts
+++ b/src/locales/prompts.ts
@@ -1,13 +1,13 @@
-import dePrompts from "./de/prompts.json";
-import enPrompts from "./en/prompts.json";
-import esPrompts from "./es/prompts.json";
-import frPrompts from "./fr/prompts.json";
-import itPrompts from "./it/prompts.json";
-import jaPrompts from "./ja/prompts.json";
-import ptPrompts from "./pt/prompts.json";
-import ruPrompts from "./ru/prompts.json";
-import zhCNPrompts from "./zh-CN/prompts.json";
-import zhTWPrompts from "./zh-TW/prompts.json";
+import dePrompts from "./de/prompts.json" with { type: "json" };
+import enPrompts from "./en/prompts.json" with { type: "json" };
+import esPrompts from "./es/prompts.json" with { type: "json" };
+import frPrompts from "./fr/prompts.json" with { type: "json" };
+import itPrompts from "./it/prompts.json" with { type: "json" };
+import jaPrompts from "./ja/prompts.json" with { type: "json" };
+import ptPrompts from "./pt/prompts.json" with { type: "json" };
+import ruPrompts from "./ru/prompts.json" with { type: "json" };
+import zhCNPrompts from "./zh-CN/prompts.json" with { type: "json" };
+import zhTWPrompts from "./zh-TW/prompts.json" with { type: "json" };
 
 export interface PromptBundle {
   cleanupPrompt: string;

--- a/src/locales/translations.ts
+++ b/src/locales/translations.ts
@@ -1,13 +1,13 @@
-import deTranslation from "./de/translation.json";
-import enTranslation from "./en/translation.json";
-import esTranslation from "./es/translation.json";
-import frTranslation from "./fr/translation.json";
-import itTranslation from "./it/translation.json";
-import jaTranslation from "./ja/translation.json";
-import ptTranslation from "./pt/translation.json";
-import ruTranslation from "./ru/translation.json";
-import zhCNTranslation from "./zh-CN/translation.json";
-import zhTWTranslation from "./zh-TW/translation.json";
+import deTranslation from "./de/translation.json" with { type: "json" };
+import enTranslation from "./en/translation.json" with { type: "json" };
+import esTranslation from "./es/translation.json" with { type: "json" };
+import frTranslation from "./fr/translation.json" with { type: "json" };
+import itTranslation from "./it/translation.json" with { type: "json" };
+import jaTranslation from "./ja/translation.json" with { type: "json" };
+import ptTranslation from "./pt/translation.json" with { type: "json" };
+import ruTranslation from "./ru/translation.json" with { type: "json" };
+import zhCNTranslation from "./zh-CN/translation.json" with { type: "json" };
+import zhTWTranslation from "./zh-TW/translation.json" with { type: "json" };
 
 export const TRANSLATIONS_BY_LOCALE = {
   en: enTranslation,

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -1,4 +1,4 @@
-import modelDataRaw from "./modelRegistryData.json";
+import modelDataRaw from "./modelRegistryData.json" with { type: "json" };
 import { isCloudCleanupMode, getSettings } from "../stores/settingsStore";
 import { readCachedTinfoilModels } from "./tinfoilModelCache";
 import type { InferenceMode } from "../types/electron";

--- a/src/stores/policyRules.ts
+++ b/src/stores/policyRules.ts
@@ -5,7 +5,7 @@ import { compareAppVersions } from "../utils/version.ts";
 // The registry JSON directly (like policyValidation.js), NOT ModelRegistry:
 // that module pulls the settings/identity stores, whose module scope needs
 // real browser globals, and this file is imported by node-run sync tests.
-import modelRegistryData from "../models/modelRegistryData.json";
+import modelRegistryData from "../models/modelRegistryData.json" with { type: "json" };
 
 export type PolicyStatus = "idle" | "loading" | "managed" | "unmanaged" | "error";
 

--- a/src/utils/languageSupport.ts
+++ b/src/utils/languageSupport.ts
@@ -1,4 +1,4 @@
-import registry from "../config/languageRegistry.json";
+import registry from "../config/languageRegistry.json" with { type: "json" };
 
 function buildLanguageSet(key: "whisper" | "assemblyai"): Set<string> {
   const set = new Set<string>();

--- a/test/helpers/esmJsonImportAttributes.test.js
+++ b/test/helpers/esmJsonImportAttributes.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+
+// #1908: the packaged app ships raw src/**/*.ts and loads part of it through
+// Node's native ESM loader (type stripping) — no bundler in front. There a
+// JSON import without `with { type: "json" }` throws ("needs an import
+// attribute of \"type: json\"") and text cleanup dies in 1.9.x. Import each
+// affected module exactly the way the packaged runtime does: a bare node
+// child process, no tsx, no vite.
+//
+// ModelRegistry.ts carries the same fix but is not importable standalone
+// (its importers use extensionless specifiers the ESM resolver rejects), so
+// it has no probe here.
+const MODULES = [
+  "src/helpers/transcriptionRoute.ts", // the chain the issue's error came from
+  "src/stores/policyRules.ts",
+  "src/utils/languageSupport.ts",
+  "src/locales/prompts.ts",
+  "src/locales/translations.ts",
+];
+
+for (const rel of MODULES) {
+  test(`native ESM loader imports ${rel} (JSON import attributes, #1908)`, () => {
+    const abs = path.join(__dirname, "..", "..", rel);
+    const script = `import(${JSON.stringify(abs)}).then(() => console.log("IMPORT_OK")).catch((e) => { console.error(e.message); process.exit(1); });`;
+    let out;
+    try {
+      out = execFileSync(process.execPath, ["--no-warnings", "-e", script], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      assert.fail(`import failed: ${error.stderr || error.message}`);
+    }
+    assert.match(out, /IMPORT_OK/);
+  });
+}


### PR DESCRIPTION
Closes #1908.

Packaged 1.9.x ships raw `src/**/*.ts` and loads part of it through Node's native ESM loader, where a JSON import without `with { type: \"json\" }` throws:

```
Module ".../app.asar/src/models/modelRegistryData.json" needs an import attribute of "type: json"
```

and text cleanup dies while transcription keeps working. Three reports on the issue, macOS confirmed too, and macOS users can't patch locally because editing the bundle breaks the code signature. Dev builds never show it because Vite inlines JSON imports.

I reproduced it on main with the packaged app's own loading path: `node -e 'import(\"./src/helpers/transcriptionRoute.ts\")'` fails with exactly that error under Node 24.

## Changes

- Added `with { type: \"json\" }` to all 23 JSON imports across the 5 affected files: `stores/policyRules.ts`, `models/ModelRegistry.ts`, `utils/languageSupport.ts`, `locales/prompts.ts`, `locales/translations.ts`. Same style `voiceSurfaceGeometry.mjs` already uses.
- That covers both call sites from the issue plus the three follow-up sites otopba identified as next in line on the same import graph.
- Renderer-only JSON imports (settingsStore, components) are bundled by Vite and don't need the attribute, so they're untouched.

## Test

- New `test/helpers/esmJsonImportAttributes.test.js`: spawns a bare node child (no tsx, no bundler, same loader as the packaged app) and imports each of the 5 reachable modules. All 5 fail on main, 5/5 pass with the fix.
- `ModelRegistry.ts` gets the attribute but no probe: its importers use extensionless specifiers the native resolver rejects, so it isn't reachable standalone (matches otopba's analysis).
- `vite build` succeeds with the attributes, so the renderer bundle is unaffected. Full suite: no new failures vs main. Typecheck and lint clean.