### PR TITLE
fix(enterprise): hydrate managed identity in the dictation window over IPC

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -215,6 +215,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getSpaces: () => ipcRenderer.invoke("db-get-spaces"),
   setActiveAccountScope: (accountId, expectedAuthGeneration) =>
     ipcRenderer.invoke("set-active-account-scope", accountId, expectedAuthGeneration),
+  getActiveAccountScope: () => ipcRenderer.invoke("get-active-account-scope"),
+  onActiveAccountScopeChanged: registerListener(
+    "active-account-scope-changed",
+    (callback) => (_event, scope) => callback(scope)
+  ),
   deleteAccountData: (accountId, expectedAuthGeneration) =>
     ipcRenderer.invoke("delete-account-data", accountId, expectedAuthGeneration),
   updateSpace: (id, updates) => ipcRenderer.invoke("db-update-space", id, updates),

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -9,6 +9,7 @@ import BackgroundModelDownloadTray from "./components/onboarding/BackgroundModel
 import { LEGACY_ONBOARDING_STEP_KEY, ONBOARDING_SESSION_KEY } from "./components/onboarding/flow";
 import { useAuth } from "./hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
+import { mirrorActiveAccountScope } from "./lib/accountScopeMirror";
 import { usePolicyStore } from "./stores/policyStore";
 import { resolveSettledControlPanelWindowMode } from "./utils/controlPanelWindowMode.ts";
 import { isControlPanelWindow } from "./utils/windowContext.ts";
@@ -79,6 +80,13 @@ function MainApp() {
         .catch(() => {});
     }
   }, [autoSyncReady, isControlPanel]);
