### PR TITLE
feat(meeting): allow self-hosted transcription for Note Recording

### DIFF
--- a/src/components/settings/MeetingSettings.tsx
+++ b/src/components/settings/MeetingSettings.tsx
@@ -8,6 +8,7 @@ import { InferenceModeSelector, SettingsRow } from "../ui/SettingsSection";
 import type { InferenceModeOption } from "../ui/SettingsSection";
 import { Toggle } from "../ui/toggle";
 import TranscriptionModelPicker from "../TranscriptionModelPicker";
+import SelfHostedPanel from "../SelfHostedPanel";
 import type { InferenceMode } from "../../types/electron";
 import { useStartOnboarding } from "../../hooks/useStartOnboarding";
 import { getStreamingTranscriptionProviders } from "../../models/ModelRegistry";
@@ -58,6 +59,11 @@ export function MeetingTranscriptionPanel() {
     meetingCloudTranscriptionBaseUrl,
     setMeetingCloudTranscriptionBaseUrl,
     setMeetingCloudTranscriptionMode,
+    meetingRemoteTranscriptionUrl,
+    setMeetingRemoteTranscriptionUrl,
+    remoteTranscriptionUrl,
+    remoteTranscriptionModel,
+    setRemoteTranscriptionModel,
   } = useSettingsStore();
   const {
     modes: transcriptionModes,
@@ -90,8 +96,6 @@ export function MeetingTranscriptionPanel() {
         label: t("settingsPage.transcription.modes.selfHosted"),
         description: t("settingsPage.transcription.modes.selfHostedDesc"),
         icon: <Network className="w-4 h-4" />,
-        disabled: true,
-        badge: t("common.comingSoon"),
       },
     ],
     "transcription",
@@ -100,7 +104,6 @@ export function MeetingTranscriptionPanel() {
   );
   const handleTranscriptionModeSelect = (mode: InferenceMode) => {
     if (!isModeAllowed(mode)) return;
-    if (mode === "self-hosted") return;
     if (mode === "openwhispr" && !isSignedIn) {
       startOnboarding();
       return;
@@ -179,6 +182,15 @@ export function MeetingTranscriptionPanel() {
 
       {effectiveTranscriptionMode === "providers" && renderTranscriptionPicker("cloud")}
       {effectiveTranscriptionMode === "local" && renderTranscriptionPicker("local")}
+      {effectiveTranscriptionMode === "self-hosted" && (
+        <SelfHostedPanel
+          service="transcription"
+          url={meetingRemoteTranscriptionUrl || remoteTranscriptionUrl}
+          onUrlChange={setMeetingRemoteTranscriptionUrl}
+          model={remoteTranscriptionModel}
+          onModelChange={setRemoteTranscriptionModel}
+        />
+      )}
       <MeetingSpeakerDetectionRow />
     </div>
   );

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6,6 +6,7 @@ const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
 const { PARAKEET_UNSUPPORTED_OS_CODE } = require("./parakeetCapability");
 const { getModelType, isSherpaLocalProvider } = require("./parakeetModelInfo");
+const { transcribeSelfHostedChunk } = require("./selfHostedMeetingTranscription");
 const { broadcastToWindows } = require("./windowBroadcast");
 const { openExternalUrl } = require("./externalUrlOpener");
 const { resolveFailedGpuBackends } = require("./whisper");
@@ -7168,6 +7169,10 @@ class IPCHandlers {
     let meetingLocalProvider = null;
     let meetingLocalModel = null;
     let meetingLocalLanguage = null;
+    // Only set when meetingLocalProvider === "self-hosted": the buffered-chunk
+    // path POSTs each WAV to this endpoint instead of decoding it locally.
+    let meetingSelfHostedEndpoint = null;
+    let meetingSelfHostedModel = null;
     let meetingLocalTranscribing = false;
     let meetingPendingMicChunks = [];
     let meetingPendingMicFinals = [];
@@ -7563,7 +7568,23 @@ class IPCHandlers {
 
       try {
         let result;
-        if (isSherpaLocalProvider(meetingLocalProvider)) {
+        if (meetingLocalProvider === "self-hosted") {
+          const requestStartedAt = Date.now();
+          result = await transcribeSelfHostedChunk({
+            endpoint: meetingSelfHostedEndpoint,
+            model: meetingSelfHostedModel,
+            language: meetingLocalLanguage,
+            wav,
+            fetchImpl: proxyFetch,
+          });
+          debugLogger.debug("Self-hosted meeting chunk transcribed", {
+            source,
+            wavBytes: wav.length,
+            requestMs: Date.now() - requestStartedAt,
+            success: !!result?.success,
+            textLength: result?.text?.trim?.().length ?? 0,
+          });
+        } else if (isSherpaLocalProvider(meetingLocalProvider)) {
           result = await this.parakeetManager.transcribeLocalParakeet(wav, {
             model: meetingLocalModel,
             language: meetingLocalLanguage,
@@ -7766,6 +7787,8 @@ class IPCHandlers {
       meetingLocalProvider = null;
       meetingLocalModel = null;
       meetingLocalLanguage = null;
+      meetingSelfHostedEndpoint = null;
+      meetingSelfHostedModel = null;
       meetingLocalTranscribing = false;
       meetingPendingMicChunks = [];
       resetPendingMicFinals();
@@ -8127,7 +8150,8 @@ class IPCHandlers {
         return { success: false, error: `Unsupported provider: ${options.provider}` };
       }
 
-      if (options.provider === "local") {
+      // Buffered-chunk modes open no sockets, so there is nothing to pre-warm.
+      if (options.provider === "local" || options.provider === "self-hosted") {
         return { success: true };
       }
 
@@ -8274,11 +8298,14 @@ class IPCHandlers {
           });
         }
 
-        if (options.provider === "local") {
+        if (options.provider === "local" || options.provider === "self-hosted") {
           meetingLocalMode = true;
-          meetingLocalProvider = options.localProvider || "whisper";
+          meetingLocalProvider =
+            options.provider === "self-hosted" ? "self-hosted" : options.localProvider || "whisper";
           meetingLocalModel = options.localModel || null;
           meetingLocalLanguage = options.language || null;
+          meetingSelfHostedEndpoint = options.endpoint || null;
+          meetingSelfHostedModel = options.model || null;
           meetingLocalWin = BrowserWindow.fromWebContents(event.sender);
           meetingLocalBuffers = { mic: [], system: [] };
           meetingLocalTranscript = "";

--- a/src/helpers/meetingStreamingProviders.js
+++ b/src/helpers/meetingStreamingProviders.js
@@ -14,7 +14,11 @@ const STREAMING_CLIENT_BY_PROVIDER = {
 
 // Derived from the registry so an allowed provider can never lack a client
 // class and silently fall through to the OpenAI default.
-const ALLOWED_MEETING_PROVIDERS = new Set(["local", ...Object.keys(STREAMING_CLIENT_BY_PROVIDER)]);
+const ALLOWED_MEETING_PROVIDERS = new Set([
+  "local",
+  "self-hosted",
+  ...Object.keys(STREAMING_CLIENT_BY_PROVIDER),
+]);
 
 const getMeetingStreamingClient = (provider) => {
   const StreamingClient = STREAMING_CLIENT_BY_PROVIDER[provider];

--- a/src/helpers/meetingTranscriptionRouting.js
+++ b/src/helpers/meetingTranscriptionRouting.js
@@ -3,6 +3,25 @@ const DEFAULT_MANAGED_PROVIDER = {
   models: [{ id: "gpt-4o-mini-transcribe", default: true }],
 };
 
+// Mirrors the suffix stripping in config/constants.ts normalizeBaseUrl for the
+// batch transcription route. Replicated rather than imported: this module is a
+// plain .js seam loaded by the renderer and the main process alike, and
+// constants.ts pulls in the wider renderer config graph.
+const TRANSCRIPTION_BASE_SUFFIXES = [
+  [/\/v1\/audio\/transcriptions$/i, "/v1"],
+  [/\/audio\/transcriptions$/i, ""],
+];
+
+const buildSelfHostedTranscriptionEndpoint = (rawUrl) => {
+  let base = rawUrl.trim();
+  for (const [pattern, replacement] of TRANSCRIPTION_BASE_SUFFIXES) {
+    if (pattern.test(base)) {
+      base = base.replace(pattern, replacement).replace(/\/+$/, "");
+    }
+  }
+  return `${base.replace(/\/+$/, "")}/audio/transcriptions`;
+};
+
 const resolveModel = (provider, selectedModel) =>
   provider.models.find((model) => model.id === selectedModel)?.id ??
   provider.models.find((model) => model.default)?.id ??
@@ -22,6 +41,8 @@ export function resolveMeetingTranscriptionOptions({
   cortiEnvironment,
   cortiTenant,
   keyterms,
+  remoteTranscriptionUrl,
+  remoteTranscriptionModel,
 }) {
   if (transcriptionMode === "local") {
     return {
@@ -48,9 +69,17 @@ export function resolveMeetingTranscriptionOptions({
   }
 
   if (transcriptionMode === "self-hosted") {
-    throw new Error(
-      "Self-hosted realtime transcription is not supported for Note Recording. Choose Local or Cloud Providers."
-    );
+    const rawUrl = (remoteTranscriptionUrl || "").trim();
+    if (!rawUrl) {
+      throw new Error("Self-hosted transcription URL is not configured");
+    }
+    const model = (remoteTranscriptionModel || "").trim();
+    return {
+      provider: "self-hosted",
+      endpoint: buildSelfHostedTranscriptionEndpoint(rawUrl),
+      model: model || null,
+      language,
+    };
   }
 
   if (transcriptionMode !== "providers") {

--- a/src/helpers/selfHostedMeetingTranscription.js
+++ b/src/helpers/selfHostedMeetingTranscription.js
@@ -1,0 +1,29 @@
+// Transcribes one buffered meeting WAV chunk by POSTing it to a self-hosted
+// OpenAI-compatible transcription endpoint. Pure: no electron imports, the
+// caller injects the fetch implementation (Electron's proxyFetch in the main
+// process, a fake in tests).
+async function transcribeSelfHostedChunk({ endpoint, model, language, wav, fetchImpl }) {
+  const formData = new FormData();
+  formData.append("file", new Blob([wav], { type: "audio/wav" }), "chunk.wav");
+  if (model) {
+    formData.append("model", model);
+  }
+  if (language) {
+    formData.append("language", language);
+  }
+
+  const response = await fetchImpl(endpoint, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Self-hosted API Error: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  return { success: true, text: data?.text ?? "" };
+}
+
+module.exports = { transcribeSelfHostedChunk };

--- a/src/stores/meetingRecordingStore.ts
+++ b/src/stores/meetingRecordingStore.ts
@@ -168,6 +168,8 @@ const getMeetingTranscriptionOptions = () => {
     cortiEnvironment: state.cortiEnvironment,
     cortiTenant: state.cortiTenant,
     keyterms: (state.customDictionary ?? []).filter(Boolean),
+    remoteTranscriptionUrl: resolved.remoteTranscriptionUrl,
+    remoteTranscriptionModel: state.remoteTranscriptionModel,
   });
 };
 

--- a/test/helpers/dictationStreamingMatrix.test.js
+++ b/test/helpers/dictationStreamingMatrix.test.js
@@ -217,7 +217,9 @@ test("closure: every allowed meeting provider has a token entry", async () => {
   const { REALTIME_TOKEN_PROVIDERS } = await loadTokens();
   const { ALLOWED_MEETING_PROVIDERS } = await loadMeeting();
   for (const provider of ALLOWED_MEETING_PROVIDERS) {
-    if (provider === "local") continue;
+    // local and self-hosted never fetch a realtime token: they transcribe
+    // buffered chunks locally or against the user's own endpoint.
+    if (provider === "local" || provider === "self-hosted") continue;
     assert.equal(
       typeof REALTIME_TOKEN_PROVIDERS[provider],
       "function",

--- a/test/helpers/meetingStreamingProviders.test.js
+++ b/test/helpers/meetingStreamingProviders.test.js
@@ -18,7 +18,9 @@ test("every allowed realtime provider has a streaming client (no silent OpenAI f
   const { STREAMING_CLIENT_BY_PROVIDER, ALLOWED_MEETING_PROVIDERS } = await load();
 
   for (const provider of ALLOWED_MEETING_PROVIDERS) {
-    if (provider === "local") continue;
+    // local and self-hosted transcribe buffered chunks, they never open a
+    // realtime streaming socket, so they have no streaming client by design.
+    if (provider === "local" || provider === "self-hosted") continue;
     assert.equal(
       typeof STREAMING_CLIENT_BY_PROVIDER[provider],
       "function",
@@ -89,4 +91,10 @@ test("connection identity includes every provider-specific option", async () => 
     getMeetingConnectionKey(options),
     getMeetingConnectionKey({ ...options, tenant: "tenant-b" })
   );
+});
+
+test("allow-list accepts self-hosted meeting transcription", async () => {
+  const { ALLOWED_MEETING_PROVIDERS } = await load();
+
+  assert.equal(ALLOWED_MEETING_PROVIDERS.has("self-hosted"), true);
 });

--- a/test/helpers/meetingTranscriptionRouting.test.js
+++ b/test/helpers/meetingTranscriptionRouting.test.js
@@ -61,7 +61,26 @@ test("BYOK OpenAI never downgrades to managed cloud when its key is unavailable"
   );
 });
 
-test("self-hosted mode never follows a stale Tinfoil provider", async () => {
+test("self-hosted mode routes to the chunked HTTP batch transcriber", async () => {
+  const { resolveMeetingTranscriptionOptions } = await load();
+
+  assert.deepEqual(
+    resolveMeetingTranscriptionOptions({
+      ...baseOptions,
+      transcriptionMode: "self-hosted",
+      remoteTranscriptionUrl: "https://llama-swap.rodaddy.live/v1",
+      remoteTranscriptionModel: "whisper-large-v3-turbo",
+    }),
+    {
+      provider: "self-hosted",
+      endpoint: "https://llama-swap.rodaddy.live/v1/audio/transcriptions",
+      model: "whisper-large-v3-turbo",
+      language: "en",
+    }
+  );
+});
+
+test("self-hosted mode fails closed when its URL is not configured", async () => {
   const { resolveMeetingTranscriptionOptions } = await load();
 
   assert.throws(
@@ -69,8 +88,9 @@ test("self-hosted mode never follows a stale Tinfoil provider", async () => {
       resolveMeetingTranscriptionOptions({
         ...baseOptions,
         transcriptionMode: "self-hosted",
+        remoteTranscriptionUrl: "   ",
       }),
-    /Self-hosted realtime transcription is not supported/
+    /not configured/
   );
 });
 

--- a/test/helpers/selfHostedMeetingTranscription.test.js
+++ b/test/helpers/selfHostedMeetingTranscription.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/selfHostedMeetingTranscription.js");
+
+test("posts the wav chunk as multipart form data and returns the transcript", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { ok: true, json: async () => ({ text: " hello " }) };
+  };
+
+  const result = await transcribeSelfHostedChunk({
+    endpoint: "http://localhost:8000/v1/audio/transcriptions",
+    model: "whisper-1",
+    language: "en",
+    wav: Buffer.from([1, 2, 3, 4]),
+    fetchImpl,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "http://localhost:8000/v1/audio/transcriptions");
+  assert.equal(calls[0].init.method, "POST");
+
+  const body = calls[0].init.body;
+  assert.ok(body instanceof FormData);
+  const file = body.get("file");
+  assert.equal(file.name, "chunk.wav");
+  assert.equal(file.type, "audio/wav");
+  assert.equal(body.get("model"), "whisper-1");
+  assert.equal(body.get("language"), "en");
+
+  assert.deepEqual(result, { success: true, text: " hello " });
+});
+
+test("omits model and language when they are not set", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  let body = null;
+  const fetchImpl = async (_url, init) => {
+    body = init.body;
+    return { ok: true, json: async () => ({}) };
+  };
+
+  const result = await transcribeSelfHostedChunk({
+    endpoint: "http://localhost:8000/v1/audio/transcriptions",
+    model: null,
+    language: null,
+    wav: Buffer.from([1, 2, 3, 4]),
+    fetchImpl,
+  });
+
+  assert.equal(body.has("model"), false);
+  assert.equal(body.has("language"), false);
+  assert.deepEqual(result, { success: true, text: "" });
+});
+
+test("throws with the status and response body on a failed request", async () => {
+  const { transcribeSelfHostedChunk } = await load();
+
+  const fetchImpl = async () => ({
+    ok: false,
+    status: 404,
+    text: async () => "no router",
+  });
+
+  await assert.rejects(
+    () =>
+      transcribeSelfHostedChunk({
+        endpoint: "http://localhost:8000/v1/audio/transcriptions",
+        model: "whisper-1",
+        language: "en",
+        wav: Buffer.from([1, 2, 3, 4]),
+        fetchImpl,
+      }),
+    /404 no router/
+  );
+});


### PR DESCRIPTION
## Summary

Enables the Self-hosted mode for Note Recording. Today the routing
helper throws "not supported for Note Recording" and the settings card is
disabled with a Coming soon badge. A self-hosted OpenAI-compatible server
is a batch HTTP endpoint, not a realtime socket, so this reuses the
chunked pipeline that Local Note Recording already runs (buffer PCM,
downsample, WAV, 5 s cadence, the same RMS gate and mic holdback) and
POSTs each chunk to `<url>/audio/transcriptions` with the configured
model and language.

Opt-in only: nothing routes here unless the user selects Self-hosted for
Note Recording.

## How it works

- `meetingTranscriptionRouting.resolveMeetingTranscriptionOptions`
  resolves `{ provider: "self-hosted", endpoint, model, language }`. The
  URL is normalized the same way the dictation route does (a pasted
  `/v1/audio/transcriptions` or `/audio/transcriptions` suffix is
  stripped). It still throws, now only when the URL is empty, so the
  fail-closed behavior from #1280 holds.
- `meetingRecordingStore` passes the meeting-scoped URL (falling back to
  the dictation URL) and the global self-hosted model.
- `MeetingSettings` enables the mode and renders the existing
  `SelfHostedPanel` for URL and model.
- Main process: `prepare`/`start` accept `self-hosted`; the buffered-chunk
  path calls a small pure `selfHostedMeetingTranscription.transcribeSelfHostedChunk`
  (multipart POST, injected fetch) instead of decoding locally. A debug
  log line records per-chunk request time and result.
- `meetingStreamingProviders` adds `self-hosted` to the allowed set; the
  closure tests treat it like `local` (no socket, no token).

No locale changes: the mode label and the panel strings already exist.

## Relationship to #1337 and #1280

#1337 solves the same gap by routing meeting chunks through the batch
transcription router. This change takes a narrower path: it plugs the
self-hosted endpoint into the existing local meeting chunk loop and
touches no routing shared with Dictation or Upload. Ten files, one new
helper with its own tests. Either approach retires the Coming soon
badge; this one is offered as the smaller diff.

Refs #1280 (the custom Cloud Providers endpoint for Note Recording is a
separate problem and is not touched here).

## Verification

macOS 27.0 arm64, Node 24, branch on `main` at a2d0ab27. Endpoint:
llama-swap serving `parakeet-tdt-0.6b-v2` on a LAN GPU box.

```
npm run quality-check   # format:check + typecheck: pass
npm run lint            # 0 errors, 0 warnings
npm run i18n:check      # [i18n] Locale keys and placeholders are consistent.
npm test                # 3782 tests, 3584 pass, 1 fail
```

The one failure is `activateTargetPid resolves false for an unmapped PID`
in `test/helpers/textEditMonitorSelection.test.js`. It fails identically
on an untouched checkout of `main` (a2d0ab27) on this machine (times out
at ~3 s), so it is unrelated to this change.

Live run (packaged build of this branch):

Two-minute note recording (03:17:37 to 03:19:45 UTC) with a podcast playing through the speakers, Self-hosted selected for Note Recording, debug logging on. Every chunk the pipeline sent got a 200 with text back:

```
source  chunks  full 5 s chunks  returned text  request ms (min / avg / max)
system      26               23             26          71 / 116 / 250
mic         17                6             17          65 / 119 / 402
```

Consecutive full system-audio chunks arrived 4.92 to 5.08 s apart (the pipeline's 5 s buffer), full chunks exactly 160044 bytes (5.000 s of 16 kHz mono WAV), a shorter flush chunk at stop. Mic chunks are fewer because the existing RMS gate skips silence and the holdback logic suppresses bleed from the speakers; both behave the same as on the Local path.

First and last entries from the debug log (`Self-hosted meeting chunk transcribed` is the new debug line in this PR):

```
2026-09-09T03:17:42.881Z system 153644 146 true 55
2026-09-09T03:17:47.868Z system 160044 134 true 42
2026-09-09T03:17:52.812Z system 160044 76 true 51
...
2026-09-09T03:19:43.020Z mic 160044 67 true 55
2026-09-09T03:19:45.601Z system 78752 250 true 17
```
(columns: time, source, wavBytes, requestMs, success, textLength)


## Screenshots

The note's Transcript view after the two-minute run above (system audio
chunks transcribed by the self-hosted endpoint; the speaker label is a
user-assigned name from the existing diarization flow):

![Transcript from the self-hosted note recording run](https://raw.githubusercontent.com/rodaddy/openwhispr/pr-assets/note-transcript.jpg)

Settings, Speech-to-Text, Note Recording with Self-Hosted selected (the
existing `SelfHostedPanel` for URL and model; server address replaced
with a placeholder):

![Note Recording settings with Self-Hosted selected](https://raw.githubusercontent.com/rodaddy/openwhispr/ebd6346075c8e558221f97d8f18731f3b0b21849/note-settings.jpg)
