### PR TITLE
fix(linux): prevent target detection from delaying dictation

### DIFF
--- a/resources/linux-fast-paste.c
+++ b/resources/linux-fast-paste.c
@@ -488,6 +488,7 @@ static int atspi_active_pid(AtspiAccessible *app) {
 }
 
 static int print_atspi_target(void) {
+    if (atspi_init() != 0) return 1;
     AtspiAccessible *app = NULL;
     AtspiAccessible *win = find_active_atspi_window(&app);
     int pid = app ? atspi_active_pid(app) : 0;
@@ -499,6 +500,7 @@ static int print_atspi_target(void) {
 }
 
 static int print_atspi_selection(void) {
+    if (atspi_init() != 0) return 1;
     AtspiAccessible *app = NULL;
     AtspiAccessible *win = find_active_atspi_window(&app);
     int pid = app ? atspi_active_pid(app) : 0;

--- a/scripts/build-linux-fast-paste.js
+++ b/scripts/build-linux-fast-paste.js
@@ -182,7 +182,7 @@ if (gioAvailable) {
 
 if (atspiAvailable) {
   log("atspi-2 found, enabling AT-SPI2 terminal detection");
-  compileArgs.push("-DHAVE_ATSPI", ...getAtspiFlags());
+  compileArgs.push("-DHAVE_ATSPI", ...getAtspiFlags(), "-lgobject-2.0");
 } else {
   log("atspi-2 not found, building without AT-SPI2 terminal detection");
 }

--- a/src/helpers/selectionManager.js
+++ b/src/helpers/selectionManager.js
@@ -10,6 +10,8 @@ const MAX_SELECTION_EDIT_CODE_POINTS = 6000;
 const COPY_TIMEOUT_MS = 1200;
 const CLIPBOARD_POLL_MS = 20;
 const ATSPI_TARGET_TIMEOUT_MS = 2000;
+const TARGET_CAPTURE_FRESHNESS_MS = 250;
+const ATSPI_COOLDOWN_MS = 2000;
 
 // Editors that copy the whole current line when Ctrl+C (⌘C on macOS) lands with
 // an empty selection (VS Code's editor.emptySelectionClipboard, Scintilla,
@@ -60,19 +62,20 @@ function runFile(command, args, options = {}) {
 
 function runSpawn(command, args, options = {}) {
   return new Promise((resolve) => {
+    const { timeout = COPY_TIMEOUT_MS, ...spawnOptions } = options;
     const child = spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
-      ...options,
+      ...spawnOptions,
     });
     let stdout = "";
     let stderr = "";
     let settled = false;
-    const finish = (success) => {
+    const finish = (success, timedOut = false) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve({ success, stdout, stderr });
+      resolve({ success, timedOut, stdout, stderr });
     };
     child.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
     child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
@@ -83,8 +86,8 @@ function runSpawn(command, args, options = {}) {
     child.on("close", (code) => finish(code === 0));
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
-      finish(false);
-    }, options.timeout || COPY_TIMEOUT_MS);
+      finish(false, true);
+    }, timeout);
   });
 }
 
@@ -102,18 +105,34 @@ class SelectionManager {
     this.sessions = new Map();
     this.lastTarget = null;
     this._captureTargetPromise = null;
+    this._lastTargetCaptureAt = null;
+    this._atspiCooldownUntil = 0;
+    this._atspiProbeGeneration = 0;
   }
 
-  async captureTarget() {
+  async captureTarget({ force = false } = {}) {
     if (this.platform === "darwin") return;
+    if (!force) {
+      if (this._captureTargetPromise) return this._captureTargetPromise;
+      if (
+        this._lastTargetCaptureAt !== null &&
+        this.now() - this._lastTargetCaptureAt < TARGET_CAPTURE_FRESHNESS_MS
+      ) {
+        return;
+      }
+    }
     this.lastTarget = null;
     const probe = this._probeTarget();
     this._captureTargetPromise = probe;
-    const target = await probe;
-    // A newer toggle press may have started its own probe while this one ran;
-    // only the latest probe's result may land in lastTarget.
+    let target = null;
+    try {
+      target = await probe;
+    } catch (error) {
+      debugLogger.warn("Target probe failed", { error: error.message });
+    }
     if (this._captureTargetPromise === probe) {
       this.lastTarget = target;
+      this._lastTargetCaptureAt = this.now();
       this._captureTargetPromise = null;
     }
   }
@@ -156,6 +175,9 @@ class SelectionManager {
     // on); without it the probe's binary spawn would be pure waste.
     const probeEditable = options.probeEditable === true;
     return this.clipboardManager.runClipboardOperation(async () => {
+      if (this.platform === "darwin") {
+        await this.textEditMonitor?.captureTargetPid?.();
+      }
       // captureTarget() fires on every toggle press, including stop. Fast
       // cloud transcription can get here before the stop-press probe lands
       // (~1s on Wayland AT-SPI), when lastTarget is still nulled from the
@@ -531,8 +553,16 @@ class SelectionManager {
 
   async _readLinuxAtspiSelection(binary, expectedTarget) {
     if (!binary) return { status: "unavailable", code: "copy_helper_unavailable" };
+    if (this.now() < this._atspiCooldownUntil) {
+      return { status: "unavailable", code: "accessibility_unavailable" };
+    }
 
+    const generation = ++this._atspiProbeGeneration;
     const result = await runSpawn(binary, ["--atspi-selection"], { timeout: COPY_TIMEOUT_MS });
+    if (result.timedOut && generation === this._atspiProbeGeneration) {
+      this._atspiCooldownUntil = this.now() + ATSPI_COOLDOWN_MS;
+      debugLogger.warn("AT-SPI selection probe timed out", { cooldownMs: ATSPI_COOLDOWN_MS });
+    }
     if (!result.success) return { status: "unavailable", code: "accessibility_unavailable" };
 
     const selected = result.stdout.match(/^ATSPI_SELECTED\s+(\d+)\s+([A-Za-z0-9+/=]+)$/m);
@@ -561,7 +591,8 @@ class SelectionManager {
     // On native Wayland, xdotool can report a stale XWayland window. Prefer
     // AT-SPI when available so the target and selected text come from the
     // compositor's actual focused accessibility object.
-    if (this.clipboardManager._isWayland?.()) {
+    const isWayland = this.clipboardManager._isWayland?.() === true;
+    if (isWayland) {
       const atspiTarget = await this._getLinuxAtspiTarget();
       if (atspiTarget) return atspiTarget;
     }
@@ -607,15 +638,21 @@ class SelectionManager {
       }
     }
 
-    return this._getLinuxAtspiTarget();
+    return isWayland ? null : this._getLinuxAtspiTarget();
   }
 
   async _getLinuxAtspiTarget() {
+    if (this.now() < this._atspiCooldownUntil) return null;
     const binary = this.clipboardManager.resolveLinuxFastPasteBinary();
     if (!binary) return null;
+    const generation = ++this._atspiProbeGeneration;
     const result = await runSpawn(binary, ["--atspi-target"], {
       timeout: ATSPI_TARGET_TIMEOUT_MS,
     });
+    if (result.timedOut && generation === this._atspiProbeGeneration) {
+      this._atspiCooldownUntil = this.now() + ATSPI_COOLDOWN_MS;
+      debugLogger.warn("AT-SPI target probe timed out", { cooldownMs: ATSPI_COOLDOWN_MS });
+    }
     const match = result.stdout.match(/^TARGET\s+ATSPI\s+(\d+)$/m);
     return result.success && match ? { kind: "atspi-pid", id: match[1] } : null;
   }

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -870,7 +870,7 @@ class WindowManager {
       // sites in main.js; a stop-press capture resolves the same frontmost
       // app, since NSWorkspace ignores the overlay panel.
       const targetPidPromise = this.textEditMonitor?.captureTargetPid?.();
-      void this.selectionManager?.captureTarget?.();
+      void this.selectionManager?.captureTarget?.({ force: !isStarting });
       if (!isStarting) {
         this._mainWindowPlacementCoordinator.cancelPending();
       }

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -148,11 +148,9 @@ export const useAudioRecording = (toast, options = {}) => {
         // still the user's actual editing target here. Refresh it for recordings
         // started from the panel itself as well as from global hotkeys; otherwise
         // paste can reactivate a stale target from the preceding dictation.
-        try {
-          await window.electronAPI.captureDictationTarget?.();
-        } catch (error) {
+        window.electronAPI.captureDictationTarget?.().catch((error) => {
           logger.warn("Failed to refresh dictation target", { error: error?.message });
-        }
+        });
 
         demoKindRef.current = getOnboardingDemoKind(voiceAgentRequested);
         audioManagerRef.current.setVoiceAgentRequested(voiceAgentRequested);

--- a/test/helpers/selectionManager.test.js
+++ b/test/helpers/selectionManager.test.js
@@ -71,6 +71,40 @@ test("captures an exact selection in an opaque session", async () => {
   assert.ok(result.sessionId);
 });
 
+test("macOS selection capture joins the target PID capture", async () => {
+  let resolvePid;
+  let reads = 0;
+  const textEditMonitor = {
+    lastTargetPid: null,
+    captureTargetPid: () =>
+      new Promise((resolve) => {
+        resolvePid = (pid) => {
+          textEditMonitor.lastTargetPid = pid;
+          resolve(pid);
+        };
+      }),
+    getSelectedText: async () => {
+      reads += 1;
+      return { state: "selected", text: "picked" };
+    },
+  };
+  const manager = new SelectionManager({
+    clipboardManager: { runClipboardOperation: (operation) => operation() },
+    textEditMonitor,
+    platform: "darwin",
+    now: () => 1000,
+  });
+
+  const pending = manager.captureSelectedText();
+  await Promise.resolve();
+  assert.equal(reads, 0);
+
+  resolvePid(42);
+  const result = await pending;
+  assert.equal(result.status, "selected");
+  assert.equal(result.text, "picked");
+});
+
 test("captures a verified writable caret in an opaque delivery session", async () => {
   const { manager } = makeHarness({ selections: [{ state: "none", editable: true }] });
   const result = await manager.captureSelectedText({ probeEditable: true });
@@ -193,8 +227,7 @@ test("a Linux AT-SPI terminal pid never becomes a caret delivery target", async 
   const editor = { kind: "atspi-pid", id: "8765" };
 
   assert.equal(
-    (await manager._markEditableCaret({ status: "none", target: terminal }, terminal, true))
-      .status,
+    (await manager._markEditableCaret({ status: "none", target: terminal }, terminal, true)).status,
     "none"
   );
   assert.equal(probes.length, 0, "a terminal pid must be refused without probing");
@@ -436,7 +469,54 @@ test("captureSelectedText awaits an in-flight target probe before reading lastTa
   assert.equal(result.text, "picked");
 });
 
-test("a superseded probe never overwrites the newer probe's target", async () => {
+test("start target captures share in-flight and recent work", async () => {
+  let now = 1000;
+  let calls = 0;
+  const resolvers = [];
+  const manager = new SelectionManager({
+    clipboardManager: {},
+    textEditMonitor: {},
+    platform: "linux",
+    now: () => now,
+  });
+  manager._probeTarget = () => {
+    calls += 1;
+    return new Promise((resolve) => resolvers.push(resolve));
+  };
+
+  const first = manager.captureTarget();
+  const joined = manager.captureTarget();
+  assert.equal(calls, 1);
+  resolvers[0]({ kind: "atspi-pid", id: "1" });
+  await Promise.all([first, joined]);
+
+  await manager.captureTarget();
+  assert.equal(calls, 1);
+
+  now += 250;
+  const refreshed = manager.captureTarget();
+  assert.equal(calls, 2);
+  resolvers[1]({ kind: "atspi-pid", id: "2" });
+  await refreshed;
+});
+
+test("target probe failures are contained", async () => {
+  const manager = new SelectionManager({
+    clipboardManager: {},
+    textEditMonitor: {},
+    platform: "linux",
+    now: () => 1000,
+  });
+  manager._probeTarget = async () => {
+    throw new Error("probe failed");
+  };
+
+  await manager.captureTarget();
+  assert.equal(manager.lastTarget, null);
+  assert.equal(manager._captureTargetPromise, null);
+});
+
+test("a forced probe stays fresh and older work cannot overwrite it", async () => {
   const clipboardManager = { runClipboardOperation: (operation) => operation() };
   const manager = new SelectionManager({
     clipboardManager,
@@ -448,13 +528,133 @@ test("a superseded probe never overwrites the newer probe's target", async () =>
   manager._getLinuxTarget = () => new Promise((resolve) => resolvers.push(resolve));
 
   const first = manager.captureTarget();
-  const second = manager.captureTarget();
+  const second = manager.captureTarget({ force: true });
   resolvers[1]({ kind: "atspi-pid", id: "2" });
   await second;
   resolvers[0]({ kind: "atspi-pid", id: "1" });
   await first;
 
   assert.deepEqual(manager.lastTarget, { kind: "atspi-pid", id: "2" });
+});
+
+test("Wayland target lookup attempts AT-SPI once", async () => {
+  const spawnCalls = [];
+  const SpawningSelectionManager = loadSelectionManager({
+    spawn: (command, args) => {
+      spawnCalls.push({ command, args });
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      process.nextTick(() => child.emit("close", 1));
+      return child;
+    },
+  });
+  const manager = new SpawningSelectionManager({
+    clipboardManager: {
+      _isWayland: () => true,
+      commandExists: () => false,
+      resolveLinuxFastPasteBinary: () => "/tmp/linux-fast-paste",
+    },
+    platform: "linux",
+    now: () => 1000,
+  });
+
+  assert.equal(await manager._getLinuxTarget(), null);
+  assert.equal(await manager._getLinuxTarget(), null);
+  assert.deepEqual(spawnCalls, [
+    { command: "/tmp/linux-fast-paste", args: ["--atspi-target"] },
+    { command: "/tmp/linux-fast-paste", args: ["--atspi-target"] },
+  ]);
+});
+
+test("an AT-SPI timeout opens a cooldown and retries after it expires", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let now = 1000;
+  let spawns = 0;
+  let kills = 0;
+  const SpawningSelectionManager = loadSelectionManager({
+    spawn: () => {
+      spawns += 1;
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        kills += 1;
+      };
+      return child;
+    },
+  });
+  const manager = new SpawningSelectionManager({
+    clipboardManager: {
+      resolveLinuxFastPasteBinary: () => "/tmp/linux-fast-paste",
+    },
+    platform: "linux",
+    now: () => now,
+  });
+
+  const first = manager._getLinuxAtspiTarget();
+  t.mock.timers.tick(2000);
+  assert.equal(await first, null);
+  assert.equal(spawns, 1);
+  assert.equal(kills, 1);
+
+  assert.equal(await manager._getLinuxAtspiTarget(), null);
+  assert.equal(spawns, 1);
+
+  now += 2000;
+  const retry = manager._getLinuxAtspiTarget();
+  t.mock.timers.tick(2000);
+  assert.equal(await retry, null);
+  assert.equal(spawns, 2);
+  assert.equal(kills, 2);
+
+  now += 2000;
+  const selection = manager._readLinuxAtspiSelection("/tmp/linux-fast-paste", {
+    kind: "atspi-pid",
+    id: "42",
+  });
+  t.mock.timers.tick(1200);
+  assert.equal((await selection).status, "unavailable");
+  assert.equal(spawns, 3);
+  assert.equal(kills, 3);
+  assert.equal(await manager._getLinuxAtspiTarget(), null);
+  assert.equal(spawns, 3);
+});
+
+test("an older AT-SPI timeout cannot cool down a newer successful probe", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let spawns = 0;
+  const SpawningSelectionManager = loadSelectionManager({
+    spawn: () => {
+      spawns += 1;
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      if (spawns === 2) {
+        process.nextTick(() => {
+          child.stdout.emit("data", "TARGET ATSPI 42\n");
+          child.emit("close", 0);
+        });
+      }
+      return child;
+    },
+  });
+  const manager = new SpawningSelectionManager({
+    clipboardManager: {
+      resolveLinuxFastPasteBinary: () => "/tmp/linux-fast-paste",
+    },
+    platform: "linux",
+    now: () => 1000,
+  });
+
+  const older = manager._getLinuxAtspiTarget();
+  const newer = manager._getLinuxAtspiTarget();
+  assert.deepEqual(await newer, { kind: "atspi-pid", id: "42" });
+  t.mock.timers.tick(2000);
+  assert.equal(await older, null);
+  assert.equal(manager._atspiCooldownUntil, 0);
 });
 
 // The Windows paste path restores the window captured at record start (#859).

--- a/test/helpers/useAudioRecordingPreparingReset.test.js
+++ b/test/helpers/useAudioRecordingPreparingReset.test.js
@@ -39,12 +39,13 @@ export default class FakeAudioManager {
   cancelPreparedMicCapture() {}
   cleanup() {}
   async startRecording() {
+    globalThis.__openWhisprStartRecording?.();
     return false;
   }
 }
 `;
 
-test("a failed dictation start reports the lifecycle back to idle instead of sticking on preparing", async (t) => {
+test("dictation start does not wait for target capture and resets a failed start", async (t) => {
   // t.after hooks run in registration order, so this unmount must be
   // registered before installBrowserGlobals/installHookDom's own cleanup —
   // otherwise window/document are already torn down when unmount runs.
@@ -54,6 +55,17 @@ test("a failed dictation start reports the lifecycle back to idle instead of sti
   });
 
   const reported = [];
+  let startCalled = false;
+  let resolveTargetCapture;
+  const targetCapture = new Promise((resolve) => {
+    resolveTargetCapture = resolve;
+  });
+  globalThis.__openWhisprStartRecording = () => {
+    startCalled = true;
+  };
+  t.after(() => {
+    delete globalThis.__openWhisprStartRecording;
+  });
   const noopDispose = () => () => {};
   installBrowserGlobals(t, {
     window: {
@@ -69,6 +81,7 @@ test("a failed dictation start reports the lifecycle back to idle instead of sti
         onPrepareDictation: noopDispose,
         onCancelDictationPreparation: noopDispose,
         onStopDictation: noopDispose,
+        captureDictationTarget: () => targetCapture,
         dictationLifecycleStateChanged: (state, inputKind) =>
           reported.push(`${state}:${inputKind}`),
       },
@@ -107,8 +120,15 @@ test("a failed dictation start reports the lifecycle back to idle instead of sti
   reported.length = 0;
 
   let started;
+  let startPromise;
   await React.act(async () => {
-    started = await api.startRecording();
+    startPromise = api.startRecording();
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+  assert.equal(startCalled, true);
+  resolveTargetCapture({ success: true, pid: null });
+  await React.act(async () => {
+    started = await startPromise;
   });
 
   assert.equal(started, false);


### PR DESCRIPTION
Fixes #1810 and fixes #1944 by removing Linux window detection from the recording startup path. Dictation now starts immediately even when AT-SPI is slow or unresponsive.

This also reduces redundant window probes, improves recovery from AT-SPI failures, and makes Linux target detection faster and more reliable across Wayland and X11 environments.