### PR TITLE
fix(transcription): harden dictionary prompt recovery

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -2033,6 +2033,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           } catch (retryError) {
             if (strictDictionaryEcho) throw retryError;
             // A heuristic recovery is best-effort; keep the initial text if it fails.
+            logger.warn(
+              "Dictionary-fragment retry failed; keeping the initial transcript",
+              { message: retryError?.message },
+              "audio"
+            );
           }
 
           const retryText = retry?.success && typeof retry.text === "string" ? retry.text : "";

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -85,9 +85,9 @@ import { syncService } from "../services/SyncService.js";
 import { evaluateFinishedRecording, withSalvageWarning } from "./recordingValidation";
 import { isEmptyRecording } from "./recordingGuard";
 import {
+  analyzeDictionaryPromptFragment,
   DICTIONARY_ECHO_CODE,
   dictionaryEchoError,
-  isLikelyDictionaryPromptFragment,
   matchesDictionaryPrompt,
 } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
@@ -111,8 +111,8 @@ const RECORDING_TIMESLICE_MS = 250; // flush chunks periodically so short record
 // Failure detector only: fires when the worklet or audio graph is dead and never flushes.
 const PREVIEW_FLUSH_WATCHDOG_MS = 1000;
 const neverCancelled = () => false;
-const normalizedAlphanumericLength = (text) =>
-  String(text || "").replace(/[^\p{L}\p{N}]/gu, "").length;
+const MIN_SPARSE_RECORDING_DURATION_SECONDS = 3;
+const MIN_UNIQUE_WORD_GAIN = 2;
 
 const micDeviceKey = (settings) =>
   `${settings.microphoneSelectionMode}|${settings.selectedMicDeviceId}`;
@@ -2009,10 +2009,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           (matchesDictionaryPrompt(result.text, dictionaryPrompt) ||
             matchesDictionaryPrompt(result.text, customDictionaryPrompt))
         );
-        const shortDictionaryFragment =
-          !strictDictionaryEcho && isLikelyDictionaryPromptFragment(result.text, dictionaryPrompt);
+        const initialFragment = analyzeDictionaryPromptFragment(result.text, dictionaryPrompt);
+        const dictionaryPromptFragment = !strictDictionaryEcho && initialFragment.isPromptFragment;
 
-        if (strictDictionaryEcho || shortDictionaryFragment) {
+        if (strictDictionaryEcho || dictionaryPromptFragment) {
           // A prompt-free, VAD-free retry distinguishes real speech from Whisper
           // continuing either the whole dictionary prompt or a short fragment of it.
           const retryStart = performance.now();
@@ -2023,21 +2023,39 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
               ...(options.language ? { language: options.language } : {}),
               skipVad: true,
             });
-          } catch {
-            // A heuristic recovery is best-effort; strict echoes still fail below.
+          } catch (retryError) {
+            if (strictDictionaryEcho) throw retryError;
+            // A heuristic recovery is best-effort; keep the initial text if it fails.
           }
 
           const retryText = retry?.success && typeof retry.text === "string" ? retry.text : "";
           const hasRetryText = Boolean(retryText.trim());
+          const retryFragment = analyzeDictionaryPromptFragment(retryText, dictionaryPrompt);
+          const retryStrictDictionaryEcho = Boolean(
+            hasRetryText &&
+            (matchesDictionaryPrompt(retryText, dictionaryPrompt) ||
+              matchesDictionaryPrompt(retryText, customDictionaryPrompt))
+          );
+          const retryStillPromptLike = retryStrictDictionaryEcho || retryFragment.isPromptFragment;
+          const retryAddsUniqueWords =
+            retryFragment.uniqueWordCount > initialFragment.uniqueWordCount;
+          const repeatedFragmentRecovered =
+            initialFragment.hasRepeatedWords && retryAddsUniqueWords;
+          // A non-repeated dictionary term or snippet is valid short-form
+          // dictation unless a long recording yields substantially more content.
+          const sparseRecordingRecovered =
+            Number.isFinite(metadata.durationSeconds) &&
+            metadata.durationSeconds >= MIN_SPARSE_RECORDING_DURATION_SECONDS &&
+            retryFragment.uniqueWordCount >= initialFragment.uniqueWordCount + MIN_UNIQUE_WORD_GAIN;
           const recovered =
             hasRetryText &&
