### PR TITLE
fix(meetings): fall back to renderer loopback when WASAPI capture is silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Meetings
+
+- **Windows meetings that recorded only your own voice.** On some machines the system-audio helper starts up reporting itself healthy and then captures nothing but digital silence, so meeting notes contained your microphone and none of the other participants — with no error anywhere in the app. The check that picked the capture method only asked Windows whether loopback capture was *available*, never whether any audio was actually arriving, so the working fallback was never reached. The helper now compares its own output against what your speakers or headphones are really playing, and a recording that hits this switches to the fallback a few seconds in and keeps the rest of the call. (#1935, thanks @KishenG)
+
 ## [1.9.2] - 2026-08-29
 
 A repair release for two 1.9.1 regressions. Windows desktop sign-in works again — every provider button had gone dead — and the three transcription paths that only failed in packaged builds are back on all platforms. Meeting prompts also pick up swipe-to-dismiss.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
 
 - **windows-key-listener.c**: C source for Windows low-level keyboard hook (Push-to-Talk)
 - **windows-mic-listener.c**: C source for WASAPI mic session monitor (event-driven mic detection)
-- **windows-system-audio-helper.c**: C source for WASAPI process-loopback system audio capture (meeting transcription). Excludes OpenWhispr's own process tree, so it hears every app on every output device. Requires Windows 10 2004+; falls back to Chromium display-media loopback when unavailable. Outputs 24 kHz mono s16le PCM on stdout, line-delimited JSON events on stderr (same protocol as linux-system-audio-helper)
+- **windows-system-audio-helper.c**: C source for WASAPI process-loopback system audio capture (meeting transcription). Excludes OpenWhispr's own process tree, so it hears every app on every output device. Requires Windows 10 2004+; falls back to Chromium display-media loopback when unavailable, and mid-session when the helper emits a `capture_silent` warning (its own stream is silent while a render endpoint is metering output — activation success cannot detect that). Outputs 24 kHz mono s16le PCM on stdout, line-delimited JSON events on stderr (same protocol as linux-system-audio-helper)
 - **macos-mic-listener.swift**: Swift source for CoreAudio mic property listener (event-driven mic detection)
 - **globe-listener.swift**: Swift source for macOS Globe/Fn key detection
 - **bin/**: Directory for compiled native binaries (whisper-cpp, nircmd, key/mic listeners)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -156,7 +156,8 @@ On GNOME and KDE, the first automatic paste can show a remote-interaction permis
 
 1. System audio is captured by `windows-system-audio-helper.exe` (WASAPI process loopback), which hears every app on every output device — no permission prompt is needed
 2. If the helper is missing or fails (requires Windows 10 2004+), OpenWhispr automatically falls back to Chromium loopback, which only hears the _default_ output device — make sure your meeting app plays through the default device in that case
-3. If transcription shows "Continuing with microphone only", system audio capture failed entirely; check debug logs for `windows-system-audio-helper` entries
+3. On some machines the helper starts successfully but captures only digital silence. OpenWhispr detects this a few seconds in (its capture is silent while an output device is still metering audio) and switches that recording to Chromium loopback; the debug log shows `Windows system audio helper captured only silence, switching to renderer loopback`
+4. If transcription shows "Continuing with microphone only", system audio capture failed entirely; check debug logs for `windows-system-audio-helper` entries
 
 **All Platforms:**
 

--- a/preload.js
+++ b/preload.js
@@ -861,6 +861,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     "meeting-system-audio-silent",
     (callback) => (_event, data) => callback(data)
   ),
+  onMeetingSystemAudioDegraded: registerListener(
+    "meeting-system-audio-degraded",
+    (callback) => () => callback()
+  ),
 
   // Dictation realtime streaming
   dictationRealtimeWarmup: (options) => ipcRenderer.invoke("dictation-realtime-warmup", options),

--- a/resources/windows-system-audio-helper.c
+++ b/resources/windows-system-audio-helper.c
@@ -32,6 +32,7 @@
 #include <initguid.h>
 #include <mmdeviceapi.h>
 #include <audioclient.h>
+#include <endpointvolume.h>
 #include <fcntl.h>
 #include <io.h>
 #include <stdarg.h>
@@ -92,6 +93,15 @@ typedef struct {
 DEFINE_GUID(HELPER_IID_IAgileObject,
     0x94ea2b94, 0xe9cc, 0x49e0, 0xc0, 0xff, 0xee, 0x64, 0xca, 0x8f, 0x5b, 0x90);
 
+/* Render-endpoint metering, used to tell a broken capture apart from a quiet
+ * machine. Locally named for the same reason as the IIDs above. */
+DEFINE_GUID(HELPER_CLSID_MMDeviceEnumerator,
+    0xbcde0395, 0xe52f, 0x467c, 0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e);
+DEFINE_GUID(HELPER_IID_IMMDeviceEnumerator,
+    0xa95664d2, 0x9614, 0x4f35, 0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6);
+DEFINE_GUID(HELPER_IID_IAudioMeterInformation,
+    0xc02216f6, 0x8c67, 0x4b5b, 0x9d, 0x00, 0xd0, 0x08, 0xe7, 0x3e, 0x00, 0x64);
+
 #define DEFAULT_SAMPLE_RATE 24000
 #define CAPTURE_CHANNELS 2
 #define BYTES_PER_SAMPLE 2
@@ -104,6 +114,14 @@ DEFINE_GUID(HELPER_IID_IAgileObject,
 #define SILENCE_GAP_MAX_MS 5000
 #define SILENCE_FILL_CHUNK_FRAMES 2400
 #define BUFFER_DURATION_HNS 200000 /* 20 ms, matches the Microsoft sample */
+/* Sample magnitude (of 32767) above which captured audio counts as real and
+ * not converter dither — roughly -60 dBFS. */
+#define CAPTURE_AUDIBLE_LEVEL 32
+/* Render-endpoint peak (0.0-1.0) above which something is audibly playing. */
+#define ENDPOINT_AUDIBLE_PEAK 0.01f
+/* Consecutive one-second checks with a playing endpoint and a silent capture
+ * before we call process loopback broken. */
+#define CAPTURE_SILENT_CONFIRM_TICKS 5
 
 static volatile LONG g_running = TRUE;
 
@@ -329,6 +347,63 @@ static HRESULT activate_process_loopback(
 }
 
 /* ========================================================================
+ * Silent-capture detection
+ *
+ * Activation succeeding proves only that the OS exposes process loopback; on
+ * some machines it then delivers nothing but digital silence. Silence alone
+ * is ambiguous — an idle machine looks identical — so it only counts as a
+ * failure while a render endpoint is metering real output.
+ * ======================================================================== */
+
+static BOOL any_render_endpoint_audible(IMMDeviceEnumerator *enumerator)
+{
+    IMMDeviceCollection *devices = NULL;
+    UINT count = 0;
+    UINT i;
+    BOOL audible = FALSE;
+
+    if (FAILED(IMMDeviceEnumerator_EnumAudioEndpoints(enumerator, eRender, DEVICE_STATE_ACTIVE,
+                                                      &devices))) {
+        return FALSE;
+    }
+
+    if (SUCCEEDED(IMMDeviceCollection_GetCount(devices, &count))) {
+        for (i = 0; i < count && !audible; i++) {
+            IMMDevice *device = NULL;
+            IAudioMeterInformation *meter = NULL;
+            float peak = 0.0f;
+
+            if (FAILED(IMMDeviceCollection_Item(devices, i, &device))) {
+                continue;
+            }
+            if (SUCCEEDED(IMMDevice_Activate(device, &HELPER_IID_IAudioMeterInformation,
+                                             CLSCTX_ALL, NULL, (void **)&meter))) {
+                if (SUCCEEDED(IAudioMeterInformation_GetPeakValue(meter, &peak)) &&
+                    peak > ENDPOINT_AUDIBLE_PEAK) {
+                    audible = TRUE;
+                }
+                IAudioMeterInformation_Release(meter);
+            }
+            IMMDevice_Release(device);
+        }
+    }
+
+    IMMDeviceCollection_Release(devices);
+    return audible;
+}
+
+static BOOL samples_are_audible(const short *samples, UINT32 count)
+{
+    UINT32 i;
+    for (i = 0; i < count; i++) {
+        if (samples[i] > CAPTURE_AUDIBLE_LEVEL || samples[i] < -CAPTURE_AUDIBLE_LEVEL) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+/* ========================================================================
  * Capture loop
  * ======================================================================== */
 
@@ -366,7 +441,13 @@ static int run_capture(DWORD excludePid, UINT32 sampleRate)
     size_t monoBufferFrames = 0;
     LARGE_INTEGER qpcFrequency;
     LARGE_INTEGER captureStart;
+    LARGE_INTEGER lastSilenceCheck;
     UINT64 emittedFrames = 0;
+    IMMDeviceEnumerator *deviceEnumerator = NULL;
+    /* Disarmed for good once real audio proves capture works, or once the
+     * warning has been emitted — either way there is nothing left to watch. */
+    BOOL silenceDetectionArmed = TRUE;
+    int endpointAudibleTicks = 0;
     const char *errorCode = NULL;
     HRESULT hr;
     int exitCode = 0;
@@ -409,6 +490,15 @@ static int run_capture(DWORD excludePid, UINT32 sampleRate)
 
     QueryPerformanceFrequency(&qpcFrequency);
     QueryPerformanceCounter(&captureStart);
+    lastSilenceCheck = captureStart;
+
+    /* Best-effort: without a meter we simply never report a silent capture. */
+    if (FAILED(CoCreateInstance(&HELPER_CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+                                &HELPER_IID_IMMDeviceEnumerator, (void **)&deviceEnumerator))) {
+        deviceEnumerator = NULL;
+        silenceDetectionArmed = FALSE;
+    }
+
     emit_event("start", NULL, NULL);
 
     while (InterlockedCompareExchange(&g_running, TRUE, TRUE)) {
@@ -456,6 +546,10 @@ static int run_capture(DWORD excludePid, UINT32 sampleRate)
                     for (i = 0; i < frames; i++) {
                         monoBuffer[i] = (short)(((int)stereo[i * 2] + (int)stereo[i * 2 + 1]) / 2);
                     }
+                }
+
+                if (silenceDetectionArmed && samples_are_audible(monoBuffer, frames)) {
+                    silenceDetectionArmed = FALSE;
                 }
 
                 if (!write_pcm(monoBuffer, frames)) {
@@ -518,11 +612,26 @@ static int run_capture(DWORD excludePid, UINT32 sampleRate)
             }
         }
 
+        if (silenceDetectionArmed &&
+            now.QuadPart - lastSilenceCheck.QuadPart >= qpcFrequency.QuadPart) {
+            lastSilenceCheck = now;
+            if (!any_render_endpoint_audible(deviceEnumerator)) {
+                endpointAudibleTicks = 0;
+            } else if (++endpointAudibleTicks >= CAPTURE_SILENT_CONFIRM_TICKS) {
+                silenceDetectionArmed = FALSE;
+                emit_event("warning", "capture_silent",
+                           "Process loopback captured silence while a render endpoint was playing");
+            }
+        }
+
         fflush(stdout);
     }
 
 done:
     IAudioClient_Stop(audioClient);
+    if (deviceEnumerator) {
+        IMMDeviceEnumerator_Release(deviceEnumerator);
+    }
     IAudioCaptureClient_Release(captureClient);
     IAudioClient_Release(audioClient);
     CloseHandle(samplesReadyEvent);

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6253,6 +6253,7 @@ class IPCHandlers {
       meetingMicDiarizationPath = null;
       meetingMicDiarizationStartedAt = null;
       meetingSystemAudioHeard = false;
+      meetingSystemAudioDegraded = false;
       meetingDiarizationSegments = [];
       const { pcmPath, startedAt, diarizedSource, cleanupPcmPaths } = resolveDiarizationInput({
         systemPcmPath,
@@ -6799,6 +6800,7 @@ class IPCHandlers {
     let meetingMicDiarizationPath = null;
     let meetingMicDiarizationStartedAt = null;
     let meetingSystemAudioHeard = false;
+    let meetingSystemAudioDegraded = false;
     let meetingDiarizationSegments = [];
     let meetingLiveSpeakerActive = false;
     let meetingLiveSpeakerState = null;
@@ -7399,6 +7401,7 @@ class IPCHandlers {
       meetingDiarizationStartedAt = null;
       dropMeetingMicDiarizationCapture();
       meetingSystemAudioHeard = false;
+      meetingSystemAudioDegraded = false;
       meetingDiarizationSegments = [];
       meetingLocalWin = null;
       meetingLocalTranscript = "";
@@ -8031,7 +8034,26 @@ class IPCHandlers {
       }
     };
 
-    const startManagedMeetingSystemAudio = (event, manager, warningLabel) => {
+    // The Windows helper reports capture_silent when its own stream is silent
+    // while a render endpoint is playing: activation succeeded but no audio
+    // will ever arrive, so hand the live session to Chromium's renderer
+    // loopback. The silence watchdog stays armed in case that fails too.
+    const degradeMeetingSystemAudioToLoopback = async (event) => {
+      if (meetingSystemAudioDegraded || meetingSystemAudioHeard) return;
+      meetingSystemAudioDegraded = true;
+      debugLogger.warn(
+        "Windows system audio helper captured only silence, switching to renderer loopback",
+        {},
+        "meeting"
+      );
+      await this.windowsLoopbackAudioManager?.stop().catch(() => {});
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("meeting-system-audio-degraded");
+      }
+    };
+
+    const startManagedMeetingSystemAudio = (event, manager, warningLabel, onWarningCode) => {
       const win = BrowserWindow.fromWebContents(event.sender);
       return manager.start({
         onChunk: (chunk) => {
@@ -8048,6 +8070,7 @@ class IPCHandlers {
             { code: warning.code, message: warning.message },
             "meeting"
           );
+          onWarningCode?.(warning.code);
         },
       });
     };
@@ -8096,7 +8119,12 @@ class IPCHandlers {
           await startManagedMeetingSystemAudio(
             event,
             this.windowsLoopbackAudioManager,
-            "Windows system audio warning"
+            "Windows system audio warning",
+            (code) => {
+              if (code === "capture_silent") {
+                void degradeMeetingSystemAudioToLoopback(event);
+              }
+            }
           );
           return { systemAudioMode, systemAudioStrategy };
         } catch (error) {

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -1321,19 +1321,13 @@ export async function startRecording(args: StartRecordingArgs): Promise<boolean>
         }
       }
 
-      if (systemCaptureResult.stream) {
-        const stream = systemCaptureResult.stream;
+      // Builds the renderer-side capture graph for the system channel. Shared
+      // by the initial start and by the mid-session takeover registered below.
+      const attachRendererSystemAudio = async (stream: MediaStream) => {
         systemStream = stream;
-        setupSystemCaptureResult = { stream: null, error: null };
-
         const ctx = new AudioContext({ sampleRate: 24000 });
         systemContext = ctx;
         await detachFromOutputDevice(ctx);
-        if (!isCurrentStart()) {
-          await teardownStart();
-          return;
-        }
-
         const { source, processor } = await createAudioPipeline({
           stream,
           context: ctx,
@@ -1346,14 +1340,17 @@ export async function startRecording(args: StartRecordingArgs): Promise<boolean>
             pendingSystemChunks.push(chunk.slice(0));
           },
         });
+        systemSource = source;
+        systemProcessor = processor;
+      };
+
+      if (systemCaptureResult.stream) {
+        setupSystemCaptureResult = { stream: null, error: null };
+        await attachRendererSystemAudio(systemCaptureResult.stream);
         if (!isCurrentStart()) {
-          source.disconnect();
-          await flushAndDisconnectProcessor(processor);
           await teardownStart();
           return;
         }
-        systemSource = source;
-        systemProcessor = processor;
       } else if (systemCaptureError) {
         if (systemAudioStrategy === "loopback") {
           logger.warn(
@@ -1365,6 +1362,36 @@ export async function startRecording(args: StartRecordingArgs): Promise<boolean>
             reportMeetingError("System audio capture failed. Continuing with microphone only.");
           }
         }
+      }
+
+      // Main sends this when a native helper reports it is capturing silence
+      // while audio is really playing, which activation success cannot detect.
+      // Take the channel over with Chromium loopback for the rest of the call.
+      if (systemAudioHandledInMain) {
+        const degradedCleanup = window.electronAPI?.onMeetingSystemAudioDegraded?.(() => {
+          if (activeRecordingSessionId !== sessionId || !isRecordingFlag) return;
+          if (systemStream) return;
+          void (async () => {
+            const takeover = await requestSystemAudioDisplayStream(
+              getDisplayCaptureModeForStrategy("loopback")
+            );
+            if (!takeover.stream) {
+              logger.warn(
+                "Renderer loopback takeover failed after native system audio went silent",
+                { error: takeover.error?.message },
+                "meeting"
+              );
+              return;
+            }
+            if (activeRecordingSessionId !== sessionId || !isRecordingFlag || systemStream) {
+              stopMediaStream(takeover.stream);
+              return;
+            }
+            await attachRendererSystemAudio(takeover.stream);
+            logger.info("Renderer loopback took over system audio capture", {}, "meeting");
+          })();
+        });
+        if (degradedCleanup) ipcCleanups.push(degradedCleanup);
       }
 
       if (!isCurrentStart()) {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -2625,6 +2625,7 @@ declare global {
       onMeetingSystemAudioSilent?: (
         callback: (data: { systemAudioStrategy: SystemAudioStrategy }) => void
       ) => () => void;
+      onMeetingSystemAudioDegraded?: (callback: () => void) => () => void;
 
       // Speaker diarization
       downloadDiarizationModels?: () => Promise<{ success: boolean; error?: string }>;

--- a/test/helpers/meetingStreamingWiring.test.js
+++ b/test/helpers/meetingStreamingWiring.test.js
@@ -53,3 +53,34 @@ test("silent system audio warning arms on start and clears on every teardown pat
   );
   assert.match(stopSection, /clearMeetingSystemAudioSilenceTimer\(\);/);
 });
+
+test("a silent Windows capture hands the live session to renderer loopback", () => {
+  // probe/activation success cannot see this failure, so the helper's own
+  // capture_silent warning is the only trigger back to the Chromium fallback.
+  assert.match(
+    source,
+    /if \(code === "capture_silent"\) \{\s*void degradeMeetingSystemAudioToLoopback\(event\);/
+  );
+
+  const degradeStart = source.indexOf("const degradeMeetingSystemAudioToLoopback");
+  assert.ok(degradeStart >= 0);
+  const degradeSection = source.slice(
+    degradeStart,
+    source.indexOf("const startManagedMeetingSystemAudio")
+  );
+  // One-shot, and never fires once the helper has proven it can hear audio.
+  assert.match(
+    degradeSection,
+    /if \(meetingSystemAudioDegraded \|\| meetingSystemAudioHeard\) return;/
+  );
+  assert.match(degradeSection, /windowsLoopbackAudioManager\?\.stop\(\)/);
+  assert.match(degradeSection, /send\("meeting-system-audio-degraded"\)/);
+
+  // Leaking the latch across sessions would pin the fallback off for the rest
+  // of the app's life, so it resets everywhere the heard-audio latch does.
+  assert.equal(
+    (source.match(/meetingSystemAudioHeard = false;\s*\n\s*meetingSystemAudioDegraded = false;/g) ?? [])
+      .length,
+    2
+  );
+});

--- a/test/stores/meetingRecordingStoreSystemAudioDegraded.test.js
+++ b/test/stores/meetingRecordingStoreSystemAudioDegraded.test.js
@@ -1,0 +1,141 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createRendererServer,
+  installBrowserGlobals,
+  installMicCaptureGlobals,
+} = require("../lib/rendererTestHarness");
+
+// Pins the mid-session takeover: when main reports that a native system-audio
+// helper is capturing silence, the renderer starts Chromium loopback itself.
+// Activation success cannot detect that failure, so this is the only path back
+// to a working system channel once a call is already running.
+
+const START_ARGS = {
+  noteId: null,
+  noteTitle: null,
+  folderId: null,
+  autoEndEligible: false,
+};
+
+function installDisplayCaptureGlobals(t) {
+  installMicCaptureGlobals(t);
+
+  const calls = { getDisplayMedia: 0 };
+  const makeTrack = (kind) => ({ kind, readyState: "live", stop() {}, getSettings: () => ({}) });
+  navigator.mediaDevices.getDisplayMedia = async () => {
+    calls.getDisplayMedia += 1;
+    const audio = makeTrack("audio");
+    const video = makeTrack("video");
+    return {
+      getTracks: () => [audio, video],
+      getAudioTracks: () => [audio],
+      getVideoTracks: () => [video],
+    };
+  };
+  return calls;
+}
+
+function createElectronAPI({ systemAudioMode, systemAudioStrategy }) {
+  const listeners = { systemAudioDegraded: null };
+  const noopListener = () => () => {};
+  const api = {
+    checkSystemAudioAccess: async () => ({
+      granted: true,
+      status: "granted",
+      mode: systemAudioMode,
+      strategy: systemAudioStrategy,
+    }),
+    meetingTranscriptionStart: async () => ({
+      success: true,
+      systemAudioMode,
+      systemAudioStrategy,
+    }),
+    meetingTranscriptionSetSystemAudioAvailable: async () => ({ success: true }),
+    meetingTranscriptionStop: async () => ({ success: true }),
+    meetingTranscriptionSend: () => {},
+    onMeetingTranscriptionSegment: noopListener,
+    onMeetingSpeakerIdentified: noopListener,
+    onMeetingSpeakersMerged: noopListener,
+    onMeetingSessionSpeakerConfigUpdated: noopListener,
+    onMeetingTranscriptionError: noopListener,
+    onMeetingTranscriptionFatalError: noopListener,
+    onMeetingSystemAudioSilent: noopListener,
+    onMeetingSystemAudioDegraded: (callback) => {
+      listeners.systemAudioDegraded = callback;
+      return () => {
+        if (listeners.systemAudioDegraded === callback) listeners.systemAudioDegraded = null;
+      };
+    },
+  };
+  return { api, listeners };
+}
+
+async function loadStore(t, api) {
+  installBrowserGlobals(t, {
+    window: { electronAPI: api, setTimeout: (fn, ms) => setTimeout(fn, ms) },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-meeting-system-audio-degraded-test-",
+  });
+  return vite.ssrLoadModule("/stores/meetingRecordingStore.ts");
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("degrade event starts renderer loopback once for a native Windows session", async (t) => {
+  const calls = installDisplayCaptureGlobals(t);
+  const { api, listeners } = createElectronAPI({
+    systemAudioMode: "loopback",
+    systemAudioStrategy: "wasapi-loopback",
+  });
+  const store = await loadStore(t, api);
+
+  assert.equal(await store.startRecording(START_ARGS), true);
+  // Main owns the helper, so the renderer captures nothing up front.
+  assert.equal(calls.getDisplayMedia, 0);
+  assert.equal(typeof listeners.systemAudioDegraded, "function");
+
+  listeners.systemAudioDegraded();
+  await flush();
+  assert.equal(calls.getDisplayMedia, 1);
+
+  // A repeat must not stack a second capture graph on the same session.
+  listeners.systemAudioDegraded();
+  await flush();
+  assert.equal(calls.getDisplayMedia, 1);
+
+  await store.stopRecording();
+});
+
+test("degrade event is ignored once the recording has stopped", async (t) => {
+  const calls = installDisplayCaptureGlobals(t);
+  const { api, listeners } = createElectronAPI({
+    systemAudioMode: "loopback",
+    systemAudioStrategy: "wasapi-loopback",
+  });
+  const store = await loadStore(t, api);
+
+  assert.equal(await store.startRecording(START_ARGS), true);
+  const degraded = listeners.systemAudioDegraded;
+  await store.stopRecording();
+
+  degraded();
+  await flush();
+  assert.equal(calls.getDisplayMedia, 0);
+});
+
+test("a renderer-loopback session never registers the takeover listener", async (t) => {
+  installDisplayCaptureGlobals(t);
+  const { api, listeners } = createElectronAPI({
+    systemAudioMode: "loopback",
+    systemAudioStrategy: "loopback",
+  });
+  const store = await loadStore(t, api);
+
+  assert.equal(await store.startRecording(START_ARGS), true);
+  // The renderer already owns capture here; there is nothing to take over.
+  assert.equal(listeners.systemAudioDegraded, null);
+
+  await store.stopRecording();
+});


### PR DESCRIPTION
## Problem

`windows-system-audio-helper.exe probe` only proves the OS exposes `VAD\Process_Loopback` and accepts our `WAVEFORMATEX`. `run_probe()` activates the interface, releases it, and prints `ok:true` — it never calls `IAudioClient_Start()` and never reads a frame. On some machines activation then succeeds and every delivered sample is zero.

Nothing downstream can notice. `getWindowsSystemAudioAccess` maps `capability.available` straight onto `wasapi-loopback` vs `loopback`, and the only downgrade fires when `manager.start()` *rejects* — but `start()` resolves on the helper's `{"type":"start"}` event, which is emitted the instant `IAudioClient_Start()` returns, before any capture. So sample data never influences strategy selection, and the Chromium fallback is unreachable for the whole session.

The silence filler hides it: `write_silence()` pads output against QPC so the timeline stays continuous, which means a completely dead capture emits a well-formed, correctly paced stream. The reporter measured 141280 samples of nothing while their output endpoint peaked at 0.3859.

Their only workaround was renaming the binary so `resolveBinary()` fails.

## Fix

Silence alone is ambiguous — an idle machine looks identical — so the helper only calls its own capture broken **while a render endpoint is metering real output**:

- Enumerates active `eRender` endpoints and reads `IAudioMeterInformation::GetPeakValue()` once a second, but only while its own capture has been silent.
- Requires five consecutive confirming checks, and disarms permanently the moment any real audio arrives (a working capture is never watched again).
- Reports it once as `{"type":"warning","code":"capture_silent"}` on the stderr channel that already exists.

Main treats that warning as proof the native path cannot work: it stops the helper and hands the live session to Chromium loopback. The renderer builds the capture graph mid-call through `attachRendererSystemAudio`, extracted from the initial start path so both routes share one implementation.

The 45s silence toast added in #1864 stays armed as the backstop for when the fallback also fails. No new user-facing copy: if the takeover works, audio simply starts arriving and the existing warning never fires.

## Scope notes

- **Windows only.** The renderer listener is registered only when main owns capture, and only the Windows branch sends the event; the macOS tap and Linux PipeWire paths are untouched (both still degrade to mic-only, unchanged).
- **`startManagedMeetingSystemAudio` gained an optional 4th parameter.** The other two call sites are unchanged.
- **Requires a new helper release.** `resources/windows-system-audio-helper.c` changed, so `build-windows-system-audio-helper.yml` needs to be dispatched with a bumped version before the next app release; `download-windows-system-audio-helper.js` resolves the latest tag, so nothing in-repo needs pinning.

## Not addressed here

#1864 confirmed a separate cause of the same symptom (`shell.openExternal` making a cold-started browser a descendant of our PID, which `EXCLUDE_TARGET_PROCESS_TREE` then silences) and routes http/https through `explorer.exe`. That fix still skips any URL containing `?`, `#`, `=` or `,` (`EXPLORER_BREAKING_CHARS`), which covers most real Teams/Zoom/Meet join links. That trade-off is deliberate and documented, but worth a follow-up — this PR makes such a session recover instead of silently recording one side.

Also left alone: the `wasapi-loopback → loopback` downgrade is still not reflected in `check-system-audio-access`, so a renderer re-querying mid-session sees the stale strategy.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` — 3132 pass, 0 fail (4 new).
- New `test/stores/meetingRecordingStoreSystemAudioDegraded.test.js` drives the real `startRecording` flow: the takeover runs on the degrade event, is idempotent, is ignored after stop, and is never registered for a session the renderer already owns.
- New source-level pin in `meetingStreamingWiring.test.js` (same convention as the existing meeting wiring tests) covers the `capture_silent` → degrade hop, the one-shot guard, and the per-session latch reset.
- The C change is compile-verified by `build-windows-system-audio-helper.yml`; **the silent-capture path itself needs a manual check on affected hardware** — start a meeting recording with audio playing and confirm the log shows `Windows system audio helper captured only silence, switching to renderer loopback` followed by `Renderer loopback took over system audio capture`.

Fixes #1891
