### PR TITLE
fix(reasoning): floor GLM-5.3 thinking suppression at low effort

### DIFF
--- a/src/services/ai/modelFamilyConstraints.ts
+++ b/src/services/ai/modelFamilyConstraints.ts
@@ -9,7 +9,7 @@
  * like thinkingSuppressionDialects.
  */
 export interface ModelFamilyConstraints {
-  family: "gpt-oss" | "qwen" | "magistral";
+  family: "gpt-oss" | "qwen" | "magistral" | "glm-5.3";
   reasoningEffort?: {
     /** Value that best approximates "thinking off" for reasoning_effort. */
     suppressValue: string;
@@ -40,6 +40,13 @@ const FAMILIES: Array<ModelFamilyConstraints & { match: RegExp }> = [
     // qwen3 accepts none|default only (Groq's enum; "none" is also what the
     // generic dialect sends everywhere, so the fact is provider-agnostic).
     reasoningEffort: { suppressValue: "none" },
+  },
+  {
+    family: "glm-5.3",
+    match: /glm[-_]?5[-.]?3/,
+    // GLM-5.3/Flash always reason: low|high|max only, no off switch.
+    // "low" is the closest to off; no cleanupValue, default sends nothing.
+    reasoningEffort: { suppressValue: "low" },
   },
   {
     family: "magistral",

--- a/test/helpers/thinkingSuppressionDialects.test.js
+++ b/test/helpers/thinkingSuppressionDialects.test.js
@@ -108,6 +108,18 @@ test("lan sends a family's suppress floor inside the reasoning object, not a fla
   assert.ok(!("reasoning_effort" in body), "flat reasoning_effort trips vLLM on lan (#1611)");
 });
 
+test("lan glm-5.3 floors at low: the family cannot disable reasoning", async () => {
+  const { suppressThinking } = await load();
+
+  const body = {};
+  suppressThinking(body, "lan", "glm-5.3-flash");
+
+  assert.deepEqual(body, {
+    reasoning: { effort: "low" },
+    chat_template_kwargs: { enable_thinking: false },
+  });
+});
+
 test("unlisted providers keep the legacy reasoning_effort none plus chat_template_kwargs", async () => {
   const { suppressThinking } = await load();
 

--- a/test/services/llmRequestShapeMatrix.test.js
+++ b/test/services/llmRequestShapeMatrix.test.js
@@ -68,6 +68,10 @@ const MATRIX = [
     { max_tokens: MAX_TOKENS, temperature: 0, reasoning_effort: "low", reasoning: { effort: "low" }, chat_template_kwargs: { enable_thinking: false } }],
   ["lan gpt-oss suppression sends the family floor, never the off value the family lacks", "lan", "gpt-oss-20b-mxfp4", null, AGENT_NO_THINK,
     { max_tokens: MAX_TOKENS, temperature: 0.3, reasoning: { effort: "low" }, chat_template_kwargs: { enable_thinking: false } }],
+  ["lan glm-5.3 default sends no reasoning params, server applies its max default", "lan", "glm-5.3-flash", null, CLEANUP,
+    { max_tokens: MAX_TOKENS, temperature: 0 }],
+  ["lan glm-5.3 suppression floors at low, never the unsupported none", "lan", "glm-5.3-flash", null, CLEANUP_NO_THINK,
+    { max_tokens: MAX_TOKENS, temperature: 0, reasoning: { effort: "low" }, chat_template_kwargs: { enable_thinking: false } }],
   ["local llama.cpp gets think false plus chat_template_kwargs (#783)", "local", "qwen3.5-4b-gguf", null, CLEANUP_NO_THINK,
     { max_tokens: MAX_TOKENS, temperature: 0, think: false, chat_template_kwargs: { enable_thinking: false } }],
 

--- a/test/services/modelFamilyConstraints.test.js
+++ b/test/services/modelFamilyConstraints.test.js
@@ -23,3 +23,14 @@ test("gpt-oss has no reasoning off switch: suppress and cleanup both floor at lo
   const effort = getModelFamilyConstraints("gpt-oss-120b")?.reasoningEffort;
   assert.deepEqual(effort, { suppressValue: "low", cleanupValue: "low" });
 });
+
+test("glm-5.3 always reasons: suppress floors at low, no cleanup pin (server max default)", async () => {
+  const { getModelFamilyConstraints } = await load();
+  assert.deepEqual(getModelFamilyConstraints("glm-5.3")?.reasoningEffort, {
+    suppressValue: "low",
+  });
+  assert.equal(getModelFamilyConstraints("glm-5.3-flash")?.family, "glm-5.3");
+  assert.equal(getModelFamilyConstraints("glm-5-3")?.family, "glm-5.3");
+  assert.equal(getModelFamilyConstraints("GLM-5.3-Flash:cloud")?.family, "glm-5.3");
+  assert.equal(getModelFamilyConstraints("glm-5-2")?.family, undefined);
+});


### PR DESCRIPTION
**GLM-5.3** and **GLM-5.3-Flash** always reason and accept only `low/high/max` effort. 

This adds a `glm-5.3` entry to the shared model-family constraints with `suppressValue: "low"` (same precedent as gpt-oss), with no `cleanupValue` so the default path sends nothing and the server applies its `max` default.

related #2008 