### PR TITLE
feat: configure activation mode per hotkey

### DIFF
--- a/main.js
+++ b/main.js
@@ -1003,6 +1003,7 @@ async function startApp() {
   applyOpenWhisprOriginHeader(session.defaultSession);
 
   await windowManager.setActivationModeCache(environmentManager.getActivationMode());
+  await windowManager.setActivationModesCache(environmentManager.getActivationModes());
   windowManager.setFloatingIconAutoHide(environmentManager.getFloatingIconAutoHide());
   windowManager.setPanelStartPosition(environmentManager.getPanelStartPosition());
 
@@ -1029,6 +1030,35 @@ async function startApp() {
       })
       .catch((err) => {
         debugLogger.error("Failed to change activation mode", { error: err.message }, "hotkey");
+      });
+  });
+
+  ipcMain.on("activation-modes-changed", (_event, modes) => {
+    activationModeChangeQueue = activationModeChangeQueue
+      .then(async () => {
+        const success = await windowManager.setActivationModesCache(modes);
+        const effectiveModes = windowManager.hotkeyManager.getActivationModes();
+        if (success) {
+          environmentManager.saveActivationModes(effectiveModes);
+        } else {
+          for (const browserWindow of BrowserWindow.getAllWindows()) {
+            if (!browserWindow.isDestroyed()) {
+              browserWindow.webContents.send("setting-updated", {
+                key: "activationModeByHotkey",
+                value: effectiveModes,
+              });
+            }
+          }
+        }
+        windowManager.resetWindowsPushState();
+        windowManager.reconcileNativeKeyListeners();
+      })
+      .catch((err) => {
+        debugLogger.error(
+          "Failed to change per-hotkey activation modes",
+          { error: err.message },
+          "hotkey"
+        );
       });
   });
 
