### PR TITLE
fix: give Audio Upload its own self-hosted transcription URL

### DIFF
--- a/src/components/notes/UploadAudioView.tsx
+++ b/src/components/notes/UploadAudioView.tsx
@@ -288,6 +288,7 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
     cloudTranscriptionBaseUrl,
     cloudTranscriptionMode,
     transcriptionMode,
+    remoteTranscriptionUrl,
   } = useSettingsStore(
     useShallow((settings) =>
       selectResolvedUploadTranscription(selectPolicyEffectiveSettings(settings, policyState))
@@ -295,7 +296,6 @@ export default function UploadAudioView({ onNoteCreated, onOpenSettings }: Uploa
   );
   const uploadAllowedByPolicy = useTranscriptionContextAllowed("upload");
 
-  const remoteTranscriptionUrl = useSettingsStore((s) => s.remoteTranscriptionUrl);
   const remoteTranscriptionModel = useSettingsStore((s) => s.remoteTranscriptionModel);
 
   const setUploadTranscriptionMode = useSettingsStore((s) => s.setUploadTranscriptionMode);

--- a/src/components/settings/UploadSettings.tsx
+++ b/src/components/settings/UploadSettings.tsx
@@ -34,8 +34,8 @@ export function UploadTranscriptionPanel() {
     uploadCloudTranscriptionBaseUrl,
     setUploadCloudTranscriptionBaseUrl,
     setUploadCloudTranscriptionMode,
-    remoteTranscriptionUrl,
-    setRemoteTranscriptionUrl,
+    uploadRemoteTranscriptionUrl,
+    setUploadRemoteTranscriptionUrl,
     remoteTranscriptionModel,
     setRemoteTranscriptionModel,
   } = useSettingsStore();
@@ -146,8 +146,8 @@ export function UploadTranscriptionPanel() {
       {effectiveTranscriptionMode === "self-hosted" && (
         <SelfHostedPanel
           service="transcription"
-          url={remoteTranscriptionUrl}
-          onUrlChange={setRemoteTranscriptionUrl}
+          url={uploadRemoteTranscriptionUrl}
+          onUrlChange={setUploadRemoteTranscriptionUrl}
           model={remoteTranscriptionModel}
           onModelChange={setRemoteTranscriptionModel}
         />

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -454,6 +454,7 @@ const UPLOAD_TRANSCRIPTION_PAIRS: ReadonlyArray<[string, string]> = [
   ["cloudTranscriptionBaseUrl", "uploadCloudTranscriptionBaseUrl"],
   ["cloudTranscriptionMode", "uploadCloudTranscriptionMode"],
   ["transcriptionMode", "uploadTranscriptionMode"],
+  ["remoteTranscriptionUrl", "uploadRemoteTranscriptionUrl"],
 ];
 
 function migrateUploadTranscription() {
@@ -715,6 +716,7 @@ export interface SettingsState
   uploadCloudTranscriptionModel: string;
   uploadCloudTranscriptionBaseUrl: string;
   uploadCloudTranscriptionMode: string;
+  uploadRemoteTranscriptionUrl: string;
 
   /** Last model used per scope+provider (`"<context>:<providerId>"`), so switching providers restores it. */
   transcriptionModelByProvider: Record<string, string>;
@@ -819,6 +821,7 @@ export interface SettingsState
   setUploadCloudTranscriptionModel: (value: string) => void;
   setUploadCloudTranscriptionBaseUrl: (value: string) => void;
   setUploadCloudTranscriptionMode: (value: string) => void;
+  setUploadRemoteTranscriptionUrl: (value: string) => void;
 
   setNoteFormattingMode: (mode: InferenceMode) => void;
   setNoteFormattingProvider: (value: string) => void;
@@ -1500,6 +1503,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   uploadCloudTranscriptionModel: readString("uploadCloudTranscriptionModel", ""),
   uploadCloudTranscriptionBaseUrl: readString("uploadCloudTranscriptionBaseUrl", ""),
   uploadCloudTranscriptionMode: readString("uploadCloudTranscriptionMode", ""),
+  uploadRemoteTranscriptionUrl: readString("uploadRemoteTranscriptionUrl", ""),
 
   noteFormattingMode: (() => {
     const v = readString("noteFormattingMode", "openwhispr");
@@ -1594,6 +1598,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setUploadCloudTranscriptionModel: createStringSetter("uploadCloudTranscriptionModel"),
   setUploadCloudTranscriptionBaseUrl: createStringSetter("uploadCloudTranscriptionBaseUrl"),
   setUploadCloudTranscriptionMode: createStringSetter("uploadCloudTranscriptionMode"),
+  setUploadRemoteTranscriptionUrl: createStringSetter("uploadRemoteTranscriptionUrl"),
 
   setNoteFormattingMode: createStringSetter("noteFormattingMode") as (mode: InferenceMode) => void,
   setNoteFormattingProvider: createStringSetter("noteFormattingProvider"),
@@ -2539,6 +2544,7 @@ export interface ResolvedUploadTranscription {
   cloudTranscriptionBaseUrl: string;
   cloudTranscriptionMode: string;
   transcriptionMode: InferenceMode;
+  remoteTranscriptionUrl: string;
 }
 
 // Audio upload is batch (not streaming), so unset values fall back to the base
@@ -2558,6 +2564,7 @@ export const selectResolvedUploadTranscription = (
     state.uploadCloudTranscriptionBaseUrl || state.cloudTranscriptionBaseUrl || "",
   cloudTranscriptionMode: state.uploadCloudTranscriptionMode || state.cloudTranscriptionMode,
   transcriptionMode: state.uploadTranscriptionMode,
+  remoteTranscriptionUrl: state.uploadRemoteTranscriptionUrl || state.remoteTranscriptionUrl,
 });
 
 export interface ResolvedNoteFormatting {

--- a/test/helpers/uploadRemoteTranscriptionUrlIsolation.test.js
+++ b/test/helpers/uploadRemoteTranscriptionUrlIsolation.test.js
@@ -1,0 +1,34 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+// Regression for #2049: Dictation and Audio Upload both read/wrote the same
+// shared `remoteTranscriptionUrl` key, so changing one silently changed the
+// other despite the Settings UI presenting them as independent tabs.
+// `uploadRemoteTranscriptionUrl` gives Audio Upload its own key (falling back
+// to the shared value when unset), mirroring the existing meeting-context
+// pattern (`meetingRemoteTranscriptionUrl`).
+test("audio upload self-hosted URL is isolated from dictation's", async (t) => {
+  installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-upload-remote-url-test-",
+  });
+  const { useSettingsStore, selectResolvedUploadTranscription } = await vite.ssrLoadModule(
+    "/stores/settingsStore.ts"
+  );
+
+  // No upload-specific override yet: falls back to the shared (dictation) URL.
+  useSettingsStore.getState().setRemoteTranscriptionUrl("http://dictation-server:8090");
+  let resolved = selectResolvedUploadTranscription(useSettingsStore.getState());
+  assert.equal(resolved.remoteTranscriptionUrl, "http://dictation-server:8090");
+
+  // Setting Audio Upload's URL must not clobber Dictation's.
+  useSettingsStore.getState().setUploadRemoteTranscriptionUrl("http://upload-server:8090");
+  assert.equal(
+    useSettingsStore.getState().remoteTranscriptionUrl,
+    "http://dictation-server:8090",
+    "dictation's shared URL must be unchanged"
+  );
+  resolved = selectResolvedUploadTranscription(useSettingsStore.getState());
+  assert.equal(resolved.remoteTranscriptionUrl, "http://upload-server:8090");
+});


### PR DESCRIPTION
Fixes #2049

## Root cause
Settings → Speech-to-Text presents separate tabs for Dictation, Note Recording, and Audio Upload, each with its own self-hosted server config UI. But Audio Upload's Server URL read/wrote the same shared `remoteTranscriptionUrl` key that Dictation uses — `UploadSettings.tsx` and `UploadAudioView.tsx` both referenced the raw shared field directly instead of an upload-specific one. Changing the URL in one tab silently changed it in the other, exactly as reported (confirmed by reproducing the repro steps against `main`).

Every other upload-context field (`uploadWhisperModel`, `uploadCloudTranscriptionProvider`, etc.) already has its own `upload*`-prefixed key with a documented "audio upload gets its own context" migration (`UPLOAD_TRANSCRIPTION_PAIRS`) — `remoteTranscriptionUrl` was simply missing from that list. The meeting context already has the analogous `meetingRemoteTranscriptionUrl` field (`state.meetingRemoteTranscriptionUrl || state.remoteTranscriptionUrl`), so this change follows that exact, already-established pattern rather than inventing a new one.

## Fix
- Added `uploadRemoteTranscriptionUrl` (state field, setter, default read from localStorage) mirroring `meetingRemoteTranscriptionUrl`.
- Added it to `UPLOAD_TRANSCRIPTION_PAIRS` for backward-compat migration consistency with the other upload fields.
- `selectResolvedUploadTranscription` (the selector the actual upload transcription runtime consumes) now resolves `uploadRemoteTranscriptionUrl || remoteTranscriptionUrl`, so existing single-server users see no change until they explicitly set an Audio Upload-specific URL.
- `UploadSettings.tsx` (Settings UI) and `UploadAudioView.tsx` (runtime config builder) now read/write the upload-specific field instead of the shared one.

Scoped to the reported Server URL field only — left `remoteTranscriptionModel` shared, since that's already the established behavior for the meeting context too (no per-context model override exists there either), so decoupling it here would be inconsistent with the rest of the codebase rather than fixing a reported bug.

## Test evidence
Added `test/helpers/uploadRemoteTranscriptionUrlIsolation.test.js`, which reproduces the exact issue repro (set Dictation's URL, then Audio Upload's URL, assert Dictation's is unchanged) and confirms the fallback for existing single-server setups. Red-before-green verified: fails on `main` with `dictation-server:8090` clobbered to `undefined`/overwritten, passes with this fix.

```
✔ audio upload self-hosted URL is isolated from dictation's
```

Also ran the full adjacent settings-store test suite (`policyEffectiveSettings`, `settingsStoreLocalProviderMigrations`, `settingsStoreRetiredGroqModels`, `transcriptionModelMemory`) — all 22 tests pass, no regressions. `tsc --noEmit` and `eslint` both clean on the touched files.