### PR TITLE
fix(linux): drop override-redirect while the assistant panel needs the keyboard

### DIFF
--- a/src/helpers/assistantPanelChrome.js
+++ b/src/helpers/assistantPanelChrome.js
@@ -1,0 +1,18 @@
+/**
+ * Overlay chrome for the dictation/assistant window.
+ *
+ * On Linux X11/XWayland, Chromium maps always-on-top frameless windows to
+ * override-redirect. The WM then cannot give the assistant panel keyboard
+ * focus, so typing lands in the previously focused app (#2027).
+ */
+function getAssistantPanelChrome({ platform, open }) {
+  if (!open) {
+    return { focusable: false, alwaysOnTop: true, skipTaskbar: true };
+  }
+  if (platform === "linux") {
+    return { focusable: true, alwaysOnTop: false, skipTaskbar: false };
+  }
+  return { focusable: true, alwaysOnTop: true, skipTaskbar: true };
+}
+
+module.exports = { getAssistantPanelChrome };

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -40,6 +40,7 @@ const {
   WINDOW_SIZES,
   WindowPositionUtil,
 } = require("./windowConfig");
+const { getAssistantPanelChrome } = require("./assistantPanelChrome");
 const AGENT_DICTATION_PILL_SIZE = Object.freeze({ ...WINDOW_SIZES.BASE });
 const { centeredBounds, clampedBounds } = require("./onboardingWindowBounds");
 const { ONBOARDING_DEMO_KINDS, isOnboardingInputAllowed } = require("./onboardingInputPolicy");
@@ -193,10 +194,16 @@ class WindowManager {
       this._assistantPanelBusy = false;
     }
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      const chrome = getAssistantPanelChrome({
+        platform: process.platform,
+        open: this._assistantPanelOpen,
+      });
       if (this._assistantPanelOpen) {
         // The window may have been hidden while the command was in flight
         // (PTT tap, auto-hide, tray); focus() is a no-op on a hidden window.
         if (!this.mainWindow.isVisible()) this.mainWindow.showInactive();
+        if (!chrome.alwaysOnTop) this.mainWindow.setAlwaysOnTop(false);
+        if (!chrome.skipTaskbar) this.mainWindow.setSkipTaskbar(false);
         this.mainWindow.setFocusable(true);
         this.mainWindow.focus();
       } else {
@@ -205,8 +212,9 @@ class WindowManager {
         // the foreground back to the app the user was in.
         this.mainWindow.blur();
         this.mainWindow.setFocusable(false);
+        if (process.platform === "linux") this.mainWindow.setSkipTaskbar(true);
       }
-      this.enforceMainWindowOnTop();
+      if (chrome.alwaysOnTop) this.enforceMainWindowOnTop();
     }
     if (this._assistantPanelOpen) this.showAgentDictationPill();
     else this.hideAgentDictationPill();

--- a/test/helpers/assistantPanelChrome.test.js
+++ b/test/helpers/assistantPanelChrome.test.js
@@ -1,0 +1,30 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { getAssistantPanelChrome } = require("../../src/helpers/assistantPanelChrome");
+
+test("Linux drops always-on-top while the assistant panel needs the keyboard", () => {
+  assert.deepEqual(getAssistantPanelChrome({ platform: "linux", open: true }), {
+    focusable: true,
+    alwaysOnTop: false,
+    skipTaskbar: false,
+  });
+});
+
+test("Linux restores overlay chrome when the assistant panel closes", () => {
+  assert.deepEqual(getAssistantPanelChrome({ platform: "linux", open: false }), {
+    focusable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+  });
+});
+
+test("macOS and Windows keep the overlay above other windows while the panel is open", () => {
+  for (const platform of ["darwin", "win32"]) {
+    assert.deepEqual(getAssistantPanelChrome({ platform, open: true }), {
+      focusable: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+    });
+  }
+});

--- a/test/helpers/windowManagerAssistantPanel.test.js
+++ b/test/helpers/windowManagerAssistantPanel.test.js
@@ -112,6 +112,8 @@ function fakeWindow({ visible }) {
       focus: () => calls.push("focus"),
       blur: () => calls.push("blur"),
       setFocusable: (value) => calls.push(`focusable:${value}`),
+      setAlwaysOnTop: (value) => calls.push(`alwaysOnTop:${value}`),
+      setSkipTaskbar: (value) => calls.push(`skipTaskbar:${value}`),
       setContentProtection: () => undefined,
       getBounds: () => ({ x: 0, y: 0, width: 96, height: 96 }),
     },
@@ -312,7 +314,12 @@ test("live transcript events are mirrored to the companion only for plain dictat
 test("opening the assistant panel surfaces a hidden pill window before focusing it", () => {
   const { manager, calls } = makeManager({ visible: false });
   manager.setAssistantPanelOpen(true);
-  assert.deepEqual(calls, ["showInactive", "focusable:true", "focus"]);
+  const expected = ["showInactive"];
+  if (process.platform === "linux") {
+    expected.push("alwaysOnTop:false", "skipTaskbar:false");
+  }
+  expected.push("focusable:true", "focus");
+  assert.deepEqual(calls, expected);
 });
 
 test("showDictationPanel still surfaces a hidden window while the panel is open", () => {


### PR DESCRIPTION
## Summary
- On Linux X11/XWayland, always-on-top frameless windows are override-redirect, so the WM cannot give the Voice Assistant panel keyboard focus.
- While the panel is open, Linux now drops always-on-top and skip-taskbar so the follow-up input (and Escape) actually receive keys. Overlay chrome is restored when the panel closes.
- macOS and Windows keep the existing always-on-top overlay.

Fixes #2027

## Test plan
- [ ] On GNOME Wayland (XWayland app): open Voice Assistant, click the follow-up field, type — text should stay in the panel, not the previous app.
- [ ] Escape still dismisses the panel.
- [ ] After closing, dictation pill still floats above other windows.
- [ ] `ELECTRON_OVERRIDE_DIST_PATH=/tmp node --test test/helpers/assistantPanelChrome.test.js test/helpers/windowManagerAssistantPanel.test.js`