### PR TITLE
chore(deps): bump fast-uri to 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8190,9 +8190,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- bump the transitive fast-uri dependency from 3.1.5 to 3.1.7
- resolve the four high-severity host-confusion and SSRF advisories affecting versions through 3.1.5
- keep package.json and the remaining dependency graph unchanged

## Testing
- npm audit --audit-level=high (0 vulnerabilities)
- npm test (3,434 passed, 0 failed, 6 skipped, 1 todo)
- npm run quality-check
- npm run build:renderer