### PR TITLE
fix: support copying Assistant response selections

### DIFF
--- a/src/components/dictation/AssistantPanel.tsx
+++ b/src/components/dictation/AssistantPanel.tsx
@@ -27,6 +27,7 @@ import {
   normalizeAgentSelectionContext,
   type AgentSelectionContext,
 } from "../../utils/agentSelectionContext";
+import { getSelectionForCopyShortcut, getSelectionInside } from "../../utils/assistantSelection";
 import { AssistantEmptyState } from "./AssistantEmptyState";
 import { useToast } from "../ui/useToast";
 import {
@@ -341,15 +342,11 @@ export function AssistantPanel({
     if (!open || !isResponseReady || !latestAssistantMessage) return undefined;
 
     const captureSelection = () => {
-      const selection = window.getSelection();
-      const root = responseSelectionRootRef.current;
-      if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !root) return;
-
-      const range = selection.getRangeAt(0);
-      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return;
+      const selectedText = getSelectionInside(responseSelectionRootRef.current);
+      if (!selectedText) return;
 
       const context = normalizeAgentSelectionContext({
-        text: selection.toString(),
+        text: selectedText,
         sourceMessageId: latestAssistantMessage.id,
       });
       if (!context) return;
@@ -391,6 +388,18 @@ export function AssistantPanel({
       const target = e.target as HTMLElement | null;
       const isEditable =
         target?.isContentEditable || target?.tagName === "INPUT" || target?.tagName === "TEXTAREA";
+      if (isResponseReady) {
+        const selectedText = getSelectionForCopyShortcut(
+          e,
+          responseSelectionRootRef.current,
+          Boolean(isEditable)
+        );
+        if (selectedText) {
+          e.preventDefault();
+          void handleCopy(selectedText);
+          return;
+        }
+      }
       if (
         isResponseReady &&
         footerPhase === "actions" &&

--- a/src/components/dictation/AssistantPanel.tsx
+++ b/src/components/dictation/AssistantPanel.tsx
@@ -27,7 +27,11 @@ import {
   normalizeAgentSelectionContext,
   type AgentSelectionContext,
 } from "../../utils/agentSelectionContext";
-import { getSelectionForCopyShortcut, getSelectionInside } from "../../utils/assistantSelection";
+import {
+  getSelectionForCopyShortcut,
+  getSelectionInside,
+  isEditableTarget,
+} from "../../utils/assistantSelection";
 import { AssistantEmptyState } from "./AssistantEmptyState";
 import { useToast } from "../ui/useToast";
 import {
@@ -143,6 +147,7 @@ export function AssistantPanel({
   const {
     copied,
     copy: handleCopy,
+    copyText,
     confirmCopied,
   } = useCopyFeedback(responseContent, {
     resetMs: MANUAL_COPY_FEEDBACK_MS,
@@ -385,21 +390,15 @@ export function AssistantPanel({
         return;
       }
 
-      const target = e.target as HTMLElement | null;
-      const isEditable =
-        target?.isContentEditable || target?.tagName === "INPUT" || target?.tagName === "TEXTAREA";
       if (isResponseReady) {
-        const selectedText = getSelectionForCopyShortcut(
-          e,
-          responseSelectionRootRef.current,
-          Boolean(isEditable)
-        );
+        const selectedText = getSelectionForCopyShortcut(e, responseSelectionRootRef.current);
         if (selectedText) {
           e.preventDefault();
-          void handleCopy(selectedText);
+          void copyText(selectedText);
           return;
         }
       }
+      const isEditable = isEditableTarget(e.target);
       if (
         isResponseReady &&
         footerPhase === "actions" &&
@@ -415,7 +414,17 @@ export function AssistantPanel({
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [voiceState, isBusy, streaming, open, onClose, isResponseReady, footerPhase, handleCopy]);
+  }, [
+    voiceState,
+    isBusy,
+    streaming,
+    open,
+    onClose,
+    isResponseReady,
+    footerPhase,
+    handleCopy,
+    copyText,
+  ]);
 
   return (
     <>

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1,4 +1,4 @@
-const { app, screen, BrowserWindow, dialog, ipcMain } = require("electron");
+const { app, screen, BrowserWindow, dialog, ipcMain, Menu } = require("electron");
 const debugLogger = require("./debugLogger");
 // Aliased: this class has an openExternalUrl method wrapping the helper.
 const { openExternalUrl: openUrlInExternalBrowser } = require("./externalUrlOpener");
@@ -132,6 +132,7 @@ class WindowManager {
 
     this.setMainWindowInteractivity(false);
     this.registerMainWindowEvents();
+    this.registerAssistantSelectionContextMenu();
 
     // Register load event handlers BEFORE loading to catch all events
     this.mainWindow.webContents.on(
@@ -171,6 +172,14 @@ class WindowManager {
     await this.initializeHotkey();
     this.dragManager.setTargetWindow(this.mainWindow);
     MenuManager.setupMainMenu(() => this.openSettings());
+  }
+
+  registerAssistantSelectionContextMenu() {
+    this.mainWindow?.webContents.on("context-menu", (_event, params) => {
+      if (!this._assistantPanelOpen || !params?.selectionText?.trim()) return;
+
+      Menu.buildFromTemplate([{ role: "copy" }]).popup({ window: this.mainWindow });
+    });
   }
 
   _updateMainContentProtection() {

--- a/src/hooks/useCopyFeedback.ts
+++ b/src/hooks/useCopyFeedback.ts
@@ -5,7 +5,7 @@ export function useCopyFeedback(
   { resetMs = 1800 }: { resetMs?: number } = {}
 ): {
   copied: boolean;
-  copy: () => Promise<void>;
+  copy: (textOverride?: string) => Promise<void>;
   confirmCopied: (copiedText: string, durationMs?: number) => void;
 } {
   const [copied, setCopied] = useState(false);
@@ -36,9 +36,9 @@ export function useCopyFeedback(
     [resetMs]
   );
 
-  const copy = useCallback(async () => {
-    const textToCopy = text.trim();
-    if (!textToCopy) return;
+  const copy = useCallback(async (textOverride?: string) => {
+    const textToCopy = textOverride ?? text.trim();
+    if (!textToCopy.trim()) return;
 
     try {
       const result = await window.electronAPI?.writeClipboard?.(textToCopy);
@@ -52,7 +52,7 @@ export function useCopyFeedback(
       }
     }
 
-    confirmCopied(text, resetMs);
+    confirmCopied(textOverride === undefined ? text : textToCopy, resetMs);
   }, [confirmCopied, text, resetMs]);
 
   return { copied, copy, confirmCopied };

--- a/src/hooks/useCopyFeedback.ts
+++ b/src/hooks/useCopyFeedback.ts
@@ -5,7 +5,8 @@ export function useCopyFeedback(
   { resetMs = 1800 }: { resetMs?: number } = {}
 ): {
   copied: boolean;
-  copy: (textOverride?: string) => Promise<void>;
+  copy: () => Promise<void>;
+  copyText: (textToCopy: string) => Promise<boolean>;
   confirmCopied: (copiedText: string, durationMs?: number) => void;
 } {
   const [copied, setCopied] = useState(false);
@@ -36,24 +37,36 @@ export function useCopyFeedback(
     [resetMs]
   );
 
-  const copy = useCallback(async (textOverride?: string) => {
-    const textToCopy = textOverride ?? text.trim();
-    if (!textToCopy.trim()) return;
+  // Writes without touching the copied state: the shared feedback belongs to
+  // the full-text copy, not to a partial selection.
+  const copyText = useCallback(async (textToCopy: string) => {
+    if (!textToCopy.trim()) return false;
 
     try {
       const result = await window.electronAPI?.writeClipboard?.(textToCopy);
       if (result?.success === false) throw new Error("clipboard-write-failed");
+      return true;
     } catch {
       try {
         await navigator.clipboard.writeText(textToCopy);
+        return true;
       } catch {
-        setCopied(false);
-        return;
+        return false;
       }
     }
+  }, []);
 
-    confirmCopied(textOverride === undefined ? text : textToCopy, resetMs);
-  }, [confirmCopied, text, resetMs]);
+  const copy = useCallback(async () => {
+    const textToCopy = text.trim();
+    if (!textToCopy) return;
 
-  return { copied, copy, confirmCopied };
+    if (!(await copyText(textToCopy))) {
+      setCopied(false);
+      return;
+    }
+
+    confirmCopied(text, resetMs);
+  }, [confirmCopied, copyText, text, resetMs]);
+
+  return { copied, copy, copyText, confirmCopied };
 }

--- a/src/utils/assistantSelection.ts
+++ b/src/utils/assistantSelection.ts
@@ -1,0 +1,27 @@
+export function getSelectionInside(root: HTMLElement | null): string | null {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !root) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return null;
+
+  const text = selection.toString();
+  return text.trim() ? text : null;
+}
+
+export function getSelectionForCopyShortcut(
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey">,
+  root: HTMLElement | null,
+  isEditableTarget = false
+): string | null {
+  if (
+    isEditableTarget ||
+    event.key.toLowerCase() !== "c" ||
+    event.altKey ||
+    (!event.ctrlKey && !event.metaKey)
+  ) {
+    return null;
+  }
+
+  return getSelectionInside(root);
+}

--- a/src/utils/assistantSelection.ts
+++ b/src/utils/assistantSelection.ts
@@ -1,3 +1,10 @@
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  return Boolean(
+    element?.isContentEditable || element?.tagName === "INPUT" || element?.tagName === "TEXTAREA"
+  );
+}
+
 export function getSelectionInside(root: HTMLElement | null): string | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0 || !root) return null;
@@ -10,12 +17,11 @@ export function getSelectionInside(root: HTMLElement | null): string | null {
 }
 
 export function getSelectionForCopyShortcut(
-  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey">,
-  root: HTMLElement | null,
-  isEditableTarget = false
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "target">,
+  root: HTMLElement | null
 ): string | null {
   if (
-    isEditableTarget ||
+    isEditableTarget(event.target) ||
     event.key.toLowerCase() !== "c" ||
     event.altKey ||
     (!event.ctrlKey && !event.metaKey)

--- a/test/helpers/assistantPanel.test.js
+++ b/test/helpers/assistantPanel.test.js
@@ -641,6 +641,110 @@ test("an automatic clipboard delivery keeps the shared Copy button confirmed for
   assert.ok(scheduledDelays.includes(6000));
 });
 
+test("Assistant selection copy preserves the selected text", async (t) => {
+  let root = null;
+  t.after(async () => {
+    if (root) await React.act(async () => root.unmount());
+  });
+  installBrowserGlobals(t);
+  const container = installInteractiveDom(t);
+  const writes = [];
+  const originalElectronAPI = globalThis.window.electronAPI;
+  t.after(() => {
+    globalThis.window.electronAPI = originalElectronAPI;
+  });
+  globalThis.window.electronAPI = {
+    writeClipboard: async (text) => {
+      writes.push(text);
+      return { success: true };
+    },
+  };
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-selection-copy-feedback-test-",
+  });
+  const { useCopyFeedback } = await vite.ssrLoadModule("/hooks/useCopyFeedback.ts");
+  const { createRoot } = require("react-dom/client");
+  let copyFeedback;
+
+  function Harness() {
+    copyFeedback = useCopyFeedback("Full Agent answer");
+    return React.createElement("button");
+  }
+
+  root = createRoot(container);
+  await React.act(async () => root.render(React.createElement(Harness)));
+  await React.act(async () => copyFeedback.copy(" selected answer "));
+  await React.act(async () => copyFeedback.copy());
+
+  assert.deepEqual(writes, [" selected answer ", "Full Agent answer"]);
+});
+
+test("Assistant selection must stay entirely inside the response root", async (t) => {
+  installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-assistant-selection-test-",
+  });
+  const { getSelectionForCopyShortcut, getSelectionInside } = await vite.ssrLoadModule(
+    "/utils/assistantSelection.ts"
+  );
+  const insideStart = {};
+  const insideEnd = {};
+  const outside = {};
+  const responseRoot = {
+    contains: (node) => node === insideStart || node === insideEnd,
+  };
+  const originalGetSelection = globalThis.window.getSelection;
+  t.after(() => {
+    globalThis.window.getSelection = originalGetSelection;
+  });
+
+  globalThis.window.getSelection = () => ({
+    isCollapsed: false,
+    rangeCount: 1,
+    getRangeAt: () => ({ startContainer: insideStart, endContainer: insideEnd }),
+    toString: () => "selected answer",
+  });
+  assert.equal(getSelectionInside(responseRoot), "selected answer");
+  assert.equal(
+    getSelectionForCopyShortcut(
+      { key: "c", ctrlKey: true, metaKey: false, altKey: false },
+      responseRoot
+    ),
+    "selected answer"
+  );
+  assert.equal(
+    getSelectionForCopyShortcut(
+      { key: "c", ctrlKey: false, metaKey: true, altKey: false },
+      responseRoot
+    ),
+    "selected answer"
+  );
+  assert.equal(
+    getSelectionForCopyShortcut(
+      { key: "c", ctrlKey: true, metaKey: false, altKey: true },
+      responseRoot
+    ),
+    null
+  );
+  assert.equal(
+    getSelectionForCopyShortcut(
+      { key: "c", ctrlKey: true, metaKey: false, altKey: false },
+      responseRoot,
+      true
+    ),
+    null
+  );
+
+  globalThis.window.getSelection = () => ({
+    isCollapsed: false,
+    rangeCount: 1,
+    getRangeAt: () => ({ startContainer: insideStart, endContainer: outside }),
+    toString: () => "mixed selection",
+  });
+  assert.equal(getSelectionInside(responseRoot), null);
+});
+
 test("a failed Assistant resize releases its open claim so opening can retry", async (t) => {
   installBrowserGlobals(t);
   const vite = await createRendererServer(t, {

--- a/test/helpers/assistantPanel.test.js
+++ b/test/helpers/assistantPanel.test.js
@@ -641,7 +641,7 @@ test("an automatic clipboard delivery keeps the shared Copy button confirmed for
   assert.ok(scheduledDelays.includes(6000));
 });
 
-test("Assistant selection copy preserves the selected text", async (t) => {
+test("Assistant selection copy preserves the selected text without claiming Copied", async (t) => {
   let root = null;
   t.after(async () => {
     if (root) await React.act(async () => root.unmount());
@@ -674,8 +674,10 @@ test("Assistant selection copy preserves the selected text", async (t) => {
 
   root = createRoot(container);
   await React.act(async () => root.render(React.createElement(Harness)));
-  await React.act(async () => copyFeedback.copy(" selected answer "));
+  await React.act(async () => copyFeedback.copyText(" selected answer "));
+  assert.equal(copyFeedback.copied, false, "a partial copy never shows the Copied state");
   await React.act(async () => copyFeedback.copy());
+  assert.equal(copyFeedback.copied, true);
 
   assert.deepEqual(writes, [" selected answer ", "Full Agent answer"]);
 });
@@ -729,9 +731,8 @@ test("Assistant selection must stay entirely inside the response root", async (t
   );
   assert.equal(
     getSelectionForCopyShortcut(
-      { key: "c", ctrlKey: true, metaKey: false, altKey: false },
-      responseRoot,
-      true
+      { key: "c", ctrlKey: true, metaKey: false, altKey: false, target: { tagName: "TEXTAREA" } },
+      responseRoot
     ),
     null
   );

--- a/test/helpers/windowManagerAssistantPanel.test.js
+++ b/test/helpers/windowManagerAssistantPanel.test.js
@@ -4,6 +4,7 @@ const Module = require("node:module");
 const requestedMainWindowPositions = [];
 const createdBrowserWindows = [];
 const screenListeners = [];
+const builtMenus = [];
 
 // Same stub set as windowManagerMeetingNotification.test.js: WindowManager
 // pulls in electron + sibling managers at require time.
@@ -48,6 +49,16 @@ Module._load = function loadWindowManagerWithStubs(request, parent, isMain) {
         showInactive() { this.visible = true; }
         hide() { this.visible = false; }
         moveTop() {}
+      },
+      Menu: {
+        buildFromTemplate: (template) => {
+          const menu = {
+            popupCalls: [],
+            popup(options) { this.popupCalls.push(options); },
+          };
+          builtMenus.push({ template, menu });
+          return menu;
+        },
       },
       shell: {},
       dialog: {},
@@ -129,6 +140,30 @@ function makeManager(windowState) {
   manager.hideAgentDictationPill = () => undefined;
   return { manager, calls: fake.calls };
 }
+
+test("the Assistant response context menu exposes native Copy only for selected text", () => {
+  builtMenus.length = 0;
+  const manager = new WindowManager();
+  const listeners = new Map();
+  manager.mainWindow = {
+    webContents: { on: (event, listener) => listeners.set(event, listener) },
+  };
+  manager._assistantPanelOpen = true;
+  manager.registerAssistantSelectionContextMenu();
+
+  const onContextMenu = listeners.get("context-menu");
+  assert.ok(onContextMenu);
+  onContextMenu(null, { selectionText: "selected answer" });
+  onContextMenu(null, { selectionText: "   " });
+
+  assert.equal(builtMenus.length, 1);
+  assert.deepEqual(builtMenus[0].template, [{ role: "copy" }]);
+  assert.deepEqual(builtMenus[0].menu.popupCalls, [{ window: manager.mainWindow }]);
+
+  manager._assistantPanelOpen = false;
+  onContextMenu(null, { selectionText: "outside Assistant" });
+  assert.equal(builtMenus.length, 1);
+});
 
 test("the Agent companion follows the edge opposite the panel", () => {
   requestedMainWindowPositions.length = 0;


### PR DESCRIPTION
## Summary

- copy a text selection inside the Voice Assistant response with `Ctrl+C` or `Cmd+C`
- preserve the existing bare `C` and footer actions for copying the full response
- show Electron's native Copy context menu when the Assistant window has selected text
- leave editable controls and selections outside the response to their normal clipboard behavior

Fixes #2023.

## Validation

- `node --import tsx --test test/helpers/assistantPanel.test.js test/helpers/windowManagerAssistantPanel.test.js` (42 passed)
- `npm run typecheck`
- `npm run lint -- --no-fix`
- `npx prettier --check src/utils/assistantSelection.ts`
- `git diff --check`

The repository-wide Prettier check currently reports pre-existing formatting drift across the baseline, so validation was kept focused on the new utility while ESLint and TypeScript were run repository-wide.
