### PR TITLE
fix(windows): only hand explorer.exe URLs it can actually deliver

### DIFF
--- a/src/helpers/externalUrlOpener.js
+++ b/src/helpers/externalUrlOpener.js
@@ -13,9 +13,26 @@ const debugLogger = require("./debugLogger");
 // outside our process tree. The protocol gate is load-bearing: explorer.exe
 // EXECUTES non-URL arguments such as file paths. The absolute path is too:
 // a bare "explorer.exe" resolves from the CWD first (binary planting).
+// explorer.exe cannot deliver every URL: its command-line parser treats "="
+// and "," as field separators, so query strings (?callbackURL=… — which broke
+// every desktop OAuth sign-in, microsoft/WSL#3832), fragments (neovim#23401),
+// and a bare "=" or "," in a path (rauschma/openurl#2) open a File Explorer
+// window or an error dialog instead of the browser — silently, because the
+// spawn itself succeeds. Those URLs go through shell.openExternal: losing the
+// loopback exclusion for one open beats a link that never opens. Gate on the
+// serialized href (the argv token explorer receives) — URL.search reports ""
+// for a bare trailing "?". Serialization percent-encodes spaces, quotes and
+// non-ASCII, so explorer always gets one ASCII token; "%" itself stays
+// eligible because this shell-less spawn never expands %VAR%-style sequences.
+const EXPLORER_BREAKING_CHARS = /[?#=,]/;
+
 async function openExternalUrl(url) {
   const { protocol, href } = new URL(url);
-  if (process.platform === "win32" && (protocol === "http:" || protocol === "https:")) {
+  if (
+    process.platform === "win32" &&
+    (protocol === "http:" || protocol === "https:") &&
+    !EXPLORER_BREAKING_CHARS.test(href)
+  ) {
     const explorerPath = path.win32.join(process.env.SystemRoot || "C:\\Windows", "explorer.exe");
     try {
       await new Promise((resolve, reject) => {

--- a/test/helpers/externalUrlOpener.test.js
+++ b/test/helpers/externalUrlOpener.test.js
@@ -119,9 +119,59 @@ test("explorer.exe receives a single percent-encoded argv token", async () => {
   const { openExternalUrl, spawnCalls } = loadOpener();
   setPlatform("win32");
 
-  await openExternalUrl('https://example.com/join?name=a b"c');
+  await openExternalUrl('https://example.com/join room "4"');
 
-  assert.deepEqual(spawnCalls[0].args, ["https://example.com/join?name=a%20b%22c"]);
+  assert.deepEqual(spawnCalls[0].args, ["https://example.com/join%20room%20%224%22"]);
+});
+
+test("win32 query-string URLs go to shell.openExternal — explorer.exe opens File Explorer instead of the browser for them", async () => {
+  const { openExternalUrl, spawnCalls, openExternalCalls } = loadOpener();
+  setPlatform("win32");
+
+  const oauthUrl =
+    "https://auth.openwhispr.com/api/desktop-signin/google?callbackURL=openwhispr%3A%2F%2Fauth";
+  await openExternalUrl(oauthUrl);
+
+  assert.equal(spawnCalls.length, 0);
+  assert.deepEqual(openExternalCalls, [oauthUrl]);
+});
+
+test("a bare trailing ? still counts as a query string for the explorer.exe gate", async () => {
+  const { openExternalUrl, spawnCalls, openExternalCalls } = loadOpener();
+  setPlatform("win32");
+
+  // URL.search reports "" here, but the serialized href explorer.exe receives
+  // keeps the "?" — the gate must judge the delivered token, not the parse.
+  await openExternalUrl("https://example.com/checkout?");
+
+  assert.equal(spawnCalls.length, 0);
+  assert.deepEqual(openExternalCalls, ["https://example.com/checkout?"]);
+});
+
+test("win32 fragment URLs go to shell.openExternal — explorer.exe mishandles them too", async () => {
+  const { openExternalUrl, spawnCalls, openExternalCalls } = loadOpener();
+  setPlatform("win32");
+
+  await openExternalUrl("https://docs.openwhispr.com/changelog#windows");
+
+  assert.equal(spawnCalls.length, 0);
+  assert.deepEqual(openExternalCalls, ["https://docs.openwhispr.com/changelog#windows"]);
+});
+
+test("win32 URLs with explorer's = or , argv separators go to shell.openExternal", async () => {
+  const { openExternalUrl, spawnCalls, openExternalCalls } = loadOpener();
+  setPlatform("win32");
+
+  // Neither URL has a query string or fragment — the separator alone breaks
+  // explorer.exe's argument parsing (rauschma/openurl#2, superuser 1552619).
+  await openExternalUrl("https://example.com/products/id=42");
+  await openExternalUrl("https://example.com/maps/@37.77,-122.41");
+
+  assert.equal(spawnCalls.length, 0);
+  assert.deepEqual(openExternalCalls, [
+    "https://example.com/products/id=42",
+    "https://example.com/maps/@37.77,-122.41",
+  ]);
 });
 
 test("win32 mailto URLs fall through to shell.openExternal untouched", async () => {


### PR DESCRIPTION
Windows desktop sign-in (Google/Microsoft/Apple/SSO) has been dead since v1.9.1: explorer.exe silently drops any URL carrying a query string. Those URLs now open via shell.openExternal again.

explorer.exe remains the opener for URLs it can actually deliver, so cold-started browsers still land outside our process tree for WASAPI loopback exclusion; URLs it would swallow fall back to shell.openExternal. Fixes the Windows OAuth browser-handoff regression from #1864.

## Problem

Since v1.9.1, clicking a desktop sign-in provider button on Windows shows a spinner for a few seconds, then nothing — no browser opens. Two support threads reported it (a new signup who refunded, and an existing paying customer whose login broke on auto-update). Prod data confirms fleet-wide impact: Windows Google-only desktop activation fell from ~72–81% to ~3% on 08-28, while password-workaround account creation spiked from ~2/day to 30. UTM-tagged outbound links and Teams/Zoom join links (`?context=` / `?pwd=`) are equally affected. macOS/Linux are untouched.

## Root cause

#1864 routes every Windows http/https open through `spawn(explorer.exe, [url])` so cold-started browsers land outside our process tree (WASAPI loopback capture excludes our tree — `PROCESS_LOOPBACK_MODE_EXCLUDE_TARGET_PROCESS_TREE`). But explorer.exe silently fails on any URL containing a query string: it opens a File Explorer window instead of the browser (microsoft/WSL#3832). Desktop OAuth URLs always carry `?callbackURL=…`, so every provider sign-in broke.

The failure is triple-silent: the spawn "succeeds" so the `shell.openExternal` fallback never fires, the `open-external` IPC returns success, and `openExternalLink()` ignores the result anyway. #1864's tests mock spawn and only exercise a query-free `meet.google.com` URL, so nothing caught it.

## Fix

`openExternalUrl()` takes the explorer.exe path only for URLs explorer can actually deliver — serialized `href` containing none of `?` `#` `=` `,` — and falls back to `shell.openExternal` for everything else. The gate inspects the `href` (the exact argv token explorer receives), because `URL.search` reports `""` for a bare trailing `?`. mailto and non-Windows behavior are unchanged.

Why the gate is wider than "query string": explorer.exe's command-line parser treats `=` and `,` as field separators (Geoff Chappell's Explorer command-line study), so a bare `=` in a *path* breaks it with no `?` in sight (rauschma/openurl#2, superuser.com/q/1552619), and a fragment-only URL hard-fails with an "invalid URL" dialog (neovim#23401 — neovim abandoned explorer.exe for exactly this in their PR #24392). No source in the public record demonstrates any fragment URL surviving explorer.exe, so fragments are excluded wholesale on the same risk asymmetry as query strings: a wrongly-included URL fails silently for the user; a wrongly-excluded one only loses the loopback exclusion.

Accepted tradeoff: query-string opens lose the loopback process-tree exclusion. That only matters for a cold-started browser during an active meeting capture — and the meeting links that motivated #1864's explorer path (bare `meet.google.com` URLs) keep it — versus sign-in being broken for the entire Windows fleet.

## Tests

Written red-first against main:

- **New (RED → GREEN):** a win32 query-string URL (real OAuth shape) must go to `shell.openExternal`, not explorer.exe — failed on main with the bug's exact signature (URL spawned to explorer, `shell.openExternal` never called).
- **New (RED → GREEN):** a bare trailing `?` still counts as a query string (href-vs-search gate edge — `URL.search` is `""` there).
- **New (RED → GREEN):** a fragment URL goes to `shell.openExternal`.
- **New (RED → GREEN):** URLs with `=` or `,` in the path (no query, no fragment) go to `shell.openExternal`.
- **Kept green:** query-free URLs keep the explorer.exe path (absolute path, argv, spawn options, unref) and the spawn-error → `shell.openExternal` fallback still holds.
- **Re-vehicled:** the percent-encoding argv test now uses a gate-clean URL that still carries spaces and a double quote (`join room "4"` → `join%20room%20%224%22`), preserving the single-token/quote-encoding guarantee on the explorer path.

Full suite: 3313 tests, 0 new failures (the single failure, `enterpriseIdentityStoreImports` localStorage-global, also fails on pristine main; 185 skips are the normal local Electron-ABI better-sqlite3 skips). Prettier/eslint clean on touched files.

One deliberate non-exclusion: `%` stays explorer-eligible. It is not a documented explorer argv separator, the shell-less spawn never does cmd-style `%VAR%` expansion, and percent-encoded URLs have gone through `explorer.exe` at scale for years (wslview lineage) with no failure reports — while excluding it would forfeit the loopback exclusion for every spaced/non-ASCII link, including the meeting-join class the explorer path exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