+
+  useEffect(() => {
+    // The dictation window cannot resolve a session (see mirrorActiveAccountScope),
+    // so its policy and managed identity follow the main process's account scope.
+    if (!isDictationPanel) return;
+    return mirrorActiveAccountScope();
+  }, [isDictationPanel]);
 
   useEffect(() => {
     if (!authLoaded) return;

--- a/src/helpers/accountScopeBinding.js
+++ b/src/helpers/accountScopeBinding.js
@@ -45,6 +45,15 @@ function resolveBootAccountScope({ token, binding }) {
   return binding.accountId;
 }
 
+// The scope a window without a resolvable session hydrates from (the dictation
+// window has no cross-origin fetch, so its session never resolves): the same
+// validated binding boot restores, paired with the credential generation the
+// policy and managed-config handlers gate on.
+function resolveActiveAccountScope({ token, generation, binding }) {
+  const accountId = resolveBootAccountScope({ token, binding });
+  return accountId ? { accountId, authGeneration: generation } : null;
+}
+
 function read() {
   try {
     const parsed = JSON.parse(fs.readFileSync(bindingFile(), "utf8"));
@@ -77,4 +86,12 @@ function clear() {
   }
 }
 
-module.exports = { clear, evaluateScopeRequest, hashToken, persist, read, resolveBootAccountScope };
+module.exports = {
+  clear,
+  evaluateScopeRequest,
+  hashToken,
+  persist,
+  read,
+  resolveActiveAccountScope,
+  resolveBootAccountScope,
+};

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -641,6 +641,7 @@ class IPCHandlers {
       if (!token) {
         this.databaseManager.setActiveAccountId(null);
         accountScopeBinding.clear();
+        broadcastToWindows("active-account-scope-changed", null);
       }
       broadcastToWindows("auth-token-state-changed", {
         generation,
@@ -1983,8 +1984,19 @@ class IPCHandlers {
       this.databaseManager.setActiveAccountId(accountId);
       if (accountId !== null) accountScopeBinding.persist(accountId, state.token);
       else accountScopeBinding.clear();
+      broadcastToWindows(
+        "active-account-scope-changed",
+        accountId !== null ? { accountId, authGeneration: state.generation } : null
+      );
       return { success: true };
     });
+
+    ipcMain.handle("get-active-account-scope", () =>
+      accountScopeBinding.resolveActiveAccountScope({
+        ...tokenStore.getState(),
+        binding: accountScopeBinding.read(),
+      })
+    );
 
     ipcMain.handle("delete-account-data", async (_event, accountId, expectedGeneration) => {
       const state = tokenStore.getState();

--- a/src/lib/accountScopeMirror.ts
+++ b/src/lib/accountScopeMirror.ts
@@ -1,0 +1,57 @@
+import { useEnterpriseIdentityStore } from "../stores/enterpriseIdentityStore";
+import { usePolicyStore } from "../stores/policyStore";
+import { ACTIVE_WORKSPACE_KEY, refreshManagedEnterpriseIdentity } from "../stores/workspaceStore";
+import type { ActiveAccountScope } from "../types/electron";
+
+/**
+ * Hydrates the workspace policy and managed enterprise identity in a window
+ * that cannot resolve its own session. The dictation window is sandboxed with
+ * web security enforced, so Better Auth's cross-origin session fetch fails
+ * there and the session-driven hydration in useAuth never runs. The control
+ * panel validates the session and the main process persists that scope; this
+ * mirrors it back over IPC, both the value at boot and every later change
+ * (re-validation under a new credential generation, sign-out). The active
+ * workspace is the control panel's choice, read from the localStorage key it
+ * writes, which every window of this origin shares.
+ */
+export function mirrorActiveAccountScope(): () => void {
+  let scope: ActiveAccountScope | null = null;
+  let broadcastReceived = false;
+
+  const refreshIdentity = () => {
+    if (!scope) return;
+    refreshManagedEnterpriseIdentity(
+      scope.accountId,
+      scope.authGeneration,
+      localStorage.getItem(ACTIVE_WORKSPACE_KEY)
+    );
+  };
+  const applyScope = (next: ActiveAccountScope | null) => {
+    scope = next;
+    if (!next) {
+      usePolicyStore.getState().clearPolicy();
+      useEnterpriseIdentityStore.getState().clear();
+      return;
+    }
+    void usePolicyStore.getState().fetchPolicy(next.accountId, next.authGeneration);
+    refreshIdentity();
+  };
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === ACTIVE_WORKSPACE_KEY) refreshIdentity();
+  };
+
+  window.addEventListener("storage", onStorage);
+  const unsubscribe = window.electronAPI?.onActiveAccountScopeChanged?.((next) => {
+    broadcastReceived = true;
+    applyScope(next);
+  });
+  // A scope validated while the boot read was in flight has already arrived by
+  // broadcast; the read's answer is the older of the two.
+  void window.electronAPI?.getActiveAccountScope?.().then((next) => {
+    if (!broadcastReceived) applyScope(next);
+  });
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    unsubscribe?.();
+  };
+}

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -20,7 +20,8 @@ interface WorkspaceState {
   refreshMembers: (workspaceId: string) => Promise<void>;
 }
 
-const ACTIVE_WORKSPACE_KEY = "activeWorkspaceId";
+// Shared by every window of this origin; the dictation window mirrors it (lib/accountScopeMirror).
+export const ACTIVE_WORKSPACE_KEY = "activeWorkspaceId";
 
 function readActiveWorkspaceId(): string | null {
   if (typeof window === "undefined") return null;

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -135,6 +135,12 @@ export interface AuthTokenMutationResult extends AuthTokenState {
   code?: string;
 }
 
+/** The validated account scope the main process holds, as seen by any window. */
+export interface ActiveAccountScope {
+  accountId: string;
+  authGeneration: number;
+}
+
 export interface TranscriptionItem {
   id: number;
   text: string;
@@ -1287,6 +1293,10 @@ declare global {
         accountId: string | null,
         expectedAuthGeneration?: number
       ) => Promise<{ success: boolean; code?: string; error?: string }>;
+      getActiveAccountScope?: () => Promise<ActiveAccountScope | null>;
+      onActiveAccountScopeChanged?: (
+        callback: (scope: ActiveAccountScope | null) => void
+      ) => () => void;
       deleteAccountData?: (
         accountId: string,
         expectedAuthGeneration: number

--- a/test/helpers/accountScopeBinding.test.js
+++ b/test/helpers/accountScopeBinding.test.js
@@ -130,3 +130,19 @@ test("clear removes the binding and read tolerates absence and corruption", (t) 
   assert.equal(binding.read(), null);
   binding.clear();
 });
+
+test("resolveActiveAccountScope pairs the restorable account with the current credential generation", () => {
+  const valid = { version: 1, accountId: "account-a", tokenHash: sha256("token-a") };
+  assert.deepEqual(
+    binding.resolveActiveAccountScope({ token: "token-a", generation: 3, binding: valid }),
+    { accountId: "account-a", authGeneration: 3 }
+  );
+  assert.equal(
+    binding.resolveActiveAccountScope({ token: "rotated-token", generation: 4, binding: valid }),
+    null
+  );
+  assert.equal(
+    binding.resolveActiveAccountScope({ token: null, generation: 4, binding: null }),
+    null
+  );
+});

--- a/test/helpers/accountScopeIpc.test.js
+++ b/test/helpers/accountScopeIpc.test.js
@@ -1,0 +1,150 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+const handlersModulePath = require.resolve("../../src/helpers/ipcHandlers");
+const originalLoad = Module._load;
+
+// Registers the real handler closures against a fake `this` (the scaffolding
+// from agentDictationPillIpc.test.js) with the bearer state under test control
+// and the binding file in a temporary userData directory, so the scope
+// handlers run against the real accountScopeBinding.
+const handlers = new Map();
+const broadcasts = [];
+const userDataDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "account-scope-ipc-"));
+let tokenState = { token: null, generation: 0 };
+
+const electronStub = {
+  app: {
+    getPath: () => userDataDirectory,
+    getName: () => "test",
+    getVersion: () => "0.0.0",
+    isPackaged: false,
+    on: () => {},
+    requestSingleInstanceLock: () => true,
+  },
+  ipcMain: {
+    handle: (channel, fn) => handlers.set(channel, fn),
+    on: () => {},
+    removeHandler: () => {},
+  },
+  net: {
+    fetch: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => "{}",
+    }),
+  },
+  BrowserWindow: class BrowserWindow {
+    static getAllWindows() {
+      return [];
+    }
+    static fromWebContents() {
+      return null;
+    }
+  },
+  shell: {},
+  dialog: {},
+  screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 0, height: 0 } }) },
+  systemPreferences: { getMediaAccessStatus: () => "granted" },
+  session: { fromPartition: () => ({}) },
+  clipboard: {},
+  nativeImage: {},
+  globalShortcut: {},
+  utilityProcess: {},
+  MessageChannelMain: class {},
+};
+
+Module._load = function loadWithMocks(request, parent, isMain) {
+  if (request === "electron") return electronStub;
+  if (parent?.filename === handlersModulePath) {
+    if (request === "./tokenStore") {
+      return {
+        get: () => tokenState.token,
+        getState: () => ({ ...tokenState }),
+        subscribe: () => () => {},
+      };
+    }
+    if (request === "./windowBroadcast") {
+      return { broadcastToWindows: (channel, data) => broadcasts.push([channel, data]) };
+    }
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+function anything() {
+  return new Proxy(function () {}, {
+    get: (target, property) => {
+      if (property === Symbol.toPrimitive || property === "toString") return () => "";
+      if (property === "then") return undefined;
+      return anything();
+    },
+    apply: () => anything(),
+  });
+}
+
+function buildFakeThis() {
+  const target = { sessionId: "test-session" };
+  return new Proxy(target, {
+    get: (value, property) => (property in value ? value[property] : anything()),
+  });
+}
+
+test.before(() => {
+  delete require.cache[handlersModulePath];
+  const IPCHandlers = require(handlersModulePath);
+  const Ctor = IPCHandlers.default || IPCHandlers;
+  Ctor.prototype.setupHandlers.call(buildFakeThis());
+});
+
+test.after(() => {
+  Module._load = originalLoad;
+  fs.rmSync(userDataDirectory, { recursive: true, force: true });
+});
+
+const getScope = () => handlers.get("get-active-account-scope")();
+const setScope = (accountId, generation) =>
+  handlers.get("set-active-account-scope")({}, accountId, generation);
+
+test("no scope is readable before a session has been validated", async () => {
+  tokenState = { token: "token-a", generation: 1 };
+  assert.equal(await getScope(), null);
+});
+
+test("a validated scope is readable back and broadcast to every window", async () => {
+  tokenState = { token: "token-a", generation: 1 };
+  broadcasts.length = 0;
+  assert.deepEqual(await setScope("account-a", 1), { success: true });
+  assert.deepEqual(await getScope(), { accountId: "account-a", authGeneration: 1 });
+  assert.deepEqual(broadcasts, [
+    ["active-account-scope-changed", { accountId: "account-a", authGeneration: 1 }],
+  ]);
+});
+
+test("a rotated bearer hides the scope until the session is validated again", async () => {
+  tokenState = { token: "token-b", generation: 2 };
+  assert.equal(await getScope(), null);
+  await setScope("account-a", 2);
+  assert.deepEqual(await getScope(), { accountId: "account-a", authGeneration: 2 });
+});
+
+test("a rejected scope request changes nothing and broadcasts nothing", async () => {
+  tokenState = { token: "token-b", generation: 3 };
+  broadcasts.length = 0;
+  const result = await setScope("account-b", 2);
+  assert.equal(result.success, false);
+  assert.equal(result.code, "AUTH_CONTEXT_CHANGED");
+  assert.deepEqual(broadcasts, []);
+});
+
+test("a validated sign-out clears the scope and broadcasts the clearing", async () => {
+  tokenState = { token: null, generation: 4 };
+  broadcasts.length = 0;
+  assert.deepEqual(await setScope(null, 4), { success: true });
+  assert.equal(await getScope(), null);
+  assert.deepEqual(broadcasts, [["active-account-scope-changed", null]]);
+});

--- a/test/helpers/accountScopeRestoreContract.test.js
+++ b/test/helpers/accountScopeRestoreContract.test.js
@@ -46,3 +46,17 @@ test("boot restores the validated scope before any main-process consumer constru
   assert.ok(bootWindow[1].includes("resolveBootAccountScope"));
   assert.ok(bootWindow[1].includes("databaseManager.setActiveAccountId(bootAccountId)"));
 });
+
+test("clearing the bearer token broadcasts the cleared account scope to every window", () => {
+  const source = read("src/helpers/ipcHandlers.js");
+  const subscription = source.match(
+    /tokenStore\.subscribe\(\(\{ generation, token \}\) => \{([\s\S]*?)\n {4}\}\);/
+  );
+  assert.ok(subscription, "token subscription is present");
+  const cleared = subscription[1].match(/if \(!token\) \{([\s\S]*?)\n {6}\}/);
+  assert.ok(cleared, "the no-token branch is present");
+  assert.ok(
+    cleared[1].includes('broadcastToWindows("active-account-scope-changed", null)'),
+    "the no-token branch broadcasts the cleared scope"
+  );
+});

--- a/test/lib/accountScopeMirror.test.js
+++ b/test/lib/accountScopeMirror.test.js
@@ -1,0 +1,229 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+// The dictation window cannot resolve a session (sandboxed, web security
+// enforced), so the managed identity there is hydrated from the main
+// process's validated account scope instead. These tests drive that mirror
+// with the same probe the live verification uses: isManagedTranscriptionActive.
+const azureSttRequired = {
+  workspaceId: "workspace-a",
+  version: 1,
+  generation: 1,
+  identity: {
+    issuer: "https://api.example.com/enterprise-identity",
+    jwksUri: "https://api.example.com/enterprise-identity/jwks.json",
+    subject: "workspace:workspace-a",
+    audiences: { bedrock: "sts.amazonaws.com", azure: "api://AzureADTokenExchange" },
+  },
+  providers: [
+    {
+      provider: "azure",
+      mode: "managed_required",
+      allowManualSetup: false,
+      config: {
+        tenantId: "11111111-1111-4111-8111-111111111111",
+        clientId: "22222222-2222-4222-8222-222222222222",
+        endpoint: "https://example.openai.azure.com",
+        apiVersion: "preview",
+        transcription: {
+          allowedDeployments: ["gpt-4o-transcribe"],
+          defaultDeployment: "gpt-4o-transcribe",
+        },
+      },
+      version: 1,
+      updatedAt: "2026-08-10T00:00:00.000Z",
+    },
+  ],
+};
+const policy = {
+  version: 1,
+  transcription: {
+    allowedModes: ["enterprise", "local"],
+    allowedByokProviders: [],
+    allowedEnterpriseProviders: ["azure"],
+  },
+  llm: { allowedModes: ["openwhispr"], allowedByokProviders: [], allowedEnterpriseProviders: [] },
+  features: { agentEnabled: true, webSearchEnabled: false },
+  sharing: { externalLinkSharing: "disabled" },
+  dataRetention: {
+    audioRetentionMaxDays: null,
+    localHistoryMode: "user_choice",
+    cloudBackupAllowed: false,
+  },
+  minAppVersion: null,
+};
+
+function windowEvents() {
+  const listeners = new Map();
+  return {
+    add: (type, listener) => listeners.set(type, [...(listeners.get(type) ?? []), listener]),
+    remove: (type, listener) =>
+      listeners.set(
+        type,
+        (listeners.get(type) ?? []).filter((candidate) => candidate !== listener)
+      ),
+    dispatch: (type, event) => (listeners.get(type) ?? []).forEach((listener) => listener(event)),
+    count: (type) => (listeners.get(type) ?? []).length,
+  };
+}
+
+async function waitFor(check, label) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${label}`);
+}
+
+async function boot(t, { scope = null, activeWorkspaceId = null, readScope } = {}) {
+  // Registered before installBrowserGlobals so the mirror detaches while `window` still exists.
+  let stop = () => {};
+  t.after(() => stop());
+  const events = windowEvents();
+  const calls = { policy: [], config: [] };
+  let onScopeChanged = null;
+  const electronAPI = {
+    getAppVersion: async () => ({ version: "1.10.0" }),
+    getActiveAccountScope: readScope ?? (async () => scope),
+    onActiveAccountScopeChanged: (callback) => {
+      onScopeChanged = callback;
+      return () => {
+        onScopeChanged = null;
+      };
+    },
+    getWorkspacePolicy: async (accountId, authGeneration) => {
+      calls.policy.push([accountId, authGeneration]);
+      return {
+        success: true,
+        revision: calls.policy.length,
+        accountId,
+        authGeneration,
+        managed: true,
+        policy,
+      };
+    },
+    getManagedEnterpriseConfig: async (accountId, workspaceId, authGeneration) => {
+      calls.config.push([accountId, workspaceId, authGeneration]);
+      return {
+        success: true,
+        status: "network",
+        accountId,
+        workspaceId,
+        authGeneration,
+        config: azureSttRequired,
+      };
+    },
+    clearManagedEnterpriseIdentity: async () => {},
+  };
+  const { storage } = installBrowserGlobals(t, {
+    initialStorage: activeWorkspaceId ? { activeWorkspaceId } : {},
+    window: { electronAPI, addEventListener: events.add, removeEventListener: events.remove },
+  });
+  const vite = await createRendererServer(t, { cachePrefix: "openwhispr-account-scope-mirror-" });
+  const { mirrorActiveAccountScope } = await vite.ssrLoadModule("/lib/accountScopeMirror.ts");
+  const managed = await vite.ssrLoadModule("/services/managedTranscription.ts");
+  const { usePolicyStore } = await vite.ssrLoadModule("/stores/policyStore.ts");
+  const { useEnterpriseIdentityStore } = await vite.ssrLoadModule(
+    "/stores/enterpriseIdentityStore.ts"
+  );
+  stop = mirrorActiveAccountScope();
+  return {
+    managed,
+    usePolicyStore,
+    useEnterpriseIdentityStore,
+    calls,
+    events,
+    stop,
+    broadcast: (next) => onScopeChanged?.(next),
+    listeningForBroadcasts: () => onScopeChanged !== null,
+    // Browser semantics: the other window's write has landed before the event fires here.
+    setActiveWorkspace: (id) => {
+      storage.setItem("activeWorkspaceId", id);
+      events.dispatch("storage", { key: "activeWorkspaceId", newValue: id });
+    },
+  };
+}
+
+test("a window without a session hydrates managed transcription from the main process scope", async (t) => {
+  const { managed, calls, broadcast, usePolicyStore, useEnterpriseIdentityStore } = await boot(t, {
+    scope: { accountId: "account-a", authGeneration: 1 },
+    activeWorkspaceId: "workspace-a",
+  });
+  await waitFor(() => managed.isManagedTranscriptionActive(), "managed transcription");
+  const resolution = managed.getManagedTranscriptionResolution();
+  assert.equal(resolution.kind, "managed");
+  assert.equal(resolution.provider, "azure");
+  assert.equal(resolution.deployment, "gpt-4o-transcribe");
+  assert.deepEqual(
+    [
+      resolution.context.accountId,
+      resolution.context.workspaceId,
+      resolution.context.authGeneration,
+    ],
+    ["account-a", "workspace-a", 1]
+  );
+  assert.deepEqual(calls.policy, [["account-a", 1]]);
+  assert.deepEqual(calls.config, [["account-a", "workspace-a", 1]]);
+
+  await t.test("a new credential generation re-resolves policy and identity", async () => {
+    broadcast({ accountId: "account-a", authGeneration: 2 });
+    await waitFor(
+      () => managed.getManagedTranscriptionResolution()?.context?.authGeneration === 2,
+      "generation 2"
+    );
+    assert.deepEqual(calls.policy.at(-1), ["account-a", 2]);
+    assert.deepEqual(calls.config.at(-1), ["account-a", "workspace-a", 2]);
+    assert.equal(managed.isManagedTranscriptionActive(), true);
+  });
+
+  await t.test("a cleared scope (sign-out) clears the mirrored identity at once", () => {
+    broadcast(null);
+    assert.equal(managed.isManagedTranscriptionActive(), false);
+    assert.equal(managed.getManagedTranscriptionResolution(), undefined);
+    assert.equal(usePolicyStore.getState().status, "idle");
+    assert.equal(useEnterpriseIdentityStore.getState().status, "idle");
+    assert.equal(useEnterpriseIdentityStore.getState().accountId, null);
+  });
+});
+
+test("a scope validated after boot arrives by broadcast and the workspace by storage", async (t) => {
+  const { managed, calls, broadcast, setActiveWorkspace, usePolicyStore } = await boot(t);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(managed.isManagedTranscriptionActive(), false);
+  assert.deepEqual(calls.policy, []);
+
+  broadcast({ accountId: "account-a", authGeneration: 1 });
+  await waitFor(() => usePolicyStore.getState().status === "managed", "policy");
+  // No active workspace is known yet, so nothing can be managed.
+  assert.equal(managed.isManagedTranscriptionActive(), false);
+  assert.deepEqual(calls.config, []);
+
+  setActiveWorkspace("workspace-a");
+  await waitFor(() => managed.isManagedTranscriptionActive(), "managed transcription");
+  assert.deepEqual(calls.config, [["account-a", "workspace-a", 1]]);
+});
+
+test("a broadcast that lands while the boot read is in flight is not overwritten by it", async (t) => {
+  let resolveRead;
+  const { managed, broadcast } = await boot(t, {
+    activeWorkspaceId: "workspace-a",
+    readScope: () => new Promise((resolve) => (resolveRead = resolve)),
+  });
+  broadcast({ accountId: "account-a", authGeneration: 1 });
+  await waitFor(() => managed.isManagedTranscriptionActive(), "managed transcription");
+  resolveRead(null);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(managed.isManagedTranscriptionActive(), true);
+});
+
+test("stopping the mirror detaches both the broadcast and the storage listener", async (t) => {
+  const { stop, events, listeningForBroadcasts } = await boot(t, {
+    activeWorkspaceId: "workspace-a",
+  });
+  assert.equal(events.count("storage"), 1);
+  assert.equal(listeningForBroadcasts(), true);
+  stop();
+  assert.equal(events.count("storage"), 0);
+  assert.equal(listeningForBroadcasts(), false);
+});


### PR DESCRIPTION
**Problem:** The dictation window never resolves a session, so managed Azure STT resolves `active: true` in Settings but `active: false` in the only window that records; dictation silently falls through to the personal lane.

**Fix:** Expose the main process's validated account scope over IPC (`get-active-account-scope` + an `active-account-scope-changed` broadcast) and hydrate the dictation window's policy and managed identity from it, through the same store entry points `useAuth` already uses. No window capability changes.

## Problem

Reproduced on a live rig (2026-09-05) on top of #1964. With managed Azure STT configured and enforced, the two renderer windows disagree:

```js
const mt = await import("/services/managedTranscription.ts");
JSON.stringify({ active: mt.isManagedTranscriptionActive(), res: mt.getManagedTranscriptionResolution() });
// control panel (?panel=true) -> active: true
// dictation window (bare URL)  -> active: false
```

Settings shows "Managed by your organization"; the dictation window, which is where audio is actually transcribed, does not consider itself managed and records through the personal lane. This breaks the feature for every user on every host, and it fails silently.

Probing the network capability directly in each window:

```js
await fetch("https://api.openwhispr.com/api/workspaces");
// control panel    -> 401 (a real response)
// dictation window -> TypeError: Failed to fetch
```

## Root cause

The dictation window (`MAIN_WINDOW_CONFIG`, `src/helpers/windowConfig.js`) runs with `sandbox: true` and `webSecurity` enforced, while the control panel (`CONTROL_PANEL_CONFIG`) overrides `webSecurity: false`; Better Auth's client uses renderer `fetch`, so its cross-origin session request fails in the dictation window, `useAuth` never reports a signed-in session there, and `refreshManagedEnterpriseIdentity` (`src/hooks/useAuth.ts`, reached only from a resolved session) never runs in that window.

This is explicitly **not** "the stores fail to initialise": `policyStore` and `enterpriseIdentityStore` reach the API over `window.electronAPI` (IPC) and work perfectly in the dictation window. The only thing that window lacks is the identity (`accountId` + credential generation) to ask with.

## Fix

Option (a) from the handover: hand the dictation window the one thing it is missing over IPC, the way every other piece of this feature already crosses the boundary.

**Main process** (`src/helpers/ipcHandlers.js`, `src/helpers/accountScopeBinding.js`):

- `get-active-account-scope` returns `{ accountId, authGeneration } | null`. The account id comes from the persisted account-scope binding through the same hash-checked `resolveBootAccountScope` the boot restore uses, so a binding validated under a rotated bearer resolves to `null` rather than a stale account; the generation is the token store's current one, which is what `get-workspace-policy` and `get-managed-enterprise-config` already gate on. The main process holds both halves before any window resolves a session (the binding is on disk and restored at boot).
- `set-active-account-scope` broadcasts `active-account-scope-changed` with the new scope after persisting, or `null` after a validated sign-out clears it. The token-store subscription broadcasts `null` when the bearer is cleared, so a sign-out that never reaches the handler still clears every window.

**Preload / types**: `getActiveAccountScope`, `onActiveAccountScopeChanged`, and an `ActiveAccountScope` type next to `setActiveAccountScope`.

**Renderer** (`src/lib/accountScopeMirror.ts`, started from `src/AppRouter.jsx` in the dictation window only):

- Subscribes to the broadcast, then reads the scope once at boot; if a broadcast landed while the read was in flight, the read's older answer is ignored.
- A scope is applied through the same two entry points `useAuth` uses for a validated session: `policyStore.fetchPolicy(accountId, authGeneration)` and `refreshManagedEnterpriseIdentity(accountId, authGeneration, workspaceId)`. The active workspace is the control panel's choice, read from the shared `activeWorkspaceId` localStorage key it writes (every window of the origin shares it, the same mechanism `settingsStore` already uses for cross-window sync) and re-applied on that key's `storage` event.
- A `null` scope clears policy and identity.
- No timers or polling: the boot read plus three existing events (scope broadcast, storage event, and the managed-config broadcast the identity store already subscribes to on first refresh) cover every transition.

Behaviours covered:

- Pill boots after a settled sign-in: boot read returns the scope, hydration completes without any user action.
- Pill boots before sign-in, or before the control panel has resolved the workspace: the scope arrives by broadcast; the workspace arrives by storage event; nothing is managed until both are known.
- Sign-out: `null` broadcast, policy and identity cleared in the pill at once.
- Credential rotation (new generation): the main process clears its managed cache as before; the pill keeps its previous identity until the control panel re-validates and re-broadcasts, then clears and refreshes in one tick. Any managed call made in the gap carries the old generation and is rejected by the main process (`AUTH_CONTEXT_CHANGED`), so the gap fails closed rather than falling through; the persisted enforced-scope hint holds transcription closed while the refresh is loading.

Why the pill does not call `useWorkspaceStore.refresh()` itself: the cloud proxy fences every authenticated request on a validated credential generation (`AUTH_CONTEXT_UNVALIDATED` otherwise), which only the control panel's session path commits. Listing workspaces is the control panel's job; the pill mirrors its choice.

This adds **no capability** to the dictation window: `webPreferences` are unchanged, and the new IPC read returns only an account id and an integer generation that the main process already validated.

## Alternatives considered

- **(b) Move the managed decision into the main process entirely.** The Entra token already lives there and `managed-transcribe` is already an IPC call, so the renderer arguably should not be deciding whether it is managed at all. This is the cleaner long-term shape, and it should be on record. It is the largest diff and touches `transcriptionRoute.ts`, so it is out of scope for a fix on top of #1964; this change is compatible with doing it later (the IPC scope becomes an input to that decision rather than to the renderer stores).
- **(c) `webSecurity: false` on `MAIN_WINDOW_CONFIG`.** One line and it would work, but it disables the same-origin policy on an always-on-top window that is currently `sandbox: true`, and the only cross-origin request that window needs is the one session read this fix replaces. Rejected: the fix should add information to the pill window, not capability.
- A previous session's `AppRouter.jsx` scaffold (a `useEffect` polling `localStorage` for the usage account id up to ten times and then calling the same store entry points) is deliberately not shipped; it served only to prove that IPC-driven hydration brings the pill to `isManagedTranscriptionActive() === true`.

## Base branch

Targeted at `feat/managed-transcription-provider` alongside the sibling fixes from the same rig session. The cause lives in files #1964 does not touch (`windowConfig.js`, `useAuth.ts`, `AppRouter.jsx`), and the fix's own hunks do not overlap #1964's changes in the three files both touch (`preload.js`, `ipcHandlers.js`, `electron.ts`).

The diff **applies cleanly to `main`** as well (verified with `git apply --check` against `origin/main` via a temporary index). Author's choice: keep it on this PR so managed STT lands working, or rebase it onto `main` as a standalone fix; it needs no changes for either.

## Deliberately untouched

- `src/helpers/windowConfig.js`: no capability change; the pill stays `sandbox: true` with `webSecurity` enforced.
- `src/hooks/useAuth.ts`: the control panel keeps hydrating from the real session; the pill's `useAuth` still reports signed-out, which is existing behaviour and not what this defect is about.
- `src/stores/enterpriseIdentityStore.ts`, `src/stores/policyStore.ts`: reused through their existing entry points, unchanged.
- `src/stores/workspaceStore.ts`: logic unchanged; only the `activeWorkspaceId` key is exported so the mirror reads the same key the store writes.
- `src/helpers/transcriptionRoute.ts`: option (b) territory.
- `DatabaseManager.activeAccountId`: not exposed; the binding file is the self-verifying source and the boot restore already reads it the same way.

## Tests

Fail-first. Each new test was run alone before the implementation and captured RED:

- `test/helpers/accountScopeIpc.test.js` (new; registers the real handlers against a fake `this`, real `accountScopeBinding` in a temp userData dir, bearer state under test control):
  `TypeError: handlers.get(...) is not a function` (4 of 5; the fifth — a rejected scope request broadcasts nothing — passed vacuously against the old handler).
- `test/helpers/accountScopeBinding.test.js` (extended): `TypeError: binding.resolveActiveAccountScope is not a function`.
- `test/helpers/accountScopeRestoreContract.test.js` (extended, source-pinned like its neighbours because the token-store subscription is constructor wiring the handler harness cannot reach): `AssertionError [ERR_ASSERTION]: the no-token branch broadcasts the cleared scope` (`actual: false, expected: true`).
- `test/lib/accountScopeMirror.test.js` (new; Vite SSR harness with a stubbed `electronAPI`, real policy/identity/workspace stores, and the same `isManagedTranscriptionActive()` probe the live check uses): `Error: Failed to load url /lib/accountScopeMirror.ts ... Does the file exist?` (all 4).

After the implementation, alone: 5/5, 5/5, 4/4, 6/6 (4 tests + 2 subtests). The mirror tests cover: boot with a settled scope reaches `kind: "managed"`, `provider: "azure"`, `deployment: "gpt-4o-transcribe"` with the expected context; a scope that arrives after boot by broadcast and a workspace that arrives by storage event; a new credential generation re-resolving policy and identity with that generation; a `null` scope clearing both stores synchronously; a broadcast landing during the boot read not being overwritten by the read; and `stop()` detaching both listeners.

Full suite (`npm test`, this branch at the commit): 3473 tests, 3285 pass, 185 skipped (the usual Electron-ABI DB skips), 1 todo, 2 fail. Both failures are pre-existing environmental cases, not regressions:

- `test/stores/enterpriseIdentityStoreImports.test.js` "settingsStore imports without a bare localStorage global": the known Node 25 global-`localStorage` failure; this change does not touch `settingsStore`.
- `test/helpers/textEditMonitorWindowBounds.test.js` "a reported window rect is parsed" (`actual: null` for a real window rect read from the OS under suite load). The file alone, three times: 5/5, 4/5, 5/5, with the only miss being the already-known load-flaky "reads are cached per pid for one press, then re-read"; "a reported window rect is parsed" passed in all three solo runs. Nothing in this change is near `textEditMonitor`.

The known-flaky `textEditMonitorSelection` "activateTargetPid resolves false for an unmapped PID" did not fail in this run.

`npx prettier --check` clean on every touched file; `eslint` clean under the `src/` config for the renderer files (`src/helpers/*.js` is ignored by both eslint configs in this repo); `tsc --noEmit` reports only the 4 pre-existing missing-optional-dependency errors (`canvas-confetti`, `@tiptap/extension-mention`, `@tiptap/suggestion`).

## Live verification (still to run)

On a clean boot, signed in to a workspace with managed Azure STT enforced, with no manual step, in both windows:

```js
const mt = await import("/services/managedTranscription.ts");
JSON.stringify({ active: mt.isManagedTranscriptionActive(), res: mt.getManagedTranscriptionResolution() });
```

- Before: `active: true` in `?panel=true`, `active: false` in the bare window.
- After: both `true`, with the same `context.accountId`, `context.workspaceId`, and `context.authGeneration` in each.
- Then one real dictation must log `source: "azure-managed"`.
- Worth adding: sign out in the control panel and re-run the probe in the bare window (`active: false`, no restart); sign back in (`active: true` again, no restart).

## Provenance

Found while proving managed Azure STT end to end on 2026-09-05; on top of #1964.
