### PR TITLE
fix(transcription): boost quiet audio before parakeet decode

### DIFF
--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -267,6 +267,28 @@ function computeFloat32RMS(float32Buffer) {
   return Math.sqrt(sumSquares / numSamples);
 }
 
+// Scales samples in place toward targetRms, capped so no sample exceeds
+// maxPeak. Never attenuates. Returns the gain applied (1 = unchanged).
+function boostFloat32SamplesToRms(float32Buffer, targetRms, maxPeak) {
+  const numSamples = float32Buffer.length / 4;
+  const rms = computeFloat32RMS(float32Buffer);
+  if (numSamples === 0 || rms === 0) return 1;
+
+  let peak = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const val = Math.abs(float32Buffer.readFloatLE(i * 4));
+    if (val > peak) peak = val;
+  }
+
+  const gain = Math.min(targetRms / rms, maxPeak / peak);
+  if (gain <= 1) return 1;
+
+  for (let i = 0; i < numSamples; i++) {
+    float32Buffer.writeFloatLE(float32Buffer.readFloatLE(i * 4) * gain, i * 4);
+  }
+  return gain;
+}
+
 function parseFfmpegDuration(stderr) {
   const match = stderr?.match(/Duration:\s*(\d+):([0-5]\d):([0-5]\d(?:\.\d+)?)/);
   if (!match) return null;
@@ -463,6 +485,7 @@ module.exports = {
   parseFfmpegDuration,
   wavToFloat32Samples,
   computeFloat32RMS,
+  boostFloat32SamplesToRms,
   mergeAudioSegments,
   clearCache,
 };

--- a/src/helpers/parakeetServer.js
+++ b/src/helpers/parakeetServer.js
@@ -9,6 +9,7 @@ const {
   convertToWav,
   wavToFloat32Samples,
   computeFloat32RMS,
+  boostFloat32SamplesToRms,
 } = require("./ffmpegUtils");
 const { getSafeTempDir } = require("./safeTempDir");
 const { createAbortError } = require("./abortError");
@@ -30,6 +31,15 @@ const COHERE_MAX_SEGMENT_SECONDS = 30;
 // bound only caps memory when transcribing very long files.
 const ONLINE_MAX_SEGMENT_SECONDS = 600;
 const SILENCE_RMS_THRESHOLD = 0.001;
+// Quiet-but-audible recordings (quiet mics, no OS input AGC) make the int8
+// parakeet transducers deterministically decode segments longer than ~12s to
+// empty text, while short segments still decode — the final transcript keeps
+// only the tail of the dictation, and retrying cannot heal it (#1435). Boosting
+// the decode-time samples to normal speech level avoids the failure entirely;
+// the recording saved to history is untouched.
+const QUIET_RMS_THRESHOLD = 0.02;
+const QUIET_BOOST_TARGET_RMS = 0.08;
+const QUIET_BOOST_MAX_PEAK = 0.95;
 
 class ParakeetServerManager {
   constructor() {
@@ -141,6 +151,24 @@ class ParakeetServerManager {
         return { text: "", elapsed: 0 };
       }
 
+      let appliedGain = 1;
+      if (rms < QUIET_RMS_THRESHOLD) {
+        appliedGain = boostFloat32SamplesToRms(
+          samples,
+          QUIET_BOOST_TARGET_RMS,
+          QUIET_BOOST_MAX_PEAK
+        );
+        if (appliedGain > 1) {
+          debugLogger.debug("Parakeet boosted quiet audio for decode", {
+            rms,
+            appliedGain,
+          });
+        }
+      }
+      // Segment RMS is measured on boosted samples, so the silence cutoff
+      // scales with the gain — boosted room noise must still read as silence.
+      const segmentSilenceRms = SILENCE_RMS_THRESHOLD * appliedGain;
+
       const maxSegmentSeconds =
         runtime === "online"
           ? ONLINE_MAX_SEGMENT_SECONDS
@@ -179,7 +207,7 @@ class ParakeetServerManager {
         const segment = samples.subarray(offset, end);
         let result = await this.wsServer.transcribe(segment, SAMPLE_RATE, { signal });
         totalElapsed += result.elapsed || 0;
-        if (!result.text && computeFloat32RMS(segment) >= SILENCE_RMS_THRESHOLD) {
+        if (!result.text && computeFloat32RMS(segment) >= segmentSilenceRms) {
           throwIfAborted();
           // An empty decode of audible audio silently amputates the transcript
           // (#1435: dictation openings dropped); retry once before conceding.

--- a/test/helpers/parakeetServer.test.js
+++ b/test/helpers/parakeetServer.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const ParakeetServerManager = require("../../src/helpers/parakeetServer");
+const { computeFloat32RMS } = require("../../src/helpers/ffmpegUtils");
 
 const SAMPLE_RATE = 16000;
 const SEGMENT_BYTES = 15 * SAMPLE_RATE * 4; // float32, mirrors MAX_SEGMENT_SECONDS
@@ -26,7 +27,7 @@ function wavFromSeconds(spans) {
   buf.writeUInt32LE(dataSize, 40);
   let offset = 44;
   for (const span of spans) {
-    const amplitude = span.silent ? 0 : 8000;
+    const amplitude = span.silent ? 0 : (span.amplitude ?? 8000);
     for (let i = 0; i < span.seconds * SAMPLE_RATE; i++) {
       buf.writeInt16LE(i % 2 === 0 ? amplitude : -amplitude, offset);
       offset += 2;
@@ -129,6 +130,67 @@ test("a silent segment decoding to empty is not retried or flagged", async () =>
   assert.equal(result.text, "alpha omega");
   assert.ok(!result.truncated, "silence is not data loss");
   assert.equal(fake.calls.length, 3);
+});
+
+test("quiet-but-audible audio is boosted to normal speech level before decode", async () => {
+  const received = [];
+  const fake = fakeWsServer([{ text: "hello" }], {
+    onCall: () => {},
+  });
+  const innerTranscribe = fake.transcribe;
+  fake.transcribe = async (samplesBuffer, ...rest) => {
+    received.push(Buffer.from(samplesBuffer));
+    return innerTranscribe(samplesBuffer, ...rest);
+  };
+  const manager = managerWith(fake);
+
+  // 150/32768 ≈ 0.0046 RMS: inside the empty-decode band, above the silence gate.
+  const result = await manager.transcribe(wavFromSeconds([{ seconds: 10, amplitude: 150 }]));
+
+  assert.equal(result.text, "hello");
+  const decodedRms = computeFloat32RMS(received[0]);
+  assert.ok(
+    Math.abs(decodedRms - 0.08) < 0.005,
+    `expected decode-time RMS near the boost target, got ${decodedRms}`
+  );
+});
+
+test("normal-level audio is decoded unmodified", async () => {
+  const received = [];
+  const fake = fakeWsServer([{ text: "hello" }]);
+  const innerTranscribe = fake.transcribe;
+  fake.transcribe = async (samplesBuffer, ...rest) => {
+    received.push(Buffer.from(samplesBuffer));
+    return innerTranscribe(samplesBuffer, ...rest);
+  };
+  const manager = managerWith(fake);
+
+  await manager.transcribe(wavFromSeconds([{ seconds: 10 }]));
+
+  const decodedRms = computeFloat32RMS(received[0]);
+  assert.ok(
+    Math.abs(decodedRms - 8000 / 32768) < 0.01,
+    `expected decode-time RMS unchanged, got ${decodedRms}`
+  );
+});
+
+test("boosted room noise still reads as silence in the segment loop", async () => {
+  // 15s of quiet speech then 16s of sub-silence-gate noise. The boost lifts the
+  // noise above the unscaled gate, so an unscaled cutoff would retry the empty
+  // noise segments and falsely flag truncation.
+  const fake = fakeWsServer([{ text: "alpha" }, { text: "" }, { text: "" }]);
+  const manager = managerWith(fake);
+
+  const result = await manager.transcribe(
+    wavFromSeconds([
+      { seconds: 15, amplitude: 150 },
+      { seconds: 16, amplitude: 20 },
+    ])
+  );
+
+  assert.equal(result.text, "alpha");
+  assert.ok(!result.truncated, "boosted noise is not data loss");
+  assert.equal(fake.calls.length, 3, "empty noise segments must not be retried");
 });
 
 test("a pre-aborted signal rejects before any decode is issued", async () => {


### PR DESCRIPTION
Addresses #1435 (Parakeet path).

**Problem:** Quiet recordings (RMS below ~-40 dB — quiet mic, no OS input gain) make the int8 Parakeet models deterministically decode any segment longer than ~12s as empty text, so long dictations paste as just the last sentence while the live preview (1.5s chunks) shows everything. Deterministic per input, which is why the retry from #1462 never heals it and re-transcribing reproduces it.

**Fix:** When a recording passes the silence gate but sits below RMS 0.02, boost the decode-time samples to normal speech level (target RMS 0.08, peak-capped at 0.95 so nothing clips). Constant gain per recording, applied only to the buffer sent to sherpa-onnx — saved audio, echo detection, and mic gating are untouched. The segment-loop silence cutoff scales with the applied gain so boosted room noise still reads as silence.

**Trade-offs:**
- Noise is amplified as much as speech: near-silent recordings that used to return "No audio detected" may now decode noise into spurious words (preview included).
- A single transient spike (click/pop) caps the gain via the peak limit and silently disables the boost. A percentile-based peak would close this; kept simple for now.

**Decisions / open questions:**
- Threshold (0.02) and target (0.08) are empirical from one voice; observed failures topped out at RMS 0.010, so there's 2x margin — but we could instead always normalize toward the target and remove the cliff.
- Same symptom is reported on local Whisper in #1435; this PR only covers Parakeet. Decide whether to port the boost to the whisper path.
- The underlying int8 decode bug should be reported upstream to sherpa-onnx; this is a workaround.

**Testing:**
- Repro: 21.5s three-sentence clip at 0.1x volume → before: only last sentence survives; after: full transcript (verified end-to-end against the real sherpa server with parakeet-unified-en-0.6b; tdt-0.6b-v3 fails/recovers identically).
- 3 new unit tests (boost applied, normal audio unmodified, boosted noise not flagged truncated); full suite passes.
- Still needed: confirmation from an affected user's machine (real quiet-mic hardware, Linux/Windows), and a hallucination spot-check on noise-only recordings.