### PR TITLE
fix(transcription): route managed Azure v1/preview aliases to the dated deployments URL

### DIFF
--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -115,10 +115,12 @@ export function buildAzureTranscriptionUrl(
   }
 }
 
-// Workload-identity (managed) Azure STT. On the `/openai/v1` route Azure only
-// serves audio on the preview surface — GA v1 has no audio operations — so
-// both "v1" and "preview" send `api-version=preview`. Dated versions use the
-// legacy deployments route above.
+// Workload-identity (managed) Azure STT. Only the deployments route serves a
+// transcription deployment: `/openai/v1/audio/transcriptions?api-version=preview`
+// answers 404 DeploymentNotFound, and the deployments route rejects the
+// v1-surface aliases ("v1", "preview") outright — so those aliases are
+// translated to the dated version that is known to serve audio. Dated versions
+// pass through unchanged.
 export function buildManagedAzureTranscriptionUrl(
   endpoint: string,
   deployment: string,
@@ -130,8 +132,9 @@ export function buildManagedAzureTranscriptionUrl(
   } catch {
     return null;
   }
-  if (apiVersion === "v1" || apiVersion === "preview") {
-    return `${origin}/openai/v1/audio/transcriptions?api-version=preview`;
-  }
-  return buildAzureTranscriptionUrl(origin, deployment, apiVersion);
+  const version =
+    apiVersion === "v1" || apiVersion === "preview"
+      ? DEFAULT_AZURE_TRANSCRIPTION_API_VERSION
+      : apiVersion;
+  return buildAzureTranscriptionUrl(origin, deployment, version);
 }

