### PR TITLE
fix(transcription): send .opus uploads to managed Azure under an .ogg filename

### DIFF
--- a/src/helpers/managedTranscriptionExecutor.js
+++ b/src/helpers/managedTranscriptionExecutor.js
@@ -4,6 +4,13 @@
 // workspace's Azure resource. No user-owned API key is involved.
 const DEFAULT_TIMEOUT_MS = 120_000;
 
+// Azure keys the accepted-format check off the multipart filename's extension
+// and does not list "opus". Every .opus file is Opus in an Ogg container, so
+// the .ogg name it does accept describes the same bytes.
+function azureFileName(fileName) {
+  return fileName.replace(/\.opus$/i, ".ogg");
+}
+
 function createManagedTranscriptionExecutor({
   resolveEnterpriseRuntime,
   proxyFetch,
@@ -33,7 +40,11 @@ function createManagedTranscriptionExecutor({
     }
     const token = await managedTokenProvider();
     const formData = new FormData();
-    formData.append("file", new Blob([audioBuffer], { type: contentType }), fileName);
+    formData.append(
+      "file",
+      new Blob([audioBuffer], { type: contentType }),
+      azureFileName(fileName)
+    );
     formData.append("model", deployment);
     formData.append("response_format", "json");
     if (route.language && route.language !== "auto") {

--- a/test/helpers/managedTranscriptionExecutor.test.js
+++ b/test/helpers/managedTranscriptionExecutor.test.js
@@ -80,6 +80,22 @@ test("posts multipart audio to the workspace deployment with an Entra bearer", a
   assert.ok(calls[0].init.signal instanceof AbortSignal);
 });
 
+test("sends .opus uploads under an .ogg filename, the container Azure recognises", async () => {
+  // Proven live 2026-09-07: identical Ogg-Opus bytes are rejected as "Unsupported
+  // file format opus" under a .opus name and transcribed under a .ogg name.
+  const calls = [];
+  const run = executor({
+    fetch: async (_url, init) => {
+      calls.push(init);
+      return new Response(JSON.stringify({ text: "ok" }), { status: 200 });
+    },
+  });
+  await run({}, route, { ...input, fileName: "ow-url-123.opus", contentType: "audio/ogg" });
+  const file = calls[0].body.get("file");
+  assert.equal(file.name, "ow-url-123.ogg");
+  assert.equal(file.type, "audio/ogg");
+});
+
 test("maps Azure failures to coded errors", async () => {
   for (const [status, code] of [
     [429, "PROVIDER_RATE_LIMITED"],


### PR DESCRIPTION
Fifth follow-up to #1964, found on the 2026-09-07 manual verification round of the branch with #2036/#2037/#2038 merged.

## Problem
**Upload → paste a YouTube link** under managed Azure STT fails:

> Azure transcription error: 400 `{"error":{"message":"Unsupported file format opus","param":"file","code":"unsupported_value"}}`

Dictation on the same workspace works (`source: "azure-managed"` in the log).

## Root cause
`urlAudioDownloader` runs yt-dlp with `-x --audio-format best`, which keeps YouTube's native Opus and writes `ow-url-….opus`. The managed branch of `transcribe-audio-file-byok` forwards that basename verbatim, and Azure decides the accepted format from the **multipart filename's extension** — its list has `ogg` but not `opus`. OpenAI's own endpoint accepts `opus`, which is why the BYOK lane never needed anything here. A picked `.opus` file hits the same wall.

Proven live with a real Entra token against `openwhispr-foundry-stt` / `gpt-4o-transcribe`: the **identical Ogg-Opus bytes** return 400 under `sample.opus` and a correct transcript under `sample.ogg`.

## Fix
Every `.opus` file is Opus in an Ogg container, so `managedTranscriptionExecutor` normalises that one extension to `.ogg` on the multipart filename. No transcode, no extra I/O, MIME unchanged (`audio/ogg` already). Kept in the executor so dictation, upload and history retry all get it.

## Tests
- New: `sends .opus uploads under an .ogg filename, the container Azure recognises`. Watched it fail (`actual 'ow-url-123.opus' / expected 'ow-url-123.ogg'`) before the change.
- `test/helpers/managedTranscriptionExecutor.test.js`: 6/6.
- Full suite: 3292 pass, 1 fail — `settingsStore imports without a bare localStorage global` (`test/stores/enterpriseIdentityStoreImports.test.js`), which fails identically on the untouched base `0828d762`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