-            (strictDictionaryEcho ||
-              normalizedAlphanumericLength(retryText) > normalizedAlphanumericLength(result.text));
+            !retryStillPromptLike &&
+            (strictDictionaryEcho || repeatedFragmentRecovered || sparseRecordingRecovered);
 
           logger.info(
             "Local dictionary-prompt recovery attempt",
             {
-              reason: strictDictionaryEcho ? "strict-echo" : "short-fragment",
+              reason: strictDictionaryEcho ? "strict-echo" : "prompt-fragment",
               retryDurationMs: Math.round(performance.now() - retryStart),
               promptLength: dictionaryPrompt.length,
               initialTextLength: result.text.length,

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -87,6 +87,7 @@ import { isEmptyRecording } from "./recordingGuard";
 import {
   DICTIONARY_ECHO_CODE,
   dictionaryEchoError,
+  isLikelyDictionaryPromptFragment,
   matchesDictionaryPrompt,
 } from "../utils/dictionaryEchoFilter.js";
 import { getDictionaryHintWords } from "../utils/snippets";
@@ -110,6 +111,8 @@ const RECORDING_TIMESLICE_MS = 250; // flush chunks periodically so short record
 // Failure detector only: fires when the worklet or audio graph is dead and never flushes.
 const PREVIEW_FLUSH_WATCHDOG_MS = 1000;
 const neverCancelled = () => false;
+const normalizedAlphanumericLength = (text) =>
+  String(text || "").replace(/[^\p{L}\p{N}]/gu, "").length;
 
 const micDeviceKey = (settings) =>
   `${settings.microphoneSelectionMode}|${settings.selectedMicDeviceId}`;
@@ -1970,6 +1973,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
 
       // Add custom dictionary as initial prompt to help Whisper recognize specific words
+      const customDictionaryPrompt = this.getCustomDictionaryPrompt();
       const dictionaryPrompt = this.getWhisperPrompt();
       if (dictionaryPrompt) {
         options.initialPrompt = dictionaryPrompt;
@@ -2000,28 +2004,58 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       );
 
       if (result.success && result.text) {
-        if (this.isDictionaryEcho(result.text)) {
-          // Whisper decoded (near-)silence and continued the dictionary prompt —
-          // typically VAD stripping pause-heavy speech (#1454). Retry once
-          // without the prompt and without VAD: real speech comes back as the
-          // true transcript, true silence comes back empty.
-          const retry = await window.electronAPI.transcribeLocalWhisper(arrayBuffer, {
-            model: options.model,
-            ...(options.language ? { language: options.language } : {}),
-            skipVad: true,
-          });
-          if (!retry?.success || !retry.text?.trim() || this.isDictionaryEcho(retry.text)) {
-            throw dictionaryEchoError();
+        const strictDictionaryEcho = Boolean(
+          dictionaryPrompt &&
+          (matchesDictionaryPrompt(result.text, dictionaryPrompt) ||
+            matchesDictionaryPrompt(result.text, customDictionaryPrompt))
+        );
+        const shortDictionaryFragment =
+          !strictDictionaryEcho && isLikelyDictionaryPromptFragment(result.text, dictionaryPrompt);
+
+        if (strictDictionaryEcho || shortDictionaryFragment) {
+          // A prompt-free, VAD-free retry distinguishes real speech from Whisper
+          // continuing either the whole dictionary prompt or a short fragment of it.
+          const retryStart = performance.now();
+          let retry = null;
+          try {
+            retry = await window.electronAPI.transcribeLocalWhisper(arrayBuffer, {
+              model: options.model,
+              ...(options.language ? { language: options.language } : {}),
+              skipVad: true,
+            });
+          } catch {
+            // A heuristic recovery is best-effort; strict echoes still fail below.
           }
+
+          const retryText = retry?.success && typeof retry.text === "string" ? retry.text : "";
+          const hasRetryText = Boolean(retryText.trim());
+          const recovered =
+            hasRetryText &&
+            (strictDictionaryEcho ||
+              normalizedAlphanumericLength(retryText) > normalizedAlphanumericLength(result.text));
+
           logger.info(
-            "Recovered transcript after dictionary-echo detection",
-            { retryTextLength: retry.text.length },
+            "Local dictionary-prompt recovery attempt",
+            {
+              reason: strictDictionaryEcho ? "strict-echo" : "short-fragment",
+              retryDurationMs: Math.round(performance.now() - retryStart),
+              promptLength: dictionaryPrompt.length,
+              initialTextLength: result.text.length,
+              retryTextLength: retryText.length,
+              recovered,
+            },
             "audio"
           );
-          result = retry;
+
           timings.transcriptionProcessingDurationMs = Math.round(
             performance.now() - transcriptionStart
           );
+
+          if (recovered) {
+            result = retry;
+          } else if (strictDictionaryEcho) {
+            throw dictionaryEchoError();
+          }
         }
         const rawText = result.text;
         const reasoningStart = performance.now();

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -2011,8 +2011,15 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         );
         const initialFragment = analyzeDictionaryPromptFragment(result.text, dictionaryPrompt);
         const dictionaryPromptFragment = !strictDictionaryEcho && initialFragment.isPromptFragment;
+        // A non-repeated fragment can only be replaced by the sparse-recording rule
+        // below, so on a short recording the retry would be decoded and then discarded.
+        const retryCanBeAdopted =
+          strictDictionaryEcho ||
+          initialFragment.hasRepeatedWords ||
+          (Number.isFinite(metadata.durationSeconds) &&
+            metadata.durationSeconds >= MIN_SPARSE_RECORDING_DURATION_SECONDS);
 
-        if (strictDictionaryEcho || dictionaryPromptFragment) {
+        if ((strictDictionaryEcho || dictionaryPromptFragment) && retryCanBeAdopted) {
           // A prompt-free, VAD-free retry distinguishes real speech from Whisper
           // continuing either the whole dictionary prompt or a short fragment of it.
           const retryStart = performance.now();
@@ -2036,7 +2043,12 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
             (matchesDictionaryPrompt(retryText, dictionaryPrompt) ||
               matchesDictionaryPrompt(retryText, customDictionaryPrompt))
           );
-          const retryStillPromptLike = retryStrictDictionaryEcho || retryFragment.isPromptFragment;
+          // On the strict path a short, dictionary-spelled retry is the recovered
+          // dictation (#1454), not a second echo — only another full-prompt echo
+          // disqualifies it. The fragment test applies to the heuristic path alone.
+          const retryStillPromptLike = strictDictionaryEcho
+            ? retryStrictDictionaryEcho
+            : retryStrictDictionaryEcho || retryFragment.isPromptFragment;
           const retryAddsUniqueWords =
             retryFragment.uniqueWordCount > initialFragment.uniqueWordCount;
           const repeatedFragmentRecovered =

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -11,14 +11,61 @@ const EMPTY_FRAGMENT_ANALYSIS = Object.freeze({
   uniqueWordCount: 0,
 });
 const MAX_SHORT_FRAGMENT_CHARACTERS = 30;
+// Whisper's echo pathology loops a term many times; saying a word twice is speech.
+const LOOPED_WORD_MIN_OCCURRENCES = 3;
+// Dictation almost never recites 3+ dictionary entries in the prompt's own order.
+const MIN_CONSECUTIVE_TERM_RUN = 3;
 // Whisper continues an initial prompt in the prompt's own shape: the hint list is
-// joined with ", " (getCustomDictionaryPrompt), so a continuation arrives either
-// comma-separated or as a looped term. Vocabulary overlap alone cannot stand in for
-// that: short dictation is legitimately spelled out of dictionary words, and
-// getDictionaryHintWords appends whole snippet triggers, so multi-word triggers put
-// common words ("on", "my", "way") into the prompt and make plain speech look like
-// an echo (#1889).
+// joined with ", " (getCustomDictionaryPrompt), so a continuation arrives as a
+// looped term, a short fragment left dangling on its separator ("testing, "), or
+// a run of consecutive entries in the prompt's own order. Vocabulary overlap
+// alone cannot stand in for that: short dictation is legitimately spelled out of
+// dictionary words ("Electron, renderer"), and getDictionaryHintWords appends
+// whole snippet triggers, so multi-word triggers put common words ("on", "my",
+// "way") into the prompt and make plain speech look like an echo (#1889).
 const PROMPT_DELIMITER_RE = /[,、，]/;
+const TRAILING_DELIMITER_RE = /[,、，]\s*$/;
+
+const hasLoopedWord = (textWords) => {
+  const counts = new Map();
+  for (const word of textWords) {
+    const count = (counts.get(word) ?? 0) + 1;
+    if (count >= LOOPED_WORD_MIN_OCCURRENCES) return true;
+    counts.set(word, count);
+  }
+  return false;
+};
+
+// True when the text is MIN_CONSECUTIVE_TERM_RUN+ consecutive prompt entries in
+// the prompt's own order — a literal continuation of the hint list, however long.
+const matchesConsecutiveTermRun = (textWords, dictionaryPrompt) => {
+  const promptSequence = [];
+  let termIndex = 0;
+  for (const term of dictionaryPrompt.split(PROMPT_DELIMITER_RE)) {
+    const normalizedTerm = normalize(term);
+    if (!normalizedTerm) continue;
+    for (const word of normalizedTerm.split(" ")) {
+      promptSequence.push({ word, termIndex });
+    }
+    termIndex++;
+  }
+  for (let start = 0; start + textWords.length <= promptSequence.length; start++) {
+    let offset = 0;
+    while (offset < textWords.length && promptSequence[start + offset].word === textWords[offset]) {
+      offset++;
+    }
+    if (
+      offset === textWords.length &&
+      promptSequence[start + textWords.length - 1].termIndex -
+        promptSequence[start].termIndex +
+        1 >=
+        MIN_CONSECUTIVE_TERM_RUN
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
 
 export function analyzeDictionaryPromptFragment(text, dictionaryPrompt) {
   if (!text || !dictionaryPrompt) return EMPTY_FRAGMENT_ANALYSIS;
@@ -38,14 +85,14 @@ export function analyzeDictionaryPromptFragment(text, dictionaryPrompt) {
     if (promptWords.has(word)) matchCount++;
   }
 
-  // Tested against the raw text: normalize() strips the separator punctuation.
-  const continuesPromptShape = hasRepeatedWords || PROMPT_DELIMITER_RE.test(text);
+  // Shape tests run against the raw text: normalize() strips the separators.
+  const continuesPromptShape =
+    hasLoopedWord(textWords) ||
+    (TRAILING_DELIMITER_RE.test(text) && normalizedText.length <= MAX_SHORT_FRAGMENT_CHARACTERS) ||
+    (PROMPT_DELIMITER_RE.test(text) && matchesConsecutiveTermRun(textWords, dictionaryPrompt));
 
   return {
-    isPromptFragment:
-      matchCount / uniqueTextWords.size >= 0.9 &&
-      continuesPromptShape &&
-      (normalizedText.length <= MAX_SHORT_FRAGMENT_CHARACTERS || hasRepeatedWords),
+    isPromptFragment: matchCount / uniqueTextWords.size >= 0.9 && continuesPromptShape,
     hasRepeatedWords,
     uniqueWordCount: uniqueTextWords.size,
   };

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -5,6 +5,40 @@ const normalize = (s) =>
     .replace(/\s+/g, " ")
     .trim();
 
+const EMPTY_FRAGMENT_ANALYSIS = Object.freeze({
+  isPromptFragment: false,
+  hasRepeatedWords: false,
+  uniqueWordCount: 0,
+});
+const MAX_SHORT_FRAGMENT_CHARACTERS = 30;
+
+export function analyzeDictionaryPromptFragment(text, dictionaryPrompt) {
+  if (!text || !dictionaryPrompt) return EMPTY_FRAGMENT_ANALYSIS;
+
+  const normalizedText = normalize(text);
+  const normalizedPrompt = normalize(dictionaryPrompt);
+
+  if (!normalizedText || !normalizedPrompt) return EMPTY_FRAGMENT_ANALYSIS;
+
+  const textWords = normalizedText.split(" ");
+  const promptWords = new Set(normalizedPrompt.split(" "));
+  const uniqueTextWords = new Set(textWords);
+  const hasRepeatedWords = textWords.length > uniqueTextWords.size;
+  let matchCount = 0;
+
+  for (const word of uniqueTextWords) {
+    if (promptWords.has(word)) matchCount++;
+  }
+
+  return {
+    isPromptFragment:
+      matchCount / uniqueTextWords.size >= 0.9 &&
+      (normalizedText.length <= MAX_SHORT_FRAGMENT_CHARACTERS || hasRepeatedWords),
+    hasRepeatedWords,
+    uniqueWordCount: uniqueTextWords.size,
+  };
+}
+
 export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   if (!text || !dictionaryPrompt) return false;
 
@@ -30,22 +64,7 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
 }
 
 export function isLikelyDictionaryPromptFragment(text, dictionaryPrompt) {
-  if (!text || !dictionaryPrompt) return false;
-
-  const normalizedText = normalize(text);
-  const normalizedPrompt = normalize(dictionaryPrompt);
-
-  if (!normalizedText || !normalizedPrompt || normalizedText.length > 30) return false;
-
-  const promptWords = new Set(normalizedPrompt.split(" "));
-  const uniqueTextWords = new Set(normalizedText.split(" "));
-  let matchCount = 0;
-
-  for (const word of uniqueTextWords) {
-    if (promptWords.has(word)) matchCount++;
-  }
-
-  return matchCount / uniqueTextWords.size >= 0.9;
+  return analyzeDictionaryPromptFragment(text, dictionaryPrompt).isPromptFragment;
 }
 
 export const DICTIONARY_ECHO_CODE = "DICTIONARY_ECHO";

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -29,6 +29,25 @@ export function matchesDictionaryPrompt(text, dictionaryPrompt) {
   return textComposition >= 0.9 && dictionaryUsage >= 0.7;
 }
 
+export function isLikelyDictionaryPromptFragment(text, dictionaryPrompt) {
+  if (!text || !dictionaryPrompt) return false;
+
+  const normalizedText = normalize(text);
+  const normalizedPrompt = normalize(dictionaryPrompt);
+
+  if (!normalizedText || !normalizedPrompt || normalizedText.length > 30) return false;
+
+  const promptWords = new Set(normalizedPrompt.split(" "));
+  const uniqueTextWords = new Set(normalizedText.split(" "));
+  let matchCount = 0;
+
+  for (const word of uniqueTextWords) {
+    if (promptWords.has(word)) matchCount++;
+  }
+
+  return matchCount / uniqueTextWords.size >= 0.9;
+}
+
 export const DICTIONARY_ECHO_CODE = "DICTIONARY_ECHO";
 
 // Keeps the "No audio detected" message so the existing message comparisons and

--- a/src/utils/dictionaryEchoFilter.js
+++ b/src/utils/dictionaryEchoFilter.js
@@ -11,6 +11,14 @@ const EMPTY_FRAGMENT_ANALYSIS = Object.freeze({
   uniqueWordCount: 0,
 });
 const MAX_SHORT_FRAGMENT_CHARACTERS = 30;
+// Whisper continues an initial prompt in the prompt's own shape: the hint list is
+// joined with ", " (getCustomDictionaryPrompt), so a continuation arrives either
+// comma-separated or as a looped term. Vocabulary overlap alone cannot stand in for
+// that: short dictation is legitimately spelled out of dictionary words, and
+// getDictionaryHintWords appends whole snippet triggers, so multi-word triggers put
+// common words ("on", "my", "way") into the prompt and make plain speech look like
+// an echo (#1889).
+const PROMPT_DELIMITER_RE = /[,、，]/;
 
 export function analyzeDictionaryPromptFragment(text, dictionaryPrompt) {
   if (!text || !dictionaryPrompt) return EMPTY_FRAGMENT_ANALYSIS;
@@ -30,9 +38,13 @@ export function analyzeDictionaryPromptFragment(text, dictionaryPrompt) {
     if (promptWords.has(word)) matchCount++;
   }
 
+  // Tested against the raw text: normalize() strips the separator punctuation.
+  const continuesPromptShape = hasRepeatedWords || PROMPT_DELIMITER_RE.test(text);
+
   return {
     isPromptFragment:
       matchCount / uniqueTextWords.size >= 0.9 &&
+      continuesPromptShape &&
       (normalizedText.length <= MAX_SHORT_FRAGMENT_CHARACTERS || hasRepeatedWords),
     hasRepeatedWords,
     uniqueWordCount: uniqueTextWords.size,

--- a/test/helpers/audioManagerDictionaryPromptRecovery.test.js
+++ b/test/helpers/audioManagerDictionaryPromptRecovery.test.js
@@ -60,7 +60,9 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
           info(message, data, category) {
             globalThis.__dictionaryPromptRecoveryLogs.push({ message, data, category });
           },
-          warn() {},
+          warn(message, data, category) {
+            globalThis.__dictionaryPromptRecoveryLogs.push({ level: "warn", message, data, category });
+          },
           error() {},
           logReasoning() {},
         };
@@ -148,6 +150,37 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
 
     assert.equal(result.rawText, "On my way.");
     assert.deepEqual(processedTexts, ["On my way."]);
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("comma-separated dictionary terms are dictation, never retried", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "Electron, renderer" },
+      { success: true, text: "electron rendered a late in sea" },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 5,
+    });
+
+    assert.equal(result.rawText, "Electron, renderer");
+    assert.deepEqual(processedTexts, ["Electron, renderer"]);
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("a genuinely doubled dictionary term is never retried", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "OpenWhispr, OpenWhispr" },
+      { success: true, text: "open whisper open whisper too" },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 4,
+    });
+
+    assert.equal(result.rawText, "OpenWhispr, OpenWhispr");
     assert.equal(calls.length, 1);
   });
 
@@ -244,6 +277,37 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     });
 
     assert.equal(result.rawText, fullTranscript);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a consecutive-term continuation recovers past the length cap", async () => {
+    const fullTranscript = "The quarterly report is ready for review.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "TypeScript, Electron, testing, data, benchmark" },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 6,
+    });
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a sparse retry below the unique-word gain keeps the fragment", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "testing, " },
+      { success: true, text: "yes please" },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 5,
+    });
+
+    assert.equal(result.rawText, "testing, ");
     assert.equal(calls.length, 2);
   });
 
