### PR TITLE
fix(build): prevent download scripts from silently failing as release count grows past 50

### DIFF
--- a/scripts/download-meeting-aec-helper.js
+++ b/scripts/download-meeting-aec-helper.js
@@ -18,7 +18,7 @@ const {
 } = require("./lib/download-utils");
 
 const REPO = "OpenWhispr/openwhispr";
-const TAG_PREFIX = "meeting-aec-helper-v";
+const PINNED_TAG = "meeting-aec-helper-v1.0.0";
 const VERSION_OVERRIDE = process.env.MEETING_AEC_HELPER_VERSION || null;
 const BIN_DIR = path.join(__dirname, "..", "resources", "bin");
 
@@ -105,7 +105,7 @@ async function main() {
     console.log("\n[meeting-aec-helper] Fetching latest release...");
   }
   const release = await fetchLatestRelease(REPO, {
-    tagPrefix: VERSION_OVERRIDE || TAG_PREFIX,
+    tag: VERSION_OVERRIDE || PINNED_TAG,
   });
 
   if (!release) {

--- a/scripts/download-text-monitor.js
+++ b/scripts/download-text-monitor.js
@@ -22,7 +22,7 @@ const BIN_DIR = path.join(__dirname, "..", "resources", "bin");
 const PLATFORM_CONFIG = {
   linux: {
     label: "linux-text-monitor",
-    tagPrefix: "linux-text-monitor-v",
+    pinnedTag: "linux-text-monitor-v1.0.0",
     archiveName: "linux-text-monitor-linux-x64.tar.gz",
     binaryName: "linux-text-monitor",
     versionEnv: "LINUX_TEXT_MONITOR_VERSION",
@@ -30,7 +30,7 @@ const PLATFORM_CONFIG = {
   },
   win32: {
     label: "windows-text-monitor",
-    tagPrefix: "windows-text-monitor-v",
+    pinnedTag: "windows-text-monitor-v1.0.0",
     archiveName: "windows-text-monitor-win32-x64.zip",
     binaryName: "windows-text-monitor.exe",
     versionEnv: "WINDOWS_TEXT_MONITOR_VERSION",
@@ -45,7 +45,7 @@ async function main() {
     return;
   }
 
-  const { label, tagPrefix, archiveName, binaryName, versionEnv, compileHint } = config;
+  const { label, pinnedTag, archiveName, binaryName, versionEnv, compileHint } = config;
   const versionOverride = process.env[versionEnv] || null;
   const forceDownload = process.argv.includes("--force");
   const outputPath = path.join(BIN_DIR, binaryName);
@@ -61,11 +61,11 @@ async function main() {
   } else {
     console.log(`\n[${label}] Fetching latest release...`);
   }
-  const tagToFind = versionOverride || tagPrefix;
-  const release = await fetchLatestRelease(REPO, { tagPrefix: tagToFind });
+  const tagToFind = versionOverride || pinnedTag;
+  const release = await fetchLatestRelease(REPO, { tag: tagToFind });
 
   if (!release) {
-    console.error(`[${label}] Could not find a release matching prefix:`, tagPrefix);
+    console.error(`[${label}] Could not find release:`, tagToFind);
     console.log(`[${label}] Auto-learn correction monitoring will be disabled`);
     return;
   }

--- a/scripts/download-windows-fast-paste.js
+++ b/scripts/download-windows-fast-paste.js
@@ -21,7 +21,7 @@ const {
 } = require("./lib/download-utils");
 
 const REPO = "OpenWhispr/openwhispr";
-const TAG_PREFIX = "windows-fast-paste-v";
+const PINNED_TAG = "windows-fast-paste-v2.0.0";
 const ZIP_NAME = "windows-fast-paste-win32-x64.zip";
 const BINARY_NAME = "windows-fast-paste.exe";
 
@@ -74,11 +74,11 @@ async function main() {
   } else {
     console.log("\n[windows-fast-paste] Fetching latest release...");
   }
-  const tagToFind = VERSION_OVERRIDE || TAG_PREFIX;
-  const release = await fetchLatestRelease(REPO, { tagPrefix: tagToFind });
+  const tagToFind = VERSION_OVERRIDE || PINNED_TAG;
+  const release = await fetchLatestRelease(REPO, { tag: tagToFind });
 
   if (!release) {
-    console.error("[windows-fast-paste] Could not find a release matching prefix:", TAG_PREFIX);
+    console.error("[windows-fast-paste] Could not find release:", tagToFind);
     console.log("[windows-fast-paste] Paste will use nircmd/PowerShell fallback");
     return;
   }

--- a/scripts/download-windows-key-listener.js
+++ b/scripts/download-windows-key-listener.js
@@ -20,7 +20,7 @@ const {
 } = require("./lib/download-utils");
 
 const REPO = "OpenWhispr/openwhispr";
-const TAG_PREFIX = "windows-key-listener-v";
+const PINNED_TAG = "windows-key-listener-v1.0.0";
 const ZIP_NAME = "windows-key-listener-win32-x64.zip";
 const BINARY_NAME = "windows-key-listener.exe";
 
@@ -52,11 +52,11 @@ async function main() {
   } else {
     console.log("\n[windows-key-listener] Fetching latest release...");
   }
-  const tagToFind = VERSION_OVERRIDE || TAG_PREFIX;
-  const release = await fetchLatestRelease(REPO, { tagPrefix: tagToFind });
+  const tagToFind = VERSION_OVERRIDE || PINNED_TAG;
+  const release = await fetchLatestRelease(REPO, { tag: tagToFind });
 
   if (!release) {
-    console.error("[windows-key-listener] Could not find a release matching prefix:", TAG_PREFIX);
+    console.error("[windows-key-listener] Could not find release:", tagToFind);
     console.log(
       "[windows-key-listener] Push-to-Talk will use fallback mode (compile locally or tap mode)"
     );

--- a/scripts/download-windows-mic-listener.js
+++ b/scripts/download-windows-mic-listener.js
@@ -81,7 +81,7 @@ async function main() {
 
   const tagToFind = VERSION_OVERRIDE || readPinnedTag();
   console.log(`\n[windows-mic-listener] Using pinned version: ${tagToFind}`);
-  const release = await fetchLatestRelease(REPO, { tagPrefix: tagToFind });
+  const release = await fetchLatestRelease(REPO, { tag: tagToFind });
 
   if (!release) {
     failDownload(`Could not find a release matching: ${tagToFind}`);

--- a/scripts/download-windows-system-audio-helper.js
+++ b/scripts/download-windows-system-audio-helper.js
@@ -20,7 +20,7 @@ const {
 } = require("./lib/download-utils");
 
 const REPO = "OpenWhispr/openwhispr";
-const TAG_PREFIX = "windows-system-audio-helper-v";
+const PINNED_TAG = "windows-system-audio-helper-v1.1.0";
 const ZIP_NAME = "windows-system-audio-helper-win32-x64.zip";
 const BINARY_NAME = "windows-system-audio-helper.exe";
 
@@ -54,13 +54,13 @@ async function main() {
   }
   const release = await fetchLatestRelease(
     REPO,
-    VERSION_OVERRIDE ? { tag: VERSION_OVERRIDE } : { tagPrefix: TAG_PREFIX }
+    VERSION_OVERRIDE ? { tag: VERSION_OVERRIDE } : { tag: PINNED_TAG }
   );
 
   if (!release) {
     console.error(
-      "[windows-system-audio-helper] Could not find a release matching:",
-      VERSION_OVERRIDE || TAG_PREFIX
+      "[windows-system-audio-helper] Could not find release:",
+      VERSION_OVERRIDE || PINNED_TAG
     );
     console.log(
       "[windows-system-audio-helper] Meeting system audio will use Chromium loopback fallback"


### PR DESCRIPTION
# PR Title

```
fix(build): prevent download scripts from silently failing as release count grows past 50
```

# PR Body

### Problem

Closes #2005

Download scripts for prebuilt Windows helper binaries use `fetchLatestRelease(REPO, { tagPrefix: "..." })` to find their release on GitHub. This calls:

```
GET /repos/OpenWhispr/openwhispr/releases?per_page=50
```

…and searches the first page (50 releases) for a tag matching the prefix. As the repository has grown to 88+ releases, older binary releases have fallen past position 50 and can no longer be found.

**`windows-key-listener-v1.0.0`** (position 56) is already unreachable, causing Hold/Push-to-Talk to silently break on any fresh Windows build from source. The remaining helper binaries will break one by one as more releases are published.

### Fix

Switch all affected scripts from `{ tagPrefix: "..." }` (paginated prefix search) to `{ tag: "exact-tag" }` (direct tag lookup). The `fetchLatestRelease` function in `download-utils.js` already supports this via the GitHub endpoint `GET /repos/{owner}/{repo}/releases/tags/{tag}`, which returns the release directly without pagination.

### Changes

| File | Change |
|---|---|
| `scripts/download-windows-key-listener.js` | Pin to `windows-key-listener-v1.0.0`, use `{ tag }` |
| `scripts/download-windows-fast-paste.js` | Pin to `windows-fast-paste-v2.0.0`, use `{ tag }` |
| `scripts/download-windows-system-audio-helper.js` | Pin to `windows-system-audio-helper-v1.1.0`, use `{ tag }` |
| `scripts/download-meeting-aec-helper.js` | Pin to `meeting-aec-helper-v1.0.0`, use `{ tag }` |
| `scripts/download-text-monitor.js` | Pin to `windows-text-monitor-v1.0.0` and `linux-text-monitor-v1.0.0`, use `{ tag }` |
| `scripts/download-windows-mic-listener.js` | Switch from `{ tagPrefix }` to `{ tag }` (already reads exact version from C source via `readPinnedTag()`) |

### How It Was Verified

1. Deleted all helper binaries from `resources/bin/`.
2. Ran each download script individually — all 6 downloaded successfully via the exact tag endpoint.
3. Ran a full clean build (`npm run prebuild:win && npm run build:renderer && electron-builder --win`).
4. Confirmed `windows-key-listener.exe` appears in the signing log (previously absent):
   ```
   • signing with signtool.exe  path=dist\win-unpacked\resources\bin\windows-key-listener.exe
   ```
5. Launched the built application, switched to Hold mode, verified Push-to-Talk works.

### Before (broken)

```
[windows-key-listener] Fetching latest release...
[windows-key-listener] Could not find a release matching prefix: windows-key-listener-v
[windows-key-listener] Push-to-Talk will use fallback mode (compile locally or tap mode)
```

### After (fixed)

```
[windows-key-listener] Fetching latest release...
[windows-key-listener] Successfully downloaded windows-key-listener-v1.0.0 (146KB)
```
