### PR TITLE
fix(transcription): pass measured audio duration to speaker merge in file transcription (#1997)

### DIFF
--- a/src/services/fileTranscription.ts
+++ b/src/services/fileTranscription.ts
@@ -210,7 +210,7 @@ export async function transcribeFileWithSpeakers(
     const merged = await window.electronAPI.mergeSpeakerText?.(
       diar.segments,
       result.text,
-      durationSeconds || 0
+      measuredDuration || 0
     );
     if (merged?.success && merged.text) return { ...result, text: merged.text };
   } catch {

--- a/test/services/fileTranscriptionTimestamps.test.js
+++ b/test/services/fileTranscriptionTimestamps.test.js
@@ -61,4 +61,25 @@ test("timestamps opt-in reaches the BYOK IPC call and segments flow back", async
   assert.equal(receivedOptions.timestamps, true);
   assert.deepEqual(withSpeakers.segments, segments);
   assert.equal(withSpeakers.durationSeconds, 120);
+
+  let mergedDurationPassed = null;
+  window.electronAPI.diarizeAudioFile = async () => ({
+    success: true,
+    durationSeconds: 150,
+    segments: [{ speaker: "speaker_0", start: 0, end: 100 }],
+  });
+  window.electronAPI.mergeSpeakerText = async (_segments, text, duration) => {
+    mergedDurationPassed = duration;
+    return { success: true, text: `[Speaker 1] ${text}` };
+  };
+
+  const localDiarizeConfig = { ...byokConfig(), cloudTranscriptionProvider: "groq" };
+  const withMeasuredDuration = await transcribeFileWithSpeakers(
+    "/tmp/audio.webm",
+    localDiarizeConfig,
+    { enabled: true, localModelsReady: true, numSpeakers: null }
+  );
+  assert.equal(mergedDurationPassed, 150);
+  assert.equal(withMeasuredDuration.durationSeconds, 150);
+  assert.equal(withMeasuredDuration.text, "[Speaker 1] Hello.");
 });


### PR DESCRIPTION
## Description

Fixes audio duration propagation in `transcribeFileWithSpeakers` so that when an audio file's duration is measured by the local diarizer (rather than passed upfront), the measured duration is passed to `mergeSpeakerText`.

### Root Cause
When transcribing audio files with speaker diarization enabled, the caller often does not provide an upfront duration (`durationSeconds` is `undefined`). The diarizer measures the converted audio file and populates `measuredDuration` from `diar.durationSeconds`.

However, `mergeSpeakerText` was called with `durationSeconds || 0` instead of `measuredDuration || 0`. Because `0` was passed to the main-process merge handler, `mergeSpeakersWithText` fell back to `maxSegmentEnd` (the end timestamp of the last detected speech segment). When the audio file had trailing silence, music, or outro past the last detected speech segment, sentence midpoints were scaled against a truncated duration, skewing the sentence-to-speaker assignment across the transcript.

### Fix
Pass `measuredDuration || 0` to `window.electronAPI.mergeSpeakerText` in `transcribeFileWithSpeakers`.

## Verification
- Added test coverage in `test/services/fileTranscriptionTimestamps.test.js` confirming that the diarizer's measured duration flows to `mergeSpeakerText`.
- Ran tests: `node --test test/services/fileTranscriptionTimestamps.test.js` (passed)
- Ran linter: `npm run lint` (clean)
- Ran i18n check: `npm run i18n:check` (clean)

Closes #1997