### PR TITLE
fix(toast): guard nullish options and non-array toasts in toastPresentation

### DIFF
--- a/src/helpers/toastPresentation.js
+++ b/src/helpers/toastPresentation.js
@@ -7,14 +7,16 @@
  *   variant/isDictationPanel are accepted for callers that still pass them
  *   (e.g. Toast.tsx) but are no longer read here.
  */
-export function resolveToastPresentation({ presentation }) {
+export function resolveToastPresentation(options = {}) {
+  const { presentation } = options && typeof options === "object" ? options : {};
   return presentation === "dictation-error" ? "dictation-error" : "standard";
 }
 
 export function getDictationErrorActionCount(toasts) {
+  if (!Array.isArray(toasts)) return 0;
   const currentError = [...toasts]
     .reverse()
-    .find((toast) => toast.presentation === "dictation-error");
+    .find((toast) => toast && typeof toast === "object" && toast.presentation === "dictation-error");
   return currentError ? Math.max(1, currentError.actions?.length ?? 0) : 0;
 }
 

--- a/test/helpers/toastPresentation.test.js
+++ b/test/helpers/toastPresentation.test.js
@@ -60,3 +60,12 @@ test("long dictation errors dismiss after five seconds", async () => {
   const { getDictationErrorDuration } = await load();
   assert.equal(getDictationErrorDuration("Error", "a".repeat(200)), 5000);
 });
+
+test("safely handles nullish arguments in resolveToastPresentation and getDictationErrorActionCount", async () => {
+  const { resolveToastPresentation, getDictationErrorActionCount } = await load();
+  assert.equal(resolveToastPresentation(null), "standard");
+  assert.equal(resolveToastPresentation(), "standard");
+  assert.equal(getDictationErrorActionCount(null), 0);
+  assert.equal(getDictationErrorActionCount(undefined), 0);
+  assert.equal(getDictationErrorActionCount([null, { presentation: "dictation-error" }]), 1);
+});


### PR DESCRIPTION
Fixes #1936

### Problem
In `src/helpers/toastPresentation.js`:
- `resolveToastPresentation({ presentation })` destructured `options` without default, throwing `TypeError: Cannot destructure property 'presentation' of 'undefined' or 'null'` when called without arguments or with `null`.
- `getDictationErrorActionCount(toasts)` used `[...toasts]` directly, throwing `TypeError: toasts is not iterable` when passed `null` or `undefined`, and threw when encountering `null` toast elements.

### Solution
- Defaulted `options` destructuring in `resolveToastPresentation`.
- Guarded `toasts` with `Array.isArray(toasts)` and filtered nullish toast elements in `getDictationErrorActionCount`.
- Added unit tests in `test/helpers/toastPresentation.test.js`.

### Verification
- `node --test test/helpers/toastPresentation.test.js` (passes, 8/8 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)