### PR TITLE
fix(windows): quote Expand-Archive fallback paths that contain apostrophes

### DIFF
--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -432,6 +432,10 @@ async function checkDiskSpace(directory, requiredBytes) {
   }
 }
 
+function escapePowerShellSingleQuoted(value) {
+  return String(value).replace(/'/g, "''");
+}
+
 async function extractZipWindows(zipPath, destDir) {
   try {
     await runSystemTar(zipPath, destDir);
@@ -440,19 +444,15 @@ async function extractZipWindows(zipPath, destDir) {
     debugLogger.info("tar extraction failed, trying PowerShell", { error: error.message });
   }
 
+  const command =
+    `Expand-Archive -Force -LiteralPath '${escapePowerShellSingleQuoted(zipPath)}' ` +
+    `-DestinationPath '${escapePowerShellSingleQuoted(destDir)}'`;
+
   return new Promise((resolve, reject) => {
-    execFile(
-      "powershell",
-      [
-        "-NoProfile",
-        "-Command",
-        `Expand-Archive -Force -Path '${zipPath}' -DestinationPath '${destDir}'`,
-      ],
-      (psError) => {
-        if (psError) reject(new Error(`Zip extraction failed: ${psError.message}`));
-        else resolve();
-      }
-    );
+    execFile("powershell", ["-NoProfile", "-Command", command], (psError) => {
+      if (psError) reject(new Error(`Zip extraction failed: ${psError.message}`));
+      else resolve();
+    });
   });
 }
 

--- a/test/helpers/extractArchive.test.js
+++ b/test/helpers/extractArchive.test.js
@@ -30,7 +30,9 @@ function freshRequire({ runSystemTar } = {}) {
   delete require.cache[downloadUtilsPath];
 
   Module._load = function loadWithMocks(request, parent, isMain) {
-    if (request === "electron") return { net: {} };
+    if (request === "electron") {
+      return { net: {}, app: { isPackaged: false, isReady: () => false } };
+    }
     if (request === "./systemTar" && runSystemTar) return { runSystemTar };
     return originalLoad.call(this, request, parent, isMain);
   };
@@ -180,7 +182,7 @@ test("extractArchive falls back to PowerShell when Windows tar rejects a zip arc
         args: [
           "-NoProfile",
           "-Command",
-          "Expand-Archive -Force -Path 'C:\\cache\\binary.zip' -DestinationPath 'C:\\cache\\extract'",
+          "Expand-Archive -Force -LiteralPath 'C:\\cache\\binary.zip' -DestinationPath 'C:\\cache\\extract'",
         ],
       },
     ]);
@@ -190,3 +192,64 @@ test("extractArchive falls back to PowerShell when Windows tar rejects a zip arc
     delete require.cache[downloadUtilsPath];
   }
 });
+
+test("extractArchive PowerShell fallback quotes apostrophe paths safely", async () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalExecFile = cp.execFile;
+  const execCalls = [];
+
+  Object.defineProperty(process, "platform", { value: "win32" });
+  cp.execFile = (command, args, callback) => {
+    execCalls.push({ command, args });
+    callback(null);
+  };
+
+  const archivePath = "C:\\Users\\O'Brien\\cache\\binary.zip";
+  const destDir = "C:\\Users\\O'Brien\\cache\\extract";
+  const { extractArchive } = freshRequire({
+    runSystemTar: async () => {
+      throw new Error("tar extraction timed out");
+    },
+  });
+
+  try {
+    await extractArchive(archivePath, destDir);
+    assert.equal(execCalls.length, 1);
+    assert.equal(execCalls[0].command, "powershell");
+    assert.deepEqual(execCalls[0].args, [
+      "-NoProfile",
+      "-Command",
+      "Expand-Archive -Force -LiteralPath 'C:\\Users\\O''Brien\\cache\\binary.zip' -DestinationPath 'C:\\Users\\O''Brien\\cache\\extract'",
+    ]);
+  } finally {
+    cp.execFile = originalExecFile;
+    Object.defineProperty(process, "platform", originalPlatform);
+    delete require.cache[downloadUtilsPath];
+  }
+});
+
+test(
+  "extractArchive PowerShell fallback extracts a zip under apostrophe paths",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "O'Brien-extract-"));
+    const zipPath = writeZip(tmp, "binary.zip", Buffer.from(ZIP_FIXTURE_B64, "base64"));
+    const dest = path.join(tmp, "out");
+    fs.mkdirSync(dest);
+
+    const { extractArchive } = freshRequire({
+      runSystemTar: async () => {
+        throw new Error("tar extraction timed out");
+      },
+    });
+
+    try {
+      await extractArchive(zipPath, dest);
+      const content = fs.readFileSync(path.join(dest, "test-file.txt"), "utf8");
+      assert.equal(content.trim(), "hello from test");
+    } finally {
+      delete require.cache[downloadUtilsPath];
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+);


### PR DESCRIPTION
Windows zip extract tries `tar` first, then PowerShell `Expand-Archive`. The fallback still interpolates `-Path '${zipPath}'`. An apostrophe in the profile path closes that string early, so Expand-Archive looks for a drive named `Brien-...` and GPU/binary install fails (`gpuBinaryManager` uses this helper).

This keeps `tar` as the primary path. The fallback now uses `-LiteralPath` and doubles apostrophes inside the single-quoted command.

Fixes #2030

## Test plan

- [x] `node --import tsx --test test/helpers/extractArchive.test.js` on Win11
- [x] Command-string test for `O'Brien` (`O''Brien` in the `-Command`)
- [x] Live extract under `%TEMP%\O'Brien-extract-*` with tar forced to fail
- Ubuntu CI `npm test` (the live apostrophe extract is skipped there)

## Evidence

HEAD command against `C:\Users\stans\AppData\Local\Temp\O'Brien-ow-extract\binary.zip`:

```
OLD_RC 1
OLD_STDERR New-Item : Cannot find drive. A drive with the name 'Brien-ow-extract\binary.zip -DestinationPath C' does not exist.
```

Same zip with `-LiteralPath` and doubled `'`:

```
NEW_RC 0
NEW_FILES ...\out-new\test-file.txt
```

After the helper change, the Windows live test extracted `hello from test`. 6 passed in that file; the remaining fail is the Linux unzip corrupt-zip case (pre-existing on Win32, CI is ubuntu).

## AI assistance

Drafted with Cursor. I reproduced the fallback on this Win11 box and wrote the quoting change plus tests.
