### PR TITLE
fix(settings): inherit dictation local STT provider for upload and meeting

### DIFF
--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -174,6 +174,15 @@ function readLocalProvider(key: string): LocalTranscriptionProvider {
   return stored === "nvidia" || stored === "cohere" ? stored : "whisper";
 }
 
+// Meeting/upload keys defaulted to "whisper" even when never stored, so a
+// fresh Parakeet/Cohere install resolved uploads against Whisper `base`.
+function readScopedLocalProvider(scopeKey: string): LocalTranscriptionProvider {
+  if (isBrowser && localStorage.getItem(scopeKey) === null) {
+    return readLocalProvider("localTranscriptionProvider");
+  }
+  return readLocalProvider(scopeKey);
+}
+
 function readBoolean(key: string, fallback: boolean): boolean {
   if (!isBrowser) return fallback;
   const stored = localStorage.getItem(key);
@@ -1470,7 +1479,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   meetingUseLocalWhisper: readBoolean("meetingUseLocalWhisper", false),
   meetingWhisperModel: readString("meetingWhisperModel", ""),
-  meetingLocalTranscriptionProvider: readLocalProvider("meetingLocalTranscriptionProvider"),
+  meetingLocalTranscriptionProvider: readScopedLocalProvider("meetingLocalTranscriptionProvider"),
   meetingParakeetModel: readString("meetingParakeetModel", ""),
   meetingCohereModel: readString("meetingCohereModel", ""),
   meetingCloudTranscriptionProvider: readString("meetingCloudTranscriptionProvider", ""),
@@ -1490,7 +1499,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   })(),
   uploadUseLocalWhisper: readBoolean("uploadUseLocalWhisper", false),
   uploadWhisperModel: readString("uploadWhisperModel", ""),
-  uploadLocalTranscriptionProvider: readLocalProvider("uploadLocalTranscriptionProvider"),
+  uploadLocalTranscriptionProvider: readScopedLocalProvider("uploadLocalTranscriptionProvider"),
   uploadParakeetModel: readString("uploadParakeetModel", ""),
   uploadCohereModel: readString("uploadCohereModel", ""),
   uploadCloudTranscriptionProvider: readString("uploadCloudTranscriptionProvider", ""),
@@ -2331,6 +2340,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     s.updateTranscriptionSettings(settings);
     const {
       useLocalWhisper,
+      localTranscriptionProvider,
       cloudTranscriptionMode,
       cloudTranscriptionProvider,
       cloudTranscriptionModel,
@@ -2347,10 +2357,12 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     s.setMeetingTranscriptionMode(mode);
     s.setUploadTranscriptionMode(mode);
     s.setMeetingUseLocalWhisper(useLocalWhisper);
+    s.setMeetingLocalTranscriptionProvider(localTranscriptionProvider);
     s.setMeetingCloudTranscriptionMode(cloudTranscriptionMode);
     s.setMeetingCloudTranscriptionProvider(cloudTranscriptionProvider);
     s.setMeetingCloudTranscriptionModel(cloudTranscriptionModel);
     s.setUploadUseLocalWhisper(useLocalWhisper);
+    s.setUploadLocalTranscriptionProvider(localTranscriptionProvider);
     s.setUploadCloudTranscriptionMode(cloudTranscriptionMode);
     s.setUploadCloudTranscriptionProvider(cloudTranscriptionProvider);
     s.setUploadCloudTranscriptionModel(cloudTranscriptionModel);

--- a/test/helpers/transcriptionModelMemory.test.js
+++ b/test/helpers/transcriptionModelMemory.test.js
@@ -113,6 +113,46 @@ test("per-provider transcription model memory", async (t) => {
   });
 });
 
+test("unset upload/meeting local providers inherit dictation, and onboarding mirrors them", async (t) => {
+  installBrowserGlobals(t, {
+    initialStorage: {
+      _providerSettingsMigrated: "1",
+      uploadTranscriptionMigrated: "true",
+      localTranscriptionProvider: "nvidia",
+      parakeetModel: "parakeet-tdt-0.6b-v3",
+    },
+  });
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-upload-provider-inherit-test-",
+  });
+  const {
+    useSettingsStore,
+    selectResolvedUploadTranscription,
+    selectResolvedMeetingTranscription,
+  } = await vite.ssrLoadModule("/stores/settingsStore.ts");
+  const state = () => useSettingsStore.getState();
+
+  await t.test("a missing scoped key inherits the dictation local provider", () => {
+    assert.equal(state().localTranscriptionProvider, "nvidia");
+    assert.equal(state().uploadLocalTranscriptionProvider, "nvidia");
+    assert.equal(state().meetingLocalTranscriptionProvider, "nvidia");
+    assert.equal(selectResolvedUploadTranscription(state()).localTranscriptionProvider, "nvidia");
+    assert.equal(selectResolvedMeetingTranscription(state()).localTranscriptionProvider, "nvidia");
+  });
+
+  await t.test(
+    "setCloudTranscriptionForAllScopes writes the dictation local provider into upload and meeting",
+    () => {
+      state().setLocalTranscriptionProvider("cohere");
+      state().setCloudTranscriptionForAllScopes({ useLocalWhisper: true });
+      assert.equal(state().uploadLocalTranscriptionProvider, "cohere");
+      assert.equal(state().meetingLocalTranscriptionProvider, "cohere");
+      assert.equal(localStorage.getItem("uploadLocalTranscriptionProvider"), "cohere");
+      assert.equal(localStorage.getItem("meetingLocalTranscriptionProvider"), "cohere");
+    }
+  );
+});
+
 // The picker commits a cloud selection only on an explicit model click:
 // switchCloudTranscriptionProvider(ctx, browsedProvider) followed by
 // setCloudTranscriptionModel(clickedId). Pin that sequence at store level.


### PR DESCRIPTION
## Summary
- Audio upload (and meeting) stored their local STT provider as Whisper whenever the scoped key was missing, even if onboarding chose Parakeet or Cohere.
- Unset meeting/upload keys now inherit `localTranscriptionProvider`, and `setCloudTranscriptionForAllScopes` writes that provider into both scopes the same way it already mirrors `useLocalWhisper`.
- Fresh installs that pick Parakeet no longer resolve uploads to Whisper `base`.

Fixes #2022

## Test plan
- [ ] Fresh install, pick Parakeet in onboarding, upload an audio file: upload uses Parakeet, not Whisper `base`.
- [ ] Same path with Cohere.
- [ ] Opening Upload settings and explicitly choosing Whisper still sticks.
- [ ] `node --test test/helpers/transcriptionModelMemory.test.js`