### PR TITLE
fix(perf): prevent high cpu usage in idle ui states

### DIFF
--- a/src/components/CliIntegrationCard.tsx
+++ b/src/components/CliIntegrationCard.tsx
@@ -39,7 +39,7 @@ export default function CliIntegrationCard({ isPaid, onUpgrade }: CliIntegration
   };
 
   return (
-    <div className="rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 backdrop-blur-sm p-4">
+    <div className="rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 p-4">
       <div className="flex items-center gap-2 mb-4">
         <LogoTile src={logo} alt="OpenWhispr" />
         <div className="w-9 h-9 rounded-lg bg-white dark:bg-surface-raised shadow-[0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-none dark:border dark:border-white/5 flex items-center justify-center shrink-0">

--- a/src/components/McpIntegrationCard.tsx
+++ b/src/components/McpIntegrationCard.tsx
@@ -35,7 +35,7 @@ export default function McpIntegrationCard({ isPaid, onUpgrade }: McpIntegration
   };
 
   return (
-    <div className="rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 backdrop-blur-sm p-4">
+    <div className="rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 p-4">
       <div className="flex items-center gap-2 mb-4">
         <LogoTile src={logo} alt="OpenWhispr" />
         <Plus className="h-3 w-3 text-muted-foreground/40 shrink-0" />

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -185,7 +185,7 @@ const UI_LANGUAGE_OPTIONS: import("./ui/LanguageSelector").LanguageOption[] = [
 const RETENTION_DAY_OPTIONS = [1, 7, 14, 30, 60, 90];
 
 const RETENTION_SELECT_CLASS =
-  "h-7 rounded border border-border/70 bg-surface-1/80 px-2.5 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 transition-colors duration-200";
+  "h-7 rounded border border-border/70 bg-surface-1/80 px-2.5 text-xs font-medium text-foreground shadow-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 transition-colors duration-200";
 
 const noop = () => {};
 
@@ -3125,7 +3125,7 @@ export default function SettingsPage({
                           e.target.value as "bottom-right" | "center" | "bottom-left"
                         )
                       }
-                      className="h-7 rounded border border-border/70 bg-surface-1/80 px-2.5 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1 transition-colors duration-200"
+                      className="h-7 rounded border border-border/70 bg-surface-1/80 px-2.5 text-xs font-medium text-foreground shadow-sm hover:border-border-hover hover:bg-surface-2/70 focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1 transition-colors duration-200"
                     >
                       <option value="bottom-right">
                         {t("settingsPage.general.floatingIcon.bottomRight")}

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -110,7 +110,7 @@ function LocalModelCard({
             <div
               className={`w-1.5 h-1.5 rounded-full ${
                 isSelected
-                  ? "bg-primary shadow-[0_0_6px_oklch(0.62_0.22_260/0.6)] animate-[pulse-glow_2s_ease-in-out_infinite]"
+                  ? "bg-primary shadow-[0_0_6px_oklch(0.62_0.22_260/0.6)]"
                   : "bg-success shadow-[0_0_4px_rgba(34,197,94,0.5)]"
               }`}
             />
@@ -315,7 +315,7 @@ interface ModeToggleProps {
 function ModeToggle({ useLocalWhisper, onModeChange }: ModeToggleProps) {
   const { t } = useTranslation();
   return (
-    <div className="relative flex p-0.5 rounded-lg bg-surface-1/80 backdrop-blur-xl dark:bg-surface-1 border border-border/60 dark:border-white/8 shadow-(--shadow-metallic-light) dark:shadow-(--shadow-metallic-dark)">
+    <div className="relative flex p-0.5 rounded-lg bg-surface-1/80 dark:bg-surface-1 border border-border/60 dark:border-white/8 shadow-(--shadow-metallic-light) dark:shadow-(--shadow-metallic-dark)">
       <div
         className={`absolute top-0.5 bottom-0.5 w-[calc(50%-2px)] rounded-md bg-card border border-border/60 dark:border-border-subtle shadow-(--shadow-metallic-light) dark:shadow-(--shadow-metallic-dark) transition-transform duration-200 ease-out ${
           useLocalWhisper ? "translate-x-[calc(100%)]" : "translate-x-0"

--- a/src/components/ui/HotkeyInput.tsx
+++ b/src/components/ui/HotkeyInput.tsx
@@ -664,7 +664,7 @@ export function HotkeyInput({
         {isCapturing ? (
           <div className="flex flex-col items-center gap-3">
             <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-primary rounded-full animate-pulse" />
+              <div className="w-2 h-2 bg-primary rounded-full" />
               <span className="text-xs font-medium text-primary">{t("hotkeyInput.listening")}</span>
             </div>
             {activeModifiers.length > 0 ? (
@@ -765,16 +765,14 @@ export function HotkeyInput({
         }
       `}
     >
-      {isCapturing && (
-        <div className="absolute top-0 left-0 right-0 h-0.5 bg-primary animate-pulse" />
-      )}
+      {isCapturing && <div className="absolute top-0 left-0 right-0 h-0.5 bg-primary" />}
 
       <div className="px-4 py-3">
         {isCapturing ? (
           <>
             <div className="flex items-center justify-center gap-3">
               <div className="flex items-center gap-1.5">
-                <div className="w-1.5 h-1.5 bg-primary rounded-full animate-pulse" />
+                <div className="w-1.5 h-1.5 bg-primary rounded-full" />
                 <span className="text-xs font-medium text-muted-foreground">
                   {t("hotkeyInput.recording")}
                 </span>

--- a/src/components/ui/LanguageSelector.tsx
+++ b/src/components/ui/LanguageSelector.tsx
@@ -170,7 +170,7 @@ export default function LanguageSelector({
           group relative w-full flex items-center justify-between gap-2
           h-7 px-2.5 text-left
           rounded text-xs font-medium
-          border shadow-sm backdrop-blur-sm
+          border shadow-sm
           transition-[background-color,border-color,transform] duration-200 ease-out
           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1
           ${
@@ -205,7 +205,7 @@ export default function LanguageSelector({
               left: `${dropdownPosition.left}px`,
               width: `${dropdownPosition.width}px`,
             }}
-            className="z-9999 bg-popover/95 backdrop-blur-xl border border-border/70 rounded shadow-xl overflow-hidden"
+            className="z-9999 bg-popover/95 border border-border/70 rounded shadow-xl overflow-hidden"
           >
             {showSearch && (
               <div className="px-2 pt-2 pb-1.5 border-b border-border/50">

--- a/src/components/ui/ModelCardList.tsx
+++ b/src/components/ui/ModelCardList.tsx
@@ -115,7 +115,7 @@ export function ModelCard({
         <div
           className={`w-1.5 h-1.5 rounded-full shrink-0 ${getStatusDotClass()} ${
             isSelected && isDownloaded
-              ? "animate-[pulse-glow_2s_ease-in-out_infinite]"
+              ? ""
               : isDownloading
                 ? "animate-[spinner-rotate_1s_linear_infinite]"
                 : ""

--- a/src/components/ui/SettingsSection.tsx
+++ b/src/components/ui/SettingsSection.tsx
@@ -97,7 +97,7 @@ export function SettingsPanel({
 }) {
   return (
     <div
-      className={`rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 backdrop-blur-sm divide-y divide-border/30 dark:divide-border-subtle/50 ${className}`}
+      className={`rounded-lg border border-border/50 dark:border-border-subtle/70 bg-card/50 dark:bg-surface-2/50 divide-y divide-border/30 dark:divide-border-subtle/50 ${className}`}
     >
       {children}
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -47,10 +47,10 @@ const buttonVariants = cva(
           "active:bg-destructive/80 active:scale-[0.98]",
         ].join(" "),
 
-        // Outline — refined with subtle glassmorphism
+        // Outline
         outline: [
           "relative font-medium",
-          "text-foreground bg-muted/70 backdrop-blur-sm",
+          "text-foreground bg-muted/70",
           "border border-border/70",
           "shadow-sm",
           "hover:bg-muted hover:border-border-hover",
@@ -96,10 +96,10 @@ const buttonVariants = cva(
           "underline-offset-4",
         ].join(" "),
 
-        // Social button for auth flows - ultra-premium glassmorphism
+        // Social button for auth flows
         social: [
           "relative font-medium",
-          "text-foreground bg-surface-1/80 backdrop-blur-xl",
+          "text-foreground bg-surface-1/80",
           "border border-border/60",
           "shadow-sm gap-2",
           "hover:bg-surface-2/90 hover:border-border-hover hover:shadow",

--- a/src/index.css
+++ b/src/index.css
@@ -1097,19 +1097,6 @@ a:hover {
   }
 }
 
-/* Model picker LED pulse animation */
-@keyframes pulse-glow {
-  0%,
-  100% {
-    box-shadow: 0 0 6px oklch(0.65 0.2 260 / 0.4);
-    opacity: 0.8;
-  }
-  50% {
-    box-shadow: 0 0 8px oklch(0.65 0.2 260 / 0.6);
-    opacity: 1;
-  }
-}
-
 /* Spinner rotation for downloading state */
 @keyframes spinner-rotate {
   from {


### PR DESCRIPTION
**Root cause:** The pulse-glow animation appears to cause a repaint on every animation frame, leading to high CPU usage in idle states. CSS animations combined with backdrop-blur had a similar demand for repaints.

**Solution:** Remove the offending pulse-glow animation. Remove backdrop-blur from some components where either UX is not impacted or idle ui performance benefits.

**Setup:**
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.4 LTS
Release:	24.04
Codename:	noble

**Reproducing the CPU usage spikes:**

Open `top` and monitor OpenWhispr’s CPU usage while visiting these three UI states:

  1. Hotkey recording: Settings > Hotkeys > Dictation Hotkeys > click to change
  2. Speech-to-text: Settings > Speech-to-text > Dictation (local, OpenAI, Base)
  3. Google Calendar integration loading: Integrations > Connect to Google Calendar (do not connect in browser, return to OpenWhisper)

  In each case, CPU usage can reach 100% and remain elevated while the UI waits without further interaction.

Before changes:
<img width="1883" height="750" alt="image" src="https://github.com/user-attachments/assets/233b2d13-a215-4d4b-8113-f74efc9ea392" />

After fix:
<img width="1883" height="750" alt="image" src="https://github.com/user-attachments/assets/6d452504-7e03-4bf9-be08-e2a464feb917" />


  **Other testing activities after fix:**

  - Visit every menu, settings menu, and submenu.
  - Leave each page idle long enough for CPU usage in `top` to stabilize.
  - Confirm there is no sustained high CPU load after the UI settles.