### PR TITLE
fix(enterprise): ask the connection probe for Azure's minimum of 16 output tokens

### DIFF
--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -166,6 +166,9 @@ const AUDIO_MIME_TYPES = {
 };
 
 const CLOUD_INLINE_LIMIT = 4 * 1024 * 1024;
+// The enterprise "Test Connection" probe only needs one word back, but the
+// Azure Responses API rejects max_output_tokens below 16.
+const CONNECTION_TEST_MAX_OUTPUT_TOKENS = 16;
 const CLOUD_CHUNK_SEGMENT_SECONDS = 240;
 
 const { createAbortError } = require("./abortError");
@@ -4403,7 +4406,7 @@ class IPCHandlers {
             return generateText({
               model,
               prompt: "Say hello in one word.",
-              maxOutputTokens: 10,
+              maxOutputTokens: CONNECTION_TEST_MAX_OUTPUT_TOKENS,
               abortSignal,
               maxRetries: 0,
             });
@@ -4413,7 +4416,7 @@ class IPCHandlers {
           await generateText({
             model,
             prompt: "Say hello in one word.",
-            maxOutputTokens: 10,
+            maxOutputTokens: CONNECTION_TEST_MAX_OUTPUT_TOKENS,
           });
         }
 

--- a/test/helpers/bedrockEnterpriseIpc.test.js
+++ b/test/helpers/bedrockEnterpriseIpc.test.js
@@ -197,6 +197,30 @@ test.beforeEach(() => {
   resolveManagedRuntime = async () => ({ managed: false });
 });
 
+test("Check connection asks for at least 16 output tokens, the Azure Responses API minimum", async () => {
+  // Live 2026-09-07: Azure rejected the probe with "Invalid 'max_output_tokens':
+  // integer below minimum value. Expected a value >= 16, but got 10 instead."
+  const probes = [
+    ["bedrock", { model: "anthropic.claude-haiku", bedrockRegion: "eu-west-1" }],
+    ["azure", { model: "gpt-4.1-mini", azureEndpoint: "https://acme.openai.azure.com" }],
+  ];
+  for (const [provider, config] of probes) {
+    const result = await handlers.get("test-enterprise-connection")(
+      { sender: sender(3) },
+      provider,
+      config
+    );
+    assert.deepEqual(result, { success: true }, provider);
+  }
+  assert.equal(generateCalls.length, probes.length);
+  for (const call of generateCalls) {
+    assert.ok(
+      call.maxOutputTokens >= 16,
+      `maxOutputTokens ${call.maxOutputTokens} is below Azure's minimum of 16`
+    );
+  }
+});
+
 test("Check connection uses the Bedrock retry policy and disables nested AI SDK retries", async () => {
   let attempts = 0;
   generateBehavior = async () => {


### PR DESCRIPTION
Fourth follow-up to #1964, found on the 2026-09-07 manual verification round of the branch with #2036/#2037/#2038 merged.

## Problem
Every managed **Language Models → Test Connection** button fails on a workspace whose real cleanup, chat, translation and agent requests all work:

> Azure OpenAI error: Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 10 instead.

## Root cause
`test-enterprise-connection` hardcodes `maxOutputTokens: 10` at both call sites (`src/helpers/ipcHandlers.js`). The Azure **Responses API** enforces a minimum of 16. Bedrock and the chat-completions surface accepted 10, so this stayed latent until #2036 correctly moved Foundry text traffic onto `/openai/v1`. The real features ask for 4096 and are unaffected. The line predates this branch (it is on `main` too).

## Fix
One named constant, `CONNECTION_TEST_MAX_OUTPUT_TOKENS = 16`, used at both sites, with the reason in a comment.

## Tests
- New: `Check connection asks for at least 16 output tokens, the Azure Responses API minimum` — drives both the Bedrock and the Azure branch of the handler and asserts on the `generateText` options. Watched it fail (`maxOutputTokens 10 is below Azure's minimum of 16`) before the change.
- `test/helpers/bedrockEnterpriseIpc.test.js`: 13/13.
- Full suite: 3292 pass, 1 fail — `settingsStore imports without a bare localStorage global` (`test/stores/enterpriseIdentityStoreImports.test.js`), which fails identically on the untouched base `0828d762`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
