### PR TITLE
feat(transcription): prewarm local Whisper when dictation starts

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -396,6 +396,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Whisper server functions (faster repeated transcriptions)
   whisperServerStart: (modelName) => ipcRenderer.invoke("whisper-server-start", modelName),
+  whisperServerPrewarm: (modelName) => ipcRenderer.invoke("whisper-server-prewarm", modelName),
   whisperServerStop: () => ipcRenderer.invoke("whisper-server-stop"),
   whisperServerStatus: () => ipcRenderer.invoke("whisper-server-status"),
   whisperGpuRetry: () => ipcRenderer.invoke("whisper-gpu-retry"),

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -3079,6 +3079,24 @@ class IPCHandlers {
       );
     });
 
+    // Fire-and-forget prewarm issued when dictation recording starts (in parallel
+    // with opening the microphone), so a local Whisper cold start overlaps with
+    // the user speaking instead of happening after they stop. Resolves the same
+    // GPU + VAD options _runServerTranscription would use for a "dictation"
+    // request, so start()'s no-op guard recognizes an already-correct server and
+    // the real transcription never restarts what this just warmed up. Errors are
+    // swallowed into { success: false } — a failed prewarm never blocks
+    // recording, and the normal transcribe-local-whisper path retries the start.
+    ipcMain.handle("whisper-server-prewarm", async (event, modelName) => {
+      const vadOptions = this._resolveWhisperVadOptions("dictation");
+      const vadModelPath = vadOptions.vadEnabled ? this.whisperManager.getVadModelPath() : null;
+      return this.whisperManager.startServer(modelName, {
+        ...this.whisperManager.resolveGpuStartOptions(),
+        ...vadOptions,
+        vadModelPath,
+      });
+    });
+
     ipcMain.handle("whisper-server-stop", async () => {
       return this.whisperManager.stopServer();
     });

--- a/src/helpers/whisperPrewarmPolicy.js
+++ b/src/helpers/whisperPrewarmPolicy.js
@@ -1,0 +1,13 @@
+// Pure gating for the recording-start Whisper prewarm — no Electron/IPC
+// dependencies, so it can run in the renderer and be unit-tested directly.
+// Mirrors the exact provider check AudioManager.processAudio() uses to route a
+// dictation to processWithLocalWhisper (see audioManager.js): local whisper.cpp
+// only, never cloud, LAN/remote-self-hosted, Parakeet, or Cohere.
+export function shouldPrewarmLocalWhisper(settings = {}) {
+  return (
+    settings.useLocalWhisper === true &&
+    settings.localTranscriptionProvider === "whisper" &&
+    typeof settings.whisperModel === "string" &&
+    settings.whisperModel.length > 0
+  );
+}

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -24,6 +24,7 @@ import { waitForVisualFrames } from "../utils/visualFrame";
 import { resolveLifecycleInputKind } from "../helpers/dictationRouting";
 import { createAssistantResponseDelivery } from "../helpers/assistantResponseDelivery";
 import { recordCleanupFailure } from "../stores/cleanupFailureStore";
+import { shouldPrewarmLocalWhisper } from "../helpers/whisperPrewarmPolicy";
 
 // Maps a failed selection-replacement code to its `selectionEditing.*` toast
 // detail key; unlisted codes fall back to the generic "unavailable" message.
@@ -144,6 +145,20 @@ export const useAudioRecording = (toast, options = {}) => {
         // the compositor. startRecording() joins this prepared capture, so the
         // device still opens exactly once.
         void audioManagerRef.current.prepareMicCapture?.();
+
+        // Hide most of local Whisper's cold-start cost: kick off the model load
+        // in parallel with opening the microphone rather than after the user
+        // stops speaking. No-ops almost instantly if the right server is already
+        // running (see start()'s signature guard in whisperServer.js); a failure
+        // is logged and left for the normal transcribe-local-whisper path to
+        // retry, so it never blocks or delays the recording itself.
+        if (shouldPrewarmLocalWhisper(getSettings())) {
+          window.electronAPI?.whisperServerPrewarm?.(getSettings().whisperModel)?.catch((error) => {
+            logger.warn("Whisper prewarm failed; will retry on transcription", {
+              error: error?.message,
+            });
+          });
+        }
 
         // The floating dictation panel is non-focusable, so the foreground app is
         // still the user's actual editing target here. Refresh it for recordings

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1559,6 +1559,11 @@ declare global {
 
       // Whisper server lifecycle
       whisperServerStatus: () => Promise<WhisperServerStatus>;
+      // Fire-and-forget cold-start hider called when dictation recording begins;
+      // never awaited on the recording-start path (see useAudioRecording.js).
+      whisperServerPrewarm?: (
+        modelName: string
+      ) => Promise<{ success: boolean; port?: number; reason?: string }>;
       whisperGpuRetry: () => Promise<{ success: boolean; willRestart: boolean }>;
 
       // CUDA GPU acceleration

--- a/test/helpers/whisperPrewarmPolicy.test.js
+++ b/test/helpers/whisperPrewarmPolicy.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/whisperPrewarmPolicy.js");
+
+const base = {
+  useLocalWhisper: true,
+  localTranscriptionProvider: "whisper",
+  whisperModel: "base",
+};
+
+test("prewarms when local whisper.cpp is the active provider with a model selected", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper(base), true);
+});
+
+test("skips when local transcription is off (cloud/OpenWhispr-cloud dictation)", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper({ ...base, useLocalWhisper: false }), false);
+});
+
+test("skips the NVIDIA Parakeet provider", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper({ ...base, localTranscriptionProvider: "nvidia" }), false);
+});
+
+test("skips the Cohere (sherpa-onnx) provider", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper({ ...base, localTranscriptionProvider: "cohere" }), false);
+});
+
+test("skips when no whisper model is selected yet", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper({ ...base, whisperModel: "" }), false);
+  assert.equal(shouldPrewarmLocalWhisper({ ...base, whisperModel: undefined }), false);
+});
+
+test("skips on missing/empty settings", async () => {
+  const { shouldPrewarmLocalWhisper } = await load();
+  assert.equal(shouldPrewarmLocalWhisper({}), false);
+  assert.equal(shouldPrewarmLocalWhisper(undefined), false);
+});


### PR DESCRIPTION
## Problem

Local whisper.cpp transcription has a cold-start cost: `whisper-server` has to
boot and load the model before the first `/inference` request can be served.
Today that cost is paid *after* the user stops speaking — the server only
starts once `transcribeLocalWhisper()` is called at the end of a dictation
(or, for the very first dictation after launch, is hidden by an app-startup
pre-warm in `initializeAtStartup()`, which only covers the currently-selected
model and does nothing for a later model switch or a server that idle-unloaded
in the meantime).

## Solution

Kick off the whisper-server load in parallel with opening the microphone,
instead of after the user finishes talking:

- New `whisper-server-prewarm` IPC handler resolves the exact GPU + VAD
  options `_runServerTranscription` would use for a `"dictation"` request
  (`resolveGpuStartOptions()` + `_resolveWhisperVadOptions("dictation")`) and
  calls the existing `WhisperManager.startServer()`.
- `useAudioRecording.js` fires this, un-awaited, right next to the existing
  `prepareMicCapture()` call at the top of `performStartRecording` — so
  opening the microphone is never delayed by the model load, and the model
  loads while the user is speaking. By the time they stop, the server is
  often already warm.
- Gated by a small pure predicate, `shouldPrewarmLocalWhisper()`
  (`src/helpers/whisperPrewarmPolicy.js`): local whisper.cpp only. Cloud
  dictation, LAN/self-hosted remote whisper, NVIDIA Parakeet, and Cohere are
  all unaffected — they never call this handler.

## Lifecycle / race handling

- **No duplicate/unnecessary restarts**: `whisper-server-prewarm` reuses
  `WhisperServerManager.start()`'s existing signature guard (model path + GPU
  signature + VAD signature + thread signature). Because the prewarm resolves
  options identically to the real transcription request, a server this
  prewarmed is recognized as already-correct and the subsequent
  `transcribe-local-whisper` call is a no-op restart — it just uses the
  running server.
- **Never blocks recording**: the call is fire-and-forget
  (`.catch(...)` only, never awaited) on the recording-start path.
- **Startup failure is non-fatal**: a rejected prewarm is logged
  (`logger.warn`) and swallowed; the normal `transcribe-local-whisper` path
  already starts the server on demand and is untouched by this change, so it
  simply retries at the end of the dictation as it does today.
- **Model switches / GPU changes**: unaffected — this only adds one more
  caller of the existing `start()`/`startServer()` no-op guard, it does not
  change that guard's logic.

## Tests

- `test/helpers/whisperPrewarmPolicy.test.js` (6 cases): the gating predicate
  — local whisper.cpp only; cloud, Parakeet, Cohere, and a missing model all
  correctly skip prewarm.
- Full suite (`npm test`): 3375/3375 passing (196 pre-existing skips, 1 todo,
  unrelated to this change).
- `npm run lint` / `npm run typecheck`: clean.

## Manual validation

Ran locally on Apple Silicon macOS (arm64) with local whisper.cpp selected:
pressing the dictation hotkey now issues the prewarm call immediately
alongside microphone capture, and a subsequent dictation against the same
model does not spawn a second `whisper-server` process. Cloud/Parakeet/Cohere
dictation paths were exercised and do not trigger the new handler.

No cold-start latency numbers are included here since I did not benchmark
before/after timings — the change is a straightforward "start earlier,
in parallel" and its effect scales with however long this machine's
whisper-server cold start already takes.