### PR TITLE
fix(analytics): handle Date objects and defaults in calculateStreaks and activity days (#2044)

### DIFF
--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -30,13 +30,18 @@ export function countSpokenWords(text) {
 }
 
 export function localDateKey(date = new Date()) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  if (typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return date;
+  }
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "";
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
-export function buildAnalyticsActivityDays(daily, today = new Date()) {
+export function buildAnalyticsActivityDays(daily = [], today = new Date()) {
   const byDate = new Map(daily.map((bucket) => [bucket.date, bucket]));
   const startDate = new Date(
     today.getFullYear(),
@@ -90,10 +95,27 @@ export function resolveAnalyticsMode(settings, provider) {
 }
 
 function dayNumber(value) {
+  if (value instanceof Date) {
+    return Math.floor(Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()) / DAY_MS);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const d = new Date(value);
+    return Math.floor(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) / DAY_MS);
+  }
+  if (typeof value === "string") {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return Math.floor(Date.parse(`${value}T00:00:00Z`) / DAY_MS);
+    }
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      const d = new Date(parsed);
+      return Math.floor(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) / DAY_MS);
+    }
+  }
   return Math.floor(Date.parse(`${value}T00:00:00Z`) / DAY_MS);
 }
 
-export function calculateStreaks(ascendingDays, today) {
+export function calculateStreaks(ascendingDays = [], today = localDateKey()) {
   const days = [...new Set(ascendingDays)].sort();
   if (days.length === 0) return { currentStreakDays: 0, longestStreakDays: 0 };
 

--- a/test/helpers/analytics.test.js
+++ b/test/helpers/analytics.test.js
@@ -5,6 +5,7 @@ const {
   buildAnalyticsActivityDays,
   calculateStreaks,
   countSpokenWords,
+  localDateKey,
   resolveAnalyticsMode,
   summarizeAnalyticsDays,
 } = require("../../src/helpers/analytics.js");
@@ -111,4 +112,43 @@ test("analytics expires a stale current streak", () => {
     currentStreakDays: 0,
     longestStreakDays: 2,
   });
+  assert.deepEqual(
+    calculateStreaks(["2026-08-27", "2026-08-28"], new Date(2026, 7, 30)),
+    {
+      currentStreakDays: 0,
+      longestStreakDays: 2,
+    }
+  );
+  assert.deepEqual(calculateStreaks(["2020-01-01"]), {
+    currentStreakDays: 0,
+    longestStreakDays: 1,
+  });
+});
+
+test("analytics calculateStreaks counts active streak with Date object", () => {
+  assert.deepEqual(
+    calculateStreaks(
+      ["2026-08-28", "2026-08-29", "2026-08-30"],
+      new Date(2026, 7, 30)
+    ),
+    {
+      currentStreakDays: 3,
+      longestStreakDays: 3,
+    }
+  );
+});
+
+test("buildAnalyticsActivityDays handles omitted daily argument", () => {
+  const days = buildAnalyticsActivityDays(undefined, new Date(2026, 8, 15, 12));
+  assert.equal(days[0].date, "2026-04-01");
+  assert.equal(days.at(-1).date, "2026-09-15");
+  assert.ok(days.length > 150);
+  assert.equal(days.every((day) => day.words === 0), true);
+});
+
+test("localDateKey formats Date instances, timestamps, and date strings", () => {
+  assert.equal(localDateKey("2026-08-30"), "2026-08-30");
+  assert.equal(localDateKey(new Date(2026, 7, 30)), "2026-08-30");
+  const d = new Date(2026, 7, 30);
+  assert.equal(localDateKey(d.getTime()), "2026-08-30");
 });


### PR DESCRIPTION
### Summary of changes

This PR fixes three date and default handling issues in `src/helpers/analytics.js`:

1. **Stale streak expiration with omitted `today` or `Date` instances**:
   - In `calculateStreaks(ascendingDays, today)`, `today` previously lacked a default parameter. When omitted, `dayNumber(today)` evaluated to `NaN`, causing `dayNumber(today) - dayNumber(lastDay) > 1` to evaluate to `false`. Consequently, historical streaks never expired and were reported as active streaks.
   - When callers passed a `Date` instance (as accepted by `buildAnalyticsActivityDays`), `dayNumber` interpolated `${value}T00:00:00Z`, also parsing to `NaN` and failing to expire stale streaks.
   - **Fix**: Added default `today = localDateKey()` and updated `dayNumber` to correctly handle `Date` instances (as well as timestamps and ISO strings) by computing UTC calendar day numbers.

2. **Omitted `daily` in `buildAnalyticsActivityDays`**:
   - `buildAnalyticsActivityDays(daily, today = new Date())` previously threw a `TypeError: Cannot read properties of undefined (reading 'map')` if `daily` was omitted.
   - **Fix**: Defaulted `daily = []`.

3. **Robustness in `localDateKey`**:
   - Updated `localDateKey` to handle date strings (preserving `YYYY-MM-DD` keys directly to avoid UTC midnight timezone rollback) and timestamp numbers.

### Verification

- Added unit tests in `test/helpers/analytics.test.js` verifying:
  - Stale streak expiration when `today` is omitted (defaults to current date).
  - Stale streak expiration and active streak counting when `today` is provided as a `Date` instance.
  - `buildAnalyticsActivityDays` returns the 6-month empty activity template when `daily` is omitted.
  - `localDateKey` formats date strings, `Date` objects, and numeric timestamps.
- Ran `node --test test/helpers/analytics.test.js` (10/10 passed).
- Ran `node --test test/services/analyticsService.test.js` (17/17 passed).
- Passed `npm run lint` and `npm run i18n:check`.

Closes #2044