### PR TITLE
fix(utils): prevent duplicate date group headers in groupItemsByDate (#1999)

### DIFF
--- a/src/utils/dateGrouping.ts
+++ b/src/utils/dateGrouping.ts
@@ -23,8 +23,16 @@ export function groupItemsByDate<T>(
   const weekAgo = new Date(today);
   weekAgo.setDate(weekAgo.getDate() - 7);
 
-  const groups: Array<DateGroup<T>> = [];
-  let current: DateGroup<T> | null = null;
+  const bucketOrder = [
+    t("chat.today"),
+    t("chat.yesterday"),
+    t("chat.previousWeek"),
+    t("chat.older"),
+  ];
+  const bucketMap = new Map<string, T[]>();
+  for (const label of bucketOrder) {
+    bucketMap.set(label, []);
+  }
 
   for (const item of items) {
     const date = normalizeDbDate(getDate(item));
@@ -41,11 +49,15 @@ export function groupItemsByDate<T>(
       label = t("chat.older");
     }
 
-    if (!current || current.label !== label) {
-      current = { label, items: [] };
-      groups.push(current);
+    bucketMap.get(label)!.push(item);
+  }
+
+  const groups: Array<DateGroup<T>> = [];
+  for (const label of bucketOrder) {
+    const bucketItems = bucketMap.get(label)!;
+    if (bucketItems.length > 0) {
+      groups.push({ label, items: bucketItems });
     }
-    current.items.push(item);
   }
 
   return groups;

--- a/test/utils/dateGrouping.test.js
+++ b/test/utils/dateGrouping.test.js
@@ -84,3 +84,26 @@ test("SQLite zoneless timestamps are grouped like their UTC instant", async (t2)
   assert.equal(groups.length, 1);
   assert.equal(groups[0].label, "Today");
 });
+
+test("consolidates non-consecutive items into single canonical groups without duplicate headers", async (t2) => {
+  const { groupItemsByDate } = await load();
+  t2.mock.timers.enable({ apis: ["Date"], now: NOON_JUNE_15 });
+
+  const items = [
+    { id: 1, updated_at: localIsoDate(2024, 5, 15, 10) }, // Today
+    { id: 2, updated_at: localIsoDate(2024, 5, 14, 22) }, // Yesterday
+    { id: 3, updated_at: localIsoDate(2024, 5, 15, 8) },  // Today
+    { id: 4, updated_at: localIsoDate(2024, 0, 1, 12) },  // Older
+    { id: 5, updated_at: localIsoDate(2024, 5, 10, 12) }, // Previous 7 days
+  ];
+  const groups = groupItemsByDate(items, (i) => i.updated_at, t);
+
+  assert.deepEqual(
+    groups.map((g) => g.label),
+    ["Today", "Yesterday", "Previous 7 days", "Older"]
+  );
+  assert.deepEqual(
+    groups.map((g) => g.items.map((i) => i.id)),
+    [[1, 3], [2], [5], [4]]
+  );
+});


### PR DESCRIPTION
## Description

Fixes `groupItemsByDate` to collect items into canonical date buckets (Today, Yesterday, Previous 7 days, Older) rather than generating duplicate date group headers when items belonging to the same date bucket are non-consecutive.

### Root Cause
In `src/utils/dateGrouping.ts`, `groupItemsByDate` pushed a new `DateGroup` whenever an item's calculated date bucket label differed from the immediately preceding item's label:

```typescript
if (!current || current.label !== label) {
  current = { label, items: [] };
  groups.push(current);
}
```

If input items were not strictly sorted monotonically by timestamp (e.g., when conversations or overview notes are updated asynchronously, reordered, or contain mixed timestamps), this created duplicate date groups with identical labels (e.g. `[{ label: "Today" }, { label: "Yesterday" }, { label: "Today" }]`), resulting in duplicate headers in `ConversationList` and `OverviewNoteList` as well as duplicate React keys in virtualized lists.

### Fix
Pre-allocate canonical date buckets (Today -> Yesterday -> Previous 7 days -> Older) in a `Map` and append items to their corresponding bucket, then return non-empty groups in canonical order while preserving item order within each group.

## Verification
- Added a regression test in `test/utils/dateGrouping.test.js` confirming non-consecutive items consolidate into single canonical date groups without duplicate headers.
- Ran tests: `node --test test/utils/dateGrouping.test.js` (5/5 passed)
- Ran linter: `npm run lint` (clean)
- Ran i18n check: `npm run i18n:check` (clean)

Closes #1999