### PR TITLE
fix(macos): resolve ffmpeg and ffprobe from Nix-managed prefixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -362,9 +362,12 @@ const AUTH_BRIDGE_HOST = "127.0.0.1";
 const AUTH_BRIDGE_PORT = parseAuthBridgePort();
 const AUTH_BRIDGE_PATH = "/oauth/callback";
 
-// Set up PATH for production builds to find system tools (whisper.cpp, ffmpeg)
+// Set up PATH for production builds to find system tools (whisper.cpp, ffmpeg,
+// ffprobe). GUI launch never sources shell rc, so Nix prefixes are otherwise
+// invisible even when the binaries exist on disk (#912).
 function setupProductionPath() {
   if (process.platform === "darwin" && process.env.NODE_ENV !== "development") {
+    const { getUnixToolBinDirs } = require("./src/helpers/unixToolBinDirs");
     const commonPaths = [
       "/usr/local/bin",
       "/opt/homebrew/bin",
@@ -372,10 +375,11 @@ function setupProductionPath() {
       "/bin",
       "/usr/sbin",
       "/sbin",
+      ...getUnixToolBinDirs({ platform: "darwin" }),
     ];
 
     const currentPath = process.env.PATH || "";
-    const pathsToAdd = commonPaths.filter((p) => !currentPath.includes(p));
+    const pathsToAdd = [...new Set(commonPaths)].filter((p) => !currentPath.includes(p));
 
     if (pathsToAdd.length > 0) {
       process.env.PATH = `${currentPath}:${pathsToAdd.join(":")}`;

--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -4,6 +4,7 @@ const os = require("os");
 const path = require("path");
 const debugLogger = require("./debugLogger");
 const { createAbortError } = require("./abortError");
+const { getSystemFfmpegCandidates } = require("./unixToolBinDirs");
 
 let cachedFFmpegPath = null;
 
@@ -57,12 +58,7 @@ function getFFmpegPath() {
     debugLogger.debug("Bundled FFmpeg not available", { error: err.message });
   }
 
-  const systemCandidates =
-    process.platform === "darwin"
-      ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-      : process.platform === "win32"
-        ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-        : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
+  const systemCandidates = getSystemFfmpegCandidates();
 
   for (const candidate of systemCandidates) {
     if (fs.existsSync(candidate)) {

--- a/src/helpers/unixToolBinDirs.js
+++ b/src/helpers/unixToolBinDirs.js
@@ -1,0 +1,37 @@
+const os = require("os");
+const path = require("path");
+
+// GUI-launched Electron never sources the user's shell rc, so Nix and Homebrew
+// prefixes are missing from PATH even when the tools are installed. Keep the
+// extra dirs in one place for ffmpeg resolution and production PATH setup.
+function getUnixToolBinDirs({
+  platform = process.platform,
+  env = process.env,
+  homedir = os.homedir(),
+} = {}) {
+  const dirs = [];
+  if (platform === "darwin") {
+    dirs.push("/opt/homebrew/bin", "/usr/local/bin");
+  } else if (platform === "linux") {
+    dirs.push("/usr/bin", "/usr/local/bin");
+  }
+
+  dirs.push("/run/current-system/sw/bin");
+  const home = env.HOME || homedir || "";
+  if (home) {
+    dirs.push(path.join(home, ".nix-profile", "bin"));
+    dirs.push(path.join(home, ".local", "state", "nix", "profile", "bin"));
+  }
+  dirs.push("/nix/var/nix/profiles/default/bin");
+  return [...new Set(dirs)];
+}
+
+function getSystemFfmpegCandidates(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    return ["C:\\ffmpeg\\bin\\ffmpeg.exe"];
+  }
+  return getUnixToolBinDirs(options).map((dir) => path.join(dir, "ffmpeg"));
+}
+
+module.exports = { getUnixToolBinDirs, getSystemFfmpegCandidates };

--- a/src/helpers/whisper.js
+++ b/src/helpers/whisper.js
@@ -13,6 +13,7 @@ const {
 const WhisperServerManager = require("./whisperServer");
 const { createAbortError } = require("./abortError");
 const { getModelsDirForService } = require("./modelDirUtils");
+const { getSystemFfmpegCandidates } = require("./unixToolBinDirs");
 
 const modelRegistryData = require("../models/modelRegistryData.json");
 
@@ -850,12 +851,7 @@ class WhisperManager {
     }
 
     // Try system FFmpeg paths
-    const systemCandidates =
-      process.platform === "darwin"
-        ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-        : process.platform === "win32"
-          ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-          : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
+    const systemCandidates = getSystemFfmpegCandidates();
 
     debugLogger.debug("Trying system FFmpeg candidates", { candidates: systemCandidates });
 

--- a/src/helpers/whisperServer.js
+++ b/src/helpers/whisperServer.js
@@ -13,6 +13,7 @@ const { convertToWav } = require("./ffmpegUtils");
 const { createAbortError } = require("./abortError");
 const sidecarPidFile = require("./sidecarPidFile");
 const { BIN_SUBDIR: CUDA_BIN_SUBDIR } = require("./whisperCudaManager");
+const { getSystemFfmpegCandidates } = require("./unixToolBinDirs");
 const { BIN_SUBDIR: VULKAN_BIN_SUBDIR } = require("./whisperVulkanManager");
 const { sanitizeWhisperVadConfig, DEFAULT_WHISPER_VAD_CONFIG } = require("./whisperVadConfig");
 const {
@@ -365,12 +366,7 @@ class WhisperServerManager extends EventEmitter {
     }
 
     // Try system FFmpeg locations
-    const systemCandidates =
-      process.platform === "darwin"
-        ? ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"]
-        : process.platform === "win32"
-          ? ["C:\\ffmpeg\\bin\\ffmpeg.exe"]
-          : ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg"];
+    const systemCandidates = getSystemFfmpegCandidates();
 
     for (const candidate of systemCandidates) {
       if (fs.existsSync(candidate)) {

--- a/test/helpers/unixToolBinDirs.test.js
+++ b/test/helpers/unixToolBinDirs.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("path");
+
+const {
+  getUnixToolBinDirs,
+  getSystemFfmpegCandidates,
+} = require("../../src/helpers/unixToolBinDirs");
+
+test("macOS candidates include Homebrew and nix-darwin prefixes", () => {
+  const dirs = getUnixToolBinDirs({
+    platform: "darwin",
+    env: { HOME: "/Users/ada" },
+    homedir: "/Users/ada",
+  });
+
+  assert.ok(dirs.includes("/opt/homebrew/bin"));
+  assert.ok(dirs.includes("/usr/local/bin"));
+  assert.ok(dirs.includes("/run/current-system/sw/bin"));
+  assert.ok(dirs.includes(path.join("/Users/ada", ".nix-profile", "bin")));
+  assert.ok(dirs.includes("/nix/var/nix/profiles/default/bin"));
+  assert.ok(
+    getSystemFfmpegCandidates({ platform: "darwin", env: { HOME: "/Users/ada" } }).includes(
+      "/run/current-system/sw/bin/ffmpeg"
+    )
+  );
+});
+
+test("Linux candidates include system bins and NixOS current-system", () => {
+  const dirs = getUnixToolBinDirs({
+    platform: "linux",
+    env: { HOME: "/home/ada" },
+    homedir: "/home/ada",
+  });
+
+  assert.ok(dirs.includes("/usr/bin"));
+  assert.ok(dirs.includes("/run/current-system/sw/bin"));
+  assert.equal(getSystemFfmpegCandidates({ platform: "win32" })[0], "C:\\ffmpeg\\bin\\ffmpeg.exe");
+});


### PR DESCRIPTION
## Summary
- GUI-launched Electron never sources `~/.zshrc`, so nix-darwin ffmpeg at `/run/current-system/sw/bin` is invisible even though it is installed.
- Shared resolver now probes Homebrew plus Nix prefixes (`current-system`, `~/.nix-profile`, default profile) for ffmpeg, and production `PATH` setup on macOS includes the same dirs so yt-dlp can find sibling `ffprobe`.
- Does not spawn a login shell; keeps the previous Homebrew/system candidates.

Fixes #912

## Test plan
- [ ] On a nix-darwin Mac with ffmpeg only on `/run/current-system/sw/bin`, launch the packaged app from Finder (not a terminal) and dictate: local conversion should find ffmpeg.
- [ ] URL/file flows that need ffprobe should succeed when ffprobe sits next to that ffmpeg.
- [ ] `node --test test/helpers/unixToolBinDirs.test.js`