### PR TITLE
fix(transcription): give the model-registry JSON import its type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-08-29
+
+A repair release for two 1.9.1 regressions. Windows desktop sign-in works again — every provider button had gone dead — and the three transcription paths that only failed in packaged builds are back on all platforms. Meeting prompts also pick up swipe-to-dismiss.
+
+### Accounts
+
+- **Windows desktop sign-in works again.** Since 1.9.1, clicking Google, Microsoft, Apple, or SSO on Windows showed a spinner and then nothing. Browser links were routed through `explorer.exe`, which silently opens a File Explorer window instead of the browser for any URL carrying a query string — and every sign-in URL carries one. Connecting a calendar, opening Stripe checkout, and following tagged outbound links broke the same way. Those links now open directly; the ones `explorer.exe` can deliver still go through it, so meeting recordings keep capturing the audio of a browser launched from a meeting link. (#1932)
+
+### Transcription
+
+- **Three transcription paths failed in packaged builds.** A model-registry import added in 1.9.1 was missing the attribute Node's module loader requires for JSON, so xAI dictation, re-transcribing a saved recording, and bring-your-own-key file uploads threw `needs an import attribute of "type: json"` on Windows, macOS, and Linux while ordinary dictation kept working. Development builds inline that import, which is why it reached release. (#1908)
+
 ### Meetings
 
-- **Meeting prompts swipe away like desktop notifications.** A horizontal pointer swipe of 80px in either direction dismisses a meeting card — detection, calendar reminder, or the auto-end restart offer — taking the same path as its close button. Swipes that start on an action button are ignored.
+- **Meeting prompts swipe away like desktop notifications.** A horizontal pointer swipe of 80px in either direction dismisses a meeting card — detection, calendar reminder, or the auto-end restart offer — taking the same path as its close button. Swipes that start on an action button are ignored. (#1906)
 
 ## [1.9.1] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 A repair release for two 1.9.1 regressions. Windows desktop sign-in works again — every provider button had gone dead — and the three transcription paths that only failed in packaged builds are back on all platforms. Meeting prompts also pick up swipe-to-dismiss.
 
-### Accounts
+### Windows
 
-- **Windows desktop sign-in works again.** Since 1.9.1, clicking Google, Microsoft, Apple, or SSO on Windows showed a spinner and then nothing. Browser links were routed through `explorer.exe`, which silently opens a File Explorer window instead of the browser for any URL carrying a query string — and every sign-in URL carries one. Connecting a calendar, opening Stripe checkout, and following tagged outbound links broke the same way. Those links now open directly; the ones `explorer.exe` can deliver still go through it, so meeting recordings keep capturing the audio of a browser launched from a meeting link. (#1932)
+- **Desktop sign-in works again.** Since 1.9.1, clicking Google, Microsoft, Apple, or SSO on Windows showed a spinner and then nothing. Browser links were routed through `explorer.exe`, which silently opens a File Explorer window instead of the browser for any URL carrying a query string — and every sign-in URL carries one. Connecting a calendar, opening Stripe checkout, and following tagged outbound links broke the same way. Those links now open directly; the ones `explorer.exe` can deliver still go through it, so meeting recordings keep capturing the audio of a browser launched from a meeting link. (#1932)
 
 ### Transcription
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-whispr",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-whispr",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-whispr",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "A desktop dictation application using whisper.cpp for speech-to-text transcription",
   "main": "main.js",
   "private": true,

--- a/src/stores/policyRules.ts
+++ b/src/stores/policyRules.ts
@@ -5,7 +5,7 @@ import { compareAppVersions } from "../utils/version.ts";
 // The registry JSON directly (like policyValidation.js), NOT ModelRegistry:
 // that module pulls the settings/identity stores, whose module scope needs
 // real browser globals, and this file is imported by node-run sync tests.
-import modelRegistryData from "../models/modelRegistryData.json";
+import modelRegistryData from "../models/modelRegistryData.json" with { type: "json" };
 
 export type PolicyStatus = "idle" | "loading" | "managed" | "unmanaged" | "error";
 

--- a/test/helpers/mainProcessEsmEntries.test.js
+++ b/test/helpers/mainProcessEsmEntries.test.js
@@ -1,0 +1,27 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const { spawnSync } = require("node:child_process");
+
+// ipcHandlers.js reaches raw .ts through Electron's bare Node ESM loader, which
+// rejects JSON imports without `with { type: "json" }`. The suite runs under
+// tsx, which resolves them anyway, so importing these from a normal test proves
+// nothing — each entry needs a child process with no loader hooks (#1908).
+const MAIN_PROCESS_ESM_ENTRIES = ["src/helpers/transcriptionRoute.ts"];
+
+const repoRoot = path.resolve(__dirname, "../..");
+const bareEnv = { ...process.env };
+delete bareEnv.NODE_OPTIONS;
+
+for (const entry of MAIN_PROCESS_ESM_ENTRIES) {
+  test(`${entry} imports under a bare Node ESM loader`, () => {
+    const specifier = pathToFileURL(path.join(repoRoot, entry)).href;
+    const result = spawnSync(process.execPath, ["-e", `import(${JSON.stringify(specifier)})`], {
+      env: bareEnv,
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+  });
+}


### PR DESCRIPTION
Three transcription paths have thrown `needs an import attribute of "type: json"` in packaged builds since 1.9.1, on every platform. One missing import attribute. Also prepares 1.9.2.

Fixes #1908

## Root cause

`policyRules.ts` gained `import modelRegistryData from "../models/modelRegistryData.json"` in 1.9.1 via #1836. `ipcHandlers.js` reaches that module through Electron's bare Node ESM loader, which requires `with { type: "json" }` on JSON imports. Reproducible straight from the source tree, no packaging needed:

```
$ node -e 'import("./src/stores/policyRules.ts")'
ERR_IMPORT_ATTRIBUTE_MISSING: Module ".../src/models/modelRegistryData.json"
needs an import attribute of "type: json"
```

`voiceSurfaceGeometry.mjs:1` already writes it the correct way, so the fix matches what is already in the tree.

## Blast radius

I walked the main-process ESM graph: 7 modules, exactly one bad JSON import. `ipcHandlers.js` is the only main-process file that imports raw `.ts`, and it does so from three handlers:

| Handler | Feature |
| --- | --- |
| `proxy-xai-transcription` | xAI dictation |
| `retry-transcription` | Re-transcribing a saved recording |
| `transcribe-audio-file-byok` | Bring-your-own-key file uploads |

Ordinary dictation is unaffected, which matches the reports.

Narrower than the issue thread suggests. `audioManager.js` and `discardedRecording.js` are renderer modules (imported by `ControlPanel.tsx` and `useAudioRecording.js`), so Vite inlines their JSON. `languageSupport.ts`, `prompts.ts` and `translations.ts` are not in the main-process graph either — `i18nMain.js` bypasses `prompts.ts` and `require()`s the raw per-locale JSON. `ModelRegistry.ts` carries the same shape but every importer uses an extensionless specifier, which Node's resolver does not resolve, so it is latent rather than reachable. Only the one site is fixed here.

## Why the existing tests passed

`test/helpers/transcriptionRoute.test.js` already imports the exact module that fails in production, 13 tests deep. The suite runs under `node --import tsx`, and tsx resolves attribute-less JSON imports:

```
node --import tsx --test  →  13 pass     # what CI runs
node --test               →  13 fail     # what the packaged app does
```

So adding another ordinary test would not have helped. The new test spawns each main-process ESM entry in a child process with `NODE_OPTIONS` stripped, so it exercises the loader the packaged app actually uses. Verified red-first: it fails without the one-line fix and passes with it.

`eslint.config.js:8` also ignores `helpers/**` and `utils/**`, so no static rule could have caught this either.

## 1.9.2

Bumps the version and moves the changelog's Unreleased entries into a `[1.9.2]` section covering everything since 1.9.1:

- #1932 — Windows desktop sign-in
- #1908 — this fix
- #1906 — swipe-to-dismiss on meeting prompts

## Verification

Ran against a freshly installed `node_modules` (my local copy was stale, which had been masking two unrelated failures):

- `npm run typecheck` — clean
- `npm run lint` — clean, zero warnings
- `npm run format` — no changes to make
- `npm test` — 3314 tests, 0 failures, 185 skips (the usual local better-sqlite3 ABI skips)
- `npm run build:renderer` — builds

Prettier is clean on all touched files. Worth noting separately: the repo's `format` script runs Prettier from inside `src`, so `test/**` is never covered by it — 38 test files are currently unformatted. Identical count before and after this change, so I left them alone rather than burying a release fix in reformatting noise.

## Follow-ups, not in this PR

- **`policyValidation.js:35` rejects forward-compatible policies.** It validates server-sent provider ids against the client's own bundled registry, so a 1.9.0 client receiving `gemini` in `allowedByokProviders` fails `isValidPolicyShape`, `workspacePolicyManager.js:288` throws "Malformed policy response", and `policyRules.ts:24` fails closed — a personal account gets a locked model selector and a "Managed by your organization" badge. The same file already documents the right pattern for `requiredLocalModels` at lines 50-53, and both behaviors are pinned by contradictory tests (`policyValidation.test.js:79` accepts unknown model ids, `:121` rejects unknown providers). As written, every provider added server-side breaks every older client.
- **Main process should not load raw TS.** `electron-builder.json` hand-enumerates `src/stores/policyRules.ts` and `src/services/transcriptionBaseUrl.ts` file by file, which is the packaging config signalling how fragile this is. Bundling main would remove the whole bug class.
- The issue title says "text cleanup", but none of the three reachable handlers is cleanup — @lysacor's "re-transcribe a recording" is the accurate repro.