### PR TITLE
fix(meeting): ignore late stderr from inactive child in WindowsLoopbackAudioManager (#2016)

### DIFF
--- a/src/helpers/windowsLoopbackAudioManager.js
+++ b/src/helpers/windowsLoopbackAudioManager.js
@@ -174,6 +174,7 @@ class WindowsLoopbackAudioManager {
       });
 
       child.stderr.on("data", (chunk) => {
+        if (this.process !== child) return;
         this._consumeStderr(chunk, (message) => {
           if (message.type === "start") {
             finish(resolve);

--- a/test/helpers/windowsLoopbackAudioManager.test.js
+++ b/test/helpers/windowsLoopbackAudioManager.test.js
@@ -18,9 +18,12 @@ function setPlatform(platform) {
 
 afterEach(() => setPlatform(originalPlatform));
 
-function loadManagerClass() {
+function loadManagerClass(mocks = {}) {
   delete require.cache[managerModulePath];
   Module._load = function loadWithMocks(request, parent, isMain) {
+    if (mocks[request]) {
+      return mocks[request];
+    }
     if (request === "./debugLogger") {
       return {
         info() {},
@@ -232,4 +235,49 @@ test("live helper probe succeeds on this machine when the binary is present", as
   const parsed = JSON.parse(output);
   assert.equal(parsed.ok, true);
   assert.equal(parsed.supportsNativeCapture, true);
+});
+
+test("stderr output from an inactive child is ignored after process change", async () => {
+  setPlatform("win32");
+  const { EventEmitter } = require("node:events");
+
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = new EventEmitter();
+  child.kill = () => {};
+
+  const MockedManager = loadManagerClass({
+    child_process: {
+      spawn: () => {
+        process.nextTick(() => {
+          child.stderr.emit("data", JSON.stringify({ type: "start" }) + "\n");
+        });
+        return child;
+      },
+    },
+  });
+
+  const manager = new MockedManager();
+  manager.resolveBinary = () => "C:\\helper.exe";
+  manager.getCapability = async () => ({ available: true });
+
+  const errors = [];
+  await manager.start({
+    onError: (err) => errors.push(err),
+  });
+
+  assert.equal(manager.process, child);
+
+  // Process is replaced or cleared (e.g. stopped)
+  manager.process = null;
+
+  // Stale stderr arrives from the old child
+  child.stderr.emit(
+    "data",
+    JSON.stringify({ type: "error", error: "stale process failure" }) + "\n"
+  );
+
+  assert.equal(errors.length, 0);
+  assert.equal(manager.stderrBuffer, "");
 });


### PR DESCRIPTION
## Description

Guards `child.stderr.on("data")` with `if (this.process !== child) return;` in `WindowsLoopbackAudioManager.prototype.start` so that late stderr chunks from stopped or replaced helper processes do not corrupt the active manager's state or trigger spurious error/warning callbacks.

### Root Cause
In `src/helpers/windowsLoopbackAudioManager.js`, `child.stdout.on("data")` checks `if (this.process !== child) return;`, but `child.stderr.on("data")` was missing this guard.
When a capture session stopped or restarted (`this.process = null` or replaced with a new child), any lingering stderr output written during helper teardown was fed into `this._consumeStderr`. This corrupted `this.stderrBuffer` on the active instance and invoked `onError` or `onWarning` on the wrong/new session. This aligns with the pattern used in the macOS loopback manager (`src/helpers/audioTapManager.js`).

### Fix
Added `if (this.process !== child) return;` at the top of `child.stderr.on("data")`.

## Verification
- Added a unit test in `test/helpers/windowsLoopbackAudioManager.test.js` confirming that stderr chunks emitted by an inactive child after process teardown or replacement are ignored without invoking `onError` or mutating `stderrBuffer`.
- Ran tests: `node --test test/helpers/windowsLoopbackAudioManager.test.js` (10/10 passed)
- Ran linter: `npm run lint` (clean)
- Ran i18n check: `npm run i18n:check` (clean)

Closes #2016