### PR TITLE
fix(notes): hide attendees on personal notes

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -68,6 +68,7 @@ import {
   serializeTranscriptSegments,
 } from "../../utils/transcriptSpeakerState";
 import NoteParticipants from "./NoteParticipants";
+import { shouldShowNoteParticipants } from "./shared";
 import type { CalendarAttendee } from "../../types/calendar";
 import { observeFloatingChatLayout } from "./floatingChatLayout";
 
@@ -837,7 +838,9 @@ export default function NoteEditor({
                 <span className="truncate max-w-40">{calendarEventName}</span>
               </span>
             )}
-            <NoteParticipants noteId={note.id} participants={parsedParticipants} />
+            {shouldShowNoteParticipants(note.note_type) && (
+              <NoteParticipants noteId={note.id} participants={parsedParticipants} />
+            )}
             {isTeamNote && space && (
               <>
                 <button

--- a/src/components/notes/shared.ts
+++ b/src/components/notes/shared.ts
@@ -1,5 +1,5 @@
 import { cn } from "../lib/utils";
-import type { FolderItem } from "../../types/electron";
+import type { FolderItem, NoteItem } from "../../types/electron";
 
 export const DEFAULT_FOLDER_NAME = "Personal";
 export const MEETINGS_FOLDER_NAME = "Meetings";
@@ -7,6 +7,10 @@ export const VIDEOS_FOLDER_NAME = "Videos";
 
 export function findDefaultFolder(folders: FolderItem[]): FolderItem | undefined {
   return folders.find((f) => f.name === DEFAULT_FOLDER_NAME && f.is_default);
+}
+
+export function shouldShowNoteParticipants(noteType: NoteItem["note_type"]): boolean {
+  return noteType === "meeting";
 }
 
 // URL downloads route to "Videos" by name: a pre-existing user-created folder with

--- a/test/components/notesShared.test.js
+++ b/test/components/notesShared.test.js
@@ -17,6 +17,14 @@ test("space roots keep the generic empty title", async () => {
   assert.equal(notesEmptyTitleKey(false), "notes.empty.title");
 });
 
+test("participant controls are only available on meeting notes", async () => {
+  const { shouldShowNoteParticipants } = await load();
+
+  assert.equal(shouldShowNoteParticipants("meeting"), true);
+  assert.equal(shouldShowNoteParticipants("personal"), false);
+  assert.equal(shouldShowNoteParticipants("upload"), false);
+});
+
 test("both empty-title keys resolve to strings in the en locale", async () => {
   const { notesEmptyTitleKey } = await load();
   const en = JSON.parse(


### PR DESCRIPTION
## Summary
- show participant controls only for meeting notes
- keep attendee controls hidden for personal and upload notes
- add regression coverage for every stored note type

## Validation
- `npx prettier --check src/components/notes/NoteEditor.tsx src/components/notes/shared.ts test/components/notesShared.test.js`
- `npx eslint src/components/notes/NoteEditor.tsx src/components/notes/shared.ts test/components/notesShared.test.js`
- `node --import tsx --test test/components/notesShared.test.js`
- `npm run typecheck`