### PR TITLE
fix(enterprise): version the managed Azure base URL for AI Services and Foundry hosts

### DIFF
--- a/src/helpers/enterpriseAiProviders.js
+++ b/src/helpers/enterpriseAiProviders.js
@@ -86,11 +86,20 @@ function createAzureModel(model, apiKey, enterprise) {
 
 // One allowlist for managed Azure hosts (resource, AI Services, and Foundry),
 // shared with the envelope validator so the two can never disagree.
+//
+// @ai-sdk/azure appends `/v1` and `?api-version=` itself ONLY when the base
+// URL's hostname ends in `.openai.azure.com`; for every other host it uses the
+// base URL verbatim and sends no api-version, so the version segment has to be
+// part of it here or AI Services / Foundry requests land on `/openai/<path>`
+// and 404.
 function toAzureOpenAIBaseUrl(endpoint) {
   if (!isAllowedAzureEndpoint(endpoint)) {
     throw new Error("Managed Azure OpenAI requires a public Azure resource origin");
   }
-  return `${new URL(endpoint).origin}/openai`;
+  const url = new URL(endpoint);
+  return url.hostname.endsWith(".openai.azure.com")
+    ? `${url.origin}/openai`
+    : `${url.origin}/openai/v1`;
 }
 
 function createVertexModel(model, apiKey, enterprise) {

--- a/test/helpers/enterpriseAiProvidersAzureHosts.test.js
+++ b/test/helpers/enterpriseAiProvidersAzureHosts.test.js
@@ -1,25 +1,106 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { toAzureOpenAIBaseUrl } = require("../../src/helpers/enterpriseAiProviders.js");
+const {
+  getEnterpriseAIModel,
+  toAzureOpenAIBaseUrl,
+} = require("../../src/helpers/enterpriseAiProviders.js");
 const { AZURE_HOST_SUFFIXES } = require("../../src/helpers/enterpriseManagedConfig.mjs");
 
-test("managed Azure LLM accepts every host the envelope validator accepts", () => {
-  for (const suffix of AZURE_HOST_SUFFIXES) {
-    const endpoint = `https://acme${suffix}`;
-    assert.equal(toAzureOpenAIBaseUrl(endpoint), `${endpoint}/openai`, endpoint);
+// @ai-sdk/azure appends `/v1` and `?api-version=` itself only when the base
+// URL's hostname ends in `.openai.azure.com`; for every other host it uses the
+// base URL verbatim. The two shapes are asserted separately so they can never
+// silently converge on one template again.
+const SDK_VERSIONED_SUFFIXES = [".openai.azure.com"];
+const VERBATIM_SUFFIXES = [".cognitiveservices.azure.com", ".services.ai.azure.com"];
+
+const prompt = [{ role: "user", content: [{ type: "text", text: "Hello" }] }];
+
+test("every allowlisted Azure host suffix is classified into exactly one base-URL shape", () => {
+  assert.deepEqual(
+    [...SDK_VERSIONED_SUFFIXES, ...VERBATIM_SUFFIXES].sort(),
+    [...AZURE_HOST_SUFFIXES].sort()
+  );
+});
+
+test("Azure OpenAI resources keep the SDK-managed base and never gain a /v1 of their own", () => {
+  for (const suffix of SDK_VERSIONED_SUFFIXES) {
+    for (const endpoint of [`https://acme${suffix}`, `https://acme${suffix}/`]) {
+      assert.equal(toAzureOpenAIBaseUrl(endpoint), `https://acme${suffix}/openai`, endpoint);
+    }
   }
 });
 
-test("managed Azure LLM still rejects spoofed and path-qualified hosts", () => {
+test("AI Services and Foundry resources carry the /v1 segment the SDK will not add", () => {
+  for (const suffix of VERBATIM_SUFFIXES) {
+    for (const endpoint of [`https://acme${suffix}`, `https://acme${suffix}/`]) {
+      assert.equal(toAzureOpenAIBaseUrl(endpoint), `https://acme${suffix}/openai/v1`, endpoint);
+    }
+  }
+});
+
+test("managed Azure LLM rejects path- or query-qualified endpoints on every host class", () => {
+  for (const suffix of AZURE_HOST_SUFFIXES) {
+    for (const endpoint of [
+      `https://acme${suffix}/openai`,
+      `https://acme${suffix}/openai/v1`,
+      `https://acme${suffix}?api-version=v1`,
+    ]) {
+      assert.throws(() => toAzureOpenAIBaseUrl(endpoint), /public Azure resource origin/, endpoint);
+    }
+  }
+});
+
+test("managed Azure LLM still rejects spoofed hosts", () => {
   for (const endpoint of [
     "https://acme.openai.azure.us",
     "https://services.ai.azure.com",
-    "https://acme.openai.azure.com/openai",
     "http://acme.openai.azure.com",
     "https://user:pw@acme.openai.azure.com",
     "https://evil.com/acme.openai.azure.com",
   ]) {
     assert.throws(() => toAzureOpenAIBaseUrl(endpoint), /public Azure resource origin/, endpoint);
+  }
+});
+
+test("the pinned Azure SDK builds one request shape per host class", async (t) => {
+  const originalFetch = global.fetch;
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+  let request;
+  global.fetch = async (url, init) => {
+    request = {
+      url: String(url),
+      headers: Object.fromEntries(new Headers(init.headers)),
+    };
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  for (const [endpoint, expectedUrl] of [
+    [
+      "https://acme.openai.azure.com",
+      "https://acme.openai.azure.com/openai/v1/responses?api-version=v1",
+    ],
+    [
+      "https://acme.cognitiveservices.azure.com",
+      "https://acme.cognitiveservices.azure.com/openai/v1/responses",
+    ],
+    [
+      "https://acme.services.ai.azure.com",
+      "https://acme.services.ai.azure.com/openai/v1/responses",
+    ],
+  ]) {
+    const model = await getEnterpriseAIModel("azure", "deployment-a", "", {
+      azureEndpoint: endpoint,
+      azureApiVersion: "v1",
+      managedTokenProvider: async () => "temporary-bearer-token",
+    });
+    await assert.rejects(model.doGenerate({ prompt }));
+    assert.equal(request.url, expectedUrl, endpoint);
+    assert.equal(request.headers.authorization, "Bearer temporary-bearer-token", endpoint);
   }
 });


### PR DESCRIPTION
Managed Azure text inference 404s on every `*.cognitiveservices.azure.com` and `*.services.ai.azure.com` resource because the SDK only versions `*.openai.azure.com` base URLs itself.

`toAzureOpenAIBaseUrl` now returns `${origin}/openai/v1` for non-`.openai.azure.com` hosts and leaves the `.openai.azure.com` shape untouched; the host test asserts each class separately and pins the wire URL through the real SDK.

## Problem

With a managed Azure workspace pointed at an AI Services or Foundry resource, every text request (rewrite, agent, meeting summary — anything through `getEnterpriseAIModel("azure", …)`) fails with a 404 before the deployment is ever reached. Only classic Azure OpenAI resources work.

The request the app actually sends, per host class, on the current branch head:

| Configured endpoint | Base URL handed to the SDK | Request on the wire | Result |
|---|---|---|---|
| `https://acme.openai.azure.com` | `…/openai` | `https://acme.openai.azure.com/openai/v1/responses?api-version=v1` | works |
| `https://acme.cognitiveservices.azure.com` | `…/openai` | `https://acme.cognitiveservices.azure.com/openai/responses` | 404 |
| `https://acme.services.ai.azure.com` | `…/openai` | `https://acme.services.ai.azure.com/openai/responses` | 404 |

Two of the three host suffixes in `AZURE_HOST_SUFFIXES` — the allowlist the envelope validator and the LLM factory share — produce a request with no `/v1` segment and no `api-version`, which Azure does not serve.

## Root cause

`@ai-sdk/azure@3.0.84` branches on the base URL's hostname: `isAzureOpenAIBaseURL()` (`dist/index.js:49`) is true only for `*.openai.azure.com`, and `url()` (`dist/index.js:96–113`) appends `/v1` plus `?api-version=` only when it is — for every other host it concatenates `${baseURL}${path}` verbatim and sets no api-version — while `toAzureOpenAIBaseUrl` returned `${origin}/openai` for all three allowed host classes.

## Fix

`src/helpers/enterpriseAiProviders.js` — `toAzureOpenAIBaseUrl` now returns:

- `${origin}/openai` when the hostname ends in `.openai.azure.com` (unchanged; the SDK adds `/v1` and `?api-version=` itself, so adding `/v1` here would yield `/openai/v1/v1/…`);
- `${origin}/openai/v1` for every other allowlisted host, because the SDK uses that string verbatim.

The predicate is the SDK's own (`hostname.endsWith(".openai.azure.com")`) so the two cannot drift. `createAzureModel` passes only `baseURL`, `apiVersion` and the token provider — no `useDeploymentBasedUrls` — so this is the whole of the URL contract on the managed path.

The base branch is `feat/managed-transcription-provider` because `toAzureOpenAIBaseUrl` only exists there.

## Deliberately untouched

- **The `.openai.azure.com` branch** — it is correct today and pinned by an existing test; any `/v1` added there doubles up.
- **`AZURE_HOST_SUFFIXES`** — the allowlist is right; the bug was in what we did with the allowed hosts, not which hosts are allowed.
- **`buildManagedAzureTranscriptionUrl` (`src/utils/urlUtils.ts`)** — the STT URL builder already emits `/openai/v1/audio/transcriptions?api-version=preview` and is owned by a sibling PR on this branch.
- **`apiVersion` handling for non-`.openai.azure.com` hosts** — the SDK never applies the option for those hosts, so a workspace's `azureApiVersion` is a no-op on the text path for AI Services / Foundry resources. Worth a follow-up decision (surface it, or document it); not changed here because the GA `v1` surface is what the fix targets and what was proven live.
- **The manual (API-key) Azure path** — passes the user's endpoint straight through, unaffected.

## Tests

`test/helpers/enterpriseAiProvidersAzureHosts.test.js` is rewritten. The previous version iterated `AZURE_HOST_SUFFIXES` and asserted `${endpoint}/openai` uniformly — it encoded the bug, which is why CI was green on a feature that could not work for two of its three host classes. It now:

1. asserts every allowlisted suffix is classified into exactly one shape (a fourth suffix added without a classification fails);
2. asserts `.openai.azure.com` → `${origin}/openai` and never a `/v1` of its own;
3. asserts `.cognitiveservices.azure.com` and `.services.ai.azure.com` → `${origin}/openai/v1`, with and without a trailing slash;
4. rejects path- or query-qualified endpoints on every host class (a pasted `…/openai/v1` is refused, never doubled);
5. drives the real pinned SDK through `global.fetch` for all three hosts and pins the wire URL and bearer header per class.

RED on the untouched head (tests 3 and 5 fail; the `.openai.azure.com` rows pass):

```
✖ AI Services and Foundry resources carry the /v1 segment the SDK will not add
  AssertionError [ERR_ASSERTION]: https://acme.cognitiveservices.azure.com
  + actual - expected
  + 'https://acme.cognitiveservices.azure.com/openai'
  - 'https://acme.cognitiveservices.azure.com/openai/v1'

✖ the pinned Azure SDK builds one request shape per host class
  AssertionError [ERR_ASSERTION]: https://acme.cognitiveservices.azure.com
  + actual - expected
  + 'https://acme.cognitiveservices.azure.com/openai/responses'
  - 'https://acme.cognitiveservices.azure.com/openai/v1/responses'
```

GREEN after the fix: 6/6 in that file; 45/45 across the neighbouring suites (`enterpriseAiProviders`, `enterpriseManagedConfig`, `bedrockEnterpriseIpc`, `enterpriseEndpointGuard`, `managedAzureTranscriptionUrl`, `managedTranscriptionExecutor`).

Full suite: 3,464 tests / 3,275 pass / 3 fail / 185 skipped (the Electron-ABI DB skips) / 1 todo. All three failures are pre-existing and environment-only (below); neither failing file has an import path to the changed helper.

The three failures, classified:

- `test/helpers/textEditMonitorWindowBounds.test.js` — "a reported window rect is parsed" and "reads are cached per pid for one press, then re-read": load-flaky under the full suite; the file passes 5/5 on three consecutive runs alone.
- `test/stores/enterpriseIdentityStoreImports.test.js` — "settingsStore imports without a bare localStorage global": fails identically alone (`actual: 'object', expected: 'undefined'`) because Node 25 ships a global `localStorage`. Known, unrelated to this change.

(`textEditMonitorSelection` "activateTargetPid resolves false for an unmapped PID", also on the known-flaky list, passed in this run.)

Prettier and eslint clean on the touched files; `tsc --noEmit` in `src/` shows only the four baseline missing-optional-dependency errors.

## Provenance

Found while proving managed Azure end to end against a Foundry-hosted resource (`*.services.ai.azure.com`) on 2026-09-05: the same request shape returned 404 until the base URL carried `/openai/v1`. On top of #1964.