@@ -353,6 +417,45 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
       assert.equal(calls.length, 2);
     });
   }
+
+  await t.test("a failed fragment retry is logged before keeping the initial text", async () => {
+    globalThis.__dictionaryPromptRecoveryLogs.length = 0;
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "data, data, data, data," },
+      new Error("GPU inference failed"),
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, "data, data, data, data,");
+    assert.equal(calls.length, 2);
+    const warnLog = globalThis.__dictionaryPromptRecoveryLogs.find(({ level }) => level === "warn");
+    assert.ok(warnLog, "expected the swallowed retry failure to be logged");
+    assert.equal(warnLog.data.message, "GPU inference failed");
+  });
+
+  await t.test(
+    "a small-dictionary echo stays strict when the merged prompt dilutes it",
+    async () => {
+      // getWhisperPrompt may append a Chinese script bias; the strict check must
+      // also consult the dictionary alone (see isDictionaryEcho's rationale).
+      const fullTranscript = "This is what I actually said.";
+      const calls = queueTranscriptions(window, [
+        { success: true, text: "OpenWhispr, Parakeet" },
+        { success: true, text: fullTranscript },
+      ]);
+      const { manager, processedTexts } = createRecoveryManager();
+      manager.getCustomDictionaryPrompt = () => "OpenWhispr, Parakeet";
+      manager.getWhisperPrompt = () => "OpenWhispr, Parakeet, 简体中文";
+
+      const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+      assert.equal(result.rawText, fullTranscript);
+      assert.deepEqual(processedTexts, [fullTranscript]);
+      assert.equal(calls.length, 2);
+    }
+  );
 
   await t.test("normal output with a dictionary uses one inference call", async () => {
     const transcript = "Please summarize the customer meeting.";

--- a/test/helpers/audioManagerDictionaryPromptRecovery.test.js
+++ b/test/helpers/audioManagerDictionaryPromptRecovery.test.js
@@ -1,0 +1,232 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { loadAudioManager } = require("./harness/audioManager");
+
+const DICTIONARY_PROMPT = [
+  "OpenWhispr",
+  "Parakeet",
+  "Alcahest",
+  "Chromium",
+  "TypeScript",
+  "Electron",
+  "testing",
+  "data",
+  "benchmark",
+  "inference",
+  "transcription",
+  "dictionary",
+  "microphone",
+  "renderer",
+  "latency",
+  "pipeline",
+].join(", ");
+
+const AUDIO_BLOB = new Blob([new Uint8Array([1, 2, 3, 4])], { type: "audio/webm" });
+
+function queueTranscriptions(window, outcomes) {
+  const calls = [];
+  window.electronAPI.transcribeLocalWhisper = async (arrayBuffer, options) => {
+    const outcome = outcomes[calls.length];
+    calls.push({ arrayBuffer, options });
+    if (outcome instanceof Error) throw outcome;
+    return outcome;
+  };
+  return calls;
+}
+
+test("local Whisper recovers dictionary prompt echoes and fragments", async (t) => {
+  globalThis.__dictionaryPromptRecoveryLogs = [];
+  t.after(() => {
+    delete globalThis.__dictionaryPromptRecoveryLogs;
+  });
+
+  const { window, createManager } = await loadAudioManager(t, {
+    cachePrefix: "openwhispr-dictionary-prompt-recovery-test-",
+    settingsKey: "__dictionaryPromptRecoverySettings",
+    settings: {
+      allowOpenAIFallback: false,
+      cloudTranscriptionProvider: "openai",
+      useLocalWhisper: true,
+      localTranscriptionProvider: "whisper",
+      whisperModel: "base",
+      cloudTranscriptionMode: "byok",
+      isSignedIn: false,
+    },
+    mockModules: {
+      "/utils/logger": `
+        export default {
+          debug() {},
+          info(message, data, category) {
+            globalThis.__dictionaryPromptRecoveryLogs.push({ message, data, category });
+          },
+          warn() {},
+          error() {},
+          logReasoning() {},
+        };
+      `,
+    },
+  });
+
+  const createRecoveryManager = (dictionaryPrompt = DICTIONARY_PROMPT) => {
+    const processedTexts = [];
+    const manager = createManager({
+      getEffectiveSttLanguage: () => "en-US",
+      getCustomDictionaryPrompt: () => dictionaryPrompt,
+      getWhisperPrompt: () => dictionaryPrompt,
+      processTranscription: async (text) => {
+        processedTexts.push(text);
+        return `processed: ${text}`;
+      },
+    });
+    return { manager, processedTexts };
+  };
+
+  await t.test("a short prompt fragment uses the fuller prompt-free retry", async () => {
+    globalThis.__dictionaryPromptRecoveryLogs.length = 0;
+    const fullTranscript = "The database migration completed successfully.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "data, data, data, data," },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.equal(result.text, `processed: ${fullTranscript}`);
+    assert.deepEqual(processedTexts, [fullTranscript]);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[0].options, {
+      model: "base",
+      language: "en",
+      initialPrompt: DICTIONARY_PROMPT,
+    });
+    assert.deepEqual(calls[1].options, { model: "base", language: "en", skipVad: true });
+
+    const recoveryLog = globalThis.__dictionaryPromptRecoveryLogs.find(
+      ({ message }) => message === "Local dictionary-prompt recovery attempt"
+    );
+    assert.equal(recoveryLog.data.reason, "short-fragment");
+    assert.equal(recoveryLog.data.promptLength, DICTIONARY_PROMPT.length);
+    assert.equal(recoveryLog.data.initialTextLength, "data, data, data, data,".length);
+    assert.equal(recoveryLog.data.retryTextLength, fullTranscript.length);
+    assert.equal(recoveryLog.data.recovered, true);
+    assert.equal(Number.isInteger(recoveryLog.data.retryDurationMs), true);
+    assert.equal(Object.values(recoveryLog.data).includes(DICTIONARY_PROMPT), false);
+  });
+
+  await t.test("a strict full-prompt echo accepts any non-empty prompt-free retry", async () => {
+    const fullTranscript = "This is the complete dictated sentence.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "small.en");
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.deepEqual(processedTexts, [fullTranscript]);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].options.model, "small.en");
+    assert.equal(calls[1].options.language, "en");
+    assert.equal(calls[1].options.initialPrompt, undefined);
+    assert.equal(calls[1].options.skipVad, true);
+  });
+
+  await t.test("classification uses the exact prompt sent with the initial request", async () => {
+    const fullTranscript = "The complete transcript came from the saved audio.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager } = createRecoveryManager();
+    let promptReads = 0;
+    manager.getCustomDictionaryPrompt = () => null;
+    manager.getWhisperPrompt = () => {
+      promptReads += 1;
+      return promptReads === 1 ? DICTIONARY_PROMPT : "A different dictionary prompt";
+    };
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.initialPrompt, DICTIONARY_PROMPT);
+    assert.equal(promptReads, 1);
+  });
+
+  for (const [description, retryOutcome] of [
+    ["a failed", new Error("GPU inference failed")],
+    ["an empty", { success: true, text: "   " }],
+    ["a shorter", { success: true, text: "data" }],
+  ]) {
+    await t.test(`${description} heuristic retry preserves the original fragment`, async () => {
+      const originalText = "data, data, data, data,";
+      const calls = queueTranscriptions(window, [
+        { success: true, text: originalText },
+        retryOutcome,
+      ]);
+      const { manager, processedTexts } = createRecoveryManager();
+
+      const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+      assert.equal(result.rawText, originalText);
+      assert.equal(result.text, `processed: ${originalText}`);
+      assert.deepEqual(processedTexts, [originalText]);
+      assert.equal(calls.length, 2);
+    });
+  }
+
+  await t.test("normal output with a dictionary uses one inference call", async () => {
+    const transcript = "Please summarize the customer meeting.";
+    const calls = queueTranscriptions(window, [{ success: true, text: transcript }]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, transcript);
+    assert.deepEqual(processedTexts, [transcript]);
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("output without a dictionary uses one inference call", async () => {
+    const transcript = "testing,";
+    const calls = queueTranscriptions(window, [{ success: true, text: transcript }]);
+    const { manager, processedTexts } = createRecoveryManager(null);
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, transcript);
+    assert.deepEqual(processedTexts, [transcript]);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].options.initialPrompt, undefined);
+  });
+
+  await t.test("an unrecovered strict echo is saved and settles as no audio", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      { success: true, text: "" },
+    ]);
+    const { manager } = createRecoveryManager();
+    const lifecycle = [];
+    const saved = [];
+    Object.assign(manager, {
+      isProcessing: true,
+      _localSpeechGateState: null,
+      pendingAssistantConversation: null,
+      pendingSelectionEdit: null,
+      lastAudioBlob: AUDIO_BLOB,
+      onStateChange: ({ isProcessing }) => lifecycle.push(isProcessing ? "processing" : "idle"),
+      onNoAudio: () => lifecycle.push("no-audio"),
+      onError: () => lifecycle.push("error"),
+      saveFailedTranscription: (message, code) => saved.push({ message, code }),
+    });
+
+    await manager.processAudio(AUDIO_BLOB);
+
+    assert.equal(calls.length, 2);
+    assert.deepEqual(lifecycle, ["idle", "no-audio"]);
+    assert.deepEqual(saved, [{ message: "No audio detected", code: "DICTIONARY_ECHO" }]);
+  });
+});

