### PR TITLE
fix(sync): let the server stamp updated_at on note creates

### DIFF
--- a/src/helpers/cloudSyncGuards.js
+++ b/src/helpers/cloudSyncGuards.js
@@ -52,8 +52,14 @@ export function buildNoteUpdatePayload(note, cloudFolderId) {
 // POST creates a new cloud identity and therefore has no prior server
 // revision to compare. Forks from older databases can retain a stale base, so
 // derive create payloads explicitly rather than forwarding base_updated_at.
+//
+// updated_at is dropped too so the server stamps the row itself. The local
+// value is the last edit, possibly hours old by the time the row uploads, and
+// the server stores it as-is — mobile's delta cursor (the newest updated_at
+// it has seen) would then skip the row forever. PATCHes are server-stamped.
 export function buildNoteCreatePayload(note, cloudFolderId) {
   const payload = buildNoteUpdatePayload(note, cloudFolderId);
   delete payload.base_updated_at;
+  delete payload.updated_at;
   return payload;
 }

--- a/test/helpers/cloudSyncGuards.test.js
+++ b/test/helpers/cloudSyncGuards.test.js
@@ -138,3 +138,13 @@ test("note create payloads never send a stale optimistic-concurrency base", asyn
   assert.equal(payload.content, localNote.content);
   assert.equal(payload.folder_id, "cloud-folder-3");
 });
+
+// A create carrying the local last-edit time lands behind mobile's delta
+// cursor when it uploads late (see buildNoteCreatePayload), so it must not.
+
+test("note create payloads let the server stamp updated_at", async () => {
+  const { buildNoteCreatePayload } = await load();
+  const payload = buildNoteCreatePayload(localNote, "cloud-folder-3");
+  assert.equal("updated_at" in payload, false);
+  assert.equal(payload.content, localNote.content);
+});


### PR DESCRIPTION
## Why

`buildNoteCreatePayload` forwarded a note's local last-edit time as `updated_at`, and the API stores whatever a create carries. Mobile's delta pull asks for rows newer than the newest `updated_at` it has already seen, so any note uploaded later than its last edit (offline work, cloud backup enabled after months of local use) landed behind that cursor and never reached mobile until a later edit PATCHed it with a server timestamp.

This is the desktop half of a two-sided problem. The mobile half is already on main: mobile creates carried the same stale stamp and desktop's wall-clock cursor skipped them the same way.

## What changed

Creates no longer send `updated_at`, so the server stamps the row with `now()`. PATCHes are untouched; the server already stamps those itself.

The one-time migration POST in `startMigration` deliberately still sends `updated_at`. Its rows adopt a cloud id but stay pending (`settleIfUnchanged: false`), and SyncService follows with a full PATCH that re-stamps them, so they are never stranded.

## Files

- `src/helpers/cloudSyncGuards.js`: `buildNoteCreatePayload` drops `updated_at` alongside `base_updated_at`, with a comment on why. Covers both sync create paths (batch create and the single-note fallback), which both spread this helper.
- `test/helpers/cloudSyncGuards.test.js`: new test asserting the create payload carries no `updated_at`, watched failing before the fix.

## Verification

- Guard test files: 17 tests, 0 failures
- Full suite (`npm test`): 3558 tests, 0 failures, 196 pre-existing skips
- eslint and prettier clean

## Trade-offs and follow-ups

- A create that retries over a row another device has since edited (a lost create acknowledgement) no longer trips the API's stale-write guard on the upsert. Rare, and not closable client-side.
- Late-uploaded notes now sort as just-edited on every device, since their `updated_at` becomes the upload time.
- Both go away with the durable fix: a server-stamped sync column in the API that `since` filters on, leaving `updated_at` client-owned for last-write-wins. That is a separate API change plus cursor updates in both clients.
- Notes desktop already skipped before the mobile fix do not self-heal. A one-time clear of `lastSyncedAt.notes` in desktop localStorage forces a snapshot pull and recovers them.