### PR TITLE
fix(policy): normalize version whitespace and default headers in withPolicyRequestHeaders

### DIFF
--- a/src/helpers/policyRequestHeaders.js
+++ b/src/helpers/policyRequestHeaders.js
@@ -3,13 +3,15 @@ const { isCanonicalAppVersion } = require("./appVersion");
 const POLICY_CAPABILITY_VERSION = "1";
 
 function withPolicyRequestHeaders(headers, appVersion) {
-  if (!isCanonicalAppVersion(appVersion)) {
+  const version = typeof appVersion === "string" ? appVersion.trim() : appVersion;
+  if (!isCanonicalAppVersion(version)) {
     throw new Error("Policy requests require a canonical app version");
   }
+  const baseHeaders = headers && typeof headers === "object" ? headers : {};
   return {
-    ...headers,
+    ...baseHeaders,
     "x-openwhispr-policy-version": POLICY_CAPABILITY_VERSION,
-    "x-openwhispr-version": appVersion,
+    "x-openwhispr-version": version,
   };
 }
 

--- a/test/helpers/policyRequestHeaders.test.js
+++ b/test/helpers/policyRequestHeaders.test.js
@@ -35,3 +35,10 @@ test("rejects a non-canonical app version instead of advertising a malformed cli
   assert.throws(() => withPolicyRequestHeaders({}, "1.8"), /canonical app version/i);
   assert.throws(() => withPolicyRequestHeaders({}, "1.8.1-beta.1"), /canonical app version/i);
 });
+
+test("normalizes whitespace in appVersion and safely defaults null headers", () => {
+  assert.deepEqual(withPolicyRequestHeaders(null, " 1.8.1 "), {
+    "x-openwhispr-policy-version": "1",
+    "x-openwhispr-version": "1.8.1",
+  });
+});


### PR DESCRIPTION
Fixes #1940

### Problem
In `src/helpers/policyRequestHeaders.js`:
- `withPolicyRequestHeaders(headers, appVersion)` threw an error if `appVersion` had leading or trailing whitespace (e.g. `" 1.9.2 "`), failing regex validation.
- `headers` was spread without guarding against `null` or non-object types.

### Solution
- Trimmed `appVersion` before canonical version validation and header assignment.
- Defaulted `headers` to a safe empty object if nullish or non-object.
- Added unit tests in `test/helpers/policyRequestHeaders.test.js`.

### Verification
- `node --test test/helpers/policyRequestHeaders.test.js` (passes, 4/4 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)