### PR TITLE
fix(onboarding): guard nullish inputs and fallback coordinates in onboardingWindowBounds

### DIFF
--- a/src/helpers/onboardingWindowBounds.js
+++ b/src/helpers/onboardingWindowBounds.js
@@ -1,25 +1,56 @@
 function centeredBounds(current, target, workArea) {
-  const width = Math.min(target.width, workArea.width);
-  const height = Math.min(target.height, workArea.height);
-  const centerX = current.x + current.width / 2;
-  const centerY = current.y + current.height / 2;
+  const cur = current && typeof current === "object" ? current : {};
+  const tgt = target && typeof target === "object" ? target : {};
+  const area = workArea && typeof workArea === "object" ? workArea : {};
+
+  const areaWidth = typeof area.width === "number" ? area.width : 0;
+  const areaHeight = typeof area.height === "number" ? area.height : 0;
+  const areaX = typeof area.x === "number" ? area.x : 0;
+  const areaY = typeof area.y === "number" ? area.y : 0;
+
+  const targetWidth = typeof tgt.width === "number" ? tgt.width : 0;
+  const targetHeight = typeof tgt.height === "number" ? tgt.height : 0;
+
+  const width = Math.min(targetWidth, areaWidth);
+  const height = Math.min(targetHeight, areaHeight);
+
+  const curX = typeof cur.x === "number" ? cur.x : areaX;
+  const curY = typeof cur.y === "number" ? cur.y : areaY;
+  const curWidth = typeof cur.width === "number" ? cur.width : width;
+  const curHeight = typeof cur.height === "number" ? cur.height : height;
+
+  const centerX = curX + curWidth / 2;
+  const centerY = curY + curHeight / 2;
   const x = Math.round(
-    Math.max(workArea.x, Math.min(centerX - width / 2, workArea.x + workArea.width - width))
+    Math.max(areaX, Math.min(centerX - width / 2, areaX + areaWidth - width))
   );
   const y = Math.round(
-    Math.max(workArea.y, Math.min(centerY - height / 2, workArea.y + workArea.height - height))
+    Math.max(areaY, Math.min(centerY - height / 2, areaY + areaHeight - height))
   );
   return { x, y, width, height };
 }
 
 function clampedBounds(bounds, workArea) {
-  const width = Math.min(bounds.width, workArea.width);
-  const height = Math.min(bounds.height, workArea.height);
+  const b = bounds && typeof bounds === "object" ? bounds : {};
+  const area = workArea && typeof workArea === "object" ? workArea : {};
+
+  const areaWidth = typeof area.width === "number" ? area.width : 0;
+  const areaHeight = typeof area.height === "number" ? area.height : 0;
+  const areaX = typeof area.x === "number" ? area.x : 0;
+  const areaY = typeof area.y === "number" ? area.y : 0;
+
+  const bWidth = typeof b.width === "number" ? b.width : 0;
+  const bHeight = typeof b.height === "number" ? b.height : 0;
+  const bX = typeof b.x === "number" ? b.x : areaX;
+  const bY = typeof b.y === "number" ? b.y : areaY;
+
+  const width = Math.min(bWidth, areaWidth);
+  const height = Math.min(bHeight, areaHeight);
   const x = Math.round(
-    Math.max(workArea.x, Math.min(bounds.x, workArea.x + workArea.width - width))
+    Math.max(areaX, Math.min(bX, areaX + areaWidth - width))
   );
   const y = Math.round(
-    Math.max(workArea.y, Math.min(bounds.y, workArea.y + workArea.height - height))
+    Math.max(areaY, Math.min(bY, areaY + areaHeight - height))
   );
   return { x, y, width, height };
 }

--- a/test/helpers/onboardingWindowBounds.test.js
+++ b/test/helpers/onboardingWindowBounds.test.js
@@ -32,3 +32,12 @@ test("clamps compact windows to small and negative-origin work areas", () => {
     { x: 0, y: 0, width: 800, height: 600 }
   );
 });
+
+test("safely handles nullish and incomplete geometry inputs", () => {
+  assert.deepEqual(
+    centeredBounds(null, { width: 480, height: 576 }, { x: 0, y: 0, width: 1920, height: 1080 }),
+    { x: 0, y: 0, width: 480, height: 576 }
+  );
+  assert.deepEqual(centeredBounds(null, null, null), { x: 0, y: 0, width: 0, height: 0 });
+  assert.deepEqual(clampedBounds(null, null), { x: 0, y: 0, width: 0, height: 0 });
+});


### PR DESCRIPTION
Fixes #1938

### Problem
In `src/helpers/onboardingWindowBounds.js`:
- `centeredBounds` and `clampedBounds` accessed geometry properties (`width`, `height`, `x`, `y`) directly on arguments without guarding against `null` or incomplete objects, throwing `TypeError: Cannot read properties of null`.

### Solution
- Checked each geometry object argument defensively and defaulted coordinate/dimension values to safe numeric fallbacks.
- Added unit tests in `test/helpers/onboardingWindowBounds.test.js`.

### Verification
- `node --test test/helpers/onboardingWindowBounds.test.js` (passes, 3/3 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)