### PR TITLE
feat(autostart): elevated launch at login on Windows (mechanism only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ OpenWhispr is an Electron-based desktop dictation application that uses whisper.
   - `HIDDEN_LAUNCH_FLAG` (`--hidden`) is how a login launch tells the app to start in the tray. Windows has no native equivalent (`openAsHidden` is macOS-only and a no-op on macOS 13+), so the flag rides on the login item's `args`; Linux puts it on the autostart entry's `Exec`; macOS uses `wasOpenedAtLogin` instead
   - On Windows, read the state from `executableWillLaunchAtLogin`, never from `openAtLogin`: `openAtLogin` only compares the `Run` value against the current executable and args and ignores the `StartupApproved` key that Task Manager and Settings write when a user disables a startup app
   - Reads and writes must pass identical `args`, or `openAtLogin` always reports false
+  - `getLoginItemLookupPath()` supplies the Windows `path`, **quoted**. Electron parses both that path and every `Run` value with `CommandLine::FromString` and compares the parsed programs, so an unquoted `C:\Program Files\...` truncates to `C:\Program` and compares equal to any other unquoted `Run` entry under `C:\Program Files`. Unquoted, `executableWillLaunchAtLogin` reports an unrelated app's startup entry as ours, stays true after our own entry is deleted, and returns true for a path that does not exist. Passing no `path` is not a way out: Electron then falls back to the equally unquoted `GetProcessExecPath()`
 - **linuxAutostart.js**: Launch-at-login on Linux via an XDG autostart entry
   - `app.setLoginItemSettings()` is a no-op on Linux, so the entry is written directly to `$XDG_CONFIG_HOME/autostart/open-whispr.desktop`, matching the executable name electron-builder packages under
   - `Exec` resolves from `$APPIMAGE` first: `process.execPath` is the ephemeral AppImage FUSE mount
@@ -857,6 +858,7 @@ Raster UI assets live in `src/assets/` (onboarding ones are named `onboarding-*`
 - whisper.cpp bundled for x64
 - **Launch at login**: `HKCU\...\Run` entry written by Electron, named after the AppUserModelId, carrying `--hidden` so a login launch goes to the tray
   - Read the state from `executableWillLaunchAtLogin`; `openAtLogin` misses a startup app disabled from Task Manager or Settings
+  - Pass the executable path to `getLoginItemSettings()` **quoted** (`getLoginItemLookupPath()`). Unquoted, Electron truncates it at the first space and matches unrelated `Run` entries, which pins the launch-at-login toggle on and makes `syncAutoStartEntry()` recreate the entry on every launch
   - `resources/nsis/installer.nsh` removes the `Run` and `StartupApproved\Run` values on uninstall (but not on update), which Electron itself never cleans up
 - **Push-to-Talk**: Native key listener binary (`windows-key-listener.exe`) enables true push-to-talk
   - Uses Windows Low-Level Keyboard Hook (`WH_KEYBOARD_LL`)

--- a/src/helpers/autoStart.js
+++ b/src/helpers/autoStart.js
@@ -6,6 +6,7 @@ const { app } = require("electron");
 const linuxAutostart = require("./linuxAutostart");
 const {
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -14,7 +15,12 @@ const {
 const isLinux = () => process.platform === "linux";
 
 function readLoginItemSettings() {
-  return app.getLoginItemSettings({ args: getLoginItemArgs(process.platform) });
+  const options = { args: getLoginItemArgs(process.platform) };
+  // Windows needs the path passed quoted, or executableWillLaunchAtLogin reports
+  // another app's Run entry as ours. See getLoginItemLookupPath.
+  const lookupPath = getLoginItemLookupPath(process.platform, process.execPath);
+  if (lookupPath) options.path = lookupPath;
+  return app.getLoginItemSettings(options);
 }
 
 function writeLoginItem(enabled) {

--- a/src/helpers/autoStartPolicy.js
+++ b/src/helpers/autoStartPolicy.js
@@ -39,13 +39,47 @@ function getLoginItemLookupPath(platform, execPath) {
   return alreadyQuoted ? execPath : `"${execPath}"`;
 }
 
+// Windows can start us elevated at login, which a Run entry can never do: Explorer
+// launches those with the user's filtered token, and no flag changes that. A Scheduled
+// Task with RunLevel=Highest and LogonType=Interactive is the only mechanism that
+// starts a process elevated at login without a UAC prompt, because Task Scheduler runs
+// as SYSTEM and mints the token itself rather than requesting elevation.
+//
+// This matters because Windows blocks synthetic input (UIPI) from a lower-integrity
+// process into a higher-integrity window, silently. Unelevated, dictation into an
+// administrator terminal is discarded with no error.
+function supportsElevatedAutoStart(platform) {
+  return platform === "win32";
+}
+
+// The Run entry and the scheduled task would BOTH start the app at login, so exactly
+// one owns startup. Enabling elevation must clear the Run entry and vice versa, or the
+// two instances race the single-instance lock and which one wins is a coin toss.
+function resolveAutoStartMechanism({ platform, enabled, elevated }) {
+  if (!supportsElevatedAutoStart(platform)) {
+    return { loginItem: !!enabled, scheduledTask: false };
+  }
+  if (!enabled) return { loginItem: false, scheduledTask: false };
+  return elevated
+    ? { loginItem: false, scheduledTask: true }
+    : { loginItem: true, scheduledTask: false };
+}
+
 // For the platforms setLoginItemSettings covers: win32 and darwin.
-function resolveAutoStartState({ platform, loginItemSettings }) {
+// elevatedTaskPresent is Windows-only and comes from windowsElevatedAutostart.
+function resolveAutoStartState({ platform, loginItemSettings, elevatedTaskPresent }) {
   if (platform === "win32") {
     // openAtLogin only checks whether the Run entry matches this executable and
     // args; it ignores Explorer's StartupApproved key, which is what Task Manager
     // writes when a user disables a startup app. Only this field covers both.
-    return { enabled: !!loginItemSettings.executableWillLaunchAtLogin, requiresApproval: false };
+    //
+    // Either mechanism starting us counts as enabled, so the switch does not read
+    // as off while the scheduled task is the one launching the app.
+    return {
+      enabled: !!loginItemSettings.executableWillLaunchAtLogin || !!elevatedTaskPresent,
+      requiresApproval: false,
+      elevated: !!elevatedTaskPresent,
+    };
   }
   return {
     enabled: !!loginItemSettings.openAtLogin,
@@ -60,8 +94,13 @@ function resolveAutoStartState({ platform, loginItemSettings }) {
 // we write and reads as disabled while still launching the app with its window
 // showing. Rewriting reuses the same registry value name, so it re-points that
 // entry rather than adding a second one.
-function needsHiddenFlagMigration({ platform, loginItemSettings }) {
+//
+// It must not fire while the elevated task owns startup: the Run entry is absent by
+// design there, and restoring it would reintroduce the double launch that switching
+// to the task removed.
+function needsHiddenFlagMigration({ platform, loginItemSettings, elevatedTaskPresent }) {
   if (platform !== "win32") return false;
+  if (elevatedTaskPresent) return false;
   return !!loginItemSettings.executableWillLaunchAtLogin && !loginItemSettings.openAtLogin;
 }
 
@@ -75,6 +114,8 @@ module.exports = {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
   getLoginItemLookupPath,
+  supportsElevatedAutoStart,
+  resolveAutoStartMechanism,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,

--- a/src/helpers/autoStartPolicy.js
+++ b/src/helpers/autoStartPolicy.js
@@ -13,6 +13,32 @@ function getLoginItemArgs(platform) {
   return platform === "win32" ? [HIDDEN_LAUNCH_FLAG] : [];
 }
 
+// Windows only: the executable path to hand getLoginItemSettings, quoted.
+//
+// executableWillLaunchAtLogin is built by comparing parsed program paths, and BOTH
+// sides go through CommandLine::FromString first (browser_win.cc,
+// GetLoginItemSettingsHelper). An unquoted path containing spaces therefore truncates
+// at the first space, so C:\Program Files\<app>\<app>.exe collapses to "C:\Program" —
+// and so does every OTHER unquoted Run entry under C:\Program Files, of which there
+// are usually several. Those then compare equal, so the field reports true because an
+// unrelated app is set to launch, and keeps reporting true after our own entry is
+// removed. Left unquoted it even returns true for a path that does not exist on disk.
+//
+// The same truncation excludes our own correctly quoted entry from launchItems, since
+// it parses to the full path and no longer matches the truncated lookup.
+//
+// Passing no path is not a way out: getLoginItemSettings then falls back to
+// GetProcessExecPath(), which is unquoted and truncates identically.
+//
+// Safe for openAtLogin, which uses this same path: FormatCommandLineString strips
+// surrounding double quotes before re-quoting with AddQuoteForArg, so the string
+// compared against the registry value is byte-for-byte the same either way.
+function getLoginItemLookupPath(platform, execPath) {
+  if (platform !== "win32" || !execPath) return null;
+  const alreadyQuoted = execPath.length >= 2 && execPath.startsWith('"') && execPath.endsWith('"');
+  return alreadyQuoted ? execPath : `"${execPath}"`;
+}
+
 // For the platforms setLoginItemSettings covers: win32 and darwin.
 function resolveAutoStartState({ platform, loginItemSettings }) {
   if (platform === "win32") {
@@ -48,6 +74,7 @@ function wasLaunchedHidden({ platform, argv, loginItemSettings }) {
 module.exports = {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,

--- a/src/helpers/windowsElevatedAutostart.js
+++ b/src/helpers/windowsElevatedAutostart.js
@@ -1,0 +1,175 @@
+// Launch at login, elevated, on Windows. Mirrors linuxAutostart.js: a platform where
+// setLoginItemSettings() cannot express what is needed, so a bespoke mechanism sits
+// behind the same autoStart.js interface.
+//
+// Why a scheduled task rather than the Run entry: Explorer starts Run entries with the
+// user's filtered (medium-integrity) token, and no flag changes that. Windows blocks
+// synthetic input from a lower-integrity process into a higher-integrity window (UIPI)
+// and reports nothing to the sender, so an unelevated OpenWhispr silently discards
+// every dictation aimed at an administrator window. A task with RunLevel=Highest is the
+// only way to start elevated at login WITHOUT a UAC prompt every time: Task Scheduler
+// already runs as SYSTEM and mints the token itself instead of requesting elevation.
+//
+// Creating or deleting the task needs administrator rights once, which is the single
+// UAC prompt the user sees when they flip the switch.
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { HIDDEN_LAUNCH_FLAG } = require("./autoStartPolicy");
+
+// Task names are machine-global, so scope it to the account it launches for. Two users
+// on one machine would otherwise fight over a single task with one UserId.
+function getTaskName(username = os.userInfo().username) {
+  return `OpenWhispr Launch At Login (${username})`;
+}
+
+const SCHTASKS = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "schtasks.exe");
+const TIMEOUT_MS = 20000;
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// LogonType=InteractiveToken is load-bearing: it keeps the process in the user's
+// interactive session. Password/S4U run it non-interactively with no desktop, where a
+// GUI app has no foreground window to type into and no user-session audio endpoint.
+//
+// ExecutionTimeLimit must be PT0S. The default is PT72H, which would have Task
+// Scheduler kill a tray app after three days for no visible reason.
+// DisallowStartIfOnBatteries defaults to true, which would silently skip autostart on
+// battery power.
+function buildTaskXml({ userId, execPath, args = [HIDDEN_LAUNCH_FLAG] }) {
+  const argumentsLine = args.length
+    ? `\n      <Arguments>${xmlEscape(args.join(" "))}</Arguments>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Starts OpenWhispr elevated at log on so dictation can reach windows running as administrator.</Description>
+    <URI>\\${xmlEscape(getTaskName())}</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>${xmlEscape(userId)}</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>${xmlEscape(userId)}</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${xmlEscape(execPath)}</Command>${argumentsLine}
+    </Exec>
+  </Actions>
+</Task>
+`;
+}
+
+// Querying needs no elevation.
+function isEnabled(taskName = getTaskName()) {
+  if (process.platform !== "win32") return false;
+  try {
+    const result = spawnSync(SCHTASKS, ["/Query", "/TN", taskName], {
+      timeout: TIMEOUT_MS,
+      windowsHide: true,
+      encoding: "utf8",
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+// schtasks /XML rejects UTF-8: the file has to be UTF-16LE with a BOM, matching the
+// encoding declared in the XML prolog.
+function writeTaskXmlFile(xml) {
+  const file = path.join(os.tmpdir(), `openwhispr-autostart-${process.pid}-${Date.now()}.xml`);
+  fs.writeFileSync(file, Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(xml, "utf16le")]));
+  return file;
+}
+
+// Runs schtasks elevated via ShellExecute's runas verb, which is the one UAC prompt.
+// -Wait so the caller can report a real result instead of an optimistic one; a user who
+// dismisses the prompt produces a non-zero exit, which surfaces as a failure.
+function runElevated(args) {
+  const quoted = args.map((a) => `'${String(a).replace(/'/g, "''")}'`).join(",");
+  const script = `$p = Start-Process -FilePath '${SCHTASKS.replace(/'/g, "''")}' -ArgumentList ${quoted} -Verb RunAs -WindowStyle Hidden -Wait -PassThru; exit $p.ExitCode`;
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      timeout: TIMEOUT_MS,
+      windowsHide: true,
+      encoding: "utf8",
+    }
+  );
+  return { ok: result.status === 0, status: result.status, stderr: result.stderr || "" };
+}
+
+function enable({ execPath = process.execPath, args = [HIDDEN_LAUNCH_FLAG] } = {}) {
+  if (process.platform !== "win32") return { ok: false, reason: "unsupported-platform" };
+  const taskName = getTaskName();
+  const userId = `${os.hostname()}\\${os.userInfo().username}`;
+  const xmlFile = writeTaskXmlFile(buildTaskXml({ userId, execPath, args }));
+  try {
+    const result = runElevated(["/Create", "/TN", taskName, "/XML", xmlFile, "/F"]);
+    if (!result.ok)
+      return { ok: false, reason: "elevation-declined-or-failed", detail: result.stderr };
+    return { ok: true };
+  } finally {
+    try {
+      fs.unlinkSync(xmlFile);
+    } catch {
+      /* the temp file is best-effort */
+    }
+  }
+}
+
+function disable() {
+  if (process.platform !== "win32") return { ok: false, reason: "unsupported-platform" };
+  if (!isEnabled()) return { ok: true };
+  const result = runElevated(["/Delete", "/TN", getTaskName(), "/F"]);
+  if (!result.ok)
+    return { ok: false, reason: "elevation-declined-or-failed", detail: result.stderr };
+  return { ok: true };
+}
+
+module.exports = {
+  getTaskName,
+  buildTaskXml,
+  isEnabled,
+  enable,
+  disable,
+};

--- a/test/helpers/autoStartPolicy.test.js
+++ b/test/helpers/autoStartPolicy.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  getLoginItemLookupPath,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -18,6 +19,41 @@ test("Windows login items are read and written with the same args", () => {
 test("platforms without a hidden-launch flag pass no args", () => {
   assert.deepEqual(getLoginItemArgs("darwin"), []);
   assert.deepEqual(getLoginItemArgs("linux"), []);
+});
+
+// Electron parses the lookup path AND every Run value with CommandLine::FromString,
+// then compares the parsed programs. Unquoted, "C:\Program Files\OpenWhispr\..."
+// truncates to "C:\Program" and compares equal to any other unquoted Run entry under
+// C:\Program Files, so executableWillLaunchAtLogin reports a stranger's startup entry
+// as ours — and keeps reporting true once ours is gone, which is what makes the
+// launch-at-login switch impossible to turn off.
+test("Windows passes a quoted lookup path so the exe comparison is exact", () => {
+  assert.equal(
+    getLoginItemLookupPath("win32", "C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"),
+    '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'
+  );
+});
+
+// FormatCommandLineString strips one layer of surrounding quotes before re-quoting,
+// but double-quoting would still be wrong to write, so never wrap twice.
+test("an already quoted Windows path is not quoted twice", () => {
+  assert.equal(
+    getLoginItemLookupPath("win32", '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'),
+    '"C:\\Program Files\\OpenWhispr\\OpenWhispr.exe"'
+  );
+});
+
+// Only Windows parses the path this way, and passing one elsewhere would change what
+// macOS compares against.
+test("platforms other than Windows pass no lookup path", () => {
+  assert.equal(getLoginItemLookupPath("darwin", "/Applications/OpenWhispr.app"), null);
+  assert.equal(getLoginItemLookupPath("linux", "/usr/bin/open-whispr"), null);
+});
+
+// Falling back to no path is what the caller already did, and is still correct.
+test("a missing executable path yields no lookup path", () => {
+  assert.equal(getLoginItemLookupPath("win32", ""), null);
+  assert.equal(getLoginItemLookupPath("win32", undefined), null);
 });
 
 // The bug behind the reported "startup app not recognized": openAtLogin only

--- a/test/helpers/autoStartPolicy.test.js
+++ b/test/helpers/autoStartPolicy.test.js
@@ -5,6 +5,8 @@ const {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
   getLoginItemLookupPath,
+  supportsElevatedAutoStart,
+  resolveAutoStartMechanism,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -72,7 +74,7 @@ test("a startup item Windows will actually launch reads as enabled", () => {
     platform: "win32",
     loginItemSettings: { openAtLogin: true, executableWillLaunchAtLogin: true },
   });
-  assert.deepEqual(state, { enabled: true, requiresApproval: false });
+  assert.deepEqual(state, { enabled: true, requiresApproval: false, elevated: false });
 });
 
 // An entry written by an older build carries no --hidden, so it no longer matches
@@ -138,6 +140,69 @@ test("launch at login that is simply off is not mistaken for a stale entry", () 
     needsHiddenFlagMigration({
       platform: "win32",
       loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: false },
+    }),
+    false
+  );
+});
+
+// A Run entry cannot be elevated, so elevated launch at login is a scheduled task.
+test("only Windows supports elevated auto-start", () => {
+  assert.equal(supportsElevatedAutoStart("win32"), true);
+  assert.equal(supportsElevatedAutoStart("darwin"), false);
+  assert.equal(supportsElevatedAutoStart("linux"), false);
+});
+
+// Both mechanisms start the app at login, so running both means two instances race the
+// single-instance lock. Exactly one owns startup at a time.
+test("the Run entry and the elevated task are mutually exclusive", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: true, elevated: true }),
+    {
+      loginItem: false,
+      scheduledTask: true,
+    }
+  );
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: true, elevated: false }),
+    { loginItem: true, scheduledTask: false }
+  );
+});
+
+test("disabling launch at login clears both Windows mechanisms", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: false, elevated: true }),
+    { loginItem: false, scheduledTask: false }
+  );
+});
+
+// Asking for elevation off Windows must not silently drop launch at login.
+test("platforms without elevation support still get their login item", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "darwin", enabled: true, elevated: true }),
+    { loginItem: true, scheduledTask: false }
+  );
+});
+
+// With the task owning startup the Run entry is absent by design, so the switch must not
+// read as off just because executableWillLaunchAtLogin is false.
+test("the elevated task counts as launch at login on Windows", () => {
+  const state = resolveAutoStartState({
+    platform: "win32",
+    loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: false },
+    elevatedTaskPresent: true,
+  });
+  assert.deepEqual(state, { enabled: true, requiresApproval: false, elevated: true });
+});
+
+// The migration repairs a stale Run entry. While the task owns startup there is no Run
+// entry on purpose, and restoring one would reintroduce the double launch at logon that
+// switching to the task removed.
+test("the hidden-flag migration is suppressed while the elevated task owns startup", () => {
+  assert.equal(
+    needsHiddenFlagMigration({
+      platform: "win32",
+      loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: true },
+      elevatedTaskPresent: true,
     }),
     false
   );


### PR DESCRIPTION
Part of #2059. **Draft on purpose** — this is the mechanism only, with no UI. I would rather check the approach is one you want before writing the settings toggle and translating four new strings into ten locales.

> ⚠️ **Stacked on #2058.** This branch is based on that fix, so the diff here contains both commits. Only the second one (`feat(autostart): add the elevated Windows login mechanism`) belongs to this PR. If #2058 lands first this rebases to a single commit.

## Why

On Windows, dictation into any window owned by an elevated process is discarded silently — no error, no log line, transcription still lands in history. UIPI blocks synthetic input from a lower-integrity process into a higher-integrity window and reports nothing to the sender. All three delivery paths are affected: `SendInput` in `windows-fast-paste.exe`, the `SendKeys::SendWait('^v')` fallback in `clipboard.js`, and `nircmd.exe`.

A maintainer identified this mechanism in #1092 ("Making that failure loud instead of silent is on us"), but there is currently no way to run OpenWhispr elevated in a supported way. `setLoginItemSettings()` writes `HKCU\...\Run`, and Explorer starts `Run` entries with the user's filtered token. No flag changes that; it is a property of the mechanism.

## What is here

`windowsElevatedAutostart.js`, mirroring how `linuxAutostart.js` stands in on a platform where `setLoginItemSettings()` cannot express what is needed. It registers a Scheduled Task with `RunLevel=Highest` and `LogonType=Interactive`. Task Scheduler runs as SYSTEM and mints the token itself rather than requesting elevation, so the app starts elevated at login with **no UAC prompt**. Creating or deleting the task needs administrator rights once, which is the single prompt the user sees when they flip the switch.

Decisions live in `autoStartPolicy.js`, pure and unit-tested:

- `resolveAutoStartMechanism()` enforces that the `Run` entry and the task are **mutually exclusive**. Both start the app at login, so running both leaves two instances racing the single-instance lock.
- `needsHiddenFlagMigration()` is suppressed while the task owns startup. Without that it would restore the `Run` entry that switching to the task just removed, on every launch.
- `resolveAutoStartState()` reports `elevated`, and counts the task as launch-at-login so the switch does not read as off while the task is what starts the app.

Three task settings are load-bearing and easy to get wrong:

| setting | default | why it is overridden |
|---|---|---|
| `ExecutionTimeLimit` | `PT72H` | Task Scheduler would kill a tray app after three days, with no visible cause |
| `DisallowStartIfOnBatteries` | `true` | autostart would silently not happen on battery |
| `LogonType` | — | `InteractiveToken` keeps it in the user's session; `Password`/`S4U` run with no desktop to type into |

`schtasks /XML` also rejects UTF-8, so the file is written UTF-16LE with a BOM to match the encoding its prolog declares.

## Verification

Generated XML registered through real `schtasks` on Windows 11, with a throwaway task name:

```
CREATE status: 0   SUCCESS
PROPS: RunLevel=Highest LogonType=Interactive Trigger=MSFT_TaskLogonTrigger
       ExecTimeLimit=PT0S Batteries=True
RUN:   { "elevated": true, "user": "<machine>\\<user>", "sessionId": 1 }
DELETE status: 0
```

Elevated, in the interactive session (session 1, not session 0), no prompt. Separately confirmed that starting OpenWhispr elevated makes dictation into an administrator terminal work immediately with nothing else changed.

`test/helpers/autoStartPolicy.test.js`: 24 pass. One existing assertion changed, `"a startup item Windows will actually launch reads as enabled"`, because `resolveAutoStartState` now also returns `elevated`. `elevated` is Windows-only, so the macOS assertions are untouched.

## What is deliberately missing

- `autoStart.js` dispatch to the new mechanism
- IPC handler + `preload.js` method
- the `SettingsPage` toggle and its four i18n keys across ten locales
- a docs entry

## Questions before I finish it

1. Is a scheduled task the mechanism you want, or would you rather start with making the failure loud (#1092) and treat elevation separately?
2. Task naming: currently `OpenWhispr Launch At Login (<username>)`. Task names are machine-global and the principal is per-user, so two accounts on one machine would otherwise collide. Happy to change the shape.
3. `workspace-policy.json` suggests managed deployments may want to gate this. Should it respect a policy flag?
4. A standard (non-administrator) user cannot create a `RunLevel=Highest` task at all. Currently that surfaces as a failed result; I would rather show a specific message, but that needs a string.

Happy to close this if the direction is wrong — nothing here is load-bearing yet.

For transparency, I worked through this with Claude Code (Opus 5). The verification output and code references are real output from my machine.
