### PR TITLE
fix: route Custom BYOK transcription through main process net.fetch()

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -562,6 +562,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   proxyCortiTranscription: (data) => ipcRenderer.invoke("proxy-corti-transcription", data),
   getTinfoilChatModels: () => ipcRenderer.invoke("get-tinfoil-chat-models"),
   proxyTinfoilTranscription: (data) => ipcRenderer.invoke("proxy-tinfoil-transcription", data),
+  proxyCustomTranscription: (data) => ipcRenderer.invoke("proxy-custom-transcription", data),
 
   // Custom endpoint API keys
   getCustomTranscriptionKey: () => ipcRenderer.invoke("get-custom-transcription-key"),

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -408,6 +408,16 @@ const PROXY_TRANSCRIPTION_PROVIDERS = {
       tenant: (apiSettings.cortiTenant || "").trim() || "base",
     }),
   },
+  custom: {
+    displayName: "Custom",
+    ipc: () => window.electronAPI?.proxyCustomTranscription,
+    buildPayload: ({ audioBuffer, model, language, apiSettings, dictionaryPrompt }) => ({
+      audioBuffer,
+      model,
+      language,
+      prompt: dictionaryPrompt || undefined,
+    }),
+  },
 };
 
 class AudioManager {

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -4241,6 +4241,60 @@ class IPCHandlers {
       })
     );
 
+    // Custom BYOK endpoints are proxied through main to avoid Chromium's
+    // renderer fetch() which can fail with ERR_CONNECTION_REFUSED on some
+    // servers due to differences in DNS resolution and TLS handling.
+    ipcMain.handle(
+      "proxy-custom-transcription",
+      serializeIpcError(async (event, { audioBuffer, model, language, prompt }) => {
+        const settings = this.settingsManager.getAllSettings();
+        const rawUrl = (settings.cloudTranscriptionBaseUrl || "").trim();
+        if (!rawUrl) {
+          throw new Error("Custom transcription endpoint is not configured");
+        }
+
+        const { normalizeBaseUrl, buildApiUrl, isAzureOpenAIEndpoint, isSecureHttpEndpoint } =
+          require("./config/constants");
+        const { buildBatchEndpoint } = require("./transcriptionRoute");
+
+        const base = normalizeBaseUrl(rawUrl);
+        if (!base || !isSecureHttpEndpoint(base)) {
+          throw new Error("Custom transcription endpoint URL is invalid or unsupported");
+        }
+
+        const endpoint = buildBatchEndpoint(rawUrl, base, model || "whisper-1");
+        const apiKey = this.environmentManager.getCustomTranscriptionKey();
+
+        const formData = new FormData();
+        const audioBlob = new Blob([Buffer.from(audioBuffer)], { type: "audio/webm" });
+        formData.append("file", audioBlob, "audio.webm");
+        formData.append("model", model || "whisper-1");
+        if (language && language !== "auto") {
+          formData.append("language", language);
+        }
+        if (prompt) {
+          formData.append("prompt", prompt);
+        }
+
+        const headers = {};
+        if (apiKey) {
+          if (isAzureOpenAIEndpoint(base)) {
+            headers["api-key"] = apiKey;
+          } else {
+            headers.Authorization = `Bearer ${apiKey}`;
+          }
+        }
+
+        const response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Custom endpoint Error: ${response.status} ${errorText}`);
+        }
+
+        return await response.json();
+      })
+    );
+
     // Gemini's Interactions API takes JSON with inline base64 audio, not
     // OpenAI-compatible multipart, so batch transcription is proxied through main.
     ipcMain.handle(

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1852,6 +1852,12 @@ declare global {
         language?: string;
         prompt?: string;
       }) => Promise<ProxyTranscriptionResult>;
+      proxyCustomTranscription?: (data: {
+        audioBuffer: ArrayBuffer;
+        model?: string;
+        language?: string;
+        prompt?: string;
+      }) => Promise<ProxyTranscriptionResult>;
 
       // Custom endpoint API keys
       getCustomTranscriptionKey?: () => Promise<string | null>;


### PR DESCRIPTION
## Problem

The Custom BYOK transcription endpoint uses the renderer's `fetch()` (Chromium's network stack) instead of the main process's `net.fetch()` (Node.js network stack). This causes `net::ERR_CONNECTION_REFUSED` for servers that accept connections from Node.js but not from Chromium, due to differences in:

- DNS resolution (Chromium uses async DNS resolver)
- TLS handling (BoringSSL vs OpenSSL)
- System proxy routing

## Solution

Route Custom BYOK endpoint transcription through the main process using `net.fetch()`, consistent with how other proxied providers (Tinfoil, Mistral, Gemini, xAI, Corti) already work.

## Changes

| File | Change |
|------|--------|
| `audioManager.js` | Add `custom` to `PROXY_TRANSCRIPTION_PROVIDERS` map |
| `ipcHandlers.js` | Add `proxy-custom-transcription` IPC handler using `proxyFetch()` |
| `preload.js` | Add IPC bridge for the new handler |
| `electron.ts` | Add TypeScript type for the new IPC method |

## Testing

- [x] Custom endpoint transcription works via main process net.fetch()
- [x] Custom endpoint API key is correctly resolved from settings
- [x] Azure and standard Bearer auth are both supported
- [x] Language and prompt parameters are forwarded correctly