--- a/test/helpers/managedTranscriptionExecutor.test.js
+++ b/test/helpers/managedTranscriptionExecutor.test.js
@@ -68,7 +68,7 @@ test("posts multipart audio to the workspace deployment with an Entra bearer", a
   assert.equal(calls.length, 1);
   assert.equal(
     calls[0].url,
-    "https://acme.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview"
+    "https://acme.services.ai.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview"
   );
   assert.equal(calls[0].init.headers.Authorization, "Bearer entra-token");
   const body = calls[0].init.body;

--- a/test/utils/managedAzureTranscriptionUrl.test.js
+++ b/test/utils/managedAzureTranscriptionUrl.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert/strict");
 
 const load = () => import("../../src/utils/urlUtils.ts");
 
-test("v1 and preview both use the v1 audio route with api-version=preview (GA v1 serves no audio)", async () => {
+test("v1 and preview aliases use the deployments route with the dated transcription version", async () => {
   const { buildManagedAzureTranscriptionUrl } = await load();
   for (const apiVersion of ["v1", "preview"]) {
     assert.equal(
@@ -12,13 +12,13 @@ test("v1 and preview both use the v1 audio route with api-version=preview (GA v1
         "gpt-4o-transcribe",
         apiVersion
       ),
-      "https://acme.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview",
+      "https://acme.services.ai.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview",
       apiVersion
     );
   }
 });
 
-test("dated versions use the legacy deployments route", async () => {
+test("dated versions pass through unchanged on the deployments route", async () => {
   const { buildManagedAzureTranscriptionUrl } = await load();
   assert.equal(
     buildManagedAzureTranscriptionUrl(
@@ -28,6 +28,19 @@ test("dated versions use the legacy deployments route", async () => {
     ),
     "https://acme.openai.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview"
   );
+});
+
+test("a dated version never lands on the /openai/v1/ route", async () => {
+  const { buildManagedAzureTranscriptionUrl } = await load();
+  for (const apiVersion of ["2025-03-01-preview", "2024-10-21"]) {
+    const url = buildManagedAzureTranscriptionUrl(
+      "https://acme.services.ai.azure.com",
+      "gpt-4o-transcribe",
+      apiVersion
+    );
+    assert.doesNotMatch(url, /\/openai\/v1\//, apiVersion);
+    assert.match(url, /\/openai\/deployments\/gpt-4o-transcribe\//, apiVersion);
+  }
 });
 
 test("an unparsable endpoint yields null", async () => {


### PR DESCRIPTION
**Problem:** With api-version `preview` or `v1` — the admin console's recommended and default value — managed Azure transcription posts to `/openai/v1/audio/transcriptions?api-version=preview`, which Azure answers `404 DeploymentNotFound`.

**Fix:** `buildManagedAzureTranscriptionUrl` now translates the `v1`/`preview` aliases to the dated default (`2025-03-01-preview`) on the legacy deployments route — the only shape verified live — and passes dated versions through unchanged; the contradicted comment is replaced.

## Problem

`POST {origin}/openai/v1/audio/transcriptions?api-version=preview` (multipart `file` + `model=<deployment>`, Entra bearer minted through workload identity) returns:

```
404 DeploymentNotFound
```

Reproduced on a Foundry-hosted resource (`*.services.ai.azure.com`) on 2026-09-05 and host-independent — it was also reproduced earlier through the `.openai.azure.com` alias. The same deployment transcribes on `POST {origin}/openai/deployments/<deployment>/audio/transcriptions?api-version=2025-03-01-preview`. Because the admin console hint recommends `preview` and seeds it as the default, an admin who follows the console's own guidance gets a broken transcription setup.

## Root cause

`buildManagedAzureTranscriptionUrl` (`src/utils/urlUtils.ts`) special-cased `v1` and `preview` onto the `/openai/v1/` audio route on the belief that "GA v1 has no audio operations and only the preview surface serves it", but that route does not resolve a transcription deployment, while the legacy deployments route does.

## Probe matrix

2026-09-05. Body: 1-second 16 kHz mono WAV tone, multipart `file` + `model=<deployment>`.

| | URL shape | Authenticated (live rig, Entra bearer) | Unauthenticated (from this PR's environment — weak evidence) |
|---|---|---|---|
| a | `/openai/v1/audio/transcriptions` (no `api-version`) | not probed | 401 — reached the auth gate; says nothing about routing |
| b | `/openai/v1/audio/transcriptions?api-version=preview` | **404 DeploymentNotFound** | 401 |
| c | `/openai/deployments/<deployment>/audio/transcriptions?api-version=preview` | not probed | **404 `"Resource not found"` — refused before auth** |
| d | `/openai/deployments/<deployment>/audio/transcriptions?api-version=2025-03-01-preview` | **200, transcribes** | 401 |

How to read it: a 401 only proves the request reached the auth gate (Azure authenticates before resolving the deployment), so (a) and (b) are indistinguishable without a token. Row (c) is the informative unauthenticated result: the same path and body as (d), differing only in the `api-version` value, is rejected before credentials are examined — so forwarding the `preview` alias onto the deployments route unchanged would also fail. No authenticated probe was possible from this PR's environment (no Azure CLI or token); the authenticated column is the live-rig reproduction.

## Fix

- `buildManagedAzureTranscriptionUrl`: `v1` / `preview` → `DEFAULT_AZURE_TRANSCRIPTION_API_VERSION` (`2025-03-01-preview`). Every managed transcription URL is now built by the existing `buildAzureTranscriptionUrl` as `/openai/deployments/<deployment>/audio/transcriptions?api-version=<version>`; dated versions pass through unchanged. Function signature and the one production call site (`ipcHandlers.js`, `managed-transcribe`) are unchanged.
- The comment is replaced with the observed behaviour.

Why translate rather than reject: `v1` and `preview` stay valid config values (`isAllowedAzureApiVersion`) because text processing uses them on the v1 surface, where they are correct. Transcription is the one scope that surface does not serve, so it maps the alias to the dated version that does.

## Deliberately untouched

- `src/helpers/managedTranscriptionExecutor.js` — the form body already sends `model=<deployment>`; the body was never the problem.
- `src/helpers/enterpriseAiProviders.js` (Azure OpenAI base-URL helper for text processing) — a sibling PR fixes it; text and transcription are separate surfaces.
- `isAllowedAzureApiVersion` in `enterpriseManagedConfig.mjs` — `v1`/`preview` remain accepted; they are right for text processing.
- `buildAzureTranscriptionUrl` (BYOK path) — already correct; the fix routes through it.
- Dictation-window identity hydration — sibling PR.

## Tests

Fail-first. `test/utils/managedAzureTranscriptionUrl.test.js` was rewritten to pin the full URL strings for the aliases and for a dated version, plus a boundary test that a dated version never lands on `/openai/v1/`; the URL assertion in `test/helpers/managedTranscriptionExecutor.test.js` was updated. RED against the unfixed builder (2 of 9 failing):

```
✖ v1 and preview aliases use the deployments route with the dated transcription version
  AssertionError [ERR_ASSERTION]: v1
  + actual - expected
  + 'https://acme.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview'
  - 'https://acme.services.ai.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview'

✖ posts multipart audio to the workspace deployment with an Entra bearer
  + actual - expected
  + 'https://acme.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview'
  - 'https://acme.services.ai.azure.com/openai/deployments/gpt-4o-transcribe/audio/transcriptions?api-version=2025-03-01-preview'
```

GREEN after the fix: 9/9 across the two files.

Full suite (`npm test`): 3461 tests — 3274 pass, 185 skipped (Electron-ABI DB skips), 1 todo, 1 fail. The one failure is `test/stores/enterpriseIdentityStoreImports.test.js` "settingsStore imports without a bare localStorage global" (`typeof localStorage` is `'object'` on Node 25) — pre-existing and unrelated.

`prettier --check` clean on all three files. `eslint` clean on both test files (`src/utils/**` is a standing ignore in `src/eslint.config.js`). `tsc --noEmit` reports only the four pre-existing missing-optional-dependency errors (canvas-confetti, @tiptap/extension-mention, @tiptap/suggestion).

## Still unverified

- Row (a), authenticated: `/openai/v1/audio/transcriptions` with no `api-version`. If the v1 surface is api-version-independent (as it appears to be for text), it most likely behaves like (b), but that was not proved.
- Row (c), authenticated: the pre-auth 404 makes it very unlikely to work, but no authenticated request was sent.
- `v1` sent literally as `api-version=v1` on the v1 route — the old code always sent `preview`, so this was never exercised.
- The fixed URL was not re-run on the live rig from this PR. Its shape is byte-identical to the row-(d) URL that transcribed, which is the basis for confidence.

## Provenance

Found while proving managed Azure transcription end to end on a Foundry-hosted resource on 2026-09-05. This branch is on top of #1964 (`feat/managed-transcription-provider`). A companion admin-console PR (follows up openwhispr-admin #16) changes the API-version hint and default to a dated version.
