### PR TITLE
fix(policy): guard nullish response and improve string error fallback in policyResponseError

### DIFF
--- a/src/helpers/policyResponseError.js
+++ b/src/helpers/policyResponseError.js
@@ -12,24 +12,30 @@ function createPolicyResponseError(status, payload, fallback) {
   const details = payload?.data;
   const minAppVersion =
     payload?.minAppVersion ?? details?.minAppVersion ?? payload?.error?.minAppVersion;
+  const safeStatus = Number.isInteger(status) ? status : 500;
   return Object.assign(new Error(errorMessage(payload, fallback)), {
     ...(code ? { code } : {}),
-    status,
-    statusCode: status,
+    status: safeStatus,
+    statusCode: safeStatus,
     ...(minAppVersion ? { minAppVersion } : {}),
     ...(details !== undefined ? { details } : {}),
   });
 }
 
 async function readPolicyResponseError(response, fallback) {
-  const payload = await response.json().catch(() => null);
+  if (!response || typeof response !== "object") {
+    return createPolicyResponseError(500, null, fallback);
+  }
+  const payload = typeof response.json === "function" ? await response.json().catch(() => null) : null;
   return createPolicyResponseError(response.status, payload, fallback);
 }
 
 function toPolicyFailure(error) {
+  const message =
+    (typeof error === "string" ? error : error?.message) || "Unknown error";
   return {
     success: false,
-    error: error?.message || String(error),
+    error: message,
     ...(error?.code ? { code: error.code } : {}),
     ...(Number.isInteger(error?.status) ? { status: error.status } : {}),
     ...(error?.minAppVersion ? { minAppVersion: error.minAppVersion } : {}),

--- a/test/helpers/policyResponseError.test.js
+++ b/test/helpers/policyResponseError.test.js
@@ -46,3 +46,15 @@ test("normalizes parsed multipart policy errors without losing legacy statusCode
   assert.equal(error.statusCode, 426);
   assert.equal(error.minAppVersion, "2.1.0");
 });
+
+test("safely handles nullish response and nullish error objects", async () => {
+  const error = await readPolicyResponseError(null, "Fallback error");
+  assert.equal(error.message, "Fallback error");
+  assert.equal(error.status, 500);
+
+  const failure = toPolicyFailure(null);
+  assert.deepEqual(failure, { success: false, error: "Unknown error" });
+
+  const stringFailure = toPolicyFailure("Direct error message");
+  assert.deepEqual(stringFailure, { success: false, error: "Direct error message" });
+});


### PR DESCRIPTION
Fixes #1942

### Problem
In `src/helpers/policyResponseError.js`:
- `readPolicyResponseError(response, fallback)` attempted to call `response.json()` and read `response.status` without checking for `null` or undefined inputs, throwing `TypeError: Cannot read properties of null (reading 'json')`.
- `toPolicyFailure(error)` evaluated `String(error)` when `error.message` was missing, yielding `"null"` or `"undefined"` when passed nullish errors.

### Solution
- Added defensive check for `response` object in `readPolicyResponseError`, defaulting to status 500.
- Safely extracted string messages and defaulted to `"Unknown error"` in `toPolicyFailure`.
- Added unit tests in `test/helpers/policyResponseError.test.js`.

### Verification
- `node --test test/helpers/policyResponseError.test.js` (passes, 3/3 tests)
- `npm run typecheck` (passes, 0 errors)
- `npm run lint` (passes, 0 errors)
- `npm run i18n:check` (passes)
- `npm run build:renderer` (passes)
- `git diff --check` (clean)