### PR TITLE
feat(preview): live transcription preview on the self-hosted route

### DIFF
--- a/src/components/dictation/LiveTranscriptPanel.tsx
+++ b/src/components/dictation/LiveTranscriptPanel.tsx
@@ -70,14 +70,14 @@ export function LiveTranscriptPanel({
       >
         <div>
           {text ? (
-            <p className="select-text whitespace-pre-wrap break-words text-base leading-relaxed text-foreground">
+            <p className="min-h-[4.875rem] select-text whitespace-pre-wrap break-words text-base leading-relaxed text-foreground">
               <span>{shimmerParts.settled}</span>
               {shimmerParts.active && (
                 <span className="inline-response-shimmer">{shimmerParts.active}</span>
               )}
             </p>
           ) : (
-            <p className="text-base leading-relaxed text-muted-foreground/55">
+            <p className="min-h-[4.875rem] text-base leading-relaxed text-muted-foreground/55">
               {t("transcriptionPreview.waitingForInput")}
             </p>
           )}
@@ -125,7 +125,7 @@ export function LiveTranscriptPanel({
         className="pointer-events-none absolute inset-x-5 top-0 invisible pb-3 pt-8"
         aria-hidden="true"
       >
-        <p className="whitespace-pre-wrap break-words text-base leading-relaxed">
+        <p className="min-h-[4.875rem] whitespace-pre-wrap break-words text-base leading-relaxed">
           {measurementText || t("transcriptionPreview.waitingForInput")}
         </p>
       </div>

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1347,10 +1347,28 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         cohereModel,
       } = getSettings();
       const isNvidia = localTranscriptionProvider === "nvidia";
+      // Self-hosted (OpenAI-compatible batch endpoint) feeds the same chunked
+      // preview as local models; each chunk is one POST to the endpoint.
+      let selfHostedPreview = !useLocalWhisper && isSelfHostedTranscription(getSettings());
+      let selfHostedEndpoint = null;
+      if (selfHostedPreview) {
+        try {
+          selfHostedEndpoint = this.getTranscriptionEndpoint(
+            resolveSelfHostedTranscriptionModel(getSettings()) || ""
+          );
+        } catch (error) {
+          logger.warn(
+            "Self-hosted preview endpoint unavailable",
+            { error: error.message },
+            "audio"
+          );
+          selfHostedPreview = false;
+        }
+      }
       // Online models stream+commit during capture, so PCM runs even with preview off.
       const streamingCommit = useLocalWhisper && isNvidia && isOnlineParakeetModel(parakeetModel);
       this._streamingCommitActive = false;
-      if (useLocalWhisper && (showTranscriptionPreview || streamingCommit)) {
+      if ((useLocalWhisper || selfHostedPreview) && (showTranscriptionPreview || streamingCommit)) {
         try {
           this._previewAudioContext = new AudioContext({ sampleRate: 16000 });
           this._previewSource = this._previewAudioContext.createMediaStreamSource(micStream);
@@ -1369,16 +1387,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           };
           this._previewSource.connect(this._previewProcessor);
 
-          const model = isNvidia
-            ? parakeetModel
-            : localTranscriptionProvider === "cohere"
-              ? cohereModel
-              : whisperModel;
+          const model = selfHostedPreview
+            ? resolveSelfHostedTranscriptionModel(getSettings())
+            : isNvidia
+              ? parakeetModel
+              : localTranscriptionProvider === "cohere"
+                ? cohereModel
+                : whisperModel;
           const language = getBaseLanguageCode(getSettings().preferredLanguage);
           window.electronAPI?.startDictationPreview?.({
-            provider: localTranscriptionProvider,
+            provider: selfHostedPreview ? "self-hosted" : localTranscriptionProvider,
             model,
             language,
+            ...(selfHostedPreview ? { endpoint: selfHostedEndpoint } : {}),
             display: shouldDisplayDictationPreview(
               showTranscriptionPreview,
               this.voiceAgentRequested

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -5,6 +5,7 @@ const os = require("os");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
 const { PARAKEET_UNSUPPORTED_OS_CODE } = require("./parakeetCapability");
+const { transcribeSelfHostedChunk } = require("./selfHostedChunkTranscription");
 const { getModelType, isSherpaLocalProvider } = require("./parakeetModelInfo");
 const { broadcastToWindows } = require("./windowBroadcast");
 const { openExternalUrl } = require("./externalUrlOpener");
@@ -7781,6 +7782,8 @@ class IPCHandlers {
     let dictationPreviewProvider = null;
     let dictationPreviewModel = null;
     let dictationPreviewLanguage = null;
+    // Self-hosted preview: the resolved /audio/transcriptions URL for chunks.
+    let dictationPreviewEndpoint = null;
     let dictationPreviewSessionActive = false;
     let dictationPreviewChunkCount = 0;
     // Online-runtime models stream here instead of the 1.5s chunked path.
@@ -7859,7 +7862,15 @@ class IPCHandlers {
         const wav = pcm16ToWav(pcm);
 
         let result;
-        if (isSherpaLocalProvider(dictationPreviewProvider)) {
+        if (dictationPreviewProvider === "self-hosted") {
+          result = await transcribeSelfHostedChunk({
+            endpoint: dictationPreviewEndpoint,
+            model: dictationPreviewModel,
+            language: dictationPreviewLanguage,
+            wav,
+            fetchImpl: proxyFetch,
+          });
+        } else if (isSherpaLocalProvider(dictationPreviewProvider)) {
           result = await this.parakeetManager.transcribeLocalParakeet(wav, {
             model: dictationPreviewModel,
             language: dictationPreviewLanguage,
@@ -8784,7 +8795,7 @@ class IPCHandlers {
 
     ipcMain.handle(
       "start-dictation-preview",
-      async (_event, { provider, model, language, display = true }) => {
+      async (_event, { provider, model, language, display = true, endpoint = null }) => {
         resetDictationPreviewState();
         const gen = dictationPreviewGen;
         dictationPreviewMode = true;
@@ -8792,6 +8803,7 @@ class IPCHandlers {
         dictationPreviewProvider = provider;
         dictationPreviewModel = model;
         dictationPreviewLanguage = language || null;
+        dictationPreviewEndpoint = endpoint || null;
         dictationPreviewDisplay = display;
         dictationPreviewChunkCount = 0;
         if (display) this.windowManager.showTranscriptionPreview("");

--- a/src/helpers/selfHostedChunkTranscription.js
+++ b/src/helpers/selfHostedChunkTranscription.js
@@ -1,0 +1,29 @@
+// Transcribes one buffered meeting WAV chunk by POSTing it to a self-hosted
+// OpenAI-compatible transcription endpoint. Pure: no electron imports, the
+// caller injects the fetch implementation (Electron's proxyFetch in the main
+// process, a fake in tests).
+async function transcribeSelfHostedChunk({ endpoint, model, language, wav, fetchImpl }) {
+  const formData = new FormData();
+  formData.append("file", new Blob([wav], { type: "audio/wav" }), "chunk.wav");
+  if (model) {
+    formData.append("model", model);
+  }
+  if (language) {
+    formData.append("language", language);
+  }
+
+  const response = await fetchImpl(endpoint, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Self-hosted API Error: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  return { success: true, text: data?.text ?? "" };
+}
+
+module.exports = { transcribeSelfHostedChunk };

--- a/src/helpers/voiceSurfaceGeometry.json
+++ b/src/helpers/voiceSurfaceGeometry.json
@@ -8,7 +8,7 @@
     "maxSurfaceWidth": 600
   },
   "LIVE_TRANSCRIPT_SURFACE_LIMITS": {
-    "minHeight": 152,
+    "minHeight": 188,
     "maxHeight": 538
   }
 }

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -3028,6 +3028,7 @@ declare global {
         model: string;
         language?: string;
         display?: boolean;
+        endpoint?: string;
       }) => Promise<{ success: boolean }>;
       stopDictationPreview?: (opts?: {
         showCleanup?: boolean;

--- a/src/utils/transcriptionPreview.ts
+++ b/src/utils/transcriptionPreview.ts
@@ -4,7 +4,12 @@ export function supportsLiveTranscriptionPreview(
   mode: InferenceMode,
   selectedCloudModelStreams = false
 ): boolean {
-  return mode === "local" || (mode === "providers" && selectedCloudModelStreams);
+  // Self-hosted rides the same 1.5s chunked preview path as local models.
+  return (
+    mode === "local" ||
+    mode === "self-hosted" ||
+    (mode === "providers" && selectedCloudModelStreams)
+  );
 }
 
 export function buildLiveTranscriptionPreview(committedText = "", partialText = ""): string {

--- a/test/helpers/selfHostedChunkTranscription.test.js
+++ b/test/helpers/selfHostedChunkTranscription.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/selfHostedChunkTranscription.js");
+
+test("posts the wav chunk as multipart form data and returns the transcript", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, json: async () => ({ text: " hello " }) };
+  };
+
+  const result = await transcribeSelfHostedChunk({
+    endpoint: "http://localhost:8000/v1/audio/transcriptions",
+    model: "whisper-1",
+    language: "en",
+    wav: Buffer.from([1, 2, 3, 4]),
+    fetchImpl,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://localhost:8000/v1/audio/transcriptions");
+  assert.equal(calls[0].init.method, "POST");
+
+  const body = calls[0].init.body;
+  assert.ok(body instanceof FormData);
+  const file = body.get("file");
+  assert.equal(file.name, "chunk.wav");
+  assert.equal(file.type, "audio/wav");
+  assert.equal(body.get("model"), "whisper-1");
+  assert.equal(body.get("language"), "en");
+
+  assert.deepEqual(result, { success: true, text: " hello " });
+});
+
+test("omits model and language when they are not set", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  let body = null;
+  const fetchImpl = async (_url, init) => {
+    body = init.body;
+    return { ok: true, json: async () => ({}) };
+  };
+
+  const result = await transcribeSelfHostedChunk({
+    endpoint: "http://localhost:8000/v1/audio/transcriptions",
+    model: null,
+    language: null,
+    wav: Buffer.from([1, 2, 3, 4]),
+    fetchImpl,
+  });
+
+  assert.equal(body.has("model"), false);
+  assert.equal(body.has("language"), false);
+  assert.deepEqual(result, { success: true, text: "" });
+});
+
+test("throws with the status and response body on a failed request", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 404,
+    text: async () => "no router",
+  });
+
+  await assert.rejects(
+    () =>
+      transcribeSelfHostedChunk({
+        endpoint: "http://localhost:8000/v1/audio/transcriptions",
+        model: "whisper-1",
+        language: "en",
+        wav: Buffer.from([1, 2, 3, 4]),
+        fetchImpl,
+      }),
+    /404 no router/
+  );
+});

--- a/test/helpers/voicePillPresentation.test.js
+++ b/test/helpers/voicePillPresentation.test.js
@@ -57,7 +57,7 @@ test("Live Transcript keeps an adaptive surface instead of entering at Agent hei
   const { LIVE_TRANSCRIPT_SURFACE_LIMITS } = await load();
 
   assert.deepEqual(LIVE_TRANSCRIPT_SURFACE_LIMITS, {
-    minHeight: 152,
+    minHeight: 188,
     maxHeight: 538,
   });
   assert.ok(LIVE_TRANSCRIPT_SURFACE_LIMITS.minHeight < LIVE_TRANSCRIPT_SURFACE_LIMITS.maxHeight);

--- a/test/utils/transcriptionPreview.test.js
+++ b/test/utils/transcriptionPreview.test.js
@@ -22,10 +22,10 @@ test("BYOK preview availability follows the selected model's streaming capabilit
   assert.equal(supportsLiveTranscriptionPreview("providers", false), false);
 });
 
-test("batch-only self-hosted transcription does not advertise live preview", async () => {
+test("self-hosted transcription advertises live preview via the chunked path", async () => {
   const { supportsLiveTranscriptionPreview } = await load();
 
-  assert.equal(supportsLiveTranscriptionPreview("self-hosted", true), false);
+  assert.equal(supportsLiveTranscriptionPreview("self-hosted", false), true);
 });
 
 test("live preview joins completed cloud turns with the current partial turn", async () => {


### PR DESCRIPTION
## Summary

Self-hosted dictation (an OpenAI-compatible batch endpoint such as
llama-swap serving Parakeet) now gets the same live transcription preview
that local models have. While recording, 1.5 s PCM chunks are POSTed to
the configured `/audio/transcriptions` endpoint and the text is appended
to the preview panel. The final paste is unchanged: the whole clip still
goes through the normal transcription and replaces the interim text.

Second commit: the preview panel opens at a three-line minimum instead of
one line, so short dictations do not grow the panel one step per chunk.

## How it works

- `supportsLiveTranscriptionPreview` now advertises the toggle for the
  self-hosted route. The test that pinned the old exclusion is flipped
  deliberately.
- `audioManager.startRecording` resolves the endpoint before the PCM
  worklet is wired, so a routing error leaves no orphan stream, then
  starts the worklet with `provider: "self-hosted"` and the endpoint.
- `start-dictation-preview` / `transcribeDictationPreviewChunk` in
  `ipcHandlers.js` route `self-hosted` chunks through a new
  `transcribeSelfHostedChunk` helper (`selfHostedChunkTranscription.js`,
  multipart POST with its own unit tests) and append the result with
  `appendTranscriptionPreview`.
- Silent chunks (RMS below the existing threshold) are skipped as before.
- `voiceSurfaceGeometry.json` / `LiveTranscriptPanel`: three-line minimum
  for the transcript paragraph and its hidden measurement twin; the entry
  height matches.

## Verification

macOS 27.0 arm64, Node 24, branch rebased on `main` at a2d0ab27. Endpoint:
llama-swap serving `parakeet-tdt-0.6b-v2` on a LAN GPU box.

```
npm run quality-check   # format:check + typecheck: pass
npm run lint            # 0 errors, 0 warnings
npm run i18n:check      # [i18n] Locale keys and placeholders are consistent.
npm test                # 3780 tests, 3582 pass, 1 fail
```

The one failure is `activateTargetPid resolves false for an unmapped PID`
in `test/helpers/textEditMonitorSelection.test.js`. It fails identically
on an untouched checkout of `main` (a2d0ab27) on this machine (times out
at ~3 s), so it is unrelated to this change.

Chunk cadence from a real dictation on this branch (debug log):

```
[2026-09-09T01:49:35.810Z] [DEBUG] Dictation preview chunk {
[2026-09-09T01:49:38.811Z] [DEBUG] Dictation preview chunk {
[2026-09-09T01:49:40.312Z] [DEBUG] Dictation preview chunk {
[2026-09-09T01:49:41.813Z] [DEBUG] Dictation preview chunk {
[2026-09-09T01:49:43.314Z] [DEBUG] Dictation preview chunk {
[2026-09-09T01:49:44.815Z] [DEBUG] Dictation preview chunk {
```

Endpoint latency for one 1.5 s chunk (48 KB WAV, 16 kHz mono), four
consecutive requests with curl:

```
200 0.087s
200 0.067s
200 0.066s
200 0.068s
```

So each chunk's text lands well inside the next 1.5 s window and the
preview keeps up with speech.

## Screenshots

The preview panel mid-dictation on the self-hosted route, two chunks
apart. The window is content-protected, so these are photos of the
display rather than screen captures.

![Preview panel after the first chunks](https://raw.githubusercontent.com/rodaddy/openwhispr/pr-assets/preview-panel-1.jpg)

![Preview panel a few chunks later](https://raw.githubusercontent.com/rodaddy/openwhispr/pr-assets/preview-panel-2.jpg)