--- a/test/helpers/audioManagerDictionaryPromptRecovery.test.js
+++ b/test/helpers/audioManagerDictionaryPromptRecovery.test.js
@@ -40,18 +40,19 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     delete globalThis.__dictionaryPromptRecoveryLogs;
   });
 
-  const { window, createManager } = await loadAudioManager(t, {
+  const baseSettings = {
+    allowOpenAIFallback: false,
+    cloudTranscriptionProvider: "openai",
+    useLocalWhisper: true,
+    localTranscriptionProvider: "whisper",
+    whisperModel: "base",
+    cloudTranscriptionMode: "byok",
+    isSignedIn: false,
+  };
+  const { window, createManager, setSettings } = await loadAudioManager(t, {
     cachePrefix: "openwhispr-dictionary-prompt-recovery-test-",
     settingsKey: "__dictionaryPromptRecoverySettings",
-    settings: {
-      allowOpenAIFallback: false,
-      cloudTranscriptionProvider: "openai",
-      useLocalWhisper: true,
-      localTranscriptionProvider: "whisper",
-      whisperModel: "base",
-      cloudTranscriptionMode: "byok",
-      isSignedIn: false,
-    },
+    settings: baseSettings,
     mockModules: {
       "/utils/logger": `
         export default {
@@ -106,7 +107,7 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     const recoveryLog = globalThis.__dictionaryPromptRecoveryLogs.find(
       ({ message }) => message === "Local dictionary-prompt recovery attempt"
     );
-    assert.equal(recoveryLog.data.reason, "short-fragment");
+    assert.equal(recoveryLog.data.reason, "prompt-fragment");
     assert.equal(recoveryLog.data.promptLength, DICTIONARY_PROMPT.length);
     assert.equal(recoveryLog.data.initialTextLength, "data, data, data, data,".length);
     assert.equal(recoveryLog.data.retryTextLength, fullTranscript.length);
@@ -115,7 +116,83 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     assert.equal(Object.values(recoveryLog.data).includes(DICTIONARY_PROMPT), false);
   });
 
-  await t.test("a strict full-prompt echo accepts any non-empty prompt-free retry", async () => {
+  await t.test("a correct short dictionary term survives an unrelated longer retry", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "testing" },
+      { success: true, text: "testing the unrelated application" },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 1,
+    });
+
+    assert.equal(result.rawText, "testing");
+    assert.deepEqual(processedTexts, ["testing"]);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("an exact snippet trigger survives an equally rich retry", async () => {
+    const prompt = `${DICTIONARY_PROMPT}, cal link`;
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "cal link" },
+      { success: true, text: "calendar hyperlink" },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager(prompt);
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 1,
+    });
+
+    assert.equal(result.rawText, "cal link");
+    assert.deepEqual(processedTexts, ["cal link"]);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a sparse long recording uses a materially fuller retry", async () => {
+    const fullTranscript = "The complete sentence was recovered from the recording.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "testing" },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 5,
+    });
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a repeated fragment yields to a shorter retry with more unique words", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "data, data, data, data," },
+      { success: true, text: "data is valid" },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, "data is valid");
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a repeated long dictionary term triggers recovery", async () => {
+    const fullTranscript = "The application opened successfully.";
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "OpenWhispr, OpenWhispr, OpenWhispr" },
+      { success: true, text: fullTranscript },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.rawText, fullTranscript);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("a strict full-prompt echo accepts a non-prompt retry", async () => {
     const fullTranscript = "This is the complete dictated sentence.";
     const calls = queueTranscriptions(window, [
       { success: true, text: DICTIONARY_PROMPT },
@@ -132,6 +209,23 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     assert.equal(calls[1].options.language, "en");
     assert.equal(calls[1].options.initialPrompt, undefined);
     assert.equal(calls[1].options.skipVad, true);
+  });
+
+  await t.test("a strict echo rejects a prompt-free retry that is still the prompt", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      { success: true, text: DICTIONARY_PROMPT },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    await assert.rejects(manager.processWithLocalWhisper(AUDIO_BLOB, "base"), (error) => {
+      assert.equal(error.message, "No audio detected");
+      assert.equal(error.code, "DICTIONARY_ECHO");
+      return true;
+    });
+
+    assert.deepEqual(processedTexts, []);
+    assert.equal(calls.length, 2);
   });
 
   await t.test("classification uses the exact prompt sent with the initial request", async () => {
@@ -228,5 +322,33 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     assert.equal(calls.length, 2);
     assert.deepEqual(lifecycle, ["idle", "no-audio"]);
     assert.deepEqual(saved, [{ message: "No audio detected", code: "DICTIONARY_ECHO" }]);
+  });
+
+  await t.test("a strict retry exception reaches the configured cloud fallback", async (t) => {
+    setSettings({ ...baseSettings, allowOpenAIFallback: true });
+    t.after(() => setSettings(baseSettings));
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      new Error("IPC unavailable"),
+    ]);
+    const { manager } = createRecoveryManager();
+    let fallbackCalls = 0;
+    manager.processWithOpenAIAPI = async () => {
+      fallbackCalls += 1;
+      return {
+        success: true,
+        text: "Recovered by cloud fallback.",
+        rawText: "Recovered by cloud fallback.",
+        source: "openai",
+        timings: {},
+      };
+    };
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base");
+
+    assert.equal(result.text, "Recovered by cloud fallback.");
+    assert.equal(result.source, "openai-fallback");
+    assert.equal(fallbackCalls, 1);
+    assert.equal(calls.length, 2);
   });
 });

--- a/test/helpers/audioManagerDictionaryPromptRecovery.test.js
+++ b/test/helpers/audioManagerDictionaryPromptRecovery.test.js
@@ -116,6 +116,86 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
     assert.equal(Object.values(recoveryLog.data).includes(DICTIONARY_PROMPT), false);
   });
 
+  await t.test("a strict echo accepts a short dictionary-spelled retry", async () => {
+    // The retry is the recovered dictation, so only another full-prompt echo may
+    // reject it — the fragment heuristic would discard a genuine two-term list.
+    const calls = queueTranscriptions(window, [
+      { success: true, text: DICTIONARY_PROMPT },
+      { success: true, text: "OpenWhispr, Parakeet" },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 4,
+    });
+
+    assert.equal(result.rawText, "OpenWhispr, Parakeet");
+    assert.deepEqual(processedTexts, ["OpenWhispr, Parakeet"]);
+    assert.equal(calls.length, 2);
+  });
+
+  await t.test("ordinary speech spelled from snippet-trigger words is never retried", async () => {
+    const prompt = `${DICTIONARY_PROMPT}, on my way, let me know`;
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "On my way." },
+      { success: true, text: "I am on my way to the office now." },
+    ]);
+    const { manager, processedTexts } = createRecoveryManager(prompt);
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 4,
+    });
+
+    assert.equal(result.rawText, "On my way.");
+    assert.deepEqual(processedTexts, ["On my way."]);
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("a long recording keeps correct dictionary terms it decoded", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "Electron renderer latency" },
+      { success: true, text: "electron render or latency issue" },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 6,
+    });
+
+    assert.equal(result.rawText, "Electron renderer latency");
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("a hallucinated retry never replaces a genuine dictionary term", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "testing" },
+      { success: true, text: "Thank you for watching!" },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 6,
+    });
+
+    assert.equal(result.rawText, "testing");
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test("a fragment the retry could not replace skips the retry entirely", async () => {
+    const calls = queueTranscriptions(window, [
+      { success: true, text: "testing," },
+      { success: true, text: "The whole sentence I actually said." },
+    ]);
+    const { manager } = createRecoveryManager();
+
+    const result = await manager.processWithLocalWhisper(AUDIO_BLOB, "base", {
+      durationSeconds: 2,
+    });
+
+    assert.equal(result.rawText, "testing,");
+    assert.equal(calls.length, 1);
+  });
+
   await t.test("a correct short dictionary term survives an unrelated longer retry", async () => {
     const calls = queueTranscriptions(window, [
       { success: true, text: "testing" },
@@ -129,7 +209,7 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
 
     assert.equal(result.rawText, "testing");
     assert.deepEqual(processedTexts, ["testing"]);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 1);
   });
 
   await t.test("an exact snippet trigger survives an equally rich retry", async () => {
@@ -146,13 +226,15 @@ test("local Whisper recovers dictionary prompt echoes and fragments", async (t) 
 
     assert.equal(result.rawText, "cal link");
     assert.deepEqual(processedTexts, ["cal link"]);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 1);
   });
 
   await t.test("a sparse long recording uses a materially fuller retry", async () => {
     const fullTranscript = "The complete sentence was recovered from the recording.";
+    // The literal output reported in #1889 — a dictionary term carrying the
+    // prompt's own ", " separator.
     const calls = queueTranscriptions(window, [
-      { success: true, text: "testing" },
+      { success: true, text: "testing, " },
       { success: true, text: fullTranscript },
     ]);
     const { manager } = createRecoveryManager();

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -176,12 +176,25 @@ test("requires non-empty text and a non-empty dictionary prompt", async () => {
   assert.equal(isLikelyDictionaryPromptFragment("testing", ""), false);
 });
 
-test("does not classify normalized output longer than 30 characters as a short fragment", async () => {
+test("detects repeated long dictionary terms without a character cutoff", async () => {
   const { isLikelyDictionaryPromptFragment } =
     await import("../../src/utils/dictionaryEchoFilter.js");
 
   assert.equal(
-    isLikelyDictionaryPromptFragment("data data data data data data data", LARGE_DICTIONARY_PROMPT),
+    isLikelyDictionaryPromptFragment("OpenWhispr, OpenWhispr, OpenWhispr", LARGE_DICTIONARY_PROMPT),
+    true
+  );
+});
+
+test("does not classify long non-repeated dictionary speech as a prompt fragment", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(
+    isLikelyDictionaryPromptFragment(
+      "OpenWhispr Parakeet Alcahest Chromium",
+      LARGE_DICTIONARY_PROMPT
+    ),
     false
   );
 });

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -198,3 +198,28 @@ test("does not classify long non-repeated dictionary speech as a prompt fragment
     false
   );
 });
+
+test("requires the prompt's own separator or a repeat, not just dictionary words", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  // A bare dictionary term is short-form dictation, not a prompt continuation.
+  assert.equal(isLikelyDictionaryPromptFragment("testing", LARGE_DICTIONARY_PROMPT), false);
+  assert.equal(
+    isLikelyDictionaryPromptFragment("Electron renderer latency", LARGE_DICTIONARY_PROMPT),
+    false
+  );
+  // Whisper continuing the prompt carries the ", " the hint list was joined with.
+  assert.equal(isLikelyDictionaryPromptFragment("testing, ", LARGE_DICTIONARY_PROMPT), true);
+});
+
+test("does not treat snippet-trigger words as an echo of ordinary speech", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  // getDictionaryHintWords appends whole triggers, so a multi-word trigger puts
+  // "on", "my" and "way" into the prompt's word set.
+  const promptWithTriggers = `${LARGE_DICTIONARY_PROMPT}, on my way, let me know`;
+  assert.equal(isLikelyDictionaryPromptFragment("On my way.", promptWithTriggers), false);
+  assert.equal(isLikelyDictionaryPromptFragment("Let me know", promptWithTriggers), false);
+});

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -1,6 +1,25 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
+const LARGE_DICTIONARY_PROMPT = [
+  "OpenWhispr",
+  "Parakeet",
+  "Alcahest",
+  "Chromium",
+  "TypeScript",
+  "Electron",
+  "testing",
+  "data",
+  "benchmark",
+  "inference",
+  "transcription",
+  "dictionary",
+  "microphone",
+  "renderer",
+  "latency",
+  "pipeline",
+].join(", ");
+
 test("detects verbatim echo of dictionary prompt", async () => {
   const { matchesDictionaryPrompt } = await import("../../src/utils/dictionaryEchoFilter.js");
   assert.equal(
@@ -123,4 +142,46 @@ test("returns false when text or prompt normalizes to empty string (punctuation 
   assert.equal(matchesDictionaryPrompt("!!!", ",,,"), false);
   assert.equal(matchesDictionaryPrompt("???", "OpenWhispr, Parakeet"), false);
   assert.equal(matchesDictionaryPrompt("OpenWhispr, Parakeet", "!!!"), false);
+});
+
+test("detects short repeated fragments from a large dictionary prompt", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(
+    isLikelyDictionaryPromptFragment("data, data, data, data,", LARGE_DICTIONARY_PROMPT),
+    true
+  );
+  assert.equal(isLikelyDictionaryPromptFragment("testing,", LARGE_DICTIONARY_PROMPT), true);
+});
+
+test("does not classify normal or unrelated short speech as a dictionary fragment", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(
+    isLikelyDictionaryPromptFragment("OpenWhispr is working", LARGE_DICTIONARY_PROMPT),
+    false
+  );
+  assert.equal(isLikelyDictionaryPromptFragment("hello there", LARGE_DICTIONARY_PROMPT), false);
+});
+
+test("requires non-empty text and a non-empty dictionary prompt", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(isLikelyDictionaryPromptFragment("", LARGE_DICTIONARY_PROMPT), false);
+  assert.equal(isLikelyDictionaryPromptFragment("...", LARGE_DICTIONARY_PROMPT), false);
+  assert.equal(isLikelyDictionaryPromptFragment("testing", null), false);
+  assert.equal(isLikelyDictionaryPromptFragment("testing", ""), false);
+});
+
+test("does not classify normalized output longer than 30 characters as a short fragment", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(
+    isLikelyDictionaryPromptFragment("data data data data data data data", LARGE_DICTIONARY_PROMPT),
+    false
+  );
 });

--- a/test/helpers/dictionaryEchoFilter.test.js
+++ b/test/helpers/dictionaryEchoFilter.test.js
@@ -223,3 +223,62 @@ test("does not treat snippet-trigger words as an echo of ordinary speech", async
   assert.equal(isLikelyDictionaryPromptFragment("On my way.", promptWithTriggers), false);
   assert.equal(isLikelyDictionaryPromptFragment("Let me know", promptWithTriggers), false);
 });
+
+test("does not classify comma-separated dictionary-term dictation as a fragment", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  // Real short-form dictation of curated terms; replacing it with a prompt-free
+  // retry would misspell exactly the vocabulary the dictionary protects.
+  assert.equal(
+    isLikelyDictionaryPromptFragment("Electron, renderer", LARGE_DICTIONARY_PROMPT),
+    false
+  );
+  // Without a dangling separator, two echoed terms are indistinguishable from
+  // that dictation, so they are deliberately left alone as well.
+  assert.equal(isLikelyDictionaryPromptFragment("testing, data", LARGE_DICTIONARY_PROMPT), false);
+});
+
+test("does not classify a genuinely doubled term as a looped echo", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  // Whisper's echo pathology loops a term many times; saying it twice is speech.
+  assert.equal(
+    isLikelyDictionaryPromptFragment("OpenWhispr, OpenWhispr", LARGE_DICTIONARY_PROMPT),
+    false
+  );
+});
+
+test("detects a run of consecutive prompt terms past the character cutoff", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  // A comma-separated continuation of 3+ entries in the prompt's own order is
+  // the echo shape that outgrows the short-fragment cap.
+  assert.equal(
+    isLikelyDictionaryPromptFragment(
+      "TypeScript, Electron, testing, data, benchmark",
+      LARGE_DICTIONARY_PROMPT
+    ),
+    true
+  );
+  // The same words out of prompt order are dictation, not a continuation.
+  assert.equal(
+    isLikelyDictionaryPromptFragment(
+      "benchmark, TypeScript, data, Electron, testing",
+      LARGE_DICTIONARY_PROMPT
+    ),
+    false
+  );
+});
+
+test("a dangling separator does not outweigh non-dictionary words", async () => {
+  const { isLikelyDictionaryPromptFragment } =
+    await import("../../src/utils/dictionaryEchoFilter.js");
+
+  assert.equal(
+    isLikelyDictionaryPromptFragment("yes, no, maybe, dunno,", LARGE_DICTIONARY_PROMPT),
+    false
+  );
+});

--- a/test/helpers/dictionaryEchoRecovery.test.js
+++ b/test/helpers/dictionaryEchoRecovery.test.js
@@ -54,19 +54,18 @@ test("a real failure still reports an error and saves for retry", () => {
   assert.deepEqual(manager.calls.saved, [{ message: "Groq returned 500", code: null }]);
 });
 
-test("every dictionary-echo discard is tagged, on local and remote paths alike", async () => {
+test("every remote dictionary-echo discard is tagged", async () => {
   const fs = require("fs");
   const source = fs.readFileSync("src/helpers/audioManager.js", "utf-8");
 
   // Each isDictionaryEcho guard must throw the tagged error; a plain
   // `new Error("No audio detected")` there would be swallowed again.
   //
-  // The floor is a canary on the regex, not a target: it must track the real
-  // guard count so a pattern that silently stops matching can't make the loop
-  // below vacuous. It dropped from 7 to 4 when PROXY_TRANSCRIPTION_PROVIDERS
-  // collapsed the tinfoil/mistral/xai/corti blocks into one dispatch.
+  // Local Whisper now separates detection from the tagged failure so it can
+  // attempt recovery first; its failure behavior is covered end-to-end by the
+  // AudioManager dictionary-prompt recovery suite.
   const guards = source.match(/isDictionaryEcho\([\s\S]{0,400}?throw [^;]+;/g) ?? [];
-  assert.ok(guards.length >= 4, `expected the known echo guards, found ${guards.length}`);
+  assert.ok(guards.length >= 3, `expected the known remote echo guards, found ${guards.length}`);
   for (const guard of guards) {
     assert.match(guard, /throw dictionaryEchoError\(\);/);
   }


### PR DESCRIPTION
Fixes #1889

## Summary
Recovers transcripts that Whisper truncates into an echo of the custom-dictionary prompt (a whole sentence coming out as `testing, `), while ensuring the recovery itself can never rewrite correctly transcribed speech.

## Changes
- Preserve legitimate short dictionary terms and snippet triggers.
- Recover sparse long recordings only when the prompt-free retry adds meaningful content.
- Detect repeated dictionary echoes regardless of text length.
- Reject retries that still resemble the dictionary prompt.
- Propagate strict retry errors so configured cloud fallback can run.
- Retain the existing behavior for long, non-repeated dictionary-heavy dictation.

### Hardening (review round 2)
- A fragment must now have a definite echo shape: a looped term (3+ occurrences), a short fragment dangling on its trailing separator (`testing, `), or a comma-separated run of 3+ consecutive prompt entries in the prompt's own order.
- Comma-separated dictionary-term dictation (`Electron, renderer`) and genuinely doubled terms (`OpenWhispr, OpenWhispr`) are never retried, so the prompt-free retry can no longer replace correctly spelled dictionary speech.
- Long prompt continuations past the 30-character cap are now detected and recovered.
- Heuristic retry failures are logged instead of swallowed silently.

## Scope
Local whisper.cpp dictation only. Known follow-ups, deliberately not in this PR: truncations that don't echo dictionary vocabulary, the same prompt on cloud transcription paths (strict-only echo checks there today), and CJK dictionaries (word segmentation makes the fragment heuristic inert). Filed the follow up here https://github.com/OpenWhispr/openwhispr/issues/1965

## Testing
- Regression coverage for dictionary terms, snippet triggers, repeated echoes, prompt-like retries, and cloud fallback, plus pins for the hardened shapes, the sparse-recovery word-gain threshold, and the dictionary-only strict-echo check.
- Full test suite: 3,374 tests — 3,188 passed, 0 failed (185 environment-conditional skips).
- `npm run quality-check` (ESLint, Prettier, TypeScript) clean.