@@ -1320,7 +1350,7 @@ async function startApp() {
       debugLogger?.debug("[Globe] globe-down received", {
         currentHotkey,
         mainWindowLive,
-        activationMode: mainWindowLive ? windowManager.getActivationMode() : "n/a",
+        activationMode: mainWindowLive ? windowManager.getActivationMode("GLOBE") : "n/a",
       });
 
       // Forward to control panel for hotkey capture
@@ -1336,7 +1366,7 @@ async function startApp() {
         } else if (mainWindowLive) {
           // Capture target app PID BEFORE showing the overlay
           if (textEditMonitor) textEditMonitor.captureTargetPid();
-          const activationMode = windowManager.getActivationMode();
+          const activationMode = windowManager.getActivationMode("GLOBE");
           if (activationMode === "push") {
             const now = Date.now();
             if (now - globeLastStopTime < POST_STOP_COOLDOWN_MS) {
@@ -1390,7 +1420,7 @@ async function startApp() {
       }
 
       if (hotkeyManager.getSlotHotkeys("dictation").some(isGlobeLikeHotkey)) {
-        const activationMode = windowManager.getActivationMode();
+        const activationMode = windowManager.getActivationMode("GLOBE");
         if (activationMode === "push") {
           if (globeKeyDownTime === 0 && !globeKeyIsRecording) {
             // The press was ignored (dictation was processing); releasing it
@@ -1462,7 +1492,7 @@ async function startApp() {
       if (!isLiveWindow(windowManager.mainWindow)) return;
       if (windowManager.isDictationProcessing()) return;
 
-      const activationMode = windowManager.getActivationMode();
+      const activationMode = windowManager.getActivationMode(modifier);
       if (textEditMonitor) textEditMonitor.captureTargetPid();
       if (activationMode === "push") {
         if (rightModActiveKey && rightModActiveKey !== modifier) return;
@@ -1489,7 +1519,7 @@ async function startApp() {
       if (hotkeyManager.slotHasHotkey("dictation", modifier)) {
         if (!isLiveWindow(windowManager.mainWindow)) return;
 
-        const activationMode = windowManager.getActivationMode();
+        const activationMode = windowManager.getActivationMode(modifier);
         if (activationMode === "push" && (!rightModActiveKey || rightModActiveKey === modifier)) {
           if (rightModDownTime === 0 && !rightModIsRecording) {
             // The press was ignored (dictation was processing); releasing it
@@ -1550,7 +1580,7 @@ async function startApp() {
       if (!isLiveWindow(windowManager.mainWindow)) return;
       if (windowManager.isDictationProcessing()) return;
 
-      const activationMode = windowManager.getActivationMode();
+      const activationMode = windowManager.getActivationMode(button);
       if (textEditMonitor) textEditMonitor.captureTargetPid();
 
       if (activationMode === "push") {
@@ -1581,7 +1611,7 @@ async function startApp() {
       if (!hotkeyManager.slotHasHotkey("dictation", button)) return;
       if (!isLiveWindow(windowManager.mainWindow)) return;
 
-      const activationMode = windowManager.getActivationMode();
+      const activationMode = windowManager.getActivationMode(button);
       if (
         activationMode === "push" &&
         (!mouseButtonActiveButton || mouseButtonActiveButton === button)
@@ -1672,7 +1702,7 @@ async function startApp() {
     const dispatchNativeKeyDown = (key) => {
       if (hotkeyManager.slotHasHotkey("dictation", key)) {
         if (!isLiveWindow(windowManager.mainWindow)) return;
-        if (windowManager.getActivationMode() === "push") {
+        if (windowManager.getActivationMode(key) === "push") {
           windowManager.startWindowsPushToTalk(key);
         } else {
           windowManager.sendToggleDictation();
@@ -1697,7 +1727,7 @@ async function startApp() {
         windowManager.handleWindowsPushKeyUp(key);
       } else if (
         isLiveWindow(windowManager.mainWindow) &&
-        windowManager.getActivationMode() === "push"
+        windowManager.getActivationMode(key) === "push"
       ) {
         windowManager.handleWindowsPushKeyUp(key);
       }

--- a/preload.js
+++ b/preload.js
@@ -606,6 +606,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Activation mode persistence (file-based for reliable startup)
   getActivationMode: () => ipcRenderer.invoke("get-activation-mode"),
   saveActivationMode: (mode) => ipcRenderer.invoke("save-activation-mode", mode),
+  getActivationModes: () => ipcRenderer.invoke("get-activation-modes"),
 
   saveAllKeysToEnv: () => ipcRenderer.invoke("save-all-keys-to-env"),
   syncStartupPreferences: (prefs) => ipcRenderer.invoke("sync-startup-preferences", prefs),
@@ -949,8 +950,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
   checkAccessibilityTrusted: () => ipcRenderer.invoke("check-accessibility-trusted"),
 
-  // Notify main process of activation mode changes (for Windows Push-to-Talk)
+  // Notify main process of activation mode changes (for Push-to-Talk)
   notifyActivationModeChanged: (mode) => ipcRenderer.send("activation-mode-changed", mode),
+  notifyActivationModesChanged: (modes) => ipcRenderer.send("activation-modes-changed", modes),
   notifyHotkeyChanged: (hotkey) => ipcRenderer.send("hotkey-changed", hotkey),
   registerMeetingHotkey: (hotkey) => ipcRenderer.invoke("register-meeting-hotkey", hotkey),
 

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -132,7 +132,8 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     "onboarding",
     dictationHotkey
   );
-  const { activationMode, setActivationMode } = settings;
+  const { activationMode, activationModeByHotkey, setActivationModeForHotkey } = settings;
+  const dictationActivationMode = activationModeByHotkey[dictationHotkey] ?? activationMode;
   // This hook also starts the membership fetch for already-authenticated users;
   // relying on the login transition alone would leave resumed onboarding stuck
   // waiting for workspace resolution after an app restart.
@@ -819,15 +820,15 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
                   </p>
                   <p className="mt-1 text-sm text-[var(--onboarding-text-secondary)]">
                     {t(
-                      activationMode === "push"
+                      dictationActivationMode === "push"
                         ? "onboarding.activation.holdDescription"
                         : "onboarding.activation.tapDescription"
                     )}
                   </p>
                 </div>
                 <ActivationModeSelector
-                  value={activationMode}
-                  onChange={setActivationMode}
+                  value={dictationActivationMode}
+                  onChange={(mode) => setActivationModeForHotkey(dictationHotkey, mode)}
                   pushDisabledReason={
                     !supportsPushToTalk
                       ? pushToTalkUnavailableReason || t("windows.pttUnavailable")
@@ -835,7 +836,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
                   }
                 />
               </div>
-              {getPlatform() === "linux" && activationMode === "push" && (
+              {getPlatform() === "linux" && dictationActivationMode === "push" && (
                 <LinuxPttSetupInfo isAvailable={supportsPushToTalk} />
               )}
             </div>
@@ -851,7 +852,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
         const description = t(
           assistant
             ? "onboarding.rehaul.assistantDemo.description"
-            : activationMode === "push"
+            : dictationActivationMode === "push"
               ? "onboarding.activation.holdHotkey"
               : "onboarding.rehaul.dictationDemo.description",
           // Formatted for reading: the raw accelerator would show internal

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -76,7 +76,7 @@ import { useHotkeyModeInfo } from "../hooks/useHotkeyModeInfo";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { validateHotkeyForSlot } from "../utils/hotkeyValidation";
 import { getPlatform, getCachedPlatform } from "../utils/platform";
-import { formatHotkeyLabel } from "../utils/hotkeys";
+import { formatHotkeyLabel, parseHotkeyList } from "../utils/hotkeys";
 import {
   getLinuxPasteInstallCommands,
   needsLinuxPasteToolGuidance,
@@ -234,6 +234,36 @@ function SectionHeader({
         <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">{description}</p>
       )}
       {note && <p className="text-xs text-muted-foreground/80 mt-0.5 leading-relaxed">{note}</p>}
+    </div>
+  );
+}
+
+function DictationHotkeyActivationMode({
+  hotkey,
+  value,
+  onChange,
+  disabled,
+}: {
+  hotkey: string;
+  value: "tap" | "push";
+  onChange: (mode: "tap" | "push") => void;
+  disabled: boolean;
+}) {
+  const { t } = useTranslation();
+  const { supportsPushToTalk, pushToTalkUnavailableReason } = useHotkeyModeInfo("settings", hotkey);
+
+  return (
+    <div className="w-[132px] shrink-0">
+      <ActivationModeSelector
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        pushDisabledReason={
+          !supportsPushToTalk
+            ? pushToTalkUnavailableReason || t("windows.pttUnavailable")
+            : undefined
+        }
+      />
     </div>
   );
 }
@@ -1077,7 +1107,9 @@ export default function SettingsPage({
     useCleanupModel,
     dictationKey,
     activationMode,
+    activationModeByHotkey,
     setActivationMode,
+    setActivationModeForHotkey,
     microphoneSelectionMode,
     selectedMicDeviceId,
     selectedMicDeviceLabel,
@@ -1460,17 +1492,17 @@ export default function SettingsPage({
     [dictationKey, meetingKey, voiceAgentKey, t]
   );
 
-  const {
-    isUsingNativeShortcut,
-    isUsingHyprland,
-    hyprlandConfigStatus,
-    supportsPushToTalk,
-    pushToTalkUnavailableReason,
-  } = useHotkeyModeInfo("settings", dictationKey);
+  const { isUsingNativeShortcut, isUsingHyprland, hyprlandConfigStatus } = useHotkeyModeInfo(
+    "settings",
+    dictationKey
+  );
   const [effectiveDefaultHotkey, setEffectiveDefaultHotkey] = useState<string | null>(null);
   const [linuxPttAvailable, setLinuxPttAvailable] = useState(true);
 
   const platform = getCachedPlatform();
+  const hasPushDictationHotkey = parseHotkeyList(dictationKey).some(
+    (hotkey) => (activationModeByHotkey[hotkey] ?? activationMode) === "push"
+  );
 
   const [autoStartEnabled, setAutoStartEnabled] = useState(false);
   const [autoStartNeedsApproval, setAutoStartNeedsApproval] = useState(false);
@@ -3826,6 +3858,18 @@ EOF`,
                     disabled={isHotkeyRegistering}
                     maxHotkeys={isUsingNativeShortcut ? 1 : undefined}
                     required
+                    renderHotkeyEnd={
+                      !isUsingNativeShortcut || getCachedPlatform() === "linux"
+                        ? (hotkey) => (
+                            <DictationHotkeyActivationMode
+                              hotkey={hotkey}
+                              value={activationModeByHotkey[hotkey] ?? activationMode}
+                              onChange={(mode) => setActivationModeForHotkey(hotkey, mode)}
+                              disabled={isHotkeyRegistering}
+                            />
+                          )
+                        : undefined
+                    }
                     footerEnd={
                       effectiveDefaultHotkey &&
                       dictationKey &&
@@ -3844,25 +3888,9 @@ EOF`,
                   />
                 </SettingsPanelRow>
 
-                {(!isUsingNativeShortcut || getCachedPlatform() === "linux") && (
+                {getCachedPlatform() === "linux" && hasPushDictationHotkey && (
                   <SettingsPanelRow>
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="text-xs text-muted-foreground/80">
-                        {t("settingsPage.general.hotkey.activationMode")}
-                      </span>
-                      <ActivationModeSelector
-                        value={activationMode}
-                        onChange={setActivationMode}
-                        pushDisabledReason={
-                          !supportsPushToTalk
-                            ? pushToTalkUnavailableReason || t("windows.pttUnavailable")
-                            : undefined
-                        }
-                      />
-                    </div>
-                    {getCachedPlatform() === "linux" && activationMode === "push" && (
-                      <LinuxPttSetupInfo isAvailable={linuxPttAvailable} />
-                    )}
+                    <LinuxPttSetupInfo isAvailable={linuxPttAvailable} />
                   </SettingsPanelRow>
                 )}
               </SettingsPanel>

--- a/src/components/ui/ActivationModeSelector.tsx
+++ b/src/components/ui/ActivationModeSelector.tsx
@@ -7,6 +7,7 @@ interface ActivationModeSelectorProps {
   value: ActivationMode;
   onChange: (mode: ActivationMode) => void;
   pushDisabledReason?: string;
+  disabled?: boolean;
 }
 
 const OPTIONS = [
@@ -18,6 +19,7 @@ export function ActivationModeSelector({
   value,
   onChange,
   pushDisabledReason,
+  disabled = false,
 }: ActivationModeSelectorProps) {
   const { t } = useTranslation();
 
@@ -35,21 +37,21 @@ export function ActivationModeSelector({
 
       {OPTIONS.map(({ mode, Icon, labelKey }) => {
         const disabledReason = mode === "push" ? pushDisabledReason : undefined;
-        const disabled = Boolean(disabledReason);
+        const isDisabled = disabled || Boolean(disabledReason);
         const label = t(labelKey);
 
         return (
           <button
             key={mode}
             type="button"
-            disabled={disabled}
+            disabled={isDisabled}
             title={disabledReason}
             aria-label={disabledReason ? `${label}: ${disabledReason}` : undefined}
             onClick={() => onChange(mode)}
             className={`
               relative z-10 flex-1 flex items-center justify-center gap-1 rounded px-2.5 py-1
               transition-colors duration-150
-              ${disabled ? "cursor-not-allowed" : "cursor-pointer"}
+              ${isDisabled ? "cursor-not-allowed" : "cursor-pointer"}
               ${value === mode ? "text-foreground" : "text-muted-foreground hover:text-foreground"}
             `}
           >

--- a/src/components/ui/HotkeyListInput.tsx
+++ b/src/components/ui/HotkeyListInput.tsx
@@ -24,6 +24,8 @@ export interface HotkeyListInputProps {
   maxHotkeys?: number;
   /** Per-hotkey validation (e.g. cross-slot conflicts). Receives a single hotkey. */
   validate?: (hotkey: string) => string | null | undefined;
+  /** Optional content shown beside each configured hotkey. */
+  renderHotkeyEnd?: (hotkey: string, index: number) => ReactNode;
   /** Optional content shown on the right of the action row (e.g. a "Reset" link). */
   footerEnd?: ReactNode;
 }
@@ -42,6 +44,7 @@ export function HotkeyListInput({
   required = false,
   maxHotkeys = Infinity,
   validate,
+  renderHotkeyEnd,
   footerEnd,
 }: HotkeyListInputProps) {
   const { t } = useTranslation();
@@ -108,14 +111,18 @@ export function HotkeyListInput({
   return (
     <div className="flex flex-col gap-2">
       {items.map((hotkey, index) => (
-        <HotkeyInput
-          key={`${hotkey}-${index}`}
-          value={hotkey}
-          onChange={(next) => replaceAt(index, next)}
-          onClear={canRemove ? () => void removeAt(index) : undefined}
-          disabled={disabled}
-          validate={makeValidate(index)}
-        />
+        <div key={`${hotkey}-${index}`} className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <HotkeyInput
+              value={hotkey}
+              onChange={(next) => replaceAt(index, next)}
+              onClear={canRemove ? () => void removeAt(index) : undefined}
+              disabled={disabled}
+              validate={makeValidate(index)}
+            />
+          </div>
+          {renderHotkeyEnd?.(hotkey, index)}
+        </div>
       ))}
 
       {(items.length === 0 || adding) && (

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -41,6 +41,7 @@ const PERSISTED_KEYS = [
   "TRANSLATION_KEY",
   "MEETING_KEY",
   "ACTIVATION_MODE",
+  "ACTIVATION_MODE_BY_HOTKEY",
   "FLOATING_ICON_AUTO_HIDE",
   "PANEL_START_POSITION",
   "START_MINIMIZED",
@@ -449,6 +450,31 @@ class EnvironmentManager {
   saveActivationMode(mode) {
     const validMode = mode === "push" ? "push" : "tap";
     const result = this._saveKey("ACTIVATION_MODE", validMode);
+    this.saveAllKeysToEnvFile().catch(() => {});
+    return result;
+  }
+
+  getActivationModes() {
+    try {
+      const parsed = JSON.parse(this._getKey("ACTIVATION_MODE_BY_HOTKEY") || "{}");
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") return {};
+      return Object.fromEntries(
+        Object.entries(parsed).filter(
+          ([hotkey, mode]) => typeof hotkey === "string" && (mode === "tap" || mode === "push")
+        )
+      );
+    } catch {
+      return {};
+    }
+  }
+
+  saveActivationModes(modes) {
+    const validModes = Object.fromEntries(
+      Object.entries(modes || {}).filter(
+        ([hotkey, mode]) => typeof hotkey === "string" && (mode === "tap" || mode === "push")
+      )
+    );
+    const result = this._saveKey("ACTIVATION_MODE_BY_HOTKEY", JSON.stringify(validModes));
     this.saveAllKeysToEnvFile().catch(() => {});
     return result;
   }

--- a/src/helpers/hotkeyManager.js
+++ b/src/helpers/hotkeyManager.js
@@ -98,6 +98,8 @@ class HotkeyManager extends EventEmitter {
     this.useHyprland = false;
     this.kdeManager = null;
     this.useKDE = false;
+    this.activationMode = "tap";
+    this.activationModes = {};
   }
 
   // Ensure a slot exists and return it (slots always use the list shape).
@@ -131,6 +133,57 @@ class HotkeyManager extends EventEmitter {
     const slot = this._ensureSlot("dictation");
     slot.callback = value;
     this.slots.set("dictation", slot);
+  }
+
+  getActivationMode(hotkey, fallback = this.activationMode) {
+    const configured =
+      this.activationModes[hotkey] ??
+      (hotkey === "GLOBE"
+        ? this.activationModes.Fn
+        : hotkey === "Fn"
+          ? this.activationModes.GLOBE
+          : undefined);
+    if (configured === "tap" || configured === "push") return configured;
+    return fallback === "push" ? "push" : "tap";
+  }
+
+  getActivationModes() {
+    return { ...this.activationModes };
+  }
+
+  async setActivationModes(modes) {
+    const nextModes = Object.fromEntries(
+      Object.entries(modes || {}).filter(
+        ([hotkey, mode]) => typeof hotkey === "string" && (mode === "tap" || mode === "push")
+      )
+    );
+    const hotkey = this.currentHotkey;
+    const previousMode = this.getActivationMode(hotkey);
+    const nextMode =
+      nextModes[hotkey] === "push"
+        ? "push"
+        : nextModes[hotkey] === "tap"
+          ? "tap"
+          : this.activationMode === "push"
+            ? "push"
+            : "tap";
+
+    if (hotkey && previousMode !== nextMode) {
+      // Reuse the native-backend transition logic without changing the
+      // legacy fallback that unconfigured hotkeys inherit.
+      const legacyMode = this.activationMode;
+      this.activationMode = previousMode;
+      let success;
+      try {
+        success = await this.setActivationMode(nextMode);
+      } finally {
+        this.activationMode = legacyMode;
+      }
+      if (!success) return false;
+    }
+
+    this.activationModes = nextModes;
+    return true;
   }
 
   setListeningMode(enabled) {
@@ -263,7 +316,7 @@ class HotkeyManager extends EventEmitter {
         hotkey,
         slotName,
         callback,
-        slotName === "dictation" && this.activationMode === "push"
+        slotName === "dictation" && this.getActivationMode(hotkey) === "push"
       );
       if (result !== true) {
         const reason =
@@ -372,12 +425,13 @@ class HotkeyManager extends EventEmitter {
    * every other slot is tap-to-toggle. Globe/mouse hotkeys are macOS-only.
    * Each slot may bind several hotkeys, so we evaluate every one.
    */
-  getNativeListenerKeys(activationMode) {
+  getNativeListenerKeys(activationMode = this.activationMode) {
     const keys = [];
     for (const [slotName, slot] of this.slots) {
       for (const hotkey of slot.hotkeys ?? []) {
         if (!hotkey || isGlobeLikeHotkey(hotkey) || isMouseButtonHotkey(hotkey)) continue;
-        const pushToTalk = slotName === "dictation" && activationMode === "push";
+        const pushToTalk =
+          slotName === "dictation" && this.getActivationMode(hotkey, activationMode) === "push";
         if (pushToTalk || isModifierOnlyHotkey(hotkey) || isRightSideModifier(hotkey)) {
           keys.push(hotkey);
         }
@@ -759,7 +813,7 @@ class HotkeyManager extends EventEmitter {
     return false;
   }
 
-  async registerGnomeDictationHotkey(hotkey, callback, mode = this.activationMode) {
+  async registerGnomeDictationHotkey(hotkey, callback, mode = this.getActivationMode(hotkey)) {
     if (mode === "push") {
       if (isModifierOnlyHotkey(hotkey)) return false;
       return this.gnomeManager.registerPushToTalk(hotkey, callback);
@@ -903,7 +957,7 @@ class HotkeyManager extends EventEmitter {
 
             const success = await this.hyprlandManager.registerKeybinding(
               hotkey,
-              this.activationMode === "push"
+              this.getActivationMode(hotkey) === "push"
             );
             if (success) {
               this.currentHotkey = hotkey;
@@ -913,7 +967,7 @@ class HotkeyManager extends EventEmitter {
               );
             } else {
               const ok = await this.tryNativeFallbacks(hotkey, "Hyprland", (fb) =>
-                this.hyprlandManager.registerKeybinding(fb, this.activationMode === "push")
+                this.hyprlandManager.registerKeybinding(fb, this.getActivationMode(fb) === "push")
               );
               if (!ok) {
                 this.useHyprland = false;
@@ -950,7 +1004,7 @@ class HotkeyManager extends EventEmitter {
               hotkey,
               "dictation",
               callback,
-              this.activationMode === "push"
+              this.getActivationMode(hotkey) === "push"
             );
             if (result === true) {
               this.currentHotkey = hotkey;
@@ -959,7 +1013,12 @@ class HotkeyManager extends EventEmitter {
             } else if (result === "conflict" || result === "modifier-only") {
               const ok = await this.tryNativeFallbacks(hotkey, "KDE", (fb) =>
                 this.kdeManager
-                  .registerKeybinding(fb, "dictation", callback, this.activationMode === "push")
+                  .registerKeybinding(
+                    fb,
+                    "dictation",
+                    callback,
+                    this.getActivationMode(fb) === "push"
+                  )
                   .then((r) => r === true)
               );
               if (!ok) {
@@ -1273,7 +1332,7 @@ class HotkeyManager extends EventEmitter {
       // DE backends bind one accelerator per slot; extras stay in storage.
       const primary = hotkeys[0];
 
-      if (this.activationMode === "push" && !this.supportsPushToTalk(primary)) {
+      if (this.getActivationMode(primary) === "push" && !this.supportsPushToTalk(primary)) {
         return {
           success: false,
           message: this.getPushToTalkUnavailableReason(primary),
@@ -1314,7 +1373,7 @@ class HotkeyManager extends EventEmitter {
         debugLogger.log(`[HotkeyManager] Updating Hyprland hotkey to "${primary}"`);
         const success = await this.hyprlandManager.updateKeybinding(
           primary,
-          this.activationMode === "push"
+          this.getActivationMode(primary) === "push"
         );
         if (!success) {
           return {
@@ -1344,7 +1403,7 @@ class HotkeyManager extends EventEmitter {
           primary,
           "dictation",
           callback,
-          this.activationMode === "push"
+          this.getActivationMode(primary) === "push"
         );
         if (result !== true) {
           if (previousHotkey) {
@@ -1352,7 +1411,7 @@ class HotkeyManager extends EventEmitter {
               previousHotkey,
               "dictation",
               callback,
-              this.activationMode === "push"
+              this.getActivationMode(previousHotkey) === "push"
             );
             if (restored === true) {
               debugLogger.log(`[HotkeyManager] Restored previous KDE hotkey "${previousHotkey}"`);

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3852,7 +3852,7 @@ class IPCHandlers {
           );
           await hotkeyManager.hyprlandManager.registerKeybinding(
             effectiveHotkey,
-            this.windowManager.getActivationMode() === "push"
+            this.windowManager.getActivationMode(effectiveHotkey) === "push"
           );
         }
 
@@ -3866,7 +3866,7 @@ class IPCHandlers {
             effectiveHotkey,
             "dictation",
             callback,
-            this.windowManager.getActivationMode() === "push"
+            this.windowManager.getActivationMode(effectiveHotkey) === "push"
           );
           if (result !== true) {
             debugLogger.warn(
@@ -4610,6 +4610,10 @@ class IPCHandlers {
 
     ipcMain.handle("get-activation-mode", async () => {
       return this.environmentManager.getActivationMode();
+    });
+
+    ipcMain.handle("get-activation-modes", async () => {
+      return this.environmentManager.getActivationModes();
     });
 
     ipcMain.handle("save-activation-mode", async (event, mode) => {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -546,8 +546,8 @@ class WindowManager {
         return;
       }
 
-      const activationMode = this.getActivationMode();
       const currentHotkey = triggeredHotkey || this.hotkeyManager.getCurrentHotkey?.();
+      const activationMode = this.getActivationMode(currentHotkey);
 
       if (process.platform === "linux" && activationMode === "push") {
         if (phase === "down") {
@@ -1022,8 +1022,11 @@ class WindowManager {
     }
   }
 
-  getActivationMode() {
-    return this._cachedActivationMode;
+  getActivationMode(hotkey) {
+    return (
+      this.hotkeyManager.getActivationMode?.(hotkey, this._cachedActivationMode) ??
+      this._cachedActivationMode
+    );
   }
 
   async setActivationModeCache(mode) {
@@ -1034,6 +1037,10 @@ class WindowManager {
     return true;
   }
 
+  async setActivationModesCache(modes) {
+    return await this.hotkeyManager.setActivationModes(modes);
+  }
+
   /**
    * Sync the native low-level key listeners (Windows/Linux) so every hotkey slot
    * that needs one is watched. Call after any change to a slot hotkey or the
@@ -1042,15 +1049,16 @@ class WindowManager {
   reconcileNativeKeyListeners() {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     if (this.hotkeyManager.isInListeningMode()) return;
-    const activationMode = this.getActivationMode();
-    const nativeListenerKeys = this.hotkeyManager.getNativeListenerKeys(activationMode);
+    const nativeListenerKeys = this.hotkeyManager.getNativeListenerKeys(this._cachedActivationMode);
     // Native desktop shortcuts replace the low-level listener in tap mode. In
     // push mode, keep the dictation listener as a release-event fallback; the
     // push state machine makes duplicate backend and low-level phases harmless.
     const keys = this.hotkeyManager.isUsingNativeShortcut()
-      ? activationMode === "push"
-        ? nativeListenerKeys.filter((key) => this.hotkeyManager.slotHasHotkey("dictation", key))
-        : []
+      ? nativeListenerKeys.filter(
+          (key) =>
+            this.hotkeyManager.slotHasHotkey("dictation", key) &&
+            this.getActivationMode(key) === "push"
+        )
       : nativeListenerKeys;
     if (process.platform === "win32" && this.windowsKeyManager) {
       this.windowsKeyManager.setKeys(keys);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -60,6 +60,8 @@ export interface HotkeySettings {
   voiceAgentKey: string;
   meetingHotkeyLayoutMode: "side-panel" | "full-width";
   activationMode: "tap" | "push";
+  activationModeByHotkey: Record<string, "tap" | "push">;
+  setActivationModeForHotkey: (hotkey: string, mode: "tap" | "push") => void;
 }
 
 export interface OnboardingSettings {
@@ -352,6 +354,8 @@ function useSettingsInternal() {
     setTheme: store.setTheme,
     activationMode: store.activationMode,
     setActivationMode: store.setActivationMode,
+    activationModeByHotkey: store.activationModeByHotkey,
+    setActivationModeForHotkey: store.setActivationModeForHotkey,
     notificationsEnabled: store.notificationsEnabled,
     setNotificationsEnabled: store.setNotificationsEnabled,
     notifyMeetingDetection: store.notifyMeetingDetection,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -27,6 +27,7 @@ import {
   type InferenceScopeStoreKeys,
 } from "../config/inferenceScopes";
 import { normalizeChineseScriptPreference } from "../utils/chineseScript";
+import { parseHotkeyList } from "../utils/hotkeys";
 import { adjustBedrockModelForRegion } from "../utils/bedrockRegions";
 import modelRegistryData from "../models/modelRegistryData.json";
 import {
@@ -181,6 +182,31 @@ function readNumber(key: string, fallback: number): number {
   if (!isBrowser) return fallback;
   const parsed = parseInt(localStorage.getItem(key) ?? "", 10);
   return isNaN(parsed) ? fallback : parsed;
+}
+
+type ActivationMode = "tap" | "push";
+
+function readActivationModes(): Record<string, ActivationMode> {
+  if (!isBrowser) return {};
+  try {
+    const parsed = JSON.parse(localStorage.getItem("activationModeByHotkey") || "{}");
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([hotkey, mode]) => typeof hotkey === "string" && (mode === "tap" || mode === "push")
+      )
+    ) as Record<string, ActivationMode>;
+  } catch {
+    return {};
+  }
+}
+
+function retainActivationModes(
+  modes: Record<string, ActivationMode>,
+  dictationKey: string
+): Record<string, ActivationMode> {
+  const hotkeys = new Set(parseHotkeyList(dictationKey));
+  return Object.fromEntries(Object.entries(modes).filter(([hotkey]) => hotkeys.has(hotkey)));
 }
 
 // Durations offered by the mic warm-hold select; unknown values snap to 0 (off)
@@ -461,6 +487,19 @@ function migrateUploadTranscription() {
 }
 
 migrateUploadTranscription();
+
+function migrateActivationModesByHotkey() {
+  if (!isBrowser || localStorage.getItem("_activationModesByHotkeyMigrated") === "1") return;
+  const mode: ActivationMode = readString("activationMode", "tap") === "push" ? "push" : "tap";
+  const hotkeys = parseHotkeyList(readString("dictationKey", ""));
+  localStorage.setItem(
+    "activationModeByHotkey",
+    JSON.stringify(Object.fromEntries(hotkeys.map((hotkey) => [hotkey, mode])))
+  );
+  localStorage.setItem("_activationModesByHotkeyMigrated", "1");
+}
+
+migrateActivationModesByHotkey();
 
 function migrateAgentMode() {
   if (!isBrowser) return;
@@ -922,6 +961,7 @@ export interface SettingsState
   setOnboardingUseCaseNote: (note: string) => void;
   setSpokenLanguages: (languages: string[]) => void;
   setActivationMode: (mode: "tap" | "push") => void;
+  setActivationModeForHotkey: (hotkey: string, mode: "tap" | "push") => void;
 
   setPreferBuiltInMic: (value: boolean) => void;
   setMicrophoneSelectionMode: (mode: MicrophoneSelectionMode) => void;
@@ -1317,6 +1357,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     : "full-width") as "side-panel" | "full-width",
   activationMode: (readString("activationMode", "tap") === "push" ? "push" : "tap") as
     "tap" | "push",
+  activationModeByHotkey: readActivationModes(),
 
   microphoneSelectionMode: (() => {
     const mode = readString("microphoneSelectionMode", "system");
@@ -2007,10 +2048,16 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   setDictationKey: (key: string) => {
     if (isBrowser) localStorage.setItem("dictationKey", key);
-    set({ dictationKey: key });
+    const nextModes = retainActivationModes(
+      useSettingsStore.getState().activationModeByHotkey,
+      key
+    );
+    if (isBrowser) localStorage.setItem("activationModeByHotkey", JSON.stringify(nextModes));
+    set({ dictationKey: key, activationModeByHotkey: nextModes });
     if (isBrowser) {
       window.electronAPI?.notifyHotkeyChanged?.(key);
       window.electronAPI?.saveDictationKey?.(key);
+      window.electronAPI?.notifyActivationModesChanged?.(nextModes);
     }
   },
   setMeetingKey: (key: string) => {
@@ -2046,10 +2093,26 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   },
 
   setActivationMode: (mode: "tap" | "push") => {
+    const validMode: ActivationMode = mode === "push" ? "push" : "tap";
+    const hotkeys = parseHotkeyList(useSettingsStore.getState().dictationKey);
+    const nextModes = Object.fromEntries(hotkeys.map((hotkey) => [hotkey, validMode]));
     if (isBrowser) localStorage.setItem("activationMode", mode);
-    set({ activationMode: mode });
+    if (isBrowser) localStorage.setItem("activationModeByHotkey", JSON.stringify(nextModes));
+    set({ activationMode: validMode, activationModeByHotkey: nextModes });
     if (isBrowser) {
-      window.electronAPI?.notifyActivationModeChanged?.(mode);
+      window.electronAPI?.notifyActivationModeChanged?.(validMode);
+      window.electronAPI?.notifyActivationModesChanged?.(nextModes);
+    }
+  },
+  setActivationModeForHotkey: (hotkey: string, mode: "tap" | "push") => {
+    if (!hotkey) return;
+    const validMode: ActivationMode = mode === "push" ? "push" : "tap";
+    const current = useSettingsStore.getState();
+    const nextModes = { ...current.activationModeByHotkey, [hotkey]: validMode };
+    if (isBrowser) localStorage.setItem("activationModeByHotkey", JSON.stringify(nextModes));
+    set({ activationModeByHotkey: nextModes });
+    if (isBrowser) {
+      window.electronAPI?.notifyActivationModesChanged?.(nextModes);
     }
   },
 
@@ -3134,6 +3197,21 @@ export async function initializeSettings(): Promise<void> {
     } catch (err) {
       logger.warn(
         "Failed to sync activation mode on startup",
+        { error: (err as Error).message },
+        "settings"
+      );
+    }
+
+    try {
+      const envModes = await window.electronAPI.getActivationModes?.();
+      if (envModes && Object.keys(envModes).length > 0) {
+        const nextModes = retainActivationModes(envModes, useSettingsStore.getState().dictationKey);
+        if (isBrowser) localStorage.setItem("activationModeByHotkey", JSON.stringify(nextModes));
+        useSettingsStore.setState({ activationModeByHotkey: nextModes });
+      }
+    } catch (err) {
+      logger.warn(
+        "Failed to sync per-hotkey activation modes on startup",
         { error: (err as Error).message },
         "settings"
       );

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3204,7 +3204,7 @@ export async function initializeSettings(): Promise<void> {
 
     try {
       const envModes = await window.electronAPI.getActivationModes?.();
-      if (envModes && Object.keys(envModes).length > 0) {
+      if (envModes) {
         const nextModes = retainActivationModes(envModes, useSettingsStore.getState().dictationKey);
         if (isBrowser) localStorage.setItem("activationModeByHotkey", JSON.stringify(nextModes));
         useSettingsStore.setState({ activationModeByHotkey: nextModes });

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1935,6 +1935,7 @@ declare global {
       // Activation mode persistence (file-based for reliable startup)
       getActivationMode?: () => Promise<"tap" | "push">;
       saveActivationMode?: (mode: "tap" | "push") => Promise<void>;
+      getActivationModes?: () => Promise<Record<string, "tap" | "push">>;
 
       // Debug logging
       getLogLevel?: () => Promise<string>;
@@ -1992,6 +1993,7 @@ declare global {
 
       // Windows Push-to-Talk notifications
       notifyActivationModeChanged?: (mode: "tap" | "push") => void;
+      notifyActivationModesChanged?: (modes: Record<string, "tap" | "push">) => void;
       notifyHotkeyChanged?: (hotkey: string) => void;
       registerMeetingHotkey?: (hotkey: string) => Promise<{ success: boolean; message?: string }>;
       notifyFloatingIconAutoHideChanged?: (enabled: boolean) => void;

--- a/test/helpers/hotkeyActivationMode.test.js
+++ b/test/helpers/hotkeyActivationMode.test.js
@@ -44,3 +44,20 @@ test("a failed activation-mode registration preserves Tap and notifies the user"
   assert.equal(failures.length, 1);
   assert.equal(failures[0].hotkey, "Alt+R");
 });
+
+test("per-hotkey modes fall back to the legacy mode for unconfigured hotkeys", async () => {
+  const manager = new HotkeyManager();
+  manager.currentHotkey = "F8";
+
+  assert.equal(await manager.setActivationModes({ F8: "push" }), true);
+  assert.equal(manager.getActivationMode("F8"), "push");
+  assert.equal(manager.getActivationMode("F9"), "tap");
+});
+
+test("Globe and Fn share the same native listener activation mode", async () => {
+  const manager = new HotkeyManager();
+  manager.currentHotkey = "Fn";
+
+  assert.equal(await manager.setActivationModes({ Fn: "push" }), true);
+  assert.equal(manager.getActivationMode("GLOBE"), "push");
+});

--- a/test/helpers/nativeListenerKeys.test.js
+++ b/test/helpers/nativeListenerKeys.test.js
@@ -64,6 +64,13 @@ test("push mode watches every dictation hotkey, including regular keys", () => {
   assert.deepEqual(mgr.getNativeListenerKeys("push").sort(), ["Control+Shift+R", "F8"]);
 });
 
+test("per-hotkey modes only watch dictation hotkeys configured for Hold", () => {
+  const mgr = makeManager({ dictation: ["F8", "Control+Shift+R"] });
+  mgr.activationModes = { F8: "push", "Control+Shift+R": "tap" };
+
+  assert.deepEqual(mgr.getNativeListenerKeys("tap"), ["F8"]);
+});
+
 test("membership and lookup helpers work across multi-hotkey slots", () => {
   const mgr = makeManager({
     dictation: ["GLOBE", "Control+Shift+R"],

--- a/test/helpers/settingsStoreLocalProviderMigrations.test.js
+++ b/test/helpers/settingsStoreLocalProviderMigrations.test.js
@@ -33,3 +33,34 @@ test("provider migrations classify every registry local provider as local", asyn
     assert.equal(state.chatAgentMode, "local", `${providerId}: chatAgentMode`);
   }
 });
+
+test("main-process activation modes replace a stale renderer map even when empty", async (t) => {
+  const { storage } = installBrowserGlobals(t, {
+    initialStorage: {
+      dictationKey: "F8",
+      activationMode: "tap",
+      activationModeByHotkey: JSON.stringify({ F8: "push" }),
+    },
+    window: {
+      electronAPI: {
+        getActivationMode: async () => "tap",
+        getActivationModes: async () => ({}),
+        setDictionary: async () => {},
+      },
+    },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-activation-mode-sync-test-",
+    mockModules: {
+      "/utils/agentName": "export const ensureAgentNameInDictionary = () => {};",
+    },
+  });
+  const { initializeSettings, useSettingsStore } = await vite.ssrLoadModule(
+    "/stores/settingsStore.ts"
+  );
+
+  await initializeSettings();
+
+  assert.deepEqual(useSettingsStore.getState().activationModeByHotkey, {});
+  assert.equal(storage.getItem("activationModeByHotkey"), "{}");
+});


### PR DESCRIPTION
## Summary

- Adds independent Tap/Hold selection for each configured dictation hotkey.
- Retains the legacy global activation mode as the fallback and migration source.
- Keeps mappings synchronized between renderer and the main-process native listener configuration.

## Platform behavior

- Treats macOS Fn and Globe as aliases for the same native listener.
- Preserves Linux native-listener constraints and falls back safely when registration is unavailable.

## Validation

- Covers hotkey-aware mode resolution, native-key aliasing, startup synchronization, and registration failure behavior.

Closes #1860

<!-- watchtower:copilot-session=a1eba9e7-b3ff-4d0a-9733-9c0d5c8328e8 -->
