### PR TITLE
feat(autostart): elevated launch at login on Windows (mechanism only)

### DIFF
--- a/src/helpers/autoStartPolicy.js
+++ b/src/helpers/autoStartPolicy.js
@@ -13,13 +13,47 @@ function getLoginItemArgs(platform) {
   return platform === "win32" ? [HIDDEN_LAUNCH_FLAG] : [];
 }
 
+// Windows can start us elevated at login, which a Run entry can never do: Explorer
+// launches those with the user's filtered token, and no flag changes that. A Scheduled
+// Task with RunLevel=Highest and LogonType=Interactive is the only mechanism that
+// starts a process elevated at login without a UAC prompt, because Task Scheduler runs
+// as SYSTEM and mints the token itself rather than requesting elevation.
+//
+// This matters because Windows blocks synthetic input (UIPI) from a lower-integrity
+// process into a higher-integrity window, silently. Unelevated, dictation into an
+// administrator terminal is discarded with no error.
+function supportsElevatedAutoStart(platform) {
+  return platform === "win32";
+}
+
+// The Run entry and the scheduled task would BOTH start the app at login, so exactly
+// one owns startup. Enabling elevation must clear the Run entry and vice versa, or the
+// two instances race the single-instance lock and which one wins is a coin toss.
+function resolveAutoStartMechanism({ platform, enabled, elevated }) {
+  if (!supportsElevatedAutoStart(platform)) {
+    return { loginItem: !!enabled, scheduledTask: false };
+  }
+  if (!enabled) return { loginItem: false, scheduledTask: false };
+  return elevated
+    ? { loginItem: false, scheduledTask: true }
+    : { loginItem: true, scheduledTask: false };
+}
+
 // For the platforms setLoginItemSettings covers: win32 and darwin.
-function resolveAutoStartState({ platform, loginItemSettings }) {
+// elevatedTaskPresent is Windows-only and comes from windowsElevatedAutostart.
+function resolveAutoStartState({ platform, loginItemSettings, elevatedTaskPresent }) {
   if (platform === "win32") {
     // openAtLogin only checks whether the Run entry matches this executable and
     // args; it ignores Explorer's StartupApproved key, which is what Task Manager
     // writes when a user disables a startup app. Only this field covers both.
-    return { enabled: !!loginItemSettings.executableWillLaunchAtLogin, requiresApproval: false };
+    //
+    // Either mechanism starting us counts as enabled, so the switch does not read
+    // as off while the scheduled task is the one launching the app.
+    return {
+      enabled: !!loginItemSettings.executableWillLaunchAtLogin || !!elevatedTaskPresent,
+      requiresApproval: false,
+      elevated: !!elevatedTaskPresent,
+    };
   }
   return {
     enabled: !!loginItemSettings.openAtLogin,
@@ -34,8 +68,13 @@ function resolveAutoStartState({ platform, loginItemSettings }) {
 // we write and reads as disabled while still launching the app with its window
 // showing. Rewriting reuses the same registry value name, so it re-points that
 // entry rather than adding a second one.
-function needsHiddenFlagMigration({ platform, loginItemSettings }) {
+//
+// It must not fire while the elevated task owns startup: the Run entry is absent by
+// design there, and restoring it would reintroduce the double launch that switching
+// to the task removed.
+function needsHiddenFlagMigration({ platform, loginItemSettings, elevatedTaskPresent }) {
   if (platform !== "win32") return false;
+  if (elevatedTaskPresent) return false;
   return !!loginItemSettings.executableWillLaunchAtLogin && !loginItemSettings.openAtLogin;
 }
 
@@ -48,6 +87,8 @@ function wasLaunchedHidden({ platform, argv, loginItemSettings }) {
 module.exports = {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  supportsElevatedAutoStart,
+  resolveAutoStartMechanism,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,

--- a/src/helpers/windowsElevatedAutostart.js
+++ b/src/helpers/windowsElevatedAutostart.js
@@ -1,0 +1,175 @@
+// Launch at login, elevated, on Windows. Mirrors linuxAutostart.js: a platform where
+// setLoginItemSettings() cannot express what is needed, so a bespoke mechanism sits
+// behind the same autoStart.js interface.
+//
+// Why a scheduled task rather than the Run entry: Explorer starts Run entries with the
+// user's filtered (medium-integrity) token, and no flag changes that. Windows blocks
+// synthetic input from a lower-integrity process into a higher-integrity window (UIPI)
+// and reports nothing to the sender, so an unelevated OpenWhispr silently discards
+// every dictation aimed at an administrator window. A task with RunLevel=Highest is the
+// only way to start elevated at login WITHOUT a UAC prompt every time: Task Scheduler
+// already runs as SYSTEM and mints the token itself instead of requesting elevation.
+//
+// Creating or deleting the task needs administrator rights once, which is the single
+// UAC prompt the user sees when they flip the switch.
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { HIDDEN_LAUNCH_FLAG } = require("./autoStartPolicy");
+
+// Task names are machine-global, so scope it to the account it launches for. Two users
+// on one machine would otherwise fight over a single task with one UserId.
+function getTaskName(username = os.userInfo().username) {
+  return `OpenWhispr Launch At Login (${username})`;
+}
+
+const SCHTASKS = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "schtasks.exe");
+const TIMEOUT_MS = 20000;
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// LogonType=InteractiveToken is load-bearing: it keeps the process in the user's
+// interactive session. Password/S4U run it non-interactively with no desktop, where a
+// GUI app has no foreground window to type into and no user-session audio endpoint.
+//
+// ExecutionTimeLimit must be PT0S. The default is PT72H, which would have Task
+// Scheduler kill a tray app after three days for no visible reason.
+// DisallowStartIfOnBatteries defaults to true, which would silently skip autostart on
+// battery power.
+function buildTaskXml({ userId, execPath, args = [HIDDEN_LAUNCH_FLAG] }) {
+  const argumentsLine = args.length
+    ? `\n      <Arguments>${xmlEscape(args.join(" "))}</Arguments>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Starts OpenWhispr elevated at log on so dictation can reach windows running as administrator.</Description>
+    <URI>\\${xmlEscape(getTaskName())}</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+      <UserId>${xmlEscape(userId)}</UserId>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>${xmlEscape(userId)}</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${xmlEscape(execPath)}</Command>${argumentsLine}
+    </Exec>
+  </Actions>
+</Task>
+`;
+}
+
+// Querying needs no elevation.
+function isEnabled(taskName = getTaskName()) {
+  if (process.platform !== "win32") return false;
+  try {
+    const result = spawnSync(SCHTASKS, ["/Query", "/TN", taskName], {
+      timeout: TIMEOUT_MS,
+      windowsHide: true,
+      encoding: "utf8",
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+// schtasks /XML rejects UTF-8: the file has to be UTF-16LE with a BOM, matching the
+// encoding declared in the XML prolog.
+function writeTaskXmlFile(xml) {
+  const file = path.join(os.tmpdir(), `openwhispr-autostart-${process.pid}-${Date.now()}.xml`);
+  fs.writeFileSync(file, Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(xml, "utf16le")]));
+  return file;
+}
+
+// Runs schtasks elevated via ShellExecute's runas verb, which is the one UAC prompt.
+// -Wait so the caller can report a real result instead of an optimistic one; a user who
+// dismisses the prompt produces a non-zero exit, which surfaces as a failure.
+function runElevated(args) {
+  const quoted = args.map((a) => `'${String(a).replace(/'/g, "''")}'`).join(",");
+  const script = `$p = Start-Process -FilePath '${SCHTASKS.replace(/'/g, "''")}' -ArgumentList ${quoted} -Verb RunAs -WindowStyle Hidden -Wait -PassThru; exit $p.ExitCode`;
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      timeout: TIMEOUT_MS,
+      windowsHide: true,
+      encoding: "utf8",
+    }
+  );
+  return { ok: result.status === 0, status: result.status, stderr: result.stderr || "" };
+}
+
+function enable({ execPath = process.execPath, args = [HIDDEN_LAUNCH_FLAG] } = {}) {
+  if (process.platform !== "win32") return { ok: false, reason: "unsupported-platform" };
+  const taskName = getTaskName();
+  const userId = `${os.hostname()}\\${os.userInfo().username}`;
+  const xmlFile = writeTaskXmlFile(buildTaskXml({ userId, execPath, args }));
+  try {
+    const result = runElevated(["/Create", "/TN", taskName, "/XML", xmlFile, "/F"]);
+    if (!result.ok)
+      return { ok: false, reason: "elevation-declined-or-failed", detail: result.stderr };
+    return { ok: true };
+  } finally {
+    try {
+      fs.unlinkSync(xmlFile);
+    } catch {
+      /* the temp file is best-effort */
+    }
+  }
+}
+
+function disable() {
+  if (process.platform !== "win32") return { ok: false, reason: "unsupported-platform" };
+  if (!isEnabled()) return { ok: true };
+  const result = runElevated(["/Delete", "/TN", getTaskName(), "/F"]);
+  if (!result.ok)
+    return { ok: false, reason: "elevation-declined-or-failed", detail: result.stderr };
+  return { ok: true };
+}
+
+module.exports = {
+  getTaskName,
+  buildTaskXml,
+  isEnabled,
+  enable,
+  disable,
+};

--- a/test/helpers/autoStartPolicy.test.js
+++ b/test/helpers/autoStartPolicy.test.js
@@ -4,6 +4,8 @@ const assert = require("node:assert/strict");
 const {
   HIDDEN_LAUNCH_FLAG,
   getLoginItemArgs,
+  supportsElevatedAutoStart,
+  resolveAutoStartMechanism,
   resolveAutoStartState,
   needsHiddenFlagMigration,
   wasLaunchedHidden,
@@ -36,7 +38,7 @@ test("a startup item Windows will actually launch reads as enabled", () => {
     platform: "win32",
     loginItemSettings: { openAtLogin: true, executableWillLaunchAtLogin: true },
   });
-  assert.deepEqual(state, { enabled: true, requiresApproval: false });
+  assert.deepEqual(state, { enabled: true, requiresApproval: false, elevated: false });
 });
 
 // An entry written by an older build carries no --hidden, so it no longer matches
@@ -102,6 +104,69 @@ test("launch at login that is simply off is not mistaken for a stale entry", () 
     needsHiddenFlagMigration({
       platform: "win32",
       loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: false },
+    }),
+    false
+  );
+});
+
+// A Run entry cannot be elevated, so elevated launch at login is a scheduled task.
+test("only Windows supports elevated auto-start", () => {
+  assert.equal(supportsElevatedAutoStart("win32"), true);
+  assert.equal(supportsElevatedAutoStart("darwin"), false);
+  assert.equal(supportsElevatedAutoStart("linux"), false);
+});
+
+// Both mechanisms start the app at login, so running both means two instances race the
+// single-instance lock. Exactly one owns startup at a time.
+test("the Run entry and the elevated task are mutually exclusive", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: true, elevated: true }),
+    {
+      loginItem: false,
+      scheduledTask: true,
+    }
+  );
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: true, elevated: false }),
+    { loginItem: true, scheduledTask: false }
+  );
+});
+
+test("disabling launch at login clears both Windows mechanisms", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "win32", enabled: false, elevated: true }),
+    { loginItem: false, scheduledTask: false }
+  );
+});
+
+// Asking for elevation off Windows must not silently drop launch at login.
+test("platforms without elevation support still get their login item", () => {
+  assert.deepEqual(
+    resolveAutoStartMechanism({ platform: "darwin", enabled: true, elevated: true }),
+    { loginItem: true, scheduledTask: false }
+  );
+});
+
+// With the task owning startup the Run entry is absent by design, so the switch must not
+// read as off just because executableWillLaunchAtLogin is false.
+test("the elevated task counts as launch at login on Windows", () => {
+  const state = resolveAutoStartState({
+    platform: "win32",
+    loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: false },
+    elevatedTaskPresent: true,
+  });
+  assert.deepEqual(state, { enabled: true, requiresApproval: false, elevated: true });
+});
+
+// The migration repairs a stale Run entry. While the task owns startup there is no Run
+// entry on purpose, and restoring one would reintroduce the double launch at logon that
+// switching to the task removed.
+test("the hidden-flag migration is suppressed while the elevated task owns startup", () => {
+  assert.equal(
+    needsHiddenFlagMigration({
+      platform: "win32",
+      loginItemSettings: { openAtLogin: false, executableWillLaunchAtLogin: true },
+      elevatedTaskPresent: true,
     }),
     false
   );


### PR DESCRIPTION
Part of #2059. This is phase 1 of 2, opened as a draft so the approach can be checked before the user-facing half is written.

**Phase 1 (this PR): the mechanism.** The scheduled task, the policy decisions that go with it, and their unit tests. Nothing is wired to the UI, so on its own this changes no behaviour for any user.

**Phase 2 (follow-up): the user-facing half.** A "Launch as administrator" toggle beside "Launch at login" in Settings, the IPC to drive it, and four new strings across ten locales.

Splitting it this way keeps the reviewable surface small and means the mechanism can be corrected before the translations are written.

### On merging

Please do not merge this one on its own. It is a draft, so GitHub blocks it already, and that is deliberate: phase 1 by itself adds a module that nothing calls yet.

Phase 2 will be added as further commits on this branch rather than as a third PR, and I will mark this ready for review once it is complete. A separate PR against `main` could not work, since the settings toggle calls `windowsElevatedAutostart.js`, which only exists on this branch, and stacking a third PR on top of this one would make the two diffs overlap.

This does not depend on #2058. That is a separate fix against `main` and can be merged whenever suits you.

This is independent of #2058. It branches from `main` and shares no commits with it. An earlier draft of this PR was accidentally based on that branch, so its diff carried that fix too; this replaces it.

## Why

On Windows, dictation into any window owned by an elevated process is discarded silently, no error, no log line, transcription still lands in history. UIPI blocks synthetic input from a lower-integrity process into a higher-integrity window and reports nothing to the sender. All three delivery paths are affected: `SendInput` in `windows-fast-paste.exe`, the `SendKeys::SendWait('^v')` fallback in `clipboard.js`, and `nircmd.exe`.

A maintainer identified this mechanism in #1092 ("Making that failure loud instead of silent is on us"), but there is currently no way to run OpenWhispr elevated in a supported way. `setLoginItemSettings()` writes `HKCU\...\Run`, and Explorer starts `Run` entries with the user's filtered token. No flag changes that; it is a property of the mechanism.

## What is here

`windowsElevatedAutostart.js`, mirroring how `linuxAutostart.js` stands in on a platform where `setLoginItemSettings()` cannot express what is needed. It registers a Scheduled Task with `RunLevel=Highest` and `LogonType=Interactive`. Task Scheduler runs as SYSTEM and mints the token itself rather than requesting elevation, so the app starts elevated at login with **no UAC prompt**. Creating or deleting the task needs administrator rights once, which is the single prompt the user sees when they flip the switch.

Decisions live in `autoStartPolicy.js`, pure and unit-tested:

- `resolveAutoStartMechanism()` enforces that the `Run` entry and the task are **mutually exclusive**. Both start the app at login, so running both leaves two instances racing the single-instance lock.
- `needsHiddenFlagMigration()` is suppressed while the task owns startup. Without that it would restore the `Run` entry that switching to the task just removed, on every launch.
- `resolveAutoStartState()` reports `elevated`, and counts the task as launch-at-login so the switch does not read as off while the task is what starts the app.

Three task settings are load-bearing and easy to get wrong:

| setting | default | why it is overridden |
|---|---|---|
| `ExecutionTimeLimit` | `PT72H` | Task Scheduler would kill a tray app after three days, with no visible cause |
| `DisallowStartIfOnBatteries` | `true` | autostart would silently not happen on battery |
| `LogonType` |, | `InteractiveToken` keeps it in the user's session; `Password`/`S4U` run with no desktop to type into |

`schtasks /XML` also rejects UTF-8, so the file is written UTF-16LE with a BOM to match the encoding its prolog declares.

## Verification

Generated XML registered through real `schtasks` on Windows 11, with a throwaway task name:

```
CREATE status: 0   SUCCESS
PROPS: RunLevel=Highest LogonType=Interactive Trigger=MSFT_TaskLogonTrigger
       ExecTimeLimit=PT0S Batteries=True
RUN:   { "elevated": true, "user": "<machine>\\<user>", "sessionId": 1 }
DELETE status: 0
```

Elevated, in the interactive session (session 1, not session 0), no prompt. Separately confirmed that starting OpenWhispr elevated makes dictation into an administrator terminal work immediately with nothing else changed.

`test/helpers/autoStartPolicy.test.js`: 20 pass. One existing assertion changed, `"a startup item Windows will actually launch reads as enabled"`, because `resolveAutoStartState` now also returns `elevated`. `elevated` is Windows-only, so the macOS assertions are untouched.

## Phase 2, deliberately not in this PR

- `autoStart.js` dispatch to the new mechanism
- IPC handler + `preload.js` method
- the `SettingsPage` toggle and its four i18n keys across ten locales
- a docs entry

## Questions before I finish it

1. Is a scheduled task the mechanism you want, or would you rather start with making the failure loud (#1092) and treat elevation separately?
2. Task naming: currently `OpenWhispr Launch At Login (<username>)`. Task names are machine-global and the principal is per-user, so two accounts on one machine would otherwise collide. Happy to change the shape.
3. `workspace-policy.json` suggests managed deployments may want to gate this. Should it respect a policy flag?
4. A standard (non-administrator) user cannot create a `RunLevel=Highest` task at all. Currently that surfaces as a failed result; I would rather show a specific message, but that needs a string.

Happy to close this if the direction is wrong, nothing here is load-bearing yet.

For transparency, I worked through this with Claude Code (Opus 5). The verification output and code references are real output from my machine.


