### PR TITLE
fix(autostart): quote the Windows login-item lookup path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - `HIDDEN_LAUNCH_FLAG` (`--hidden`) is how a login launch tells the app to start in the tray. Windows has no native equivalent (`openAsHidden` is macOS-only and a no-op on macOS 13+), so the flag rides on the login item's `args`; Linux puts it on the autostart entry's `Exec`; macOS uses `wasOpenedAtLogin` instead
   - On Windows, read the state from `executableWillLaunchAtLogin`, never from `openAtLogin`: `openAtLogin` only compares the `Run` value against the current executable and args and ignores the `StartupApproved` key that Task Manager and Settings write when a user disables a startup app
   - Reads and writes must pass identical `args`, or `openAtLogin` always reports false
+  - `getLoginItemLookupPath()` supplies the Windows `path`, **quoted**. Electron parses both that path and every `Run` value with `CommandLine::FromString` and compares the parsed programs, so an unquoted `C:\Program Files\...` truncates to `C:\Program` and compares equal to any other unquoted `Run` entry under `C:\Program Files`. Unquoted, `executableWillLaunchAtLogin` reports an unrelated app's startup entry as ours, stays true after our own entry is deleted, and returns true for a path that does not exist. Passing no `path` is not a way out: Electron then falls back to the equally unquoted `GetProcessExecPath()`
 - **linuxAutostart.js**: Launch-at-login on Linux via an XDG autostart entry
   - `app.setLoginItemSettings()` is a no-op on Linux, so the entry is written directly to `$XDG_CONFIG_HOME/autostart/open-whispr.desktop`, matching the executable name electron-builder packages under
   - `Exec` resolves from `$APPIMAGE` first: `process.execPath` is the ephemeral AppImage FUSE mount
@@ -857,6 +858,7 @@ Raster UI assets live in `src/assets/` (onboarding ones are named `onboarding-*`
 - whisper.cpp bundled for x64
 - **Launch at login**: `HKCU\...\Run` entry written by Electron, named after the AppUserModelId, carrying `--hidden` so a login launch goes to the tray
   - Read the state from `executableWillLaunchAtLogin`; `openAtLogin` misses a startup app disabled from Task Manager or Settings
+  - Pass the executable path to `getLoginItemSettings()` **quoted** (`getLoginItemLookupPath()`). Unquoted, Electron truncates it at the first space and matches unrelated `Run` entries, which pins the launch-at-login toggle on and makes `syncAutoStartEntry()` recreate the entry on every launch
   - `resources/nsis/installer.nsh` removes the `Run` and `StartupApproved\Run` values on uninstall (but not on update), which Electron itself never cleans up
 - **Push-to-Talk**: Native key listener binary (`windows-key-listener.exe`) enables true push-to-talk
   - Uses Windows Low-Level Keyboard Hook (`WH_KEYBOARD_LL`)

--- a/src/helpers/autoStart.js
+++ b/src/helpers/autoStart.js
@@ -6,6 +6,7 @@ const { app } = require("electron");
 const linuxAutostart = require("./linuxAutostart");
 const {
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -14,7 +15,12 @@ const {
 const isLinux = () => process.platform === "linux";
 
 function readLoginItemSettings() {
-  return app.getLoginItemSettings({ args: getLoginItemArgs(process.platform) });
+  const options = { args: getLoginItemArgs(process.platform) };
+  // Windows needs the path passed quoted, or executableWillLaunchAtLogin reports
+  // another app's Run entry as ours. See getLoginItemLookupPath.
+  const lookupPath = getLoginItemLookupPath(process.platform, process.execPath);
+  if (lookupPath) options.path = lookupPath;
+  return app.getLoginItemSettings(options);
 }
 
 function writeLoginItem(enabled) {

--- a/src/helpers/autoStartPolicy.js
+++ b/src/helpers/autoStartPolicy.js
@@ -13,6 +13,32 @@ function getLoginItemArgs(platform) {
   return platform === "win32" ? [HIDDEN_LAUNCH_FLAG] : [];
 }
 
+// Windows only: the executable path to hand getLoginItemSettings, quoted.
+//
+// executableWillLaunchAtLogin is built by comparing parsed program paths, and BOTH
+// sides go through CommandLine::FromString first (browser_win.cc,
+// GetLoginItemSettingsHelper). An unquoted path containing spaces therefore truncates
+// at the first space, so C:\Program Files\<app>\<app>.exe collapses to "C:\Program" —
+// and so does every OTHER unquoted Run entry under C:\Program Files, of which there
+// are usually several. Those then compare equal, so the field reports true because an
+// unrelated app is set to launch, and keeps reporting true after our own entry is
+// removed. Left unquoted it even returns true for a path that does not exist on disk.
+//
+// The same truncation excludes our own correctly quoted entry from launchItems, since
+// it parses to the full path and no longer matches the truncated lookup.
+//
+// Passing no path is not a way out: getLoginItemSettings then falls back to
+// GetProcessExecPath(), which is unquoted and truncates identically.
+//
+// Safe for openAtLogin, which uses this same path: FormatCommandLineString strips
+// surrounding double quotes before re-quoting with AddQuoteForArg, so the string
+// compared against the registry value is byte-for-byte the same either way.
+function getLoginItemLookupPath(platform, execPath) {
+  if (platform !== "win32" || !execPath) return null;
+  const alreadyQuoted = execPath.length >= 2 && execPath.startsWith('"') && execPath.endsWith('"');
+  return alreadyQuoted ? execPath : `"${execPath}"`;
+}
+
 // For the platforms setLoginItemSettings covers: win32 and darwin.
 function resolveAutoStartState({ platform, loginItemSettings }) {
   if (platform === "win32") {
@@ -48,6 +74,7 @@ function wasLaunchedHidden({ platform, argv, loginItemSettings }) {
 module.exports = {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,

--- a/test/helpers/autoStartPolicy.test.js
+++ b/test/helpers/autoStartPolicy.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -18,6 +19,41 @@ test("Windows login items are read and written with the same args", () => {
 test("platforms without a hidden-launch flag pass no args", () => {
   assert.deepEqual(getLoginItemArgs("darwin"), []);
   assert.deepEqual(getLoginItemArgs("linux"), []);
+});
+
+// Electron parses the lookup path AND every Run value with CommandLine::FromString,
+// then compares the parsed programs. Unquoted, "C:\Program Files\OpenWhispr\..."
+// truncates to "C:\Program" and compares equal to any other unquoted Run entry under
+// C:\Program Files, so executableWillLaunchAtLogin reports a stranger's startup entry
+// as ours — and keeps reporting true once ours is gone, which is what makes the
+// launch-at-login switch impossible to turn off.
+test("Windows passes a quoted lookup path so the exe comparison is exact", () => {
+  assert.equal(
+    getLoginItemLookupPath("win32", "C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"),
+    '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'
+  );
+});
+
+// FormatCommandLineString strips one layer of surrounding quotes before re-quoting,
+// but double-quoting would still be wrong to write, so never wrap twice.
+test("an already quoted Windows path is not quoted twice", () => {
+  assert.equal(
+    getLoginItemLookupPath("win32", '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'),
+    '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'
+  );
+});
+
+// Only Windows parses the path this way, and passing one elsewhere would change what
+// macOS compares against.
+test("platforms other than Windows pass no lookup path", () => {
+  assert.equal(getLoginItemLookupPath("darwin", "/Applications/OpenWhispr.app"), null);
+  assert.equal(getLoginItemLookupPath("linux", "/usr/bin/open-whispr"), null);
+});
+
+// Falling back to no path is what the caller already did, and is still correct.
+test("a missing executable path yields no lookup path", () => {
+  assert.equal(getLoginItemLookupPath("win32", ""), null);
+  assert.equal(getLoginItemLookupPath("win32", undefined), null);
 });
 
 // The bug behind the reported "startup app not recognized": openAtLogin only


### PR DESCRIPTION
Fixes #2013

## The bug

On Windows the "Launch at login" switch cannot be turned off. It is worse than a stuck
control: the `Run` entry is also recreated on every launch, so deleting it by hand does not
stick either. There is currently no way for a user to disable launch at login.

## Root cause

`GetLoginItemSettingsHelper` in Electron's `shell/browser/browser_win.cc` runs **both** sides of
the comparison through `CommandLine::FromString` and then compares the parsed programs:

```cpp
lookup_exe_path = base::CommandLine::FromString(options.path).GetProgram();
// or, when options.path is empty, from GetProcessExecPath()
registry_launch_path = base::CommandLine::FromString(it->Value()).GetProgram();
bool exe_match = base::FilePath::CompareEqualIgnoreCase(
    lookup_exe_path.value(), registry_launch_path.value());
```

`autoStart.js` called `getLoginItemSettings()` without a `path`, so the lookup path came from
`GetProcessExecPath()`, unquoted. `C:\Program Files\OpenWhispr\OpenWhispr.exe` truncates at the
first space to `C:\Program`. Plenty of other apps write **unquoted** `Run` values under
`C:\Program Files`, which truncate to `C:\Program` as well, so the two compare equal.

It is not a prefix match. Both sides are truncated to the same token.

Two consequences, both user-visible:

- `resolveAutoStartState` pinned `enabled` to `true`, so switching the toggle off deleted our
  `Run` value, re-read, still saw a stranger's entry, and snapped back on.
- `needsHiddenFlagMigration` (`executableWillLaunchAtLogin && !openAtLogin`) was permanently
  true, so `syncAutoStartEntry()` called `writeLoginItem(true)` on every launch and restored the
  entry.

There is a matching irony: OpenWhispr's own `Run` value is correctly quoted, so it parses to the
full path, no longer equals the truncated lookup, and is therefore **excluded from its own
`launchItems`** while unrelated malformed entries are included.

## The fix

Pass the lookup path quoted. `autoStartPolicy.js` gains `getLoginItemLookupPath()`, and
`readLoginItemSettings()` supplies it on Windows only.

`resolveAutoStartState` and `needsHiddenFlagMigration` are **unchanged**. They were reasoning
correctly over a field that was lying to them, and quoting makes the field truthful. The existing
test `"Windows re-enables through executableWillLaunchAtLogin when only the args differ"` still
passes untouched.

This is safe for `openAtLogin`, which uses the same `path`. `FormatCommandLineString` strips
surrounding double quotes before re-quoting with `AddQuoteForArg`, so the string compared against
the registry value is unchanged:

```cpp
// Strip surrounding double quotes before re-quoting with AddQuoteForArg.
if (exe->size() >= 2 && exe->front() == L'"' && exe->back() == L'"') {
  *exe = exe->substr(1, exe->size() - 2);
}
*exe = electron::AddQuoteForArg(*exe);
```

## Verification

Measured on Windows 11 with Electron 41.10.5, via a read-only probe calling
`app.getLoginItemSettings()` directly.

With OpenWhispr having **no `Run` entry at all**, the current unquoted behaviour:

| queried path | `executableWillLaunchAtLogin` |
|---|---|
| `C:\Program Files\OpenWhispr\OpenWhispr.exe` | **true** |
| `C:\Program Files\Nonexistent\nothing.exe` (does not exist on disk) | **true** |
| `C:\ProgramFoo\bar.exe` | false |
| `C:\Windows\System32\notepad.exe` | false |
| `D:\foo\bar.exe` | false |

A path that does not exist reporting `true` shows the field was not reading our state at all.

Quoted vs unquoted, with the entry present:

| path passed | `executableWillLaunchAtLogin` | `launchItems` |
|---|---|---|
| unquoted (before) | true | `Synology Image Assistant`, `Docker Desktop` |
| quoted (after) | false | `com.gizmolabs.openwhispr`, full path, `enabled=false` |
| quoted, nonexistent exe | false | (empty) |

`enabled=false` is correct there, because the entry had been disabled under Task Manager's Startup apps
tab during testing, which is exactly the `StartupApproved` case
`executableWillLaunchAtLogin` exists to cover.

## Other platforms are unaffected

`getLoginItemLookupPath()` returns `null` off Windows and the caller only sets `options.path` when
it is non-null, so the options object is byte-identical to before:

| platform | options | vs. before |
|---|---|---|
| `win32` | `{ args: ["--hidden"], path: "\"…OpenWhispr.exe\"" }` | changed (the fix) |
| `darwin` | `{ args: [] }` | identical |
| `linux` | `{ args: [] }` | identical |

Linux never reaches this code at all. `getAutoStartState()` and `syncAutoStartEntry()` both
short-circuit to `linuxAutostart.js` first. The macOS-only `getLoginItemSettings()` call in
`wasLaunchedAtLoginHidden()` is untouched, as is the write path, so read/write symmetry is
preserved everywhere.

## Tests

Four new cases in `test/helpers/autoStartPolicy.test.js` (18 pass, 14 pre-existing + 4 new):

- Windows passes a quoted lookup path
- an already quoted path is not quoted twice
- macOS and Linux pass no lookup path
- a missing executable path yields no lookup path

`npm run typecheck` and `prettier --check` are clean.

Note: several unrelated test files fail in my environment with
`Cannot read properties of undefined (reading 'isPackaged')` because they import modules needing
Electron's `app`. I confirmed they fail identically on an unmodified tree, so they are unrelated
to this change.

## Also updated

`CLAUDE.md` documented the old behaviour in two places and would otherwise instruct the next
contributor to make the same call incorrectly.

## Note on upstream

This is arguably an Electron bug too, since `CommandLine::FromString` on an unquoted registry value is
lossy, and the resulting equality test is unsound. Happy to file that separately if you'd like;
this change is worth having regardless, since it fixes users on shipped Electron builds.

