### PR TITLE
fix(cli): validate query parameters limit and folder_id in CLI bridge endpoints (#2014)

### DIFF
--- a/src/helpers/cliBridge.js
+++ b/src/helpers/cliBridge.js
@@ -84,6 +84,18 @@ function parseIdParam(value) {
   return id;
 }
 
+function parsePositiveIntQuery(query, key, fallback) {
+  const raw = query.get(key);
+  if (raw === null || raw === "") return fallback;
+  const num = Number(raw);
+  if (!Number.isInteger(num) || num <= 0) {
+    const err = new Error(`Query parameter '${key}' must be a positive integer`);
+    err.code = "VALIDATION";
+    throw err;
+  }
+  return num;
+}
+
 function unwrapMutationResult(result, label) {
   if (!result?.success || !result[label]) {
     throw new Error(result?.error || `Failed to write ${label}`);
@@ -300,8 +312,8 @@ class CliBridge {
       exact("GET", "/v1/health", () => ({ data: { ok: true, version: 1 } })),
       exact("GET", "/v1/notes/list", ({ query }) => {
         const noteType = query.get("note_type") || null;
-        const limit = query.get("limit") ? Number(query.get("limit")) : 100;
-        const folderId = query.get("folder_id") ? Number(query.get("folder_id")) : null;
+        const limit = parsePositiveIntQuery(query, "limit", 100);
+        const folderId = parsePositiveIntQuery(query, "folder_id", null);
         const notes = db.getNotes(noteType, limit, folderId);
         return { data: notes, has_more: false, next_cursor: null };
       }),
@@ -312,7 +324,7 @@ class CliBridge {
           err.code = "VALIDATION";
           throw err;
         }
-        const limit = query.get("limit") ? Number(query.get("limit")) : 20;
+        const limit = parsePositiveIntQuery(query, "limit", 20);
         const notes = db.searchNotes(q, limit);
         return { data: notes, has_more: false, next_cursor: null };
       }),
@@ -395,7 +407,7 @@ class CliBridge {
         return { data: { words, added: result.added, removed: result.removed } };
       }),
       exact("GET", "/v1/transcriptions/list", ({ query }) => {
-        const limit = query.get("limit") ? Number(query.get("limit")) : 50;
+        const limit = parsePositiveIntQuery(query, "limit", 50);
         return {
           data: db.getTranscriptions(limit),
           has_more: false,

--- a/test/helpers/cliBridgeQueryValidation.test.js
+++ b/test/helpers/cliBridgeQueryValidation.test.js
@@ -1,0 +1,143 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === "electron") {
+    return {
+      app: {
+        getPath: () => "/tmp",
+        getAppPath: () => process.cwd(),
+        isReady: () => false,
+      },
+    };
+  }
+  if (request === "./windowBroadcast") {
+    return {
+      broadcastToWindows: () => {},
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const CliBridge = require("../../src/helpers/cliBridge.js");
+
+Module._load = originalLoad;
+
+function createBridge(dbMocks = {}) {
+  const bridge = new CliBridge({
+    databaseManager: {
+      getNotes: () => [],
+      searchNotes: () => [],
+      getTranscriptions: () => [],
+      ...dbMocks,
+    },
+  });
+  bridge.token = "test-token";
+  bridge.port = 8200;
+  return bridge;
+}
+
+class MockResponse {
+  constructor() {
+    this.statusCode = null;
+    this.headers = {};
+    this.body = "";
+  }
+  writeHead(code, headers) {
+    this.statusCode = code;
+    this.headers = headers;
+  }
+  end(chunk) {
+    if (chunk) this.body += chunk;
+  }
+}
+
+async function request(bridge, url) {
+  const req = {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: { authorization: "Bearer test-token" },
+    method: "GET",
+    url,
+  };
+  const res = new MockResponse();
+  await bridge._handleRequest(req, res);
+  const parsed = res.body ? JSON.parse(res.body) : null;
+  return { status: res.statusCode, data: parsed };
+}
+
+test("GET /v1/notes/list accepts valid limit and folder_id parameters", async () => {
+  let passedLimit = null;
+  let passedFolderId = null;
+  const bridge = createBridge({
+    getNotes(_type, limit, folderId) {
+      passedLimit = limit;
+      passedFolderId = folderId;
+      return [{ id: 1, title: "Note 1" }];
+    },
+  });
+
+  const res = await request(bridge, "/v1/notes/list?limit=25&folder_id=7");
+  assert.equal(res.status, 200);
+  assert.equal(passedLimit, 25);
+  assert.equal(passedFolderId, 7);
+  assert.deepEqual(res.data.data, [{ id: 1, title: "Note 1" }]);
+});
+
+test("GET /v1/notes/list uses defaults when parameters are omitted", async () => {
+  let passedLimit = null;
+  let passedFolderId = null;
+  const bridge = createBridge({
+    getNotes(_type, limit, folderId) {
+      passedLimit = limit;
+      passedFolderId = folderId;
+      return [];
+    },
+  });
+
+  const res = await request(bridge, "/v1/notes/list");
+  assert.equal(res.status, 200);
+  assert.equal(passedLimit, 100);
+  assert.equal(passedFolderId, null);
+});
+
+test("GET /v1/notes/list rejects non-numeric or non-positive limit with 400", async () => {
+  const bridge = createBridge();
+
+  for (const badLimit of ["abc", "-5", "0", "1.5"]) {
+    const res = await request(bridge, `/v1/notes/list?limit=${badLimit}`);
+    assert.equal(res.status, 400, `limit=${badLimit} should return 400`);
+    assert.equal(res.data.error.code, "validation_error");
+    assert.match(res.data.error.message, /must be a positive integer/);
+  }
+});
+
+test("GET /v1/notes/list rejects non-numeric or non-positive folder_id with 400", async () => {
+  const bridge = createBridge();
+
+  for (const badFolder of ["abc", "-1", "0", "2.5"]) {
+    const res = await request(bridge, `/v1/notes/list?folder_id=${badFolder}`);
+    assert.equal(res.status, 400, `folder_id=${badFolder} should return 400`);
+    assert.equal(res.data.error.code, "validation_error");
+    assert.match(res.data.error.message, /must be a positive integer/);
+  }
+});
+
+test("GET /v1/notes/search rejects invalid limit with 400", async () => {
+  const bridge = createBridge();
+
+  const res = await request(bridge, "/v1/notes/search?q=test&limit=invalid");
+  assert.equal(res.status, 400);
+  assert.equal(res.data.error.code, "validation_error");
+  assert.match(res.data.error.message, /must be a positive integer/);
+});
+
+test("GET /v1/transcriptions/list rejects invalid limit with 400", async () => {
+  const bridge = createBridge();
+
+  const res = await request(bridge, "/v1/transcriptions/list?limit=zero");
+  assert.equal(res.status, 400);
+  assert.equal(res.data.error.code, "validation_error");
+  assert.match(res.data.error.message, /must be a positive integer/);
+});


### PR DESCRIPTION
## Description

Validates positive integer query parameters (`limit` and `folder_id`) in the CLI bridge endpoints (`GET /v1/notes/list`, `GET /v1/notes/search`, and `GET /v1/transcriptions/list`) to return HTTP 400 (`validation_error`) when invalid values are provided.

### Root Cause
In `src/helpers/cliBridge.js`, endpoints converted query parameters directly via `Number(query.get(...))`.
When non-integer or non-numeric values were passed (e.g. `?limit=abc`, `?limit=-1`, `?folder_id=abc`):
1. `Number("abc")` evaluated to `NaN`.
2. In `getNotes(noteType, limit, folderId)`, `folderId != null` evaluated to `true` for `NaN`. The SQL query executed `WHERE folder_id = NaN`, matching no rows and silently returning an empty array with HTTP 200 rather than rejecting the invalid query.
3. `limit` values of `NaN` or negative numbers flowed unguarded into SQLite `LIMIT ?` clauses.

### Fix
Added `parsePositiveIntQuery(query, key, fallback)` helper to validate that query parameters, when supplied, parse to positive integers; otherwise, it throws a `VALIDATION` error that maps to HTTP 400 (`validation_error`), aligning with the CLI bridge error contract (#1519 / #1521).

## Verification
- Added unit tests in `test/helpers/cliBridgeQueryValidation.test.js` covering valid parameters, default values, non-numeric strings, negative integers, zero, and floats across all three endpoints.
- Ran tests: `node --test test/helpers/cliBridgeQueryValidation.test.js` (6/6 passed)
- Ran linter: `npm run lint` (clean)
- Ran i18n check: `npm run i18n:check` (clean)

Closes #2014