### PR TITLE
fix(transcription): re-encode to WAV for Custom STT endpoints and retries (microsoft/mai-transcribe-2)

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -4,6 +4,7 @@ import logger from "../utils/logger";
 import { isAzureOpenAIEndpoint } from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/auth";
 import { getBaseLanguageCode, getLanguageLabel } from "../utils/languageSupport";
+import { convertToWav, needsWavConversion } from "../utils/audioContainer";
 import {
   applyChineseScript,
   mergeWhisperPrompt,
@@ -3381,9 +3382,36 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         return { success: true, text, rawText: proxyText, source, timings };
       }
 
+      // Some Custom endpoints decode the upload and reject anything that isn't
+      // WAV/MP3/FLAC (Azure MAI-Transcribe via OpenRouter, for one), which
+      // Chromium's WebM/Opus recordings always are. Re-encode for those rather
+      // than failing the dictation; a conversion failure falls through to the
+      // original bytes so this can only widen what works.
+      let uploadAudio = optimizedAudio;
+      if (needsWavConversion(provider, optimizedAudio.type)) {
+        try {
+          uploadAudio = await convertToWav(optimizedAudio);
+          logger.debug(
+            "Re-encoded recording to WAV for custom endpoint",
+            {
+              fromType: optimizedAudio.type,
+              fromSize: optimizedAudio.size,
+              toSize: uploadAudio.size,
+            },
+            "transcription"
+          );
+        } catch (conversionError) {
+          logger.warn(
+            "WAV re-encode failed; uploading original container",
+            { error: conversionError?.message, type: optimizedAudio.type },
+            "transcription"
+          );
+        }
+      }
+
       const formData = new FormData();
       // Determine the correct file extension based on the blob type
-      const mimeType = optimizedAudio.type || "audio/webm";
+      const mimeType = uploadAudio.type || "audio/webm";
       const extension = mimeType.includes("webm")
         ? "webm"
         : mimeType.includes("ogg")
@@ -3401,13 +3429,13 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         {
           mimeType,
           extension,
-          optimizedSize: optimizedAudio.size,
+          optimizedSize: uploadAudio.size,
           hasApiKey: !!apiKey,
         },
         "transcription"
       );
 
-      formData.append("file", optimizedAudio, `audio.${extension}`);
+      formData.append("file", uploadAudio, `audio.${extension}`);
       formData.append("model", model);
 
       if (language) {

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -3388,7 +3388,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // than failing the dictation; a conversion failure falls through to the
       // original bytes so this can only widen what works.
       let uploadAudio = optimizedAudio;
-      if (needsWavConversion(provider, optimizedAudio.type)) {
+      if (needsWavConversion(provider, optimizedAudio.type, optimizedAudio.size)) {
         try {
           uploadAudio = await convertToWav(optimizedAudio);
           logger.debug(

--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -186,6 +186,31 @@ function convertToWav(inputPath, outputPath, options = {}) {
   });
 }
 
+// Buffer in, buffer out. convertToWav works on paths, but the retry and upload
+// paths hold recordings in memory, and every caller that bridged that gap was
+// writing the same temp-file dance by hand.
+async function convertBufferToWav(audioBuffer, options = {}) {
+  const { getSafeTempDir } = require("./safeTempDir");
+  const tempDir = getSafeTempDir();
+  const stamp = `${Date.now()}-${process.pid}`;
+  const inputPath = path.join(tempDir, `ow-reencode-${stamp}.input`);
+  const outputPath = path.join(tempDir, `ow-reencode-${stamp}.wav`);
+
+  try {
+    fs.writeFileSync(inputPath, audioBuffer);
+    await convertToWav(inputPath, outputPath, { sampleRate: 16000, channels: 1, ...options });
+    return fs.readFileSync(outputPath);
+  } finally {
+    for (const f of [inputPath, outputPath]) {
+      try {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  }
+}
+
 function parseWavFormat(wavBuffer) {
   if (!isWavFormat(wavBuffer)) return null;
 
@@ -459,6 +484,7 @@ module.exports = {
   isWavFormat,
   parseWavFormat,
   convertToWav,
+  convertBufferToWav,
   splitAudioFile,
   parseFfmpegDuration,
   wavToFloat32Samples,

--- a/src/helpers/ffmpegUtils.js
+++ b/src/helpers/ffmpegUtils.js
@@ -186,13 +186,19 @@ function convertToWav(inputPath, outputPath, options = {}) {
   });
 }
 
+let reencodeSequence = 0;
+
 // Buffer in, buffer out. convertToWav works on paths, but the retry and upload
 // paths hold recordings in memory, and every caller that bridged that gap was
 // writing the same temp-file dance by hand.
 async function convertBufferToWav(audioBuffer, options = {}) {
   const { getSafeTempDir } = require("./safeTempDir");
   const tempDir = getSafeTempDir();
-  const stamp = `${Date.now()}-${process.pid}`;
+  // process.pid is constant within a process and Date.now() only has
+  // millisecond resolution, so two concurrent conversions -- a user retrying
+  // several history entries at once -- would otherwise share both temp paths
+  // and race each other's output.
+  const stamp = `${Date.now()}-${process.pid}-${++reencodeSequence}`;
   const inputPath = path.join(tempDir, `ow-reencode-${stamp}.input`);
   const outputPath = path.join(tempDir, `ow-reencode-${stamp}.wav`);
 

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5875,6 +5875,7 @@ class IPCHandlers {
             ? preferredLanguage.split("-")[0]
             : undefined;
         const { resolveTranscriptionRoute } = await import("./transcriptionRoute.ts");
+        const { convertBufferToWav, isWavFormat } = require("./ffmpegUtils");
         // Renderer pre-flight owns policy; retry re-routes stored audio through
         // whatever is selected NOW.
         const route = resolveTranscriptionRoute({
@@ -6055,8 +6056,30 @@ class IPCHandlers {
             throw new Error(`${provider} API key not configured`);
           }
 
+          // The renderer re-encodes WebM before uploading to a Custom endpoint
+          // (src/utils/audioContainer.ts); retries re-upload stored audio from
+          // the main process, so without the same step here every retry of a
+          // dictation that failed for that reason fails again -- which is the
+          // exact recovery a user reaches for after hitting it.
+          let uploadBuffer = buffer;
+          let uploadType = "audio/webm";
+          let uploadName = "audio.webm";
+          if (provider === "custom" && buffer.length && !isWavFormat(buffer)) {
+            try {
+              uploadBuffer = await convertBufferToWav(buffer);
+              uploadType = "audio/wav";
+              uploadName = "audio.wav";
+            } catch (conversionError) {
+              // Fail open, matching the renderer: an unconverted retry is no
+              // worse than today's behaviour.
+              debugLogger.warn("WAV re-encode failed on retry; uploading stored container", {
+                error: conversionError?.message,
+              });
+            }
+          }
+
           const formData = new FormData();
-          formData.append("file", new Blob([buffer], { type: "audio/webm" }), "audio.webm");
+          formData.append("file", new Blob([uploadBuffer], { type: uploadType }), uploadName);
           if (provider === "xai") {
             // xAI STT does not accept a model field; the route pre-filters language
             if (route.language) {

--- a/src/utils/audioContainer.ts
+++ b/src/utils/audioContainer.ts
@@ -12,16 +12,30 @@
 const WAV_HEADER_BYTES = 44;
 const BYTES_PER_SAMPLE = 2;
 
-// Containers Chromium can produce that a WAV/MP3/FLAC-only backend will refuse.
-const REENCODE_CONTAINERS = ["webm", "ogg", "matroska"];
+// Speech models resample to 16 kHz mono internally, and the main process
+// already standardises on it (ffmpegUtils.convertToWav defaults to exactly
+// this), so matching it here keeps the two conversion paths consistent and
+// keeps the upload ~6x smaller than the decoded 48 kHz stream.
+const TARGET_SAMPLE_RATE = 16000;
+
+// Containers these backends already accept. Anything else is re-encoded --
+// an allowlist rather than a list of known-bad containers, so a format we
+// have not seen yet (MP4/AAC on some platforms) converts instead of being
+// uploaded and rejected.
+const ACCEPTED_CONTAINERS = ["wav", "x-wav", "wave", "mpeg", "mp3", "flac"];
 
 export function needsWavConversion(
   provider: string | undefined,
-  mimeType: string | undefined
+  mimeType: string | undefined,
+  size?: number
 ): boolean {
   if (provider !== "custom") return false;
+  // An empty recording has nothing to decode; converting it would only turn a
+  // silent no-op into a spurious "re-encode failed" warning.
+  if (size === 0) return false;
   const type = (mimeType || "").toLowerCase();
-  return REENCODE_CONTAINERS.some((container) => type.includes(container));
+  if (!type) return false;
+  return !ACCEPTED_CONTAINERS.some((container) => type.includes(container));
 }
 
 // Interleaved 16-bit PCM in a RIFF container. Kept pure and free of Web Audio
@@ -67,27 +81,45 @@ export function encodeWav(channels: Float32Array[], sampleRate: number): ArrayBu
   return buffer;
 }
 
-// Renderer-only: decodes through Web Audio rather than ffmpeg, which lives in
-// the main process and would need IPC plumbing for what is otherwise a
-// self-contained step on the upload path.
-export async function convertToWav(blob: Blob): Promise<Blob> {
-  const AudioContextCtor =
-    (globalThis as any).AudioContext || (globalThis as any).webkitAudioContext;
-  if (!AudioContextCtor) throw new Error("Web Audio is unavailable in this context");
+// Averages channels into one. Speech backends gain nothing from stereo and it
+// doubles the upload, so the mono mixdown happens before encoding.
+export function downmixToMono(channels: Float32Array[]): Float32Array {
+  if (!channels.length) throw new Error("downmixToMono requires at least one channel");
+  if (channels.length === 1) return channels[0];
 
-  const context = new AudioContextCtor();
-  try {
-    const decoded = await context.decodeAudioData(await blob.arrayBuffer());
-    const channels: Float32Array[] = [];
-    for (let i = 0; i < decoded.numberOfChannels; i++) channels.push(decoded.getChannelData(i));
-    return new Blob([encodeWav(channels, decoded.sampleRate)], { type: "audio/wav" });
-  } finally {
-    // Best-effort: an already-closed or non-closable context must not mask a
-    // decode error on the way out.
-    try {
-      await context.close?.();
-    } catch {
-      /* ignore */
-    }
+  const frameCount = channels[0].length;
+  const mono = new Float32Array(frameCount);
+  for (let frame = 0; frame < frameCount; frame++) {
+    let sum = 0;
+    for (let channel = 0; channel < channels.length; channel++) sum += channels[channel][frame];
+    mono[frame] = sum / channels.length;
   }
+  return mono;
+}
+
+// Renderer-side conversion, using Web Audio because ffmpeg is only reachable
+// from the main process. Retries re-upload stored audio from there and cannot
+// use this, so they go through ffmpegUtils.convertBufferToWav instead -- both
+// paths target 16 kHz mono so the upload is identical either way.
+export async function convertToWav(blob: Blob): Promise<Blob> {
+  const OfflineCtor =
+    (globalThis as any).OfflineAudioContext || (globalThis as any).webkitOfflineAudioContext;
+  if (!OfflineCtor) throw new Error("Web Audio is unavailable in this context");
+
+  // Decoding through an OfflineAudioContext resamples to the context rate, so
+  // the 48 kHz recording arrives already downsampled -- and unlike a live
+  // AudioContext it neither opens an output device nor inherits whatever rate
+  // the hardware happens to run at.
+  const context = new OfflineCtor(1, 1, TARGET_SAMPLE_RATE);
+  const decoded = await context.decodeAudioData(await blob.arrayBuffer());
+
+  // decodeAudioData honours the context's sample rate but not its channel
+  // count, so a stereo input still decodes to two channels and has to be
+  // downmixed explicitly.
+  const channels: Float32Array[] = [];
+  for (let i = 0; i < decoded.numberOfChannels; i++) channels.push(decoded.getChannelData(i));
+
+  return new Blob([encodeWav([downmixToMono(channels)], decoded.sampleRate)], {
+    type: "audio/wav",
+  });
 }

--- a/src/utils/audioContainer.ts
+++ b/src/utils/audioContainer.ts
@@ -1,0 +1,93 @@
+// Chromium's MediaRecorder only offers WebM/Opus (and MP4/AAC) on the desktop
+// platforms we ship, so every dictation reaches the upload path as WebM. Most
+// OpenAI-compatible transcription backends accept that, but some decode the
+// bytes themselves and reject anything outside WAV/MP3/FLAC — Azure's
+// MAI-Transcribe, reached through OpenRouter, is one. Those endpoints are only
+// selectable via the Custom provider, so the conversion is scoped there and
+// every built-in provider keeps sending Opus untouched.
+//
+// The rejection is by content, not by labelling: renaming the part or rewriting
+// its Content-Type does not help, so the audio has to actually be re-encoded.
+
+const WAV_HEADER_BYTES = 44;
+const BYTES_PER_SAMPLE = 2;
+
+// Containers Chromium can produce that a WAV/MP3/FLAC-only backend will refuse.
+const REENCODE_CONTAINERS = ["webm", "ogg", "matroska"];
+
+export function needsWavConversion(
+  provider: string | undefined,
+  mimeType: string | undefined
+): boolean {
+  if (provider !== "custom") return false;
+  const type = (mimeType || "").toLowerCase();
+  return REENCODE_CONTAINERS.some((container) => type.includes(container));
+}
+
+// Interleaved 16-bit PCM in a RIFF container. Kept pure and free of Web Audio
+// types so it can be unit-tested without a browser.
+export function encodeWav(channels: Float32Array[], sampleRate: number): ArrayBuffer {
+  if (!channels.length) throw new Error("encodeWav requires at least one channel");
+
+  const channelCount = channels.length;
+  const frameCount = channels[0].length;
+  const dataBytes = frameCount * channelCount * BYTES_PER_SAMPLE;
+  const buffer = new ArrayBuffer(WAV_HEADER_BYTES + dataBytes);
+  const view = new DataView(buffer);
+
+  const ascii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i++) view.setUint8(offset + i, text.charCodeAt(i));
+  };
+
+  ascii(0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, channelCount, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channelCount * BYTES_PER_SAMPLE, true);
+  view.setUint16(32, channelCount * BYTES_PER_SAMPLE, true);
+  view.setUint16(34, 8 * BYTES_PER_SAMPLE, true);
+  ascii(36, "data");
+  view.setUint32(40, dataBytes, true);
+
+  let offset = WAV_HEADER_BYTES;
+  for (let frame = 0; frame < frameCount; frame++) {
+    for (let channel = 0; channel < channelCount; channel++) {
+      // Clamp before scaling: decoded float samples can sit slightly outside
+      // [-1, 1] and would otherwise wrap to the opposite rail.
+      const sample = Math.max(-1, Math.min(1, channels[channel][frame]));
+      view.setInt16(offset, Math.round(sample * (sample < 0 ? 0x8000 : 0x7fff)), true);
+      offset += BYTES_PER_SAMPLE;
+    }
+  }
+
+  return buffer;
+}
+
+// Renderer-only: decodes through Web Audio rather than ffmpeg, which lives in
+// the main process and would need IPC plumbing for what is otherwise a
+// self-contained step on the upload path.
+export async function convertToWav(blob: Blob): Promise<Blob> {
+  const AudioContextCtor =
+    (globalThis as any).AudioContext || (globalThis as any).webkitAudioContext;
+  if (!AudioContextCtor) throw new Error("Web Audio is unavailable in this context");
+
+  const context = new AudioContextCtor();
+  try {
+    const decoded = await context.decodeAudioData(await blob.arrayBuffer());
+    const channels: Float32Array[] = [];
+    for (let i = 0; i < decoded.numberOfChannels; i++) channels.push(decoded.getChannelData(i));
+    return new Blob([encodeWav(channels, decoded.sampleRate)], { type: "audio/wav" });
+  } finally {
+    // Best-effort: an already-closed or non-closable context must not mask a
+    // decode error on the way out.
+    try {
+      await context.close?.();
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/test/helpers/retryTranscriptionHandler.test.js
+++ b/test/helpers/retryTranscriptionHandler.test.js
@@ -56,6 +56,20 @@ const electronStub = {
   MessageChannelMain: class {},
 };
 
+// A 44-byte RIFF header is enough for isWavFormat, which only sniffs the magic.
+const WAV_BUFFER = Buffer.concat([
+  Buffer.from("RIFF"),
+  Buffer.alloc(4),
+  Buffer.from("WAVE"),
+  Buffer.alloc(32),
+]);
+const CONVERTED_WAV = Buffer.concat([WAV_BUFFER, Buffer.from("converted")]);
+
+// Conversion is mocked rather than run: spawning ffmpeg from a unit test would
+// make it slow and dependent on the runner having a usable binary.
+const wavConversions = [];
+let convertBehavior = async () => CONVERTED_WAV;
+
 const cortiCalls = [];
 const tinfoilCalls = [];
 let cortiBehavior = async () => ({ text: "corti text" });
@@ -85,6 +99,16 @@ Module._load = function loadWithMocks(request, parent, isMain) {
     if (request === "./windowBroadcast") {
       return { broadcastToWindows: () => {} };
     }
+    if (request === "./ffmpegUtils") {
+      const real = originalLoad.call(this, request, parent, isMain);
+      return {
+        ...real,
+        convertBufferToWav: async (buffer, options) => {
+          wavConversions.push(buffer);
+          return convertBehavior(buffer, options);
+        },
+      };
+    }
   }
   return originalLoad.call(this, request, parent, isMain);
 };
@@ -103,10 +127,16 @@ function anything() {
 }
 
 function buildFakeThis() {
-  const dbRows = new Map([[7, { id: 7, audio_duration_ms: 1200 }]]);
+  const dbRows = new Map([
+    [7, { id: 7, audio_duration_ms: 1200 }],
+    [8, { id: 8, audio_duration_ms: 1200 }],
+  ]);
   const target = {
     sessionId: "test-session",
-    audioStorageManager: { getAudioBuffer: (id) => (id === 7 ? Buffer.from([1, 2, 3]) : null) },
+    audioStorageManager: {
+      // 7 is a stored WebM recording, 8 one already in WAV.
+      getAudioBuffer: (id) => (id === 7 ? Buffer.from([1, 2, 3]) : id === 8 ? WAV_BUFFER : null),
+    },
     databaseManager: {
       updateTranscriptionText: () => {},
       updateTranscriptionStatus: () => {},
@@ -222,6 +252,76 @@ test("retry: plain custom endpoints use Bearer auth at the configured URL", asyn
   assert.equal(result.success, true);
   assert.equal(fetches[0].url, "https://stt.parasail.example.com/v1/audio/transcriptions");
   assert.equal(fetches[0].init.headers.Authorization, "Bearer ck-custom");
+});
+
+const CUSTOM_SETTINGS = {
+  cloudTranscriptionProvider: "custom",
+  cloudTranscriptionMode: "byok",
+  transcriptionMode: "providers",
+  cloudTranscriptionBaseUrl: "https://stt.parasail.example.com/v1",
+  cloudTranscriptionModel: "parasail-model",
+};
+
+const uploadedPart = () => fetches[0].init.body.get("file");
+
+test("retry: a stored WebM is re-encoded before reaching a custom endpoint", async () => {
+  // Without this the renderer-side fix covers fresh dictations only, and every
+  // retry of a recording that failed for the container reason fails again.
+  fetches.length = 0;
+  wavConversions.length = 0;
+
+  const result = await invoke(CUSTOM_SETTINGS);
+
+  assert.equal(result.success, true);
+  assert.equal(wavConversions.length, 1, "the stored container must be converted");
+  const part = uploadedPart();
+  assert.equal(part.name, "audio.wav");
+  assert.equal(part.type, "audio/wav");
+  assert.equal(part.size, CONVERTED_WAV.length, "the converted bytes are what gets uploaded");
+});
+
+test("retry: audio already in WAV is uploaded untouched", async () => {
+  fetches.length = 0;
+  wavConversions.length = 0;
+
+  const result = await invoke(CUSTOM_SETTINGS, 8);
+
+  assert.equal(result.success, true);
+  assert.equal(wavConversions.length, 0, "re-encoding WAV would only cost time");
+  assert.equal(uploadedPart().size, WAV_BUFFER.length);
+});
+
+test("retry: built-in providers keep sending the stored container", async () => {
+  fetches.length = 0;
+  wavConversions.length = 0;
+
+  await invoke({
+    cloudTranscriptionProvider: "openai",
+    cloudTranscriptionMode: "byok",
+    transcriptionMode: "providers",
+    cloudTranscriptionModel: "whisper-1",
+  });
+
+  assert.equal(wavConversions.length, 0, "only custom endpoints need the re-encode");
+  assert.equal(uploadedPart().name, "audio.webm");
+});
+
+test("retry: a conversion failure falls open to the stored container", async () => {
+  fetches.length = 0;
+  wavConversions.length = 0;
+  convertBehavior = async () => {
+    throw new Error("ffmpeg missing");
+  };
+
+  try {
+    const result = await invoke(CUSTOM_SETTINGS);
+    assert.equal(result.success, true, "a failed re-encode must not fail the retry");
+    const part = uploadedPart();
+    assert.equal(part.name, "audio.webm");
+    assert.equal(part.type, "audio/webm");
+  } finally {
+    convertBehavior = async () => CONVERTED_WAV;
+  }
 });
 
 test("retry: a custom URL on Tinfoil's host is refused in the main process", async () => {

--- a/test/utils/audioContainer.test.js
+++ b/test/utils/audioContainer.test.js
@@ -1,8 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
-// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+// The .ts import is stripped by tsx, which `npm test` loads via --import.
 
 const load = () => import("../../src/utils/audioContainer.ts");
 
@@ -15,18 +14,42 @@ test("only the custom provider re-encodes, and only for containers a WAV/MP3/FLA
   assert.equal(needsWavConversion("custom", "audio/webm;codecs=opus"), true);
   assert.equal(needsWavConversion("custom", "audio/ogg"), true);
 
+  // Allowlisted rather than blocklisted: MediaRecorder emits MP4/AAC on some
+  // platforms, and AAC is no more acceptable to these backends than Opus.
+  assert.equal(needsWavConversion("custom", "audio/mp4"), true);
+  assert.equal(needsWavConversion("custom", "video/webm"), true);
+
   // Already acceptable — re-encoding would only cost bytes.
   assert.equal(needsWavConversion("custom", "audio/wav"), false);
+  assert.equal(needsWavConversion("custom", "audio/x-wav"), false);
   assert.equal(needsWavConversion("custom", "audio/mpeg"), false);
+  assert.equal(needsWavConversion("custom", "audio/flac"), false);
 
   // Built-in providers accept Opus today; leaving them alone keeps uploads small.
   for (const provider of ["openai", "groq", "mistral", "xai", "gemini", "corti", "tinfoil"]) {
     assert.equal(needsWavConversion(provider, "audio/webm"), false);
   }
 
-  // Missing/unknown type must not trigger a pointless decode.
+  // Missing type must not trigger a pointless decode.
   assert.equal(needsWavConversion("custom", undefined), false);
   assert.equal(needsWavConversion("custom", ""), false);
+
+  // An empty recording has nothing to decode; attempting it would only log a
+  // misleading "re-encode failed" warning.
+  assert.equal(needsWavConversion("custom", "audio/webm", 0), false);
+  assert.equal(needsWavConversion("custom", "audio/webm", 1024), true);
+});
+
+test("downmixToMono averages channels and passes mono through untouched", async () => {
+  const { downmixToMono } = await load();
+
+  const mono = new Float32Array([0.25, -0.5]);
+  assert.equal(downmixToMono([mono]), mono, "mono input is returned as-is, not copied");
+
+  const mixed = downmixToMono([new Float32Array([1, -1]), new Float32Array([0, 1])]);
+  assert.deepEqual(Array.from(mixed), [0.5, 0]);
+
+  assert.throws(() => downmixToMono([]), /at least one channel/);
 });
 
 test("encodeWav writes a RIFF header the upstream decoder can read", async () => {

--- a/test/utils/audioContainer.test.js
+++ b/test/utils/audioContainer.test.js
@@ -1,0 +1,89 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Requires Node's native TypeScript type-stripping (Node >= 22.6 with
+// --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
+
+const load = () => import("../../src/utils/audioContainer.ts");
+
+const readAscii = (view, offset, length) =>
+  Array.from({ length }, (_, i) => String.fromCharCode(view.getUint8(offset + i))).join("");
+
+test("only the custom provider re-encodes, and only for containers a WAV/MP3/FLAC backend refuses", async () => {
+  const { needsWavConversion } = await load();
+
+  assert.equal(needsWavConversion("custom", "audio/webm;codecs=opus"), true);
+  assert.equal(needsWavConversion("custom", "audio/ogg"), true);
+
+  // Already acceptable — re-encoding would only cost bytes.
+  assert.equal(needsWavConversion("custom", "audio/wav"), false);
+  assert.equal(needsWavConversion("custom", "audio/mpeg"), false);
+
+  // Built-in providers accept Opus today; leaving them alone keeps uploads small.
+  for (const provider of ["openai", "groq", "mistral", "xai", "gemini", "corti", "tinfoil"]) {
+    assert.equal(needsWavConversion(provider, "audio/webm"), false);
+  }
+
+  // Missing/unknown type must not trigger a pointless decode.
+  assert.equal(needsWavConversion("custom", undefined), false);
+  assert.equal(needsWavConversion("custom", ""), false);
+});
+
+test("encodeWav writes a RIFF header the upstream decoder can read", async () => {
+  const { encodeWav } = await load();
+
+  const frames = 8;
+  const buffer = encodeWav([new Float32Array(frames)], 48000);
+  const view = new DataView(buffer);
+
+  assert.equal(readAscii(view, 0, 4), "RIFF");
+  assert.equal(readAscii(view, 8, 4), "WAVE");
+  assert.equal(readAscii(view, 12, 4), "fmt ");
+  assert.equal(readAscii(view, 36, 4), "data");
+
+  assert.equal(view.getUint16(20, true), 1, "PCM format tag");
+  assert.equal(view.getUint16(22, true), 1, "channel count");
+  assert.equal(view.getUint32(24, true), 48000, "sample rate");
+  assert.equal(view.getUint32(28, true), 48000 * 2, "byte rate");
+  assert.equal(view.getUint16(32, true), 2, "block align");
+  assert.equal(view.getUint16(34, true), 16, "bits per sample");
+
+  const dataBytes = frames * 2;
+  assert.equal(view.getUint32(40, true), dataBytes, "data chunk size");
+  assert.equal(view.getUint32(4, true), 36 + dataBytes, "riff size");
+  assert.equal(buffer.byteLength, 44 + dataBytes);
+});
+
+test("samples outside [-1, 1] clamp to the rails instead of wrapping", async () => {
+  const { encodeWav } = await load();
+
+  // decodeAudioData can return values slightly past full scale; a naive
+  // multiply-and-truncate turns +1.2 into a large negative sample.
+  const view = new DataView(encodeWav([new Float32Array([1.2, -1.2, 1, -1, 0])], 16000));
+
+  assert.equal(view.getInt16(44, true), 32767);
+  assert.equal(view.getInt16(46, true), -32768);
+  assert.equal(view.getInt16(48, true), 32767);
+  assert.equal(view.getInt16(50, true), -32768);
+  assert.equal(view.getInt16(52, true), 0);
+});
+
+test("multi-channel audio is interleaved per frame", async () => {
+  const { encodeWav } = await load();
+
+  const left = new Float32Array([1, 0]);
+  const right = new Float32Array([0, -1]);
+  const view = new DataView(encodeWav([left, right], 44100));
+
+  assert.equal(view.getUint16(22, true), 2, "channel count");
+  assert.equal(view.getUint32(28, true), 44100 * 2 * 2, "byte rate");
+  assert.equal(view.getInt16(44, true), 32767, "frame 0 left");
+  assert.equal(view.getInt16(46, true), 0, "frame 0 right");
+  assert.equal(view.getInt16(48, true), 0, "frame 1 left");
+  assert.equal(view.getInt16(50, true), -32768, "frame 1 right");
+});
+
+test("encodeWav refuses an empty channel list rather than emitting a headerless file", async () => {
+  const { encodeWav } = await load();
+  assert.throws(() => encodeWav([], 16000), /at least one channel/);
+});


### PR DESCRIPTION
Fixes #2028.

## Why

Chromium's `MediaRecorder` only offers WebM/Opus (and MP4/AAC) on the desktop platforms we ship, so every dictation reaches the upload path in a container some backends refuse. Most OpenAI-compatible transcription services accept it — but some decode the bytes themselves and reject anything outside WAV/MP3/FLAC. Azure's MAI-Transcribe, reached through OpenRouter, is one, and it fails every dictation with `{"error":{"message":"Provider returned 400"}}`.

Measured against `microsoft/mai-transcribe-2`, the same one second of 220 Hz tone re-encoded into different containers:

| Container | Status |
|---|---|
| WAV | 200 |
| MP3 | 200 |
| FLAC | 200 |
| WebM/Opus | 400 |

And the rejection is by **content**, not labelling — so a rename-only fix would not work:

| Sent | Result |
|---|---|
| WAV bytes, `filename=x.webm`, `type=audio/webm` | 200 |
| WebM bytes, `filename=x.wav`, `type=audio/wav` | 400 |

Full evidence, replication counts and ruled-out alternatives are in #2028.

## What

- `src/utils/audioContainer.ts` — `needsWavConversion()` predicate, a pure `encodeWav()` (interleaved 16-bit PCM in RIFF), `downmixToMono()`, and a `convertToWav()` wrapper over `decodeAudioData`.
- `audioManager.js` re-encodes immediately before the multipart body is built, leaving the proxied-provider path above it untouched.
- `ipcHandlers.js` does the same for **retries**. `retry-transcription` re-uploads stored audio from the main process and never reaches the renderer, so without this every retry of a dictation that failed for this reason failed again — which is the exact recovery a user reaches for after hitting the bug.
- `ffmpegUtils.js` gains `convertBufferToWav()`, a buffer-in/buffer-out wrapper over the existing path-based `convertToWav()`. `whisperServer` and `parakeetServer` were each open-coding the same write-temp / convert / read / unlink dance.

Deliberate choices, happy to change any of them:

- **Scoped to `provider === "custom"`.** Built-in providers accept Opus today, so they keep sending the smaller upload. Only Custom can reach a backend with this restriction.
- **An allowlist, not a blocklist.** The predicate converts anything that is not already WAV/MP3/FLAC, rather than enumerating known-bad containers. MP4/AAC is a real case — `MediaRecorder` emits it on some platforms, the extension switch in `audioManager.js` already handles it, and AAC is no more acceptable to these backends than Opus. Confirmed: the same recording as AAC-in-MP4 returns 400.
- **16 kHz mono, matching the main process.** `ffmpegUtils.convertToWav` already defaults to exactly this, and speech models resample to it internally, so both paths now produce interchangeable uploads. `decodeAudioData` honours an `OfflineAudioContext`'s sample rate but *not* its channel count, so the mixdown has to be explicit.
- **The mono downmix is load-bearing, not a nicety.** `getAudioConstraints` requests `channelCount: 2` unconditionally (`audioManager.js:913`) — stereo is required because mono WebM breaks silence detection on Linux/PipeWire (#472). Any platform whose mic honours that constraint therefore records two channels, and without `downmixToMono()` the upload would carry two copies of the same voice. A macOS mic that only delivers mono hides this. On PipeWire it is worse than "stereo hardware only": @mazixs reports that *every* device there negotiates 2ch at 48 kHz, including a physically mono webcam mic, because PipeWire satisfies the non-exact constraint by upmixing — so the downmix matters on essentially any Linux capture.
- **`OfflineAudioContext`, not a live `AudioContext`.** It neither opens an output device nor inherits whatever rate the hardware happens to run at, so the output rate is deterministic rather than machine-dependent.
- **Two converters rather than IPC.** ffmpeg is only reachable from the main process and Web Audio only from the renderer. Plumbing either across IPC costs more than the small amount of duplication, and both targets are pinned to the same format.
- **Fails open.** A conversion error logs and uploads the original bytes, on both paths, so this can only widen what works.
- **WAV, not MP3.** MP3 would be smaller but needs an encoder dependency. At 16 kHz mono the size is no longer a concern at dictation length — see below.

## Size

Re-encoding inflates the upload, so the ceiling matters. Measured on a real 4.86 s recording:

```
source WebM/Opus            78,663 B
decoded at 48 kHz mono     466,604 B     (5.9x source)
encoded at 16 kHz mono     155,564 B     (2.0x source)
```

Downsampling on the way in cuts the output exactly 3x, which moves the point where a converted dictation would cross a 25 MB endpoint cap from roughly 4.6 minutes to roughly 13.7 minutes.

On a platform that actually delivers the requested stereo, the saving is 6x rather than 3x:

| | bytes/sec |
|---|---|
| decoded at 48 kHz, mono | 96,000 |
| decoded at 48 kHz, stereo | 192,000 |
| encoded at 16 kHz mono | 32,000 |

## Tests

`test/utils/audioContainer.test.js` — 6 cases covering the provider/container predicate (including the MP4 case and the empty-recording guard), RIFF header fields, clamping of out-of-range samples (`decodeAudioData` can return values past full scale, which a naive multiply wraps to the opposite rail), multi-channel interleaving, the mono downmix, and the empty-input guard.

`test/helpers/retryTranscriptionHandler.test.js` — 4 further cases on the retry path: a stored WebM is converted before it reaches a Custom endpoint, audio already in WAV is left alone, built-in providers are untouched, and a conversion failure falls open to the stored container. Checked by mutation — disabling the branch fails the first case rather than passing vacuously. Conversion is mocked, so the suite does not shell out to ffmpeg.

## Verification

Run on macOS 26.5.2, Apple Silicon, against `microsoft/mai-transcribe-2` via OpenRouter, using a real OpenWhispr recording rather than synthetic audio:

| Path | Bytes | Status |
|---|---|---|
| unmodified WebM (what ships today) | 78,663 | **400** |
| renderer — `audioContainer.convertToWav` | 155,564 | **200** |
| retry — `ffmpegUtils.convertBufferToWav` | 155,598 | **200** |

Both conversion paths returned the same transcript, word for word, and both produced 16 kHz mono 16-bit WAV that validates under `ffprobe` and Python's `wave`. The retry leg exercised the shipped `ffmpegUtils` code rather than a reimplementation.

One detail worth recording: `ffmpeg` reports `Error parsing Opus packet header` on OpenWhispr's own recordings. `decodeAudioData` handles them anyway, so the fail-open branch is not silently swallowing the fix — but it is why the tests cover a real capture and not just generated tone.

Gates run locally against Node 25 (the repo requires >= 24, which is what made the toolchain awkward to install on a first attempt):

- `npm run quality-check` — eslint under both configs, prettier, and `tsc --noEmit`: clean.
- `npm test` — 3,468 tests, 3,460 pass, 6 skipped, **1 fail**.

That one failure is `settingsStore imports without a bare localStorage global` in `test/stores/enterpriseIdentityStoreImports.test.js`. It reproduces on `main` at f03e027, before either commit here, so it is pre-existing and not from this branch — flagging it because CI on this PR is still pending maintainer approval and will surface it as red once it runs.

## Independent verification on Linux

Everything above was measured on macOS, outside Electron. @mazixs — unaffiliated with this PR, running a self-hosted GigaAM v3 endpoint that accepts WebM and was never hit by the bug — ran this branch at 1d86e56 on Wayland/PipeWire and covered the two gaps it could not. Their full report is in #2028; the figures below are theirs, not mine.

One 27.66 s capture, same audio through each path:

| Path | Bytes | What the server received |
|---|---|---|
| WebM/Opus (ships today) | 196,205 | `opus: 48000Hz, 2ch` |
| renderer `convertToWav` | 885,164 | `wave: 16000Hz, 1ch` |
| retry, bundled ffmpeg | 885,198 | `wave: 16000Hz, 1ch` |

Transcripts from all three are word-for-word identical to a WAV control of the same source sent straight to the endpoint. The retry leg resolved the downloaded `ffmpeg-static` 7.0.2 binary rather than a system one, and the captured invocation carries the per-process sequence number added here. `needsWavConversion` returned true for `custom` and false for `openai`, so the scoping holds. Both new test files pass.

Two details corroborate rather than merely agree with the macOS numbers: the 34-byte difference between the two encoders is identical on both platforms despite different file sizes, and 885,164 − 44 is exactly 27.66 s of 16 kHz mono 16-bit PCM.

Their WAV-to-Opus ratio reads 4.5x rather than the ~2x quoted above; they flag this themselves as an artefact of a virtual source feeding identical mono to both channels, which Opus codes at ~57 kbit/s. Real stereo capture on that machine runs ~129 kbit/s and lands on ~2x.

Still not covered:

- A **packaged** build. That run was from source, so the `app.asar.unpacked` branch of `getFFmpegPath()` remains untested — although the bundled binary it resolves to has now been exercised.
- The hotkey and pill UI. The native Linux key listener is not built without the predev step, so `AudioManager` was driven directly; everything from `startRecording()` onward is the shipped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

