### PR TITLE
fix: improve mixed-language cleanup and local ASR guidance

### DIFF
--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -18,6 +18,7 @@ import {
   TranscriptionProviderData,
   WHISPER_MODEL_INFO,
   PARAKEET_MODEL_INFO,
+  getParakeetLanguageCompatibility,
   isCohereTranscribeModel,
   isSherpaLocalProvider,
 } from "../models/ModelRegistry";
@@ -41,6 +42,7 @@ import { API_ENDPOINTS, normalizeBaseUrl } from "../config/constants";
 import { GetApiKeyLink } from "./ui/GetApiKeyLink";
 import { getCachedPlatform } from "../utils/platform";
 import logger from "../utils/logger";
+import { getLanguageLabel } from "../utils/languageSupport";
 import type { ParakeetCheckResult } from "../types/electron";
 
 interface LocalModel {
@@ -63,6 +65,7 @@ interface LocalModelCardProps {
   recommended?: boolean;
   provider: string;
   languageLabel?: string;
+  isLanguageUnsupported?: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onDownload: () => void;
@@ -84,6 +87,7 @@ function LocalModelCard({
   recommended,
   provider,
   languageLabel,
+  isLanguageUnsupported,
   onSelect,
   onDelete,
   onDownload,
@@ -92,7 +96,7 @@ function LocalModelCard({
 }: LocalModelCardProps) {
   const { t } = useTranslation();
   const handleClick = () => {
-    if (isDownloaded && !isSelected) {
+    if (isDownloaded && !isSelected && !isLanguageUnsupported) {
       onSelect();
     }
   };
@@ -100,9 +104,12 @@ function LocalModelCard({
   return (
     <div
       onClick={handleClick}
+      aria-disabled={isLanguageUnsupported || undefined}
       className={`relative w-full text-left overflow-hidden rounded-md border transition-colors duration-200 group ${
         isSelected ? cardStyles.modelCard.selected : cardStyles.modelCard.default
-      } ${isDownloaded && !isSelected ? "cursor-pointer" : ""}`}
+      } ${isDownloaded && !isSelected && !isLanguageUnsupported ? "cursor-pointer" : ""} ${
+        isLanguageUnsupported ? "opacity-60" : ""
+      }`}
     >
       <div className="flex items-center gap-1.5 p-2">
         <div className="shrink-0">
@@ -133,7 +140,14 @@ function LocalModelCard({
             <span className={cardStyles.badges.recommended}>{t("common.recommended")}</span>
           )}
           {languageLabel && (
-            <span className="text-xs text-muted-foreground/50 font-medium shrink-0">
+            <span
+              title={languageLabel}
+              className={`max-w-44 truncate text-xs font-medium shrink-0 ${
+                isLanguageUnsupported
+                  ? "text-amber-600 dark:text-amber-400"
+                  : "text-muted-foreground/50"
+              }`}
+            >
               {languageLabel}
             </span>
           )}
@@ -389,6 +403,7 @@ export default function TranscriptionModelPicker({
   const customTranscriptionApiKey = useSettingsStore((s) => s.customTranscriptionApiKey);
   const setCustomTranscriptionApiKey = useSettingsStore((s) => s.setCustomTranscriptionApiKey);
   const isSignedIn = useSettingsStore((s) => s.isSignedIn);
+  const preferredLanguage = useSettingsStore((s) => s.preferredLanguage);
   const effectiveLocal = mode === "local" ? true : mode === "cloud" ? false : useLocalWhisper;
   const [localModels, setLocalModels] = useState<LocalModel[]>([]);
   const [parakeetModels, setParakeetModels] = useState<LocalModel[]>([]);
@@ -1103,6 +1118,23 @@ export default function TranscriptionModelPicker({
             language: "en",
             recommended: false,
           };
+          const languageCompatibility = getParakeetLanguageCompatibility(
+            modelId,
+            preferredLanguage
+          );
+          const isLanguageUnsupported =
+            languageCompatibility === "language-required" ||
+            languageCompatibility === "unsupported";
+          let languageLabel: string | undefined;
+          if (languageCompatibility === "english-only") {
+            languageLabel = t("transcription.modelCompatibility.englishOnly");
+          } else if (languageCompatibility === "language-required") {
+            languageLabel = t("transcription.modelCompatibility.chooseLanguage");
+          } else if (languageCompatibility === "unsupported") {
+            languageLabel = t("transcription.modelCompatibility.unsupported", {
+              language: getLanguageLabel(preferredLanguage),
+            });
+          }
 
           return (
             <LocalModelCard
@@ -1119,6 +1151,8 @@ export default function TranscriptionModelPicker({
               isInstalling={isInstallingParakeet}
               recommended={info.recommended}
               provider={provider}
+              languageLabel={languageLabel}
+              isLanguageUnsupported={isLanguageUnsupported}
               onSelect={() => handleParakeetModelSelect(modelId)}
               onDelete={() => handleParakeetDelete(modelId)}
               onDownload={() =>
@@ -1126,7 +1160,7 @@ export default function TranscriptionModelPicker({
                   setParakeetModels((prev) =>
                     prev.map((m) => (m.model === downloadedId ? { ...m, downloaded: true } : m))
                   );
-                  handleParakeetModelSelect(downloadedId);
+                  if (!isLanguageUnsupported) handleParakeetModelSelect(downloadedId);
                 })
               }
               onCancel={cancelParakeetDownload}

--- a/src/config/languageRegistry.json
+++ b/src/config/languageRegistry.json
@@ -1,5 +1,5 @@
 {
-  "_genericTemplate": "LANGUAGE CONTEXT: The user's preferred language is set to \"{{code}}\". Detect the language of the transcribed text and write your output in that same language. Maintain proper grammar, spelling, and punctuation for the target language. If the user naturally uses English words or technical terms, preserve those as-is.",
+  "_genericTemplate": "LANGUAGE PRESERVATION (required): Keep the same sequence of language spans as the input, including code-switches in either direction. Apply the requested cleanup only within each span’s existing language; do not translate or transliterate. Keep names, quotations, loanwords, and technical terms in their original language, using Custom Dictionary spellings when provided. Preserve each script unless a selected orthography rule applies to that language. If a span’s language or wording is uncertain, copy it unchanged.",
   "languages": [
     {
       "code": "auto",
@@ -7,8 +7,7 @@
       "flag": "\uD83C\uDF10",
       "whisper": false,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The language preference is set to auto-detect. Detect the language of the transcribed text and write your entire output in that same language. Maintain consistent language throughout your output."
+      "assemblyai": false
     },
     {
       "code": "af",
@@ -24,8 +23,7 @@
       "flag": "\uD83C\uDDF8\uD83C\uDDE6",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Arabic. The transcribed text will be in Arabic. You MUST write your entire output in Arabic while maintaining proper Arabic grammar and punctuation. Preserve any English technical terms as the user spoke them."
+      "assemblyai": false
     },
     {
       "code": "hy",
@@ -65,8 +63,7 @@
       "flag": "\uD83C\uDDE7\uD83C\uDDEC",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Bulgarian. The transcribed text will be in Bulgarian. You MUST write your entire output in Bulgarian while maintaining proper Bulgarian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "ca",
@@ -74,8 +71,7 @@
       "flag": "\uD83C\uDDEA\uD83C\uDDF8",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Catalan. The transcribed text will be in Catalan. You MUST write your entire output in Catalan while maintaining proper Catalan grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "zh-CN",
@@ -84,7 +80,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Simplified Chinese (简体中文). The transcribed text will be in Chinese. You MUST write your entire output in Simplified Chinese while maintaining proper grammar and punctuation. Use simplified characters throughout (e.g., 简体, 语言, 学习). Preserve any English technical terms as the user spoke them."
+      "orthographyInstruction": "For Chinese spans, use simplified characters when correcting them."
     },
     {
       "code": "zh-TW",
@@ -93,7 +89,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Traditional Chinese (繁體中文). The transcribed text will be in Chinese. You MUST write your entire output in Traditional Chinese while maintaining proper grammar and punctuation. Use traditional characters throughout (e.g., 繁體, 語言, 學習). Preserve any English technical terms as the user spoke them."
+      "orthographyInstruction": "For Chinese spans, use traditional characters when correcting them."
     },
     {
       "code": "hr",
@@ -101,8 +97,7 @@
       "flag": "\uD83C\uDDED\uD83C\uDDF7",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Croatian. The transcribed text will be in Croatian. You MUST write your entire output in Croatian while maintaining proper Croatian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "cs",
@@ -110,8 +105,7 @@
       "flag": "\uD83C\uDDE8\uD83C\uDDFF",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Czech. The transcribed text will be in Czech. You MUST write your entire output in Czech while maintaining proper Czech grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "da",
@@ -119,8 +113,7 @@
       "flag": "\uD83C\uDDE9\uD83C\uDDF0",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Danish. The transcribed text will be in Danish. You MUST write your entire output in Danish while maintaining proper Danish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "nl",
@@ -128,8 +121,7 @@
       "flag": "\uD83C\uDDF3\uD83C\uDDF1",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Dutch. The transcribed text will be in Dutch. You MUST write your entire output in Dutch while maintaining proper Dutch grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "en-US",
@@ -138,7 +130,7 @@
       "whisper": true,
       "parakeet": true,
       "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is American English. You MUST use American English spelling conventions throughout your output (e.g., \"color\" not \"colour\", \"organize\" not \"organise\", \"center\" not \"centre\", \"defense\" not \"defence\", \"analyze\" not \"analyse\")."
+      "orthographyInstruction": "For English corrections, use American spelling conventions."
     },
     {
       "code": "en-GB",
@@ -147,7 +139,7 @@
       "whisper": true,
       "parakeet": true,
       "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is British English. You MUST use British English spelling conventions throughout your output (e.g., \"colour\" not \"color\", \"organise\" not \"organize\", \"centre\" not \"center\", \"defence\" not \"defense\", \"analyse\" not \"analyze\")."
+      "orthographyInstruction": "For English corrections, use British spelling conventions."
     },
     {
       "code": "et",
@@ -155,8 +147,7 @@
       "flag": "\uD83C\uDDEA\uD83C\uDDEA",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Estonian. The transcribed text will be in Estonian. You MUST write your entire output in Estonian while maintaining proper Estonian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "fi",
@@ -164,8 +155,7 @@
       "flag": "\uD83C\uDDEB\uD83C\uDDEE",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Finnish. The transcribed text will be in Finnish. You MUST write your entire output in Finnish while maintaining proper Finnish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "fr",
@@ -173,8 +163,7 @@
       "flag": "\uD83C\uDDEB\uD83C\uDDF7",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is French. The transcribed text will be in French. You MUST write your entire output in French while maintaining proper French grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their French speech, preserve those as-is."
+      "assemblyai": true
     },
     {
       "code": "gl",
@@ -190,8 +179,7 @@
       "flag": "\uD83C\uDDE9\uD83C\uDDEA",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is German. The transcribed text will be in German. You MUST write your entire output in German while maintaining proper German grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their German speech, preserve those as-is."
+      "assemblyai": true
     },
     {
       "code": "el",
@@ -199,8 +187,7 @@
       "flag": "\uD83C\uDDEC\uD83C\uDDF7",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Greek. The transcribed text will be in Greek. You MUST write your entire output in Greek while maintaining proper Greek grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "he",
@@ -208,8 +195,7 @@
       "flag": "\uD83C\uDDEE\uD83C\uDDF1",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Hebrew. The transcribed text will be in Hebrew. You MUST write your entire output in Hebrew while maintaining proper Hebrew grammar and punctuation. Preserve any English technical terms as the user spoke them."
+      "assemblyai": false
     },
     {
       "code": "hi",
@@ -217,8 +203,7 @@
       "flag": "\uD83C\uDDEE\uD83C\uDDF3",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Hindi. The transcribed text will be in Hindi. You MUST write your entire output in Hindi while maintaining proper Hindi grammar and punctuation. If the user mixes Hindi and English (Hinglish), preserve that natural code-switching."
+      "assemblyai": false
     },
     {
       "code": "hu",
@@ -226,8 +211,7 @@
       "flag": "\uD83C\uDDED\uD83C\uDDFA",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Hungarian. The transcribed text will be in Hungarian. You MUST write your entire output in Hungarian while maintaining proper Hungarian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "is",
@@ -243,8 +227,7 @@
       "flag": "\uD83C\uDDEE\uD83C\uDDE9",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Indonesian. The transcribed text will be in Indonesian. You MUST write your entire output in Indonesian while maintaining proper Indonesian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "it",
@@ -252,8 +235,7 @@
       "flag": "\uD83C\uDDEE\uD83C\uDDF9",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Italian. The transcribed text will be in Italian. You MUST write your entire output in Italian while maintaining proper Italian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their Italian speech, preserve those as-is."
+      "assemblyai": true
     },
     {
       "code": "ja",
@@ -262,7 +244,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Japanese. The transcribed text will be in Japanese. You MUST write your entire output in Japanese while maintaining proper Japanese grammar and punctuation. Preserve any English loanwords (katakana) or technical terms as the user spoke them."
+      "orthographyInstruction": "Preserve Japanese scripts, including katakana loanwords, as spoken."
     },
     {
       "code": "kn",
@@ -287,7 +269,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Korean. The transcribed text will be in Korean. You MUST write your entire output in Korean while maintaining proper Korean grammar and punctuation. Preserve any English loanwords or technical terms as the user spoke them."
+      "orthographyInstruction": "Preserve Korean and English loanwords in their spoken scripts."
     },
     {
       "code": "lv",
@@ -295,8 +277,7 @@
       "flag": "\uD83C\uDDF1\uD83C\uDDFB",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Latvian. The transcribed text will be in Latvian. You MUST write your entire output in Latvian while maintaining proper Latvian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "lt",
@@ -304,8 +285,7 @@
       "flag": "\uD83C\uDDF1\uD83C\uDDF9",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Lithuanian. The transcribed text will be in Lithuanian. You MUST write your entire output in Lithuanian while maintaining proper Lithuanian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "mk",
@@ -361,8 +341,7 @@
       "flag": "\uD83C\uDDF3\uD83C\uDDF4",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Norwegian. The transcribed text will be in Norwegian. You MUST write your entire output in Norwegian while maintaining proper Norwegian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "fa",
@@ -370,8 +349,7 @@
       "flag": "\uD83C\uDDEE\uD83C\uDDF7",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Persian. The transcribed text will be in Persian. You MUST write your entire output in Persian while maintaining proper Persian grammar and punctuation. Preserve any English technical terms as the user spoke them."
+      "assemblyai": false
     },
     {
       "code": "pl",
@@ -379,8 +357,7 @@
       "flag": "\uD83C\uDDF5\uD83C\uDDF1",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Polish. The transcribed text will be in Polish. You MUST write your entire output in Polish while maintaining proper Polish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "pt",
@@ -388,8 +365,7 @@
       "flag": "\uD83C\uDDF5\uD83C\uDDF9",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Portuguese. The transcribed text will be in Portuguese. You MUST write your entire output in Portuguese while maintaining proper Portuguese grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their Portuguese speech, preserve those as-is."
+      "assemblyai": true
     },
     {
       "code": "ro",
@@ -397,8 +373,7 @@
       "flag": "\uD83C\uDDF7\uD83C\uDDF4",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Romanian. The transcribed text will be in Romanian. You MUST write your entire output in Romanian while maintaining proper Romanian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "ru",
@@ -406,8 +381,7 @@
       "flag": "\uD83C\uDDF7\uD83C\uDDFA",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Russian. The transcribed text will be in Russian. You MUST write your entire output in Russian while maintaining proper Russian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their Russian speech, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "sr",
@@ -415,8 +389,7 @@
       "flag": "\uD83C\uDDF7\uD83C\uDDF8",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Serbian. The transcribed text will be in Serbian. You MUST write your entire output in Serbian while maintaining proper Serbian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "sk",
@@ -424,8 +397,7 @@
       "flag": "\uD83C\uDDF8\uD83C\uDDF0",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Slovak. The transcribed text will be in Slovak. You MUST write your entire output in Slovak while maintaining proper Slovak grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "sl",
@@ -433,8 +405,7 @@
       "flag": "\uD83C\uDDF8\uD83C\uDDEE",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Slovenian. The transcribed text will be in Slovenian. You MUST write your entire output in Slovenian while maintaining proper Slovenian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "es",
@@ -442,8 +413,7 @@
       "flag": "\uD83C\uDDEA\uD83C\uDDF8",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": true,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Spanish. The transcribed text will be in Spanish. You MUST write your entire output in Spanish while maintaining proper Spanish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms within their Spanish speech (code-switching), preserve those as-is."
+      "assemblyai": true
     },
     {
       "code": "sw",
@@ -459,8 +429,7 @@
       "flag": "\uD83C\uDDF8\uD83C\uDDEA",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Swedish. The transcribed text will be in Swedish. You MUST write your entire output in Swedish while maintaining proper Swedish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "tl",
@@ -484,8 +453,7 @@
       "flag": "\uD83C\uDDF9\uD83C\uDDED",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Thai. The transcribed text will be in Thai. You MUST write your entire output in Thai while maintaining proper Thai grammar and punctuation. Preserve any English technical terms as the user spoke them."
+      "assemblyai": false
     },
     {
       "code": "tr",
@@ -493,8 +461,7 @@
       "flag": "\uD83C\uDDF9\uD83C\uDDF7",
       "whisper": true,
       "parakeet": false,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Turkish. The transcribed text will be in Turkish. You MUST write your entire output in Turkish while maintaining proper Turkish grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "uk",
@@ -502,8 +469,7 @@
       "flag": "\uD83C\uDDFA\uD83C\uDDE6",
       "whisper": true,
       "parakeet": true,
-      "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Ukrainian. The transcribed text will be in Ukrainian. You MUST write your entire output in Ukrainian while maintaining proper Ukrainian grammar, spelling, and punctuation. If the user naturally uses English words or technical terms, preserve those as-is."
+      "assemblyai": false
     },
     {
       "code": "ur",
@@ -520,7 +486,7 @@
       "whisper": true,
       "parakeet": false,
       "assemblyai": false,
-      "instruction": "LANGUAGE CONTEXT: The user's preferred language is Vietnamese. The transcribed text will be in Vietnamese. You MUST write your entire output in Vietnamese while maintaining proper Vietnamese grammar, spelling, and diacritics. Preserve any English technical terms as the user spoke them."
+      "orthographyInstruction": "Preserve Vietnamese diacritics when correcting Vietnamese spans."
     },
     {
       "code": "cy",

--- a/src/config/prompts/index.ts
+++ b/src/config/prompts/index.ts
@@ -17,7 +17,7 @@ export interface ResolvePromptOptions {
 export function resolvePrompt(kind: PromptKind, opts: ResolvePromptOptions): string {
   const custom = useSettingsStore.getState().customPrompts[kind];
   const template = custom || getDefaultPromptText(kind, opts.uiLanguage);
-  return applySubstitutions(template, opts);
+  return applySubstitutions(kind, template, opts);
 }
 
 export function getDefaultPromptText(kind: PromptKind, uiLanguage?: string): string {
@@ -58,7 +58,11 @@ export function appendDictionarySuffix(
   return prompt + suffix + customDictionary.join(", ");
 }
 
-function applySubstitutions(template: string, opts: ResolvePromptOptions): string {
+function applySubstitutions(
+  kind: PromptKind,
+  template: string,
+  opts: ResolvePromptOptions
+): string {
   const name = opts.agentName?.trim() || "Assistant";
   let prompt = template.replace(/\{\{agentName\}\}/g, name);
 
@@ -66,8 +70,8 @@ function applySubstitutions(template: string, opts: ResolvePromptOptions): strin
     prompt = prompt.replace(/\{\{targetLanguage\}\}/g, opts.targetLanguageLabel);
   }
 
-  const langInstruction = getLanguageInstruction(opts.language);
-  if (langInstruction) prompt += "\n\n" + langInstruction;
+  const langInstruction = kind === "cleanup" ? getLanguageInstruction(opts.language) : "";
+  if (langInstruction) prompt = langInstruction + "\n\n" + prompt;
 
   return appendDictionarySuffix(prompt, opts.customDictionary, opts.uiLanguage);
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Nicht verfügbar"
     },
+    "modelCompatibility": {
+      "englishOnly": "Nur Englisch",
+      "unsupported": "Unterstützt {{language}} nicht",
+      "chooseLanguage": "Wähle eine unterstützte Sprache"
+    },
     "apiKeyOptional": "API-Schlüssel (optional)",
     "getKey": "Schlüssel holen ->",
     "endpointUrl": "Endpoint-URL",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Unavailable"
     },
+    "modelCompatibility": {
+      "englishOnly": "English only",
+      "unsupported": "Doesn't support {{language}}",
+      "chooseLanguage": "Choose a supported language"
+    },
     "apiKeyOptional": "API Key (Optional)",
     "getKey": "Get key ->",
     "endpointUrl": "Endpoint URL",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "No disponible"
     },
+    "modelCompatibility": {
+      "englishOnly": "Solo inglés",
+      "unsupported": "No admite {{language}}",
+      "chooseLanguage": "Elige un idioma compatible"
+    },
     "apiKeyOptional": "Clave API (opcional)",
     "getKey": "Obtener clave ->",
     "endpointUrl": "URL del endpoint",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Indisponible"
     },
+    "modelCompatibility": {
+      "englishOnly": "Anglais uniquement",
+      "unsupported": "Ne prend pas en charge {{language}}",
+      "chooseLanguage": "Choisissez une langue prise en charge"
+    },
     "apiKeyOptional": "Clé API (optionnelle)",
     "getKey": "Obtenir la clé ->",
     "endpointUrl": "URL du endpoint",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Non disponibile"
     },
+    "modelCompatibility": {
+      "englishOnly": "Solo inglese",
+      "unsupported": "Non supporta {{language}}",
+      "chooseLanguage": "Scegli una lingua supportata"
+    },
     "apiKeyOptional": "Chiave API (opzionale)",
     "getKey": "Ottieni chiave ->",
     "endpointUrl": "URL endpoint",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "利用不可"
     },
+    "modelCompatibility": {
+      "englishOnly": "英語のみ",
+      "unsupported": "{{language}}には対応していません",
+      "chooseLanguage": "対応言語を選択してください"
+    },
     "apiKeyOptional": "API キー（任意）",
     "getKey": "キーを取得 ->",
     "endpointUrl": "エンドポイント URL",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -788,6 +788,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Indisponível"
     },
+    "modelCompatibility": {
+      "englishOnly": "Apenas inglês",
+      "unsupported": "Não oferece suporte a {{language}}",
+      "chooseLanguage": "Escolha um idioma compatível"
+    },
     "apiKeyOptional": "Chave API (opcional)",
     "getKey": "Obter chave ->",
     "endpointUrl": "URL do endpoint",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "Недоступно"
     },
+    "modelCompatibility": {
+      "englishOnly": "Только английский",
+      "unsupported": "Не поддерживает {{language}}",
+      "chooseLanguage": "Выберите поддерживаемый язык"
+    },
     "apiKeyOptional": "API-ключ (необязательно)",
     "getKey": "Получить ключ ->",
     "endpointUrl": "URL конечной точки",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "不可用"
     },
+    "modelCompatibility": {
+      "englishOnly": "仅支持英语",
+      "unsupported": "不支持{{language}}",
+      "chooseLanguage": "请选择支持的语言"
+    },
     "apiKeyOptional": "API Key（可选）",
     "getKey": "获取密钥 ->",
     "endpointUrl": "端点 URL",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -809,6 +809,11 @@
       "requiresMacOS": "macOS {{version}}+",
       "unavailable": "無法使用"
     },
+    "modelCompatibility": {
+      "englishOnly": "僅支援英文",
+      "unsupported": "不支援{{language}}",
+      "chooseLanguage": "請選擇支援的語言"
+    },
     "apiKeyOptional": "API Key（選填）",
     "getKey": "取得金鑰 ->",
     "endpointUrl": "端點 URL",

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -525,6 +525,25 @@ export function getParakeetModelInfo(modelId: string): ParakeetModelInfo | undef
   return modelData.parakeetModels[modelId];
 }
 
+export type ParakeetLanguageCompatibility =
+  "compatible" | "english-only" | "language-required" | "unsupported";
+
+export function getParakeetLanguageCompatibility(
+  modelId: string,
+  language: string
+): ParakeetLanguageCompatibility {
+  const model = getParakeetModelInfo(modelId);
+  if (!model) return "compatible";
+
+  const baseLanguage = language === "auto" ? "" : language.split("-")[0].toLowerCase();
+  if (!baseLanguage) {
+    if (model.modelType === "cohere-transcribe") return "language-required";
+    return model.language === "en" ? "english-only" : "compatible";
+  }
+  if (!model.supportedLanguages.includes(baseLanguage)) return "unsupported";
+  return model.language === "en" ? "english-only" : "compatible";
+}
+
 export function isOnlineParakeetModel(modelId: string): boolean {
   return modelData.parakeetModels[modelId]?.runtime === "online";
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -354,7 +354,7 @@ const clampVadValue = (key: WhisperVadKey, raw: unknown): number => {
   return round ? Math.round(clamped) : clamped;
 };
 
-const LANGUAGE_MIGRATIONS: Record<string, string> = { zh: "zh-CN" };
+const LANGUAGE_MIGRATIONS: Record<string, string> = { zh: "zh-CN", en: "en-US" };
 
 function migratePreferredLanguage() {
   if (!isBrowser) return;

--- a/src/utils/languageSupport.ts
+++ b/src/utils/languageSupport.ts
@@ -15,13 +15,13 @@ function buildLanguageSet(key: "whisper" | "assemblyai"): Set<string> {
 const WHISPER_LANGUAGES = buildLanguageSet("whisper");
 const ASSEMBLYAI_UNIVERSAL3_PRO_LANGUAGES = buildLanguageSet("assemblyai");
 
-const LANGUAGE_INSTRUCTIONS: Record<string, string> = Object.fromEntries(
+const ORTHOGRAPHY_INSTRUCTIONS: Record<string, string> = Object.fromEntries(
   registry.languages
     .filter(
-      (l): l is typeof l & { instruction: string } =>
-        "instruction" in l && typeof l.instruction === "string"
+      (l): l is typeof l & { orthographyInstruction: string } =>
+        "orthographyInstruction" in l && typeof l.orthographyInstruction === "string"
     )
-    .map((l) => [l.code, l.instruction])
+    .map((l) => [l.code, l.orthographyInstruction])
 );
 
 export function getBaseLanguageCode(language: string | null | undefined): string | undefined {
@@ -31,12 +31,8 @@ export function getBaseLanguageCode(language: string | null | undefined): string
 
 export function getLanguageInstruction(language: string | undefined): string {
   if (!language) return "";
-  return LANGUAGE_INSTRUCTIONS[language] || buildGenericInstruction(language);
-}
-
-function buildGenericInstruction(langCode: string): string {
-  const template = registry._genericTemplate || "";
-  return template.replace("{{code}}", langCode);
+  const orthographyInstruction = ORTHOGRAPHY_INSTRUCTIONS[language];
+  return [registry._genericTemplate, orthographyInstruction].filter(Boolean).join(" ");
 }
 
 export function getLanguageLabel(code: string | null | undefined): string {

--- a/test/helpers/modelRegistryProviderFallback.test.js
+++ b/test/helpers/modelRegistryProviderFallback.test.js
@@ -30,6 +30,31 @@ test("non-registry ids of every local family fall back to the local provider", a
   }
 });
 
+test("Parakeet compatibility distinguishes auto and unsupported languages", async (t) => {
+  installBrowserGlobals(t, {
+    initialStorage: { _providerSettingsMigrated: "1", cleanupMode: "local" },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-model-language-compatibility-test-",
+  });
+  const { getParakeetLanguageCompatibility } = await vite.ssrLoadModule("/models/ModelRegistry.ts");
+
+  assert.equal(
+    getParakeetLanguageCompatibility("parakeet-unified-en-0.6b", "auto"),
+    "english-only"
+  );
+  assert.equal(getParakeetLanguageCompatibility("parakeet-unified-en-0.6b", "ar"), "unsupported");
+  assert.equal(getParakeetLanguageCompatibility("parakeet-tdt-0.6b-v3", "fr"), "compatible");
+  assert.equal(
+    getParakeetLanguageCompatibility("cohere-transcribe-03-2026", "auto"),
+    "language-required"
+  );
+  assert.equal(
+    getParakeetLanguageCompatibility("cohere-transcribe-03-2026", "zh-TW"),
+    "compatible"
+  );
+});
+
 test("gemma fallback does not capture gemini ids or registry cloud gemma models", async (t) => {
   installBrowserGlobals(t, {
     initialStorage: { _providerSettingsMigrated: "1", cleanupMode: "local" },

--- a/test/helpers/settingsStoreLocalProviderMigrations.test.js
+++ b/test/helpers/settingsStoreLocalProviderMigrations.test.js
@@ -8,6 +8,18 @@ const modelRegistryData = require("../../src/models/modelRegistryData.json");
 // list used to be hand-maintained and missed `liquidai` when LFM landed
 // (#1176), so a legacy LFM selection would have migrated to `providers`. Every
 // registry local provider must classify as local in both migrations.
+test("persisted English language preference migrates to US English", async (t) => {
+  const { storage } = installBrowserGlobals(t);
+  storage.setItem("preferredLanguage", "en");
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-preferred-language-migration-test-",
+  });
+
+  const { useSettingsStore } = await vite.ssrLoadModule("/stores/settingsStore.ts");
+  assert.equal(storage.getItem("preferredLanguage"), "en-US");
+  assert.equal(useSettingsStore.getState().preferredLanguage, "en-US");
+});
+
 test("provider migrations classify every registry local provider as local", async (t) => {
   const localProviderIds = modelRegistryData.localProviders.map((provider) => provider.id);
   assert.ok(localProviderIds.includes("liquidai"), "the regression case must be in the registry");


### PR DESCRIPTION
## Summary
This is a best-effort mitigation for #1412.

Some ASR models do not reliably support mixed-language speech. English-only models cannot transcribe other languages, and multilingual models may still favor the selected or dominant language. Once text is lost or mistranscribed during ASR, the cleanup model cannot reliably reconstruct the original speech.

OpenWhispr could amplify this behavior by adding cleanup instructions that required the entire output to use the selected transcription language. These instructions were assembled into the same system prompt as the user's custom cleanup prompt, creating conflicting guidance.

## Changes
   - Replaced the forced output-language instruction with a general language-preservation policy.
   - Preserved code-switches, scripts, names, quotations, loanwords, and technical terms.
   - Scoped orthography rules to matching language spans only.
   - Placed automatic language guidance before the custom cleanup prompt, allowing intentional user instructions to take priority.
   - Added local ASR model compatibility guidance to the model picker.
   - Kept incompatible models visible and downloadable, but prevented unsupported combinations from being selected automatically.
   - Added localized compatibility messages and focused compatibility tests.

## Limitations
This does not guarantee correct mixed-language transcription. It can only preserve language that reaches cleanup correctly; it cannot recover speech already lost by the ASR model.

The cleanup prompt changes currently apply to BYOK and local cleanup. Managed OpenWhispr Cloud cleanup requires corresponding server-side behavior.

@Chadpiha, this is intentionally a best-effort mitigation rather than a complete ASR-level fix.

closes #1412 