### PR TITLE
fix(cleanup): pass temperature 0 on the dictation-cleanup route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8190,9 +8190,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -221,6 +221,9 @@ function resolveReasoningRoute(
       cleanupConfig: {
         inferenceScope: /** @type {const} */ ("dictationCleanup"),
         disableThinking: settings.cleanupDisableThinking,
+        // The chain's cleanup step is the same deterministic transform — see
+        // the cleanup route below for why the value has to be explicit.
+        temperature: 0,
       },
       config: {
         ...translation.config,
@@ -280,6 +283,9 @@ function resolveReasoningRoute(
       config: {
         inferenceScope: /** @type {const} */ ("dictationCleanup"),
         disableThinking: settings.cleanupDisableThinking,
+        // Cleanup is a deterministic transform: pass 0 explicitly, because the IPC-bridged
+        // providers (local bridge, Anthropic, enterprise) otherwise apply their own default.
+        temperature: 0,
       },
     };
   }

--- a/test/helpers/cleanupRouteTemperature.test.js
+++ b/test/helpers/cleanupRouteTemperature.test.js
@@ -1,0 +1,86 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { loadAudioManager } = require("./harness/audioManager");
+
+// The cleanup configs are the only callers that can pin sampling for the
+// IPC-bridged providers: local llama-server (`?? 0.7`), Anthropic and
+// enterprise (`?? 0.3`) read `config.temperature` and otherwise keep their own
+// default. Without this the "cleanup is deterministic" rule only held on the
+// chat-completions transports and Gemini.
+async function loadRouteResolver(t) {
+  const { vite } = await loadAudioManager(t, {
+    cachePrefix: "openwhispr-cleanup-temperature-test-",
+    settingsKey: "__cleanupTemperatureSettings",
+    mockModules: {
+      "/stores/settingsStore": `
+        export const getSettings = () => globalThis.__cleanupTemperatureSettings;
+        export const getEffectiveCleanupModel = () => "cleanup-model";
+        export const selectResolvedLLMConfig = () => ({ model: "cleanup-model" });
+        export const isCloudCleanupMode = () => false;
+        export const isCloudDictationAgentMode = () => false;
+        export const isCloudTranslationMode = () => false;
+      `,
+      "/dictationAgentInference": `
+        export const resolveDictationAgentInference = () => ({
+          reachable: true,
+          model: "agent-model",
+          displayProvider: "test",
+          config: { provider: "test" },
+        });
+        export const resolveDictationAgentVisionInference = () => ({
+          active: false,
+          model: "",
+          config: {},
+        });
+      `,
+      "/dictationTranslationInference": `
+        export const resolveDictationTranslationInference = () => ({
+          reachable: true,
+          model: "translate-model",
+          displayProvider: "test",
+          config: { provider: "test" },
+        });
+      `,
+      "/config/prompts": `
+        export const resolvePrompt = () => "route prompt";
+        export const appendScreenContextSuffix = (prompt) => prompt;
+        export const wrapCleanupTranscript = (text) => text;
+        export const getCleanupSystemPrompt = () => "cleanup prompt";
+      `,
+    },
+  });
+  const settings = { useCleanupModel: true, cleanupDisableThinking: true };
+  const resolveReasoningRoute = (await vite.ssrLoadModule("/helpers/audioManager.js"))
+    .resolveReasoningRoute;
+  return (text, { voiceAgentRequested = false, translationRequested = false } = {}) =>
+    resolveReasoningRoute(text, settings, "Jarvis", voiceAgentRequested, translationRequested);
+}
+
+test("the cleanup route pins temperature 0", async (t) => {
+  const resolveRoute = await loadRouteResolver(t);
+
+  const route = resolveRoute("so um clean this up");
+
+  assert.equal(route.kind, "cleanup");
+  assert.equal(route.config.inferenceScope, "dictationCleanup");
+  assert.equal(route.config.temperature, 0);
+});
+
+test("the translation chain's cleanup step pins temperature 0 too", async (t) => {
+  const resolveRoute = await loadRouteResolver(t);
+
+  const route = resolveRoute("so um translate this", { translationRequested: true });
+
+  assert.equal(route.kind, "translation");
+  assert.equal(route.cleanupConfig.inferenceScope, "dictationCleanup");
+  assert.equal(route.cleanupConfig.temperature, 0);
+});
+
+test("the agent route keeps its provider default temperature", async (t) => {
+  const resolveRoute = await loadRouteResolver(t);
+
+  const route = resolveRoute("Jarvis, what is on my calendar", { voiceAgentRequested: true });
+
+  assert.equal(route.kind, "agent");
+  assert.equal(route.config.temperature, undefined);
+});


### PR DESCRIPTION
#1714 — Phase 0 of the "Local Model Parameter Correctness + Local Canary Coverage" plan — changed `localReasoningBridge.js` from `||` to `??` so an explicit `temperature: 0` survives the config build, and noted: "No caller passes 0 today, so this is inert until Phase 1 routes cleanup through the shared shaper […]". This PR supplies those callers: `temperature: 0` on the two cleanup config objects `resolveReasoningRoute` builds in `src/helpers/audioManager.js` — the `kind === "cleanup"` route config and the `cleanupConfig` of the translation chain. It is a parity + determinism change: the renderer-side transports already run cleanup at 0, the three IPC-bridged providers did not. If Phase 1 is close and would rather carry this, closing this PR is a fine answer — I couldn't find a public tracker for it, so the real question is whether it is still coming.

### Why

Cleanup is meant to run at 0: the shared chat-completions shaper picks 0 for a prompt-less config and says why (`src/services/ai/chatRequestBody.ts:41-43`, `config.systemPrompt ? 0.3 : 0`), `openai.ts:244` and `gemini.ts:39` resolve the same value, and #1073 said so ("Cleanup defaults to temperature 0"). The IPC-bridged providers read `config.temperature` and otherwise keep their own default, and both cleanup configs were `{ inferenceScope, disableThinking }`:

| Path | Default without this change |
|---|---|
| local llama-server — `src/services/localReasoningBridge.js:36` | `config.temperature ?? 0.7` |
| Anthropic — `src/helpers/ipcHandlers.js:4866-4872` | `config.temperature ?? 0.3` |
| enterprise/managed — `src/helpers/ipcHandlers.js:4467-4490` | `config.temperature ?? 0.3` |

So the default local model (the recommended download for a local-cleanup setup) samples dictation cleanup at 0.7, on the dictation route and on the translation chain's cleanup step alike. The lines stay correct if Phase 1 lands: the shared shaper resolves `config.temperature ?? defaultTemperature`.

### Side effects (deliberate, please review)

- **Anthropic and enterprise cleanup move from 0.3 to 0** — same object, same line. If 0.3 was deliberate there, say so and I'll scope it to local.
- **Local cleanup moves from 0.7 to 0**, nothing else in the request changes: the bridge computes `topP`/`repeatPenalty` but never forwards them (`modelManagerBridge.js:512-517`, `llamaServer.js:533-544`), so llama-server's own defaults keep applying; the truncation samplers stop mattering once decoding is greedy.
- **Nowhere does the explicit 0 add a `temperature` param that was omitted:** the IPC handlers gate on `supportsTemperature` (`anthropic.ts:23`, `ipcHandlers.js:4866` / `:4467` — Opus 4.7+ / GPT-5 / o-series still omit it), every other transport already resolves the value, OpenWhispr Cloud owns it server-side; `test/services/llmRequestShapeMatrix` is unchanged.
- **Not touched:** the agent route, the translation route's translate step, selection edits — own configs; agent/translate keep the provider default (0.3; 0.7 on the local bridge), selection edits pin their own 0.2 (`audioManager.js:2613` on `main`).

### Test

`test/helpers/cleanupRouteTemperature.test.js`, on the existing Vite-SSR audioManager harness: the cleanup route and the translation chain's `cleanupConfig` both resolve with `inferenceScope: "dictationCleanup"` and `temperature: 0` (each assertion fails on `main`, `undefined !== 0`); the agent route still carries no `temperature`. It pairs with #1714's "an explicit temperature of 0 reaches llama-server instead of the 0.7 default" (`test/helpers/localReasoningBridgeChain.test.js:113-120`): that one pins the bridge, this one the caller. Traced end to end on `main` `fad475c6` — `ReasoningService.processText` spreads `...config`, `local.ts` / `anthropic.ts` / `enterprise.ts` pass `{...config}` over IPC — and `ReasoningConfig` already declares `temperature?: number` (`BaseReasoningService.ts:10`), so no type change. `npm run quality-check` clean.

### Measured effect (parity/determinism, not a behaviour fix)

Measured before proposing, so nobody has to guess: default local model (`qwen3.5-9b-q4_k_m`), the exact system prompt + `<transcript>` wrap the app sends, 200 seeded synthetic dictations (120 question/command-shaped, 60 ordinary, 20 very short), 5 samples per input at 0.7 vs 2 at 0, on a llama.cpp CUDA build with the app's launch flags (a proxy for the app's llama-server build, not the build itself).

- answered/obeyed-instead-of-cleaned: **1.5 % at 0.7 (15/1000) vs 1.5 % at 0 (6/400)** — the same three inputs in both arms, all `translate this into <language>` commands the model executes at either temperature;
- expansion identical (p50 1.03, p90 1.07), `finish_reason: length` 0/1400, no fences or meta-commentary in either arm;
- the only effect of 0.7: wording jitter on 12/200 inputs (2–5 distinct cleanups of the same dictation across 5 runs) vs 0/200 differing between two runs at 0.

So the case is parity (#1073/#1714's stated intent; the renderer-side transports already run it at 0) plus reproducible output for the same dictation — not a lower answer-instead-of-clean rate; that residue is prompt-side and out of scope here. One caveat against the change: the corpus is short (nothing near the token cap), so it doesn't probe greedy decoding's known weakness, repetition loops on long dictations — not observed, but not tested either.

### Two things to pre-empt

- `"local"` in `LEGACY_CHAT_COMPLETIONS_PROVIDERS` (`chatRequestBody.ts:14`) is the chat-completions transport; the app's llama-server path goes over IPC (`local.ts`) and never reaches that shaper, so the matrix rows showing `temperature: 0` don't cover it.
- Placement: #1620's rule is one owner per request-param fact. Deriving the value from `inferenceScope` inside the IPC handlers would keep one owner too; I went with the caller because that is the shape #1714 described. Happy to move it.
