### PR TITLE
Add gpt-transcribe as the OpenAI BYOK batch default

### DIFF
--- a/scripts/stt-canary.mjs
+++ b/scripts/stt-canary.mjs
@@ -7,7 +7,9 @@
  * (#1624 sat in shipped builds for three days as a swallowed warmup warning).
  * Providers whose request shape is theirs alone rather than the shared
  * OpenAI-compatible multipart (Gemini, batch and Live) send a real
- * transcription through the shipped module for the same reason.
+ * transcription through the shipped module for the same reason, and OpenAI's
+ * batch default is posted the way the app builds it so a retired model or
+ * field surfaces here too.
  *
  * Run: node scripts/stt-canary.mjs
  * Keys come from STT_CANARY_<PROVIDER>_KEY env vars; providers without a key
@@ -204,6 +206,23 @@ async function probeGeminiLive(key) {
   }
 }
 
+// gpt-transcribe is the BYOK batch default and takes the custom dictionary on
+// its `keywords[]` channel, so one rides along: the request fails here first if
+// OpenAI retires either. Silence transcribes to empty text, so only acceptance
+// is asserted.
+async function probeOpenAiBatch(key, audio) {
+  const body = new FormData();
+  body.append("file", new Blob([audio], { type: "audio/wav" }), "audio.wav");
+  body.append("model", "gpt-transcribe");
+  body.append("keywords[]", "OpenWhispr");
+  const response = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${key}` },
+    body,
+  });
+  return response.ok ? { ok: true } : { ok: false, detail: `HTTP ${response.status}` };
+}
+
 const tokenDeps = (key) => ({
   environmentManager: {
     getOpenAIKey: () => key,
@@ -227,6 +246,11 @@ const PROBES = [
         awaitServerEvent: true,
       });
     },
+  },
+  {
+    id: "openai-batch",
+    keyEnv: "STT_CANARY_OPENAI_KEY",
+    run: (key) => probeOpenAiBatch(key, SILENT_WAV()),
   },
   {
     id: "deepgram-realtime",

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -108,6 +108,7 @@ import {
   payloadSendsDictionaryBias,
 } from "../utils/dictionaryEchoFilter.js";
 import { dictionaryPromptLimit, trimDictionaryPrompt } from "../utils/dictionaryPromptCap.js";
+import { dictionaryKeywords, usesTranscriptionKeywords } from "../utils/dictionaryKeywords.js";
 import { getDictionaryHintWords } from "../utils/snippets";
 import { normalizeAgentSelectionContext } from "../utils/agentSelectionContext";
 import { shouldDisplayDictationPreview } from "../utils/transcriptionPreview";
@@ -714,9 +715,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   // Whisper only accepts language "zh"; script (简体/繁體) is applied here. See #975.
   // No transcript exists yet, so only an explicit zh-CN/zh-TW may bias the prompt.
-  getWhisperPrompt(settings = getSettings()) {
+  getWhisperPrompt(settings = getSettings(), dictionaryPrompt = this.getCustomDictionaryPrompt()) {
     return mergeWhisperPrompt(
-      this.getCustomDictionaryPrompt(),
+      dictionaryPrompt,
       resolveChineseScriptTarget(
         this.getEffectiveSttLanguage(settings),
         settings.chineseScriptPreference
@@ -3063,7 +3064,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     if (!normalized || normalized === "whisper-1") {
       return false;
     }
-    if (normalized === "gpt-4o-transcribe" || normalized === "gpt-4o-transcribe-diarize") {
+    if (
+      normalized === "gpt-transcribe" ||
+      normalized === "gpt-4o-transcribe" ||
+      normalized === "gpt-4o-transcribe-diarize"
+    ) {
       return true;
     }
     return normalized.startsWith("gpt-4o-mini-transcribe");
@@ -3529,6 +3534,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
       const endpoint = this.getTranscriptionEndpoint(route);
 
+      // gpt-transcribe takes the dictionary on its own keywords[] channel (see
+      // dictionaryKeywords), so its prompt carries only the Chinese script bias.
+      const usesKeywords = usesTranscriptionKeywords(model);
+      const dictionary = this.getCustomDictionaryPrompt();
+
       // Prompt budgets follow each provider's real limit (see dictionaryPromptCap):
       // Groq's 896-char request cap, the Whisper decoders' window, and a far
       // larger context guard for the 4o transcribe models, which are LLMs and
@@ -3536,7 +3546,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // Whisper decoders read the tail of whatever they are given.
       const MAX_PROMPT_CHARS = dictionaryPromptLimit({ provider, endpoint, model });
       const trimmedPrompt = trimDictionaryPrompt(
-        this.getWhisperPrompt(apiSettings),
+        this.getWhisperPrompt(apiSettings, usesKeywords ? null : dictionary),
         MAX_PROMPT_CHARS
       );
       const dictionaryPrompt = trimmedPrompt.prompt;
@@ -3553,6 +3563,11 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           );
         }
         formData.append("prompt", dictionaryPrompt);
+      }
+      if (usesKeywords) {
+        for (const keyword of dictionaryKeywords(dictionary)) {
+          formData.append("keywords[]", keyword);
+        }
       }
 
       const shouldStream = this.shouldStreamTranscription(model, provider);
@@ -3814,7 +3829,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       if (batchModel) return batchModel;
       return resolveByokModel(provider, s.cloudTranscriptionModel);
     } catch (error) {
-      return "gpt-4o-mini-transcribe";
+      return "gpt-transcribe";
     }
   }
 

--- a/src/helpers/transcriptionRoute.ts
+++ b/src/helpers/transcriptionRoute.ts
@@ -182,7 +182,10 @@ export function resolveByokModel(provider: string, configuredModel?: string): st
   if (trimmed) {
     const matchesProvider =
       (provider === "groq" && trimmed.startsWith("whisper-large-v3")) ||
-      (provider === "openai" && (trimmed.startsWith("gpt-4o") || trimmed === "whisper-1")) ||
+      (provider === "openai" &&
+        (trimmed.startsWith("gpt-transcribe") ||
+          trimmed.startsWith("gpt-4o") ||
+          trimmed === "whisper-1")) ||
       (provider === "mistral" && trimmed.startsWith("voxtral-")) ||
       (provider === "corti" && trimmed.startsWith("corti-")) ||
       (provider === "gemini" && trimmed.startsWith("gemini-")) ||
@@ -198,7 +201,7 @@ export function resolveByokModel(provider: string, configuredModel?: string): st
   if (provider === "gemini") return "gemini-3.5-transcribe";
   if (provider === "deepgram") return "nova-3";
   if (provider === "assemblyai") return "universal-3-5-pro";
-  return "gpt-4o-mini-transcribe";
+  return "gpt-transcribe";
 }
 
 function error(message: string, code?: string, messageKey?: string): TranscriptionRoute {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -2621,6 +2621,7 @@
         "turbo": "Schnell mit guter Qualität"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Neueste, genaueste Transkription",
         "openai_gpt_4o_mini_transcribe": "Schnelle und genaue Transkription",
         "openai_gpt_4o_transcribe": "Genaueste Transkription",
         "openai_whisper_1": "Originales Whisper-Modell",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2621,6 +2621,7 @@
         "turbo": "Fast with good quality"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Newest, most accurate transcription",
         "openai_gpt_4o_mini_transcribe": "Fast and accurate transcription",
         "openai_gpt_4o_transcribe": "Most accurate transcription",
         "openai_whisper_1": "Original Whisper model",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2576,6 +2576,7 @@
         "turbo": "Rápido con buena calidad"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Transcripción más reciente y precisa",
         "openai_gpt_4o_mini_transcribe": "Transcripción rápida y precisa",
         "openai_gpt_4o_transcribe": "Transcripción más precisa",
         "openai_whisper_1": "Modelo Whisper original",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -2621,6 +2621,7 @@
         "turbo": "Rapide avec une bonne qualité"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Transcription la plus récente et précise",
         "openai_gpt_4o_mini_transcribe": "Transcription rapide et précise",
         "openai_gpt_4o_transcribe": "Transcription la plus précise",
         "openai_whisper_1": "Modèle Whisper original",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2528,6 +2528,7 @@
         "turbo": "Veloce con buona qualità"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Trascrizione più recente e accurata",
         "openai_gpt_4o_mini_transcribe": "Trascrizione rapida e accurata",
         "openai_gpt_4o_transcribe": "Trascrizione più accurata",
         "openai_whisper_1": "Modello Whisper originale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2528,6 +2528,7 @@
         "turbo": "高速で高品質"
       },
       "transcription": {
+        "openai_gpt_transcribe": "最新かつ最も正確な文字起こし",
         "openai_gpt_4o_mini_transcribe": "高速で正確な文字起こし",
         "openai_gpt_4o_transcribe": "最も正確な文字起こし",
         "openai_whisper_1": "オリジナル Whisper モデル",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2507,6 +2507,7 @@
         "turbo": "Rápido com boa qualidade"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Transcrição mais recente e precisa",
         "openai_gpt_4o_mini_transcribe": "Transcrição rápida e precisa",
         "openai_gpt_4o_transcribe": "Transcrição mais precisa",
         "openai_whisper_1": "Modelo Whisper original",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2544,6 +2544,7 @@
         "turbo": "Быстрый с хорошим качеством"
       },
       "transcription": {
+        "openai_gpt_transcribe": "Новейшая и самая точная транскрипция",
         "openai_gpt_4o_mini_transcribe": "Быстрая и точная транскрипция",
         "openai_gpt_4o_transcribe": "Максимально точная транскрипция",
         "openai_whisper_1": "Оригинальная модель Whisper",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2528,6 +2528,7 @@
         "turbo": "快速且质量良好"
       },
       "transcription": {
+        "openai_gpt_transcribe": "最新、最准确的转录",
         "openai_gpt_4o_mini_transcribe": "快速且准确的转录",
         "openai_gpt_4o_transcribe": "最准确的转录",
         "openai_whisper_1": "原始 Whisper 模型",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2528,6 +2528,7 @@
         "turbo": "速度快且品質佳"
       },
       "transcription": {
+        "openai_gpt_transcribe": "最新、最準確的轉錄",
         "openai_gpt_4o_mini_transcribe": "快速且準確的轉錄",
         "openai_gpt_4o_transcribe": "最高準確度的轉錄",
         "openai_whisper_1": "原始 Whisper 模型",

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -456,7 +456,7 @@ export function getBatchTranscriptionModel(providerId: string): string | undefin
 
 export function getDefaultTranscriptionModel(providerId: string): string {
   const models = getTranscriptionModels(providerId);
-  return models[0]?.id || "gpt-4o-mini-transcribe";
+  return models[0]?.id || "gpt-transcribe";
 }
 
 export function getWhisperModels(): WhisperModelsMap {

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -207,6 +207,12 @@
       "baseUrl": "https://api.openai.com/v1",
       "models": [
         {
+          "id": "gpt-transcribe",
+          "name": "GPT Transcribe",
+          "description": "Newest, most accurate transcription",
+          "descriptionKey": "models.descriptions.transcription.openai_gpt_transcribe"
+        },
+        {
           "id": "gpt-4o-mini-transcribe",
           "name": "GPT-4o Mini Transcribe",
           "description": "Fast and accurate transcription",

--- a/src/utils/dictionaryKeywords.js
+++ b/src/utils/dictionaryKeywords.js
@@ -1,0 +1,15 @@
+// gpt-transcribe takes the custom dictionary as one `keywords[]` multipart field
+// per term instead of the Whisper-era free-text prompt. OpenAI rejects the whole
+// request when a keyword carries `<`, `>` or a line break. Same rules as the
+// server-side adapter in openwhispr-api (lib/providers/openai.ts).
+
+export function usesTranscriptionKeywords(model) {
+  return typeof model === "string" && model.trim() === "gpt-transcribe";
+}
+
+export function dictionaryKeywords(dictionaryPrompt) {
+  return String(dictionaryPrompt ?? "")
+    .split(/[,\r\n]+/)
+    .map((term) => term.replace(/[<>]/g, "").trim())
+    .filter(Boolean);
+}

--- a/test/helpers/audioManagerTranscriptionKeywords.test.js
+++ b/test/helpers/audioManagerTranscriptionKeywords.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { loadAudioManager } = require("./harness/audioManager");
+
+const DICTIONARY = "OpenWhispr, Gizmo Labs";
+const OPENAI_ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
+
+// Captures the dictionary-bearing fields of each transcription request.
+function captureRequests(t) {
+  const originalFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.fetch = async (endpoint, init) => {
+    requests.push({
+      prompt: init.body.get("prompt"),
+      keywords: init.body.getAll("keywords[]"),
+      stream: init.body.get("stream"),
+    });
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      text: async () => JSON.stringify({ text: "transcribed text" }),
+    };
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  return requests;
+}
+
+test("the custom dictionary rides gpt-transcribe's keywords[] channel, legacy models' prompt", async (t) => {
+  const { setSettings, createManager } = await loadAudioManager(t, {
+    cachePrefix: "openwhispr-transcription-keywords-test-",
+    settingsKey: "__transcriptionKeywordsSettings",
+  });
+  setSettings({
+    useLocalWhisper: false,
+    allowLocalFallback: false,
+    cloudTranscriptionProvider: "openai",
+  });
+  const audioBlob = new Blob([new ArrayBuffer(8)], { type: "audio/webm" });
+  // getWhisperPrompt and shouldStreamTranscription are the real prototype methods.
+  const manager = (model, overrides = {}) =>
+    createManager({
+      getEffectiveSttLanguage: () => "auto",
+      getTranscriptionModel: () => model,
+      getTranscriptionEndpoint: () => OPENAI_ENDPOINT,
+      getAPIKey: async () => "test-key",
+      getCustomDictionaryPrompt: () => DICTIONARY,
+      getKeyterms: () => [],
+      isDictionaryEcho: () => false,
+      processTranscription: async (text) => text,
+      isReasoningAvailable: async () => false,
+      ...overrides,
+    });
+
+  await t.test("gpt-transcribe sends one keywords[] entry per term and no prompt", async () => {
+    const requests = captureRequests(t);
+    const result = await manager("gpt-transcribe").processWithOpenAIAPI(audioBlob, {});
+    assert.equal(result.success, true);
+    assert.deepEqual(requests, [
+      { prompt: null, keywords: ["OpenWhispr", "Gizmo Labs"], stream: "true" },
+    ]);
+  });
+
+  await t.test(
+    "a Chinese script bias still travels in the prompt beside the keywords",
+    async () => {
+      const requests = captureRequests(t);
+      await manager("gpt-transcribe", {
+        getEffectiveSttLanguage: () => "zh-TW",
+      }).processWithOpenAIAPI(audioBlob, {});
+      assert.equal(requests.length, 1);
+      assert.deepEqual(requests[0].keywords, ["OpenWhispr", "Gizmo Labs"]);
+      assert.match(requests[0].prompt, /繁體中文/);
+      assert.doesNotMatch(requests[0].prompt, /OpenWhispr/, "dictionary must not be sent twice");
+    }
+  );
+
+  await t.test("gpt-4o-mini-transcribe keeps the comma-joined prompt", async () => {
+    const requests = captureRequests(t);
+    await manager("gpt-4o-mini-transcribe").processWithOpenAIAPI(audioBlob, {});
+    assert.deepEqual(requests, [{ prompt: DICTIONARY, keywords: [], stream: "true" }]);
+  });
+
+  await t.test("whisper-1 keeps the prompt and never streams", async () => {
+    const requests = captureRequests(t);
+    await manager("whisper-1").processWithOpenAIAPI(audioBlob, {});
+    assert.deepEqual(requests, [{ prompt: DICTIONARY, keywords: [], stream: null }]);
+  });
+});

--- a/test/helpers/dictionaryKeywords.test.js
+++ b/test/helpers/dictionaryKeywords.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/utils/dictionaryKeywords.js");
+
+test("only gpt-transcribe takes the dictionary as keywords", async () => {
+  const { usesTranscriptionKeywords } = await load();
+  assert.equal(usesTranscriptionKeywords("gpt-transcribe"), true);
+  assert.equal(usesTranscriptionKeywords(" gpt-transcribe "), true);
+  for (const model of ["gpt-4o-mini-transcribe", "gpt-4o-transcribe", "whisper-1", "", undefined]) {
+    assert.equal(usesTranscriptionKeywords(model), false, String(model));
+  }
+});
+
+test("keywords split the joined dictionary on commas and line breaks", async () => {
+  const { dictionaryKeywords } = await load();
+  assert.deepEqual(dictionaryKeywords("OpenWhispr, Gizmo Labs,Corti\nVoxtral\r\nParakeet"), [
+    "OpenWhispr",
+    "Gizmo Labs",
+    "Corti",
+    "Voxtral",
+    "Parakeet",
+  ]);
+});
+
+test("keywords drop the characters OpenAI rejects and any entry left empty", async () => {
+  const { dictionaryKeywords } = await load();
+  assert.deepEqual(dictionaryKeywords("<OpenWhispr>, < >, ,, a<b>c\n\n"), ["OpenWhispr", "abc"]);
+  assert.deepEqual(dictionaryKeywords(null), []);
+  assert.deepEqual(dictionaryKeywords(""), []);
+});

--- a/test/helpers/transcriptionModelMemory.test.js
+++ b/test/helpers/transcriptionModelMemory.test.js
@@ -74,7 +74,11 @@ test("per-provider transcription model memory", async (t) => {
     // A remembered batch-only model must not survive into the streaming-filtered
     // meeting scope; the streaming default wins instead.
     const restored = state().meetingCloudTranscriptionModel;
-    assert.notEqual(restored, "");
+    assert.equal(
+      restored,
+      "gpt-4o-mini-transcribe",
+      "the batch-only gpt-transcribe default must not leak into the streaming scope"
+    );
     state().setMeetingCloudTranscriptionModel("gpt-4o-mini-transcribe");
     state().switchCloudTranscriptionProvider("meeting", "groq");
     state().switchCloudTranscriptionProvider("meeting", "openai");
@@ -90,6 +94,11 @@ test("per-provider transcription model memory", async (t) => {
     assert.equal(state().meetingCloudTranscriptionProvider, "openai");
     state().switchCloudTranscriptionProvider("upload", "custom");
     assert.equal(state().uploadCloudTranscriptionProvider, "custom");
+  });
+
+  await t.test("a first switch to openai lands the registry's batch default", () => {
+    state().switchCloudTranscriptionProvider("dictation", "openai");
+    assert.equal(state().cloudTranscriptionModel, "gpt-transcribe");
   });
 
   await t.test("an unknown context is a no-op, not a crash", () => {

--- a/test/helpers/transcriptionRoute.test.js
+++ b/test/helpers/transcriptionRoute.test.js
@@ -293,8 +293,15 @@ test("openai and groq route to fixed endpoints with provider-validated models", 
   const openai = await resolve({});
   assert.equal(openai.provider, "openai");
   assert.equal(openai.endpoint, "https://api.openai.com/v1/audio/transcriptions");
-  assert.equal(openai.model, "gpt-4o-mini-transcribe");
+  assert.equal(openai.model, "gpt-transcribe");
   assert.equal(openai.sizeCapBytes, 25 * 1024 * 1024);
+
+  // The deprecated OpenAI ids stay selectable and must reach the API untouched;
+  // only an empty or foreign selection takes the new default.
+  for (const legacy of ["gpt-4o-mini-transcribe", "gpt-4o-transcribe", "whisper-1"]) {
+    const route = await resolve({ cloudTranscriptionModel: legacy });
+    assert.equal(route.model, legacy);
+  }
 
   const groqStale = await resolve({
     cloudTranscriptionProvider: "groq",

--- a/test/helpers/transcriptionRouteModelAgreement.test.js
+++ b/test/helpers/transcriptionRouteModelAgreement.test.js
@@ -78,7 +78,7 @@ test("a model belonging to another provider degrades to the provider default", a
   const { resolveByokModel } = await load();
 
   assert.equal(resolveByokModel("groq", "gpt-4o-mini-transcribe"), "whisper-large-v3-turbo");
-  assert.equal(resolveByokModel("openai", "voxtral-mini-latest"), "gpt-4o-mini-transcribe");
+  assert.equal(resolveByokModel("openai", "voxtral-mini-latest"), "gpt-transcribe");
   assert.equal(resolveByokModel("mistral", "whisper-1"), "voxtral-mini-latest");
   assert.equal(resolveByokModel("corti", "whisper-1"), "corti-transcribe");
   assert.equal(resolveByokModel("gemini", "whisper-1"), "gemini-3.5-transcribe");


### PR DESCRIPTION
## Why

OpenAI deprecated `whisper-1`, `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` on 2026-08-26, with removal on 2027-02-26. `gpt-transcribe` is the batch successor. This PR makes it available to users who bring their own OpenAI key and makes it the default for new selections. **The deprecated models stay selectable and no stored selection is rewritten**; retiring them is a later step.

## What

- **Registry**: `gpt-transcribe` is the first OpenAI transcription model (batch only, no `streaming` flag), so `switchCloudTranscriptionProvider` and onboarding land new BYOK selections on it. The three legacy entries are unchanged.
- **Resolver**: `resolveByokModel` accepts the `gpt-transcribe` prefix and falls back to it for an empty or foreign OpenAI selection. Legacy ids still pass through untouched (pinned by test).
- **Custom dictionary → `keywords[]`**: `gpt-transcribe` has a purpose-built keywords channel, and OpenAI rejects the whole request if a keyword carries `<`, `>` or a line break. For that model the renderer sends one `keywords[]` field per dictionary term (split on commas and line breaks, scrubbed, empties dropped), and `prompt` carries only the Chinese script bias. Legacy models keep today's comma-joined prompt. The split rules mirror the server-side adapter in openwhispr-api #192 so cloud and BYOK bias the model identically. Helper: `src/utils/dictionaryKeywords.js`, beside the other dictionary utilities.
- **Streaming**: `shouldStreamTranscription` includes `gpt-transcribe`; its SSE events (`transcript.text.delta` / `transcript.text.done`) are what `readTranscriptionStream` already handles.
- **Canary**: new `openai-batch` probe on `STT_CANARY_OPENAI_KEY` posts the silent fixture as `gpt-transcribe` with a `keywords[]` entry and asserts acceptance, so a retired model or field surfaces weekly.
- **i18n**: `openai_gpt_transcribe` description in all ten locales.

### Default literals, decided per site

| Site | Decision |
|---|---|
| `transcriptionRoute.ts` OpenAI fallback | → `gpt-transcribe` (request-time only, never persisted) |
| `ModelRegistry.getDefaultTranscriptionModel` literal | → `gpt-transcribe` (unreachable for OpenAI; kept consistent) |
| `audioManager.getTranscriptionModel` catch | → `gpt-transcribe` (request-time only) |
| `settingsStore.cloudTranscriptionModel` default | **unchanged**: it is the effective value for every existing user with no stored key and also feeds the realtime session model, where `gpt-transcribe` is not valid |
| Realtime routing (`REALTIME_MODELS`, meeting routing, realtime client) | **unchanged**, separate migration |

The main-process retry and upload multipart branches send no dictionary prompt today for any model, so there was nothing to convert there; left as is.

## Verified

Live against the real API on a retained recording, with the exact multipart the renderer builds:

| Request | Result |
|---|---|
| `gpt-transcribe` + webm + `language=en` + 3× `keywords[]` | 200, correct transcript, `languages:[{code:"en"}]` |
| same + `stream=true` | 200, 53 `transcript.text.delta` + 1 `transcript.text.done` |
| 300 `keywords[]` entries | 200 |
| Chinese-bias `prompt` + `keywords[]` together | 200 |
| `node scripts/stt-canary.mjs` with the OpenAI key | `openai-realtime ✅`, `openai-batch ✅` |

Tests: full suite 3767 (3570 pass, 196 skipped, 0 fail), including new request-shape tests for `gpt-transcribe` / `gpt-4o-mini-transcribe` / `whisper-1` through the audioManager harness. `typecheck`, `lint`, `i18n:check`, prettier all clean.

## Related

- openwhispr-api #192 switches the OpenWhispr Cloud batch default to `gpt-transcribe` with the same keywords mapping.
- The realtime successor (`gpt-live-transcribe`) is handled separately: openwhispr-api #193 and openwhispr `feat/openai-live-transcribe`.
