### PR TITLE
fix(dictation): stop restacking the pill on every live transcript chunk

### DIFF
--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1319,8 +1319,13 @@ class WindowManager {
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     this.mainWindow.webContents.send("preview-text", text);
     this._sendAgentDictationPreview("preview-text", text);
-    this.mainWindow.showInactive();
-    this.enforceMainWindowOnTop();
+    // Partial results arrive many times per second. Re-showing the already
+    // visible pill and re-applying always-on-top makes Windows restack and
+    // reposition the overlay on every chunk (#1262). Surface it only once.
+    if (!this.mainWindow.isVisible()) {
+      this.mainWindow.showInactive();
+      this.enforceMainWindowOnTop();
+    }
   }
 
   appendTranscriptionPreview(text) {

--- a/test/helpers/windowManagerAssistantPanel.test.js
+++ b/test/helpers/windowManagerAssistantPanel.test.js
@@ -286,6 +286,7 @@ test("live transcript events are mirrored to the companion only for plain dictat
   manager._agentDictationPillReady = true;
   manager.mainWindow = {
     isDestroyed: () => false,
+    isVisible: () => true,
     showInactive: () => undefined,
     webContents: { send: (channel, payload) => mainMessages.push({ channel, payload }) },
   };
@@ -307,6 +308,41 @@ test("live transcript events are mirrored to the companion only for plain dictat
     { channel: "preview-text", payload: "plain" },
   ]);
   assert.deepEqual(companionMessages, [{ channel: "preview-text", payload: "plain" }]);
+});
+
+test("live transcript updates do not restack an already visible dictation window", async () => {
+  const manager = new WindowManager();
+  const calls = [];
+  manager.setOnboardingActive(false);
+  manager.mainWindow = {
+    isDestroyed: () => false,
+    isVisible: () => true,
+    showInactive: () => calls.push("showInactive"),
+    webContents: { send: () => undefined },
+  };
+  manager.enforceMainWindowOnTop = () => calls.push("onTop");
+
+  await manager.showTranscriptionPreview("one");
+  await manager.showTranscriptionPreview("two");
+
+  assert.deepEqual(calls, []);
+});
+
+test("the first live transcript update still surfaces a hidden dictation window", async () => {
+  const manager = new WindowManager();
+  const calls = [];
+  manager.setOnboardingActive(false);
+  manager.mainWindow = {
+    isDestroyed: () => false,
+    isVisible: () => false,
+    showInactive: () => calls.push("showInactive"),
+    webContents: { send: () => undefined },
+  };
+  manager.enforceMainWindowOnTop = () => calls.push("onTop");
+
+  await manager.showTranscriptionPreview("hello");
+
+  assert.deepEqual(calls, ["showInactive", "onTop"]);
 });
 
 test("opening the assistant panel surfaces a hidden pill window before focusing it", () => {


### PR DESCRIPTION
## Summary
- Live transcription preview still called `showInactive()` and re-applied always-on-top on **every** partial result, even after the renderer started buffering/measuring text.
- On Windows that restacks the already-visible dictation pill, which is the remaining cause of the overlay jumping around while you talk.
- Surface and z-order the window only when it is hidden; later chunks just send `preview-text`.

Fixes #1262

## Test plan
- [ ] Enable Live Transcription Preview, start dictation, speak for several seconds: the pill should stay put (grow for new lines is fine; it should not hop or flicker).
- [ ] Confirm a hidden pill still appears on the first preview update.
- [ ] `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/windowManagerAssistantPanel.test.js`