### PR TITLE
feat(settings): resolve API keys from env vars and login shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,18 @@ VITE_OPENWHISPR_API_URL=
 
 # OpenAI API Configuration
 # Get your API key from: https://platform.openai.com/api-keys
+# Keys exported in your shell (e.g. ~/.zshrc) are imported at startup when
+# the matching Settings field is empty. A key saved in Settings still wins.
+# Custom endpoints can also store a reference instead of the secret itself:
+#   CUSTOM_TRANSCRIPTION_API_KEY=$OPENAI_API_KEY
+# dotenv does not expand $VAR here. Only a whole-field $VAR / ${VAR} is
+# resolved at read time, and only if the name is an OpenWhispr secret
+# (OPENAI_API_KEY, GROQ_API_KEY, … — not $MY_COMPANY_KEY).
 OPENAI_API_KEY=your_openai_api_key_here
+
+# Optional: API key for a custom OpenAI-compatible transcription endpoint.
+# Leave unset to require no auth, or set / reference another variable.
+# CUSTOM_TRANSCRIPTION_API_KEY=$OPENAI_API_KEY
 
 # Optional: Customize the Whisper model
 # Available models: whisper-1 (default), whisper-1-large, whisper-1-large-v2

--- a/preload.js
+++ b/preload.js
@@ -388,6 +388,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // BYOK API keys (get/save for every provider in the secretKeys manifest)
   ...secretKeyApi,
+  resolveSecretRef: (value) => ipcRenderer.invoke("resolve-secret-ref", value),
 
   // Clipboard functions
   checkAccessibilityPermission: (silent) =>

--- a/src/components/EnterpriseProviderConfig.tsx
+++ b/src/components/EnterpriseProviderConfig.tsx
@@ -347,6 +347,7 @@ function AzureConfig({ reasoningModel, setReasoningModel }: EnterpriseProviderCo
   const getTestConfig = () => ({
     azureEndpoint: store.azureEndpoint,
     azureApiVersion: store.azureApiVersion,
+    azureApiKey: store.azureApiKey,
     apiKey: store.azureApiKey,
     model: store.azureDeploymentName || reasoningModel,
   });
@@ -424,6 +425,7 @@ function VertexConfig({ reasoningModel, setReasoningModel }: EnterpriseProviderC
   const getTestConfig = () => ({
     vertexProject: store.vertexProject,
     vertexLocation: store.vertexLocation,
+    vertexApiKey: store.vertexAuthMode === "apikey" ? store.vertexApiKey : "",
     apiKey: store.vertexAuthMode === "apikey" ? store.vertexApiKey : "",
     model: reasoningModel,
   });

--- a/src/components/OpenAICompatiblePanel.tsx
+++ b/src/components/OpenAICompatiblePanel.tsx
@@ -7,6 +7,7 @@ import ModelCardList from "./ui/ModelCardList";
 import SearchableModelList, { MODEL_SEARCH_THRESHOLD } from "./ui/SearchableModelList";
 import { buildApiUrl, getModelListBaseCandidates, normalizeBaseUrl } from "../config/constants";
 import { isSecureHttpEndpoint } from "../utils/urlUtils";
+import { resolveApiKey } from "../utils/resolveApiKey";
 import { GetApiKeyLink } from "./ui/GetApiKeyLink";
 
 interface ModelOption {
@@ -109,7 +110,7 @@ export default function OpenAICompatiblePanel({
         setModelsError(null);
       }
 
-      const trimmedKey = apiKey?.trim();
+      const trimmedKey = await resolveApiKey(apiKey);
       const effectiveKey = trimmedKey && trimmedKey.length > 0 ? trimmedKey : undefined;
       let activeBase = normalized;
 

--- a/src/components/TranscriptionModelPicker.tsx
+++ b/src/components/TranscriptionModelPicker.tsx
@@ -1220,7 +1220,7 @@ export default function TranscriptionModelPicker({
                     apiKey={customTranscriptionApiKey}
                     setApiKey={setCustomTranscriptionApiKey}
                     label={t("transcription.apiKeyOptional")}
-                    helpText=""
+                    helpText={t("transcription.apiKeyEnvHelp")}
                   />
 
                   <div className="space-y-1.5">

--- a/src/components/onboarding/ProviderSetupStep.tsx
+++ b/src/components/onboarding/ProviderSetupStep.tsx
@@ -352,6 +352,9 @@ export function ByokProviderStep({
     initialProvider === "corti" ? store.cortiClientSecret : ""
   );
   const [connected, setConnected] = useState(false);
+  // Set when commitAndProceed's store writes reject a $VAR reference, so the
+  // step stays put with an explanation instead of advancing on a failed save.
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     onConnectionChange(false);
@@ -443,42 +446,65 @@ export function ByokProviderStep({
       ? Boolean(draftCortiClientId.trim() && draftCortiClientSecret.trim() && selectedModel)
       : Boolean(selectedProvider && selectedModel && testingKey.trim());
 
+  // Secret setters reject a $VAR that points at themselves or at a name that is
+  // not an OpenWhispr secret, and they throw to say so. Every branch therefore
+  // writes the API key *first*: a rejected reference then leaves the URL, model
+  // and mode untouched instead of half-configuring the provider, and the step
+  // stays put with saveError rendered under the button.
   const commitAndProceed = () => {
-    if (selfHosted) {
-      // The connection test parses scheme-less input as https
-      // (providerConnectionTest.js), so commit the same URL it validated —
-      // the runtime's isSecureHttpEndpoint gate rejects a bare host.
-      const committedBaseUrl = draftBaseUrl.includes("://")
-        ? draftBaseUrl.trim()
-        : `https://${draftBaseUrl.trim()}`;
-      if (assistant) {
-        store.setChatAgentRemoteUrl(committedBaseUrl);
-        store.setChatAgentCustomApiKey(draftApiKey);
-        store.setChatAgentModel(draftCustomModel);
-        store.setChatAgentMode("self-hosted");
-        store.setChatAgentProvider("custom");
-      } else {
-        store.setCloudTranscriptionBaseUrl(committedBaseUrl);
-        store.setCustomTranscriptionApiKey(draftApiKey);
-        store.setCloudTranscriptionModel(draftCustomModel);
-        store.switchCloudTranscriptionProvider("dictation", "custom");
-        store.setCloudTranscriptionMode("byok");
-      }
-    } else if (assistant) {
-      knownCredential.set(draftApiKey);
-      store.setChatAgentMode("providers");
-      store.switchReasoningProvider("chatIntelligence", selectedProvider, selectedModel);
-      store.setChatAgentModel(selectedModel);
-    } else {
-      if (isCortiTranscription) {
-        store.setCortiClientId(draftCortiClientId);
-        store.setCortiClientSecret(draftCortiClientSecret);
-      } else {
+    try {
+      if (selfHosted) {
+        // The connection test parses scheme-less input as https
+        // (providerConnectionTest.js), so commit the same URL it validated —
+        // the runtime's isSecureHttpEndpoint gate rejects a bare host.
+        const committedBaseUrl = draftBaseUrl.includes("://")
+          ? draftBaseUrl.trim()
+          : `https://${draftBaseUrl.trim()}`;
+        if (assistant) {
+          store.setChatAgentCustomApiKey(draftApiKey);
+          store.setChatAgentRemoteUrl(committedBaseUrl);
+          store.setChatAgentModel(draftCustomModel);
+          store.setChatAgentMode("self-hosted");
+          store.setChatAgentProvider("custom");
+        } else {
+          store.setCustomTranscriptionApiKey(draftApiKey);
+          store.setCloudTranscriptionBaseUrl(committedBaseUrl);
+          store.setCloudTranscriptionModel(draftCustomModel);
+          store.switchCloudTranscriptionProvider("dictation", "custom");
+          store.setCloudTranscriptionMode("byok");
+        }
+      } else if (assistant) {
         knownCredential.set(draftApiKey);
+        store.setChatAgentMode("providers");
+        store.switchReasoningProvider("chatIntelligence", selectedProvider, selectedModel);
+        store.setChatAgentModel(selectedModel);
+      } else {
+        if (isCortiTranscription) {
+          store.setCortiClientId(draftCortiClientId);
+          store.setCortiClientSecret(draftCortiClientSecret);
+        } else {
+          knownCredential.set(draftApiKey);
+        }
+        store.setCloudTranscriptionMode("byok");
+        store.switchCloudTranscriptionProvider("dictation", selectedProvider);
+        store.setCloudTranscriptionModel(selectedModel);
       }
-      store.setCloudTranscriptionMode("byok");
-      store.switchCloudTranscriptionProvider("dictation", selectedProvider);
-      store.setCloudTranscriptionModel(selectedModel);
+      setSaveError(null);
+    } catch (err) {
+      const code = (err as Error & { code?: string }).code;
+      setSaveError(
+        code === "self-reference"
+          ? t("apiKeyInput.selfReference", {
+              defaultValue: "Use a different variable name here, or leave this field empty.",
+            })
+          : code === "unknown-ref"
+            ? t("apiKeyInput.unknownRef", {
+                defaultValue:
+                  "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY).",
+              })
+            : (err as Error).message
+      );
+      return;
     }
     onProceed();
   };
@@ -690,6 +716,11 @@ export function ByokProviderStep({
         >
           {t("onboarding.rehaul.provider.proceed")}
         </StepPrimaryAction>
+        {saveError && (
+          <p role="alert" className="mt-2 text-xs text-destructive">
+            {saveError}
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/components/ui/ApiKeyInput.tsx
+++ b/src/components/ui/ApiKeyInput.tsx
@@ -35,6 +35,7 @@ export default function ApiKeyInput({
   const resolvedLabel = label ?? t("apiKeyInput.label");
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasKey = apiKey.length > 0;
@@ -57,14 +58,28 @@ export default function ApiKeyInput({
   const save = useCallback(() => {
     try {
       setApiKey(draft.trim());
+      setError(null);
+      setIsEditing(false);
     } catch (err) {
+      const code = (err as Error & { code?: string }).code;
       logger.warn("Failed to save API key", { error: (err as Error).message }, "settings");
+      setError(
+        code === "self-reference"
+          ? t("apiKeyInput.selfReference", {
+              defaultValue: "Use a different variable name here, or leave this field empty.",
+            })
+          : code === "unknown-ref"
+            ? t("apiKeyInput.unknownRef", {
+                defaultValue: "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY).",
+              })
+            : (err as Error).message
+      );
     }
-    setIsEditing(false);
-  }, [draft, setApiKey]);
+  }, [draft, setApiKey, t]);
 
   const cancel = () => {
     setDraft("");
+    setError(null);
     setIsEditing(false);
   };
 
@@ -106,7 +121,10 @@ export default function ApiKeyInput({
               type="text"
               placeholder={resolvedPlaceholder}
               value={draft}
-              onChange={(e) => setDraft(e.target.value)}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                if (error) setError(null);
+              }}
               onKeyDown={handleKeyDown}
               aria-label={ariaLabel || resolvedLabel || t("apiKeyInput.label")}
               className={`h-8 text-sm font-mono pr-16 ${variantClasses}`}
@@ -160,6 +178,12 @@ export default function ApiKeyInput({
           </button>
         )}
       </div>
+
+      {error && (
+        <p role="alert" className="text-xs text-destructive mt-1">
+          {error}
+        </p>
+      )}
 
       {helpText && <p className="text-xs text-muted-foreground/70 mt-1">{helpText}</p>}
     </div>

--- a/src/config/secretKeys.js
+++ b/src/config/secretKeys.js
@@ -119,4 +119,24 @@ const BYOK_API_KEYS = [
   },
 ];
 
-module.exports = { BYOK_API_KEYS };
+// Non-BYOK secrets that $VAR references may point at. Keep in lockstep with
+// EnvironmentManager.SECRET_KEYS (the extra names beyond BYOK_API_KEYS).
+// Deepgram and AssemblyAI live in BYOK_API_KEYS now, so they must not be
+// repeated here — SECRET_ENV_NAMES feeds PERSISTED_KEYS and a duplicate would
+// write the same line to .env twice.
+const EXTRA_SECRET_ENV = [
+  "CORTI_CLIENT_ID",
+  "CORTI_CLIENT_SECRET",
+  "CUSTOM_TRANSCRIPTION_API_KEY",
+  "CUSTOM_CLEANUP_API_KEY",
+  "CUSTOM_REASONING_API_KEY",
+  "BEDROCK_ACCESS_KEY_ID",
+  "BEDROCK_SECRET_ACCESS_KEY",
+  "BEDROCK_SESSION_TOKEN",
+  "AZURE_OPENAI_API_KEY",
+  "VERTEX_API_KEY",
+];
+
+const SECRET_ENV_NAMES = [...BYOK_API_KEYS.map((k) => k.env), ...EXTRA_SECRET_ENV];
+
+module.exports = { BYOK_API_KEYS, EXTRA_SECRET_ENV, SECRET_ENV_NAMES };

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -1,5 +1,6 @@
 import ReasoningService from "../services/ReasoningService";
 import logger from "../utils/logger";
+import { resolveApiKey } from "../utils/resolveApiKey";
 import { isAzureOpenAIEndpoint } from "../utils/urlUtils";
 import { withSessionRefresh } from "../lib/auth";
 import { getBaseLanguageCode, getLanguageLabel } from "../utils/languageSupport";
@@ -2387,10 +2388,10 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     if (provider === "custom") {
       // Prefer store value (user-entered via UI) over main process (.env)
-      apiKey = s.customTranscriptionApiKey || "";
-      if (!apiKey.trim()) {
+      apiKey = await resolveApiKey(s.customTranscriptionApiKey);
+      if (!apiKey) {
         try {
-          apiKey = await window.electronAPI.getCustomTranscriptionKey?.();
+          apiKey = await resolveApiKey(await window.electronAPI.getCustomTranscriptionKey?.());
         } catch (err) {
           logger.debug(
             "Failed to get custom transcription key via IPC",
@@ -2399,7 +2400,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           );
         }
       }
-      apiKey = apiKey?.trim() || "";
+      apiKey = apiKey || "";
 
       logger.debug(
         "Custom STT API key retrieval",
@@ -2418,9 +2419,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
     } else if (provider === "mistral") {
       // Prefer store value (user-entered via UI) over main process (.env)
       // to avoid stale keys in process.env after auth mode transitions
-      apiKey = s.mistralApiKey;
+      apiKey = await resolveApiKey(s.mistralApiKey);
       if (!isValidApiKey(apiKey, "mistral")) {
-        apiKey = await window.electronAPI.getMistralKey?.();
+        apiKey = await resolveApiKey(await window.electronAPI.getMistralKey?.());
       }
       if (!isValidApiKey(apiKey, "mistral")) {
         const err = new Error(
@@ -2431,15 +2432,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
     } else if (provider === "corti") {
       // Tokens are minted in the main process; only verify credentials exist here
-      let clientId = s.cortiClientId;
-      let clientSecret = s.cortiClientSecret;
-      if (!clientId?.trim() || !clientSecret?.trim()) {
-        [clientId, clientSecret] = await Promise.all([
+      let clientId = await resolveApiKey(s.cortiClientId);
+      let clientSecret = await resolveApiKey(s.cortiClientSecret);
+      if (!clientId || !clientSecret) {
+        const [rawId, rawSecret] = await Promise.all([
           window.electronAPI.getCortiClientId?.(),
           window.electronAPI.getCortiClientSecret?.(),
         ]);
+        [clientId, clientSecret] = await Promise.all([
+          resolveApiKey(rawId),
+          resolveApiKey(rawSecret),
+        ]);
       }
-      if (!clientId?.trim() || !clientSecret?.trim()) {
+      if (!clientId || !clientSecret) {
         const err = new Error(
           "Corti credentials not found. Please set your Client ID and Client Secret in the Control Panel."
         );
@@ -2448,9 +2453,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
       apiKey = null;
     } else if (provider === "tinfoil") {
-      apiKey = s.tinfoilApiKey;
-      if (!apiKey?.trim()) {
-        apiKey = await window.electronAPI.getTinfoilKey?.();
+      apiKey = await resolveApiKey(s.tinfoilApiKey);
+      if (!apiKey) {
+        apiKey = await resolveApiKey(await window.electronAPI.getTinfoilKey?.());
       }
       if (!apiKey?.trim()) {
         const err = new Error(
@@ -2460,9 +2465,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         throw err;
       }
     } else if (provider === "gemini") {
-      apiKey = s.geminiApiKey;
-      if (!apiKey?.trim()) {
-        apiKey = await window.electronAPI.getGeminiKey?.();
+      apiKey = await resolveApiKey(s.geminiApiKey);
+      if (!apiKey) {
+        apiKey = await resolveApiKey(await window.electronAPI.getGeminiKey?.());
       }
       if (!apiKey?.trim()) {
         const err = new Error(
@@ -2473,9 +2478,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
     } else if (provider === "groq") {
       // Prefer store value (user-entered via UI) over main process (.env)
-      apiKey = s.groqApiKey;
+      apiKey = await resolveApiKey(s.groqApiKey);
       if (!isValidApiKey(apiKey, "groq")) {
-        apiKey = await window.electronAPI.getGroqKey?.();
+        apiKey = await resolveApiKey(await window.electronAPI.getGroqKey?.());
       }
       if (!isValidApiKey(apiKey, "groq")) {
         const err = new Error(
@@ -2485,9 +2490,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         throw err;
       }
     } else if (provider === "xai") {
-      apiKey = s.xaiApiKey;
+      apiKey = await resolveApiKey(s.xaiApiKey);
       if (!isValidApiKey(apiKey, "xai")) {
-        apiKey = await window.electronAPI.getXaiKey?.();
+        apiKey = await resolveApiKey(await window.electronAPI.getXaiKey?.());
       }
       if (!isValidApiKey(apiKey, "xai")) {
         const err = new Error(
@@ -2500,9 +2505,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       // Default to OpenAI
       // Prefer store value (user-entered via UI) over main process (.env)
       // to avoid stale keys in process.env after auth mode transitions
-      apiKey = s.openaiApiKey;
+      apiKey = await resolveApiKey(s.openaiApiKey);
       if (!isValidApiKey(apiKey, "openai")) {
-        apiKey = await window.electronAPI.getOpenAIKey();
+        apiKey = await resolveApiKey(await window.electronAPI.getOpenAIKey());
       }
       if (!isValidApiKey(apiKey, "openai")) {
         const err = new Error(

--- a/src/helpers/enterpriseProviderErrors.js
+++ b/src/helpers/enterpriseProviderErrors.js
@@ -572,6 +572,14 @@ function validateEnterpriseEndpoint(endpoint) {
  * Extracts the enterprise credential/config subset from an IPC payload
  * so SDK factories receive only the fields they expect.
  */
+const ENTERPRISE_SECRET_FIELDS = [
+  "bedrockAccessKeyId",
+  "bedrockSecretAccessKey",
+  "bedrockSessionToken",
+  "azureApiKey",
+  "vertexApiKey",
+];
+
 function pickEnterpriseConfig(config = {}) {
   return {
     bedrockRegion: config.bedrockRegion,
@@ -581,16 +589,38 @@ function pickEnterpriseConfig(config = {}) {
     bedrockSessionToken: config.bedrockSessionToken,
     azureEndpoint: config.azureEndpoint,
     azureApiVersion: config.azureApiVersion,
+    azureApiKey: config.azureApiKey,
     vertexProject: config.vertexProject,
     vertexLocation: config.vertexLocation,
+    vertexApiKey: config.vertexApiKey,
   };
+}
+
+// Clone + resolve each secret field in place. Never OR Azure/Vertex keys into
+// a shared apiKey unless that provider is the one being called.
+function resolveManualEnterpriseRuntime(config = {}, provider, model, resolveSecretRef) {
+  const { usableSecret } = require("./envRef.cjs");
+  const resolve = (value) => {
+    const out = resolveSecretRef ? resolveSecretRef(value || "") : usableSecret(value);
+    return usableSecret(out);
+  };
+  const picked = { ...pickEnterpriseConfig(config) };
+  for (const key of ENTERPRISE_SECRET_FIELDS) {
+    if (picked[key]) picked[key] = resolve(picked[key]);
+  }
+  let apiKey = resolve(config.apiKey);
+  if (!apiKey && provider === "azure") apiKey = picked.azureApiKey || "";
+  if (!apiKey && provider === "vertex") apiKey = picked.vertexApiKey || "";
+  return { provider, model, apiKey, enterprise: picked };
 }
 
 module.exports = {
   ENTERPRISE_PROVIDERS,
+  ENTERPRISE_SECRET_FIELDS,
   isEnterpriseProvider,
   mapEnterpriseError,
   pickEnterpriseConfig,
+  resolveManualEnterpriseRuntime,
   runAbortableOperation,
   runBedrockRequest,
   unwrapRetryError,

--- a/src/helpers/envKeyResolve.js
+++ b/src/helpers/envKeyResolve.js
@@ -1,0 +1,209 @@
+// Resolve API keys from the process environment and (on Unix) from a login
+// shell, so keys exported in ~/.zshrc / ~/.bashrc work even when the app is
+// launched from a desktop entry instead of a terminal.
+//
+// Stored Settings values still win. This module only fills empty keys and
+// expands $VAR / ${VAR} references at read time. Callers must not persist
+// imported names — EnvironmentManager tracks them and skips them on write.
+
+const fs = require("fs");
+const os = require("os");
+const { promisify } = require("util");
+const execFileAsync = promisify(require("child_process").execFile);
+const { ENV_REF_RE, isEnvRef, envRefName, usableSecret, classifySecretInput } = require("./envRef.cjs");
+
+const ENV_EXPORT_SENTINEL = "__OW_ENV__";
+
+// Exact system paths only. A basename check would accept /tmp/zsh.
+const TRUSTED_LOGIN_SHELLS = ["/bin/zsh", "/usr/bin/zsh", "/bin/bash", "/usr/bin/bash"];
+const TRUSTED_LOGIN_SHELL_SET = new Set(TRUSTED_LOGIN_SHELLS);
+
+// If `value` is `$FOO` or `${FOO}`, return env.FOO (or "" if unset).
+// Otherwise return value unchanged. One hop only — no recursive expansion.
+function resolveEnvRef(value, env = process.env) {
+  if (typeof value !== "string") return "";
+  const name = envRefName(value);
+  if (!name) return value;
+  const resolved = env[name];
+  return resolved == null ? "" : String(resolved);
+}
+
+function unquoteShellValue(raw) {
+  const s = raw.trim();
+  if (!s) return "";
+
+  if (s.startsWith("$'")) {
+    let out = "";
+    for (let i = 2; i < s.length; i++) {
+      const ch = s[i];
+      if (ch === "'" && s[i - 1] !== "\\") break;
+      if (ch === "\\" && i + 1 < s.length) {
+        const next = s[i + 1];
+        const escapes = { n: "\n", t: "\t", r: "\r", "'": "'", "\\": "\\" };
+        out += Object.prototype.hasOwnProperty.call(escapes, next) ? escapes[next] : next;
+        i++;
+        continue;
+      }
+      out += ch;
+    }
+    return out;
+  }
+
+  if (s[0] === "'") {
+    const end = s.indexOf("'", 1);
+    return end === -1 ? s.slice(1) : s.slice(1, end);
+  }
+
+  if (s[0] === '"') {
+    let out = "";
+    for (let i = 1; i < s.length; i++) {
+      if (s[i] === "\\" && i + 1 < s.length) {
+        out += s[i + 1];
+        i++;
+        continue;
+      }
+      if (s[i] === '"') break;
+      out += s[i];
+    }
+    return out;
+  }
+
+  return s.replace(/\s+#.*$/, "").split(/\s/)[0];
+}
+
+// Parse `export -p` / `declare -x` output from bash or zsh.
+function parseExportP(output, sentinel) {
+  const result = {};
+  if (!output) return result;
+  let text = String(output);
+  if (sentinel) {
+    const idx = text.indexOf(sentinel);
+    if (idx === -1) return result;
+    text = text.slice(idx + sentinel.length);
+  }
+  const lineRe = /^(?:declare -x |export )?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+  for (const rawLine of text.split(/\n/)) {
+    const line = rawLine.replace(/\r$/, "");
+    const match = line.match(lineRe);
+    if (!match) continue;
+    result[match[1]] = unquoteShellValue(match[2]);
+  }
+  return result;
+}
+
+function isTrustedLoginShell(shell) {
+  return typeof shell === "string" && TRUSTED_LOGIN_SHELL_SET.has(shell);
+}
+
+function passwdLoginShell() {
+  try {
+    return os.userInfo().shell || "";
+  } catch {
+    return "";
+  }
+}
+
+function resolveLoginShell(env = process.env, existsSync = fs.existsSync, passwdShell = passwdLoginShell()) {
+  if (env.SHELL) {
+    return isTrustedLoginShell(env.SHELL) && existsSync(env.SHELL) ? env.SHELL : null;
+  }
+  if (isTrustedLoginShell(passwdShell) && existsSync(passwdShell)) return passwdShell;
+  // Do not probe zsh/bash when passwd is missing — a bash user must not get ~/.zshrc.
+  return null;
+}
+
+function loginShellChildEnv(env, shell) {
+  const child = {
+    HOME: env.HOME,
+    PATH: env.PATH,
+    USER: env.USER,
+    LOGNAME: env.LOGNAME,
+    SHELL: shell,
+    TERM: "dumb",
+    LANG: env.LANG || "C.UTF-8",
+  };
+  for (const key of Object.keys(child)) {
+    if (child[key] == null) delete child[key];
+  }
+  return child;
+}
+
+function coalesceResolvedSecret(raw, resolved) {
+  if (typeof resolved === "string") {
+    const trimmed = resolved.trim();
+    return isEnvRef(trimmed) ? "" : trimmed;
+  }
+  return isEnvRef(raw || "") ? "" : raw || "";
+}
+
+async function importMissingSecretsFromLoginShell({
+  secretNames,
+  env = process.env,
+  platform = process.platform,
+  execFileSync,
+  execFile,
+  existsSync = fs.existsSync,
+  passwdShell = passwdLoginShell(),
+  importedSet,
+} = {}) {
+  if (platform === "win32") return { imported: [], reason: "win32" };
+  const names = (secretNames || []).filter((name) => name && !env[name]);
+  if (names.length === 0) return { imported: [], reason: "none-missing" };
+
+  const shell = resolveLoginShell(env, existsSync, passwdShell);
+  if (!shell) return { imported: [], reason: "no-trusted-shell" };
+
+  // -ilc so ~/.zshrc / ~/.bashrc are sourced (login non-interactive -lc skips them).
+  const args = ["-ilc", "printf '%s\\n' '" + ENV_EXPORT_SENTINEL + "'; export -p"];
+  const opts = {
+    encoding: "utf8",
+    timeout: 1500,
+    maxBuffer: 2 * 1024 * 1024,
+    env: loginShellChildEnv(env, shell),
+  };
+
+  let output = "";
+  try {
+    if (execFileSync) {
+      output = execFileSync(shell, args, opts) || "";
+    } else if (execFile) {
+      const result = await execFile(shell, args, opts);
+      output = (result && result.stdout) || result || "";
+    } else {
+      const { stdout } = await execFileAsync(shell, args, opts);
+      output = stdout || "";
+    }
+  } catch {
+    return { imported: [], reason: "exec-failed" };
+  }
+
+  const parsed = parseExportP(output, ENV_EXPORT_SENTINEL);
+  const imported = [];
+  for (const name of names) {
+    if (parsed[name]) {
+      // Record before mutating env so a concurrent .env write cannot persist it.
+      if (importedSet) importedSet.add(name);
+      env[name] = parsed[name];
+      imported.push(name);
+    }
+  }
+  return { imported, reason: "ok" };
+}
+
+module.exports = {
+  isEnvRef,
+  envRefName,
+  resolveEnvRef,
+  parseExportP,
+  unquoteShellValue,
+  isTrustedLoginShell,
+  resolveLoginShell,
+  loginShellChildEnv,
+  coalesceResolvedSecret,
+  usableSecret,
+  classifySecretInput,
+  ENV_REF_RE,
+  ENV_EXPORT_SENTINEL,
+  TRUSTED_LOGIN_SHELLS,
+  importMissingSecretsFromLoginShell,
+};

--- a/src/helpers/envRef.cjs
+++ b/src/helpers/envRef.cjs
@@ -1,0 +1,37 @@
+// Pure $VAR helpers for the main process. Keep in lockstep with envRef.ts (renderer).
+const ENV_REF_RE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$|^\$([A-Za-z_][A-Za-z0-9_]*)$/;
+
+function isEnvRef(value) {
+  if (typeof value !== "string") return false;
+  return ENV_REF_RE.test(value.trim());
+}
+
+function envRefName(value) {
+  if (typeof value !== "string") return null;
+  const match = value.trim().match(ENV_REF_RE);
+  if (!match) return null;
+  return match[1] || match[2];
+}
+
+// Never put a leftover $VAR on the wire as a credential.
+function usableSecret(value) {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  return !trimmed || isEnvRef(trimmed) ? "" : trimmed;
+}
+
+function classifySecretInput(value, selfEnvName, allowedNames) {
+  const name = envRefName(value);
+  if (!name) return null;
+  if (selfEnvName && name === selfEnvName) return "self-reference";
+  if (allowedNames && !allowedNames.has(name)) return "unknown-ref";
+  return null;
+}
+
+module.exports = {
+  ENV_REF_RE,
+  isEnvRef,
+  envRefName,
+  usableSecret,
+  classifySecretInput,
+};

--- a/src/helpers/envRef.ts
+++ b/src/helpers/envRef.ts
@@ -1,0 +1,33 @@
+/** Pure `$VAR` helpers for the renderer. Keep in lockstep with `envRef.cjs` (main). */
+export const ENV_REF_RE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$|^\$([A-Za-z_][A-Za-z0-9_]*)$/;
+
+export function isEnvRef(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return ENV_REF_RE.test(value.trim());
+}
+
+export function envRefName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const match = value.trim().match(ENV_REF_RE);
+  if (!match) return null;
+  return match[1] || match[2];
+}
+
+/** Never put a leftover `$VAR` on the wire as a credential. */
+export function usableSecret(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  return !trimmed || isEnvRef(trimmed) ? "" : trimmed;
+}
+
+export function classifySecretInput(
+  value: unknown,
+  selfEnvName?: string | null,
+  allowedNames?: Set<string> | null
+): "self-reference" | "unknown-ref" | null {
+  const name = envRefName(value);
+  if (!name) return null;
+  if (selfEnvName && name === selfEnvName) return "self-reference";
+  if (allowedNames && !allowedNames.has(name)) return "unknown-ref";
+  return null;
+}

--- a/src/helpers/environment.js
+++ b/src/helpers/environment.js
@@ -5,20 +5,18 @@ const { app } = require("electron");
 const debugLogger = require("./debugLogger");
 const { normalizeUiLanguage } = require("./i18nMain");
 const secretCrypto = require("./secretCrypto");
-const { BYOK_API_KEYS } = require("../config/secretKeys");
+const { BYOK_API_KEYS, SECRET_ENV_NAMES } = require("../config/secretKeys");
+const {
+  isEnvRef,
+  envRefName,
+  resolveEnvRef,
+  importMissingSecretsFromLoginShell,
+  classifySecretInput,
+} = require("./envKeyResolve");
 
-const SECRET_KEYS = [
-  ...BYOK_API_KEYS.map((k) => k.env),
-  "CORTI_CLIENT_ID",
-  "CORTI_CLIENT_SECRET",
-  "CUSTOM_TRANSCRIPTION_API_KEY",
-  "CUSTOM_CLEANUP_API_KEY",
-  "BEDROCK_ACCESS_KEY_ID",
-  "BEDROCK_SECRET_ACCESS_KEY",
-  "BEDROCK_SESSION_TOKEN",
-  "AZURE_OPENAI_API_KEY",
-  "VERTEX_API_KEY",
-];
+// Superset of the names EnvironmentManager persists: the shared allowlist in
+// secretKeys.js so $VAR references and the per-key plumbing cannot drift.
+const SECRET_KEYS = [...SECRET_ENV_NAMES];
 
 const SECRET_KEY_SET = new Set(SECRET_KEYS);
 
@@ -62,13 +60,19 @@ const PERSISTED_KEYS = [
 // Module-level so writes are serialized across all instances — hotkeyManager
 // creates its own EnvironmentManager alongside the main.js singleton.
 let envWriteQueue = Promise.resolve();
+// Shared across EnvironmentManager instances so a second constructor cannot
+// persist login-shell imports that the first one recorded.
+const shellImportedSecrets = new Set();
 
 class EnvironmentManager {
   constructor() {
+    this._shellImportedSecrets = shellImportedSecrets;
     this.loadEnvironmentVariables();
   }
 
   loadEnvironmentVariables() {
+    // Plain dotenv — it does not expand $VAR. A stored $OPENAI_API_KEY stays
+    // a reference until _getKey / resolveSecretRef.
     // App config (.env in userData) takes precedence over system env vars,
     // so keys saved by the user in Settings always win.
     const userDataEnv = path.join(app.getPath("userData"), ".env");
@@ -103,6 +107,30 @@ class EnvironmentManager {
       await this._migrateToSecureStorage();
     }
     await this._loadAllSecrets();
+    // After stored secrets win: fill any still-empty keys from a login shell
+    // (so ~/.zshrc exports work when launched from a desktop icon). Never
+    // persist these — that would copy shell secrets into Settings. Do not
+    // await: a slow rc must not gate window creation.
+    this._importLoginShellSecrets().catch((error) => {
+      debugLogger.error(
+        "login-shell secret import failed",
+        { error: error?.message || String(error) },
+        "environment"
+      );
+    });
+  }
+
+  async _importLoginShellSecrets() {
+    const { imported, reason } = await importMissingSecretsFromLoginShell({
+      secretNames: SECRET_KEYS,
+      env: process.env,
+      importedSet: this._shellImportedSecrets,
+    });
+    debugLogger.info(
+      "login-shell secret import",
+      { reason, count: imported.length },
+      "environment"
+    );
   }
 
   _getMigrationSentinelPath() {
@@ -233,6 +261,7 @@ class EnvironmentManager {
     let envContent = "# OpenWhispr Environment Variables\n";
     for (const key of PERSISTED_KEYS) {
       if (stripSecrets && SECRET_KEY_SET.has(key)) continue;
+      if (this._shellImportedSecrets.has(key)) continue;
       if (process.env[key]) {
         envContent += `${key}=${process.env[key]}\n`;
       }
@@ -242,11 +271,39 @@ class EnvironmentManager {
     await fsPromises.rename(tmpPath, envPath);
   }
 
-  _getKey(envVarName) {
+  _getRawKey(envVarName) {
     return process.env[envVarName] || "";
   }
 
+  getRawKey(envVarName) {
+    if (this._shellImportedSecrets.has(envVarName)) return `$${envVarName}`;
+    return this._getRawKey(envVarName);
+  }
+
+  getRawCleanupCustomKey() {
+    return this.getRawKey("CUSTOM_CLEANUP_API_KEY") || this.getRawKey("CUSTOM_REASONING_API_KEY");
+  }
+
+  resolveSecretRef(value) {
+    const raw = value || "";
+    const name = envRefName(raw);
+    if (name && !SECRET_KEY_SET.has(name)) return "";
+    const resolved = resolveEnvRef(raw, process.env);
+    return isEnvRef(resolved) ? "" : resolved;
+  }
+
+  _getKey(envVarName) {
+    return this.resolveSecretRef(this._getRawKey(envVarName));
+  }
+
   _saveKey(envVarName, key) {
+    const trimmed = typeof key === "string" ? key.trim() : key;
+    const reason = classifySecretInput(trimmed, envVarName, SECRET_KEY_SET);
+    if (reason === "self-reference" && shellImportedSecrets.has(envVarName)) {
+      return { success: true };
+    }
+    if (reason) return { success: false, reason };
+    this._shellImportedSecrets.delete(envVarName);
     if (SECRET_KEY_SET.has(envVarName) && this._encryptionAvailable()) {
       this._saveSecretKey(envVarName, key).catch((error) => {
         debugLogger.error(
@@ -538,3 +595,4 @@ for (const k of BYOK_API_KEYS) {
 }
 
 module.exports = EnvironmentManager;
+module.exports._resetShellImportedSecrets = () => shellImportedSecrets.clear();

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -1426,6 +1426,11 @@ class IPCHandlers {
     });
 
     ipcMain.handle("test-provider-connection", async (_event, config) => {
+      const { ENTERPRISE_SECRET_FIELDS } = require("./enterpriseProviderErrors");
+      config = { ...config };
+      for (const key of ["apiKey", "clientId", "clientSecret", ...ENTERPRISE_SECRET_FIELDS]) {
+        if (config[key]) config[key] = this.environmentManager.resolveSecretRef(config[key]);
+      }
       if (config?.provider === "corti" && config?.scope === "transcription") {
         try {
           const clientId = String(config.clientId || "").trim();
@@ -1561,9 +1566,13 @@ class IPCHandlers {
     });
 
     for (const k of BYOK_API_KEYS) {
-      ipcMain.handle(`get-${k.base}-key`, () => this.environmentManager[k.get]());
+      ipcMain.handle(`get-${k.base}-key`, () => this.environmentManager.getRawKey(k.env));
       ipcMain.handle(`save-${k.base}-key`, (event, key) => this.environmentManager[k.save](key));
     }
+
+    ipcMain.handle("resolve-secret-ref", (_event, value) => {
+      return this.environmentManager.resolveSecretRef(value);
+    });
 
     ipcMain.handle("db-save-transcription", async (event, text, rawText, options) => {
       const result = this.databaseManager.saveTranscription(text, rawText, options);
@@ -4553,7 +4562,7 @@ class IPCHandlers {
     );
 
     ipcMain.handle("get-corti-client-id", async () => {
-      return this.environmentManager.getCortiClientId();
+      return this.environmentManager.getRawKey("CORTI_CLIENT_ID");
     });
 
     ipcMain.handle("save-corti-client-id", async (event, key) => {
@@ -4561,7 +4570,7 @@ class IPCHandlers {
     });
 
     ipcMain.handle("get-corti-client-secret", async () => {
-      return this.environmentManager.getCortiClientSecret();
+      return this.environmentManager.getRawKey("CORTI_CLIENT_SECRET");
     });
 
     ipcMain.handle("save-corti-client-secret", async (event, key) => {
@@ -4625,7 +4634,7 @@ class IPCHandlers {
     );
 
     ipcMain.handle("get-custom-transcription-key", async () => {
-      return this.environmentManager.getCustomTranscriptionKey();
+      return this.environmentManager.getRawKey("CUSTOM_TRANSCRIPTION_API_KEY");
     });
 
     ipcMain.handle("save-custom-transcription-key", async (event, key) => {
@@ -4633,7 +4642,7 @@ class IPCHandlers {
     });
 
     ipcMain.handle("get-cleanup-custom-key", async () => {
-      return this.environmentManager.getCleanupCustomKey();
+      return this.environmentManager.getRawCleanupCustomKey();
     });
 
     ipcMain.handle("save-cleanup-custom-key", async (event, key) => {
@@ -4654,19 +4663,19 @@ class IPCHandlers {
       return this.environmentManager.saveBedrockProfile(value);
     });
     ipcMain.handle("get-bedrock-access-key-id", async () => {
-      return this.environmentManager.getBedrockAccessKeyId();
+      return this.environmentManager.getRawKey("BEDROCK_ACCESS_KEY_ID");
     });
     ipcMain.handle("save-bedrock-access-key-id", async (event, key) => {
       return this.environmentManager.saveBedrockAccessKeyId(key);
     });
     ipcMain.handle("get-bedrock-secret-access-key", async () => {
-      return this.environmentManager.getBedrockSecretAccessKey();
+      return this.environmentManager.getRawKey("BEDROCK_SECRET_ACCESS_KEY");
     });
     ipcMain.handle("save-bedrock-secret-access-key", async (event, key) => {
       return this.environmentManager.saveBedrockSecretAccessKey(key);
     });
     ipcMain.handle("get-bedrock-session-token", async () => {
-      return this.environmentManager.getBedrockSessionToken();
+      return this.environmentManager.getRawKey("BEDROCK_SESSION_TOKEN");
     });
     ipcMain.handle("save-bedrock-session-token", async (event, key) => {
       return this.environmentManager.saveBedrockSessionToken(key);
@@ -4678,7 +4687,7 @@ class IPCHandlers {
       return this.environmentManager.saveAzureEndpoint(value);
     });
     ipcMain.handle("get-azure-api-key", async () => {
-      return this.environmentManager.getAzureApiKey();
+      return this.environmentManager.getRawKey("AZURE_OPENAI_API_KEY");
     });
     ipcMain.handle("save-azure-api-key", async (event, key) => {
       return this.environmentManager.saveAzureApiKey(key);
@@ -4708,7 +4717,7 @@ class IPCHandlers {
       return this.environmentManager.saveVertexLocation(value);
     });
     ipcMain.handle("get-vertex-api-key", async () => {
-      return this.environmentManager.getVertexApiKey();
+      return this.environmentManager.getRawKey("VERTEX_API_KEY");
     });
     ipcMain.handle("save-vertex-api-key", async (event, key) => {
       return this.environmentManager.saveVertexApiKey(key);
@@ -6013,12 +6022,13 @@ class IPCHandlers {
       logger: debugLogger,
     });
     const resolveEnterpriseRuntime = async (event, provider, model, config = {}) => {
-      const manual = {
+      const { resolveManualEnterpriseRuntime } = require("./enterpriseProviderErrors");
+      const manual = resolveManualEnterpriseRuntime(
+        config,
         provider,
         model,
-        apiKey: config.apiKey || "",
-        enterprise: require("./enterpriseProviderErrors").pickEnterpriseConfig(config),
-      };
+        (value) => this.environmentManager.resolveSecretRef(value)
+      );
       const context = config.managedContext;
       if (!context) return manual;
       const authHeaders = await getAuthHeader(event);
@@ -9773,7 +9783,7 @@ class IPCHandlers {
         event,
         {
           filePath,
-          apiKey,
+          apiKey: rawApiKey,
           baseUrl,
           model,
           diarize,
@@ -9789,7 +9799,11 @@ class IPCHandlers {
         }
       ) => {
         const fs = require("fs");
+        let apiKey = "";
         try {
+          apiKey = require("./envRef.cjs").usableSecret(
+            this.environmentManager.resolveSecretRef(rawApiKey)
+          );
           if (typeof filePath !== "string") {
             return { success: false, error: "Invalid file path" };
           }

--- a/src/helpers/providerConnectionTest.js
+++ b/src/helpers/providerConnectionTest.js
@@ -152,8 +152,9 @@ function buildModelEndpoints(base) {
 }
 
 function resolveProviderRequest(config) {
+  const { usableSecret } = require("./envRef.cjs");
   const provider = String(config?.provider || "").toLowerCase();
-  const apiKey = typeof config?.apiKey === "string" ? config.apiKey.trim() : "";
+  const apiKey = usableSecret(typeof config?.apiKey === "string" ? config.apiKey : "");
   let endpoints = ENDPOINTS[provider] ? [ENDPOINTS[provider]] : [];
 
   if (provider === "openai") {

--- a/src/helpers/realtimeTokenProviders.js
+++ b/src/helpers/realtimeTokenProviders.js
@@ -16,7 +16,7 @@ const REALTIME_TOKEN_PROVIDERS = {
     streams
   ) => {
     if (options.mode === "byok") {
-      const apiKey = environmentManager.getAssemblyAIKey();
+      const apiKey = require("./envRef.cjs").usableSecret(environmentManager.getAssemblyAIKey());
       if (!apiKey) {
         throw new Error("No AssemblyAI API key configured. Add your key in Settings.");
       }
@@ -43,7 +43,7 @@ const REALTIME_TOKEN_PROVIDERS = {
 
   "deepgram-realtime": async ({ environmentManager, postServerToken }, options, streams) => {
     if (options.mode === "byok") {
-      const apiKey = environmentManager.getDeepgramKey();
+      const apiKey = require("./envRef.cjs").usableSecret(environmentManager.getDeepgramKey());
       if (!apiKey) {
         throw new Error("No Deepgram API key configured. Add your key in Settings.");
       }

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -351,7 +351,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "مفتاح API (اختياري)",
-      "apiKeyHelp": "اختياري. يتم إرساله كرمز Bearer للمصادقة. هذا منفصل عن مفتاح OpenAI API الخاص بك.",
+      "apiKeyHelp": "اختياري. اتركه فارغًا لاستخدام متغير البيئة المطابق، أو أدخل $OPENAI_API_KEY لإعادة استخدام اسم سر آخر في OpenWhispr. الأسماء العشوائية مثل $MY_COMPANY_KEY لا تُوسَّع. تُستورد صادرات الـ shell (مثل ~/.zshrc) عند التشغيل.",
       "applyAndRefresh": "تطبيق وتحديث",
       "queryPrefix": "سنستعلم من",
       "querySuffix": "عن النماذج المتاحة.",
@@ -3626,7 +3626,8 @@
     "tinfoil": {
       "transportNote": "يستخدم Tinfoil نموذج Voxtral Mini 4B للتفريغ المباشر (البث)، ونموذج Voxtral Small 24B للمعالجة الدفعية.",
       "docsLink": "قراءة الوثائق"
-    }
+    },
+    "apiKeyEnvHelp": "اختياري. اتركه فارغًا لاستخدام CUSTOM_TRANSCRIPTION_API_KEY، أو أدخل $OPENAI_API_KEY لإعادة استخدام مفتاح آخر. تُستورد صادرات الـ shell (مثل ~/.zshrc) عند التشغيل."
   },
   "cleanupPrompt": "التنظيف",
   "dictionarySuffix": "لاحقة القاموس",
@@ -4061,14 +4062,16 @@
     "remindLater": "ذكرني لاحقًا"
   },
   "apiKeyInput": {
-    "placeholder": "الصق مفتاح API الخاص بك",
+    "placeholder": "الصق مفتاح API أو $ENV_VAR",
     "label": "مفتاح API",
     "save": "حفظ مفتاح API",
     "cancelEdit": "إلغاء التعديل",
     "edit": "تعديل مفتاح API",
     "add": "إضافة مفتاح API",
     "editButton": "تعديل",
-    "addButton": "إضافة"
+    "addButton": "إضافة",
+    "selfReference": "استخدم اسم متغير مختلف هنا، أو اترك هذا الحقل فارغًا.",
+    "unknownRef": "يمكن الإشارة فقط إلى أسماء أسرار OpenWhispr (مثل $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "اجعل التفريغ الصوتي أسرع باستخدام تسريع GPU",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "API-Schlüssel (optional)",
-      "apiKeyHelp": "Optional. Wird als Bearer-Token zur Authentifizierung gesendet. Getrennt von Ihrem OpenAI-API-Schlüssel.",
+      "apiKeyHelp": "Optional. Leer lassen, um die passende Umgebungsvariable zu nutzen, oder $OPENAI_API_KEY eingeben. Shell-Exporte (z. B. ~/.zshrc) werden beim Start gelesen.",
       "applyAndRefresh": "Anwenden & aktualisieren",
       "queryPrefix": "Wir fragen",
       "querySuffix": "nach verfügbaren Modellen ab.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil streamt mit Voxtral Mini 4B und verarbeitet Batches mit Voxtral Small 24B.",
       "docsLink": "Zur Dokumentation"
-    }
+    },
+    "apiKeyEnvHelp": "Optional. Leer lassen für CUSTOM_TRANSCRIPTION_API_KEY, oder $OPENAI_API_KEY eingeben. Shell-Exporte (z. B. ~/.zshrc) werden beim Start gelesen."
   },
   "hooks": {
     "audioRecording": {
@@ -3627,14 +3628,16 @@
     "remindLater": "Später erinnern"
   },
   "apiKeyInput": {
-    "placeholder": "API-Schlüssel eingeben",
+    "placeholder": "API-Schlüssel oder $ENV_VAR einfügen",
     "label": "API-Schlüssel",
     "save": "Speichern",
     "cancelEdit": "Bearbeitung abbrechen",
     "edit": "Bearbeiten",
     "add": "Hinzufügen",
     "editButton": "Bearbeiten",
-    "addButton": "Hinzufügen"
+    "addButton": "Hinzufügen",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Transkription mit GPU beschleunigen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "API Key (Optional)",
-      "apiKeyHelp": "Optional. Sent as a Bearer token for authentication. This is separate from your OpenAI API key.",
+      "apiKeyHelp": "Optional. Leave blank to use the matching environment variable, or enter $OPENAI_API_KEY to reuse another OpenWhispr secret name. Arbitrary names like $MY_COMPANY_KEY are not expanded. Shell exports (e.g. ~/.zshrc) are imported at startup.",
       "applyAndRefresh": "Apply & Refresh",
       "queryPrefix": "We'll query",
       "querySuffix": "for available models.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil streams using Voxtral Mini 4B, and batches with Voxtral Small 24B.",
       "docsLink": "Read the docs"
-    }
+    },
+    "apiKeyEnvHelp": "Optional. Leave blank to use CUSTOM_TRANSCRIPTION_API_KEY, or enter $OPENAI_API_KEY to reuse another. Shell exports (e.g. ~/.zshrc) are imported at startup."
   },
   "hooks": {
     "audioRecording": {
@@ -3627,14 +3628,16 @@
     "remindLater": "Remind Me Later"
   },
   "apiKeyInput": {
-    "placeholder": "Paste your API key",
+    "placeholder": "Paste API key or $ENV_VAR",
     "label": "API Key",
     "save": "Save API key",
     "cancelEdit": "Cancel editing",
     "edit": "Edit API key",
     "add": "Add API key",
     "editButton": "edit",
-    "addButton": "add"
+    "addButton": "add",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Speed up transcription with GPU acceleration",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "Clave API (opcional)",
-      "apiKeyHelp": "Opcional. Se envía como token Bearer para autenticación. Es independiente de tu clave API de OpenAI.",
+      "apiKeyHelp": "Opcional. Déjalo vacío para usar la variable de entorno, o escribe $OPENAI_API_KEY. Los exports del shell (p. ej. ~/.zshrc) se importan al iniciar.",
       "applyAndRefresh": "Aplicar y actualizar",
       "queryPrefix": "Consultaremos",
       "querySuffix": "para modelos disponibles.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil transmite con Voxtral Mini 4B y procesa por lotes con Voxtral Small 24B.",
       "docsLink": "Ver la documentación"
-    }
+    },
+    "apiKeyEnvHelp": "Opcional. Déjalo vacío para usar CUSTOM_TRANSCRIPTION_API_KEY, o escribe $OPENAI_API_KEY. Los exports del shell (p. ej. ~/.zshrc) se importan al iniciar."
   },
   "hooks": {
     "audioRecording": {
@@ -3511,14 +3512,16 @@
     "remindLater": "Recordármelo más tarde"
   },
   "apiKeyInput": {
-    "placeholder": "Introduce tu clave API",
+    "placeholder": "Pega la API key o $ENV_VAR",
     "label": "Clave API",
     "save": "Guardar",
     "cancelEdit": "Cancelar edición",
     "edit": "Editar",
     "add": "Agregar",
     "editButton": "Editar",
-    "addButton": "Agregar"
+    "addButton": "Agregar",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Acelera la transcripción con GPU",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "Clé API (optionnelle)",
-      "apiKeyHelp": "Optionnelle. Envoyée comme token Bearer pour l'authentification. Séparée de votre clé API OpenAI.",
+      "apiKeyHelp": "Facultatif. Laissez vide pour utiliser la variable d'environnement, ou saisissez $OPENAI_API_KEY. Les exports du shell (ex. ~/.zshrc) sont lus au démarrage.",
       "applyAndRefresh": "Appliquer et actualiser",
       "queryPrefix": "Nous interrogerons",
       "querySuffix": "pour les modèles disponibles.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil diffuse avec Voxtral Mini 4B et traite les lots avec Voxtral Small 24B.",
       "docsLink": "Voir la documentation"
-    }
+    },
+    "apiKeyEnvHelp": "Facultatif. Laissez vide pour CUSTOM_TRANSCRIPTION_API_KEY, ou saisissez $OPENAI_API_KEY. Les exports du shell (ex. ~/.zshrc) sont lus au démarrage."
   },
   "hooks": {
     "audioRecording": {
@@ -3627,14 +3628,16 @@
     "remindLater": "Me le rappeler plus tard"
   },
   "apiKeyInput": {
-    "placeholder": "Collez votre clé API",
+    "placeholder": "Collez la clé API ou $ENV_VAR",
     "label": "Clé API",
     "save": "Enregistrer la clé API",
     "cancelEdit": "Annuler la modification",
     "edit": "Modifier la clé API",
     "add": "Ajouter une clé API",
     "editButton": "modifier",
-    "addButton": "ajouter"
+    "addButton": "ajouter",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Accélérez la transcription avec le GPU",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "Chiave API (opzionale)",
-      "apiKeyHelp": "Opzionale. Inviata come token Bearer per l'autenticazione. Separata dalla chiave API OpenAI.",
+      "apiKeyHelp": "Opzionale. Lascia vuoto per usare la variabile d'ambiente, oppure inserisci $OPENAI_API_KEY. Gli export della shell (es. ~/.zshrc) sono letti all'avvio.",
       "applyAndRefresh": "Applica e aggiorna",
       "queryPrefix": "Interrogheremo",
       "querySuffix": "per i modelli disponibili.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil trasmette con Voxtral Mini 4B ed elabora i batch con Voxtral Small 24B.",
       "docsLink": "Leggi la documentazione"
-    }
+    },
+    "apiKeyEnvHelp": "Opzionale. Lascia vuoto per CUSTOM_TRANSCRIPTION_API_KEY, oppure inserisci $OPENAI_API_KEY. Gli export della shell (es. ~/.zshrc) sono letti all'avvio."
   },
   "hooks": {
     "audioRecording": {
@@ -3458,14 +3459,16 @@
     "remindLater": "Ricordamelo più tardi"
   },
   "apiKeyInput": {
-    "placeholder": "Incolla la tua chiave API",
+    "placeholder": "Incolla la API key o $ENV_VAR",
     "label": "Chiave API",
     "save": "Salva",
     "cancelEdit": "Annulla modifica",
     "edit": "Modifica",
     "add": "Aggiungi",
     "editButton": "Modifica",
-    "addButton": "Aggiungi"
+    "addButton": "Aggiungi",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Velocizza la trascrizione con la GPU",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -722,7 +722,7 @@
       "ollama": "（Ollama）",
       "localAi": "（LocalAI）",
       "apiKeyOptional": "API キー（任意）",
-      "apiKeyHelp": "任意。Bearer トークンとして認証に使用されます。OpenAI API キーとは別のものです。",
+      "apiKeyHelp": "任意。空欄なら対応する環境変数を使います。$OPENAI_API_KEY と入力すると別変数を再利用します。~/.zshrc などの shell export は起動時に読み込みます。",
       "applyAndRefresh": "適用して更新",
       "queryPrefix": "問い合わせ先:",
       "querySuffix": "で利用可能なモデルを取得します。",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil はストリーミングに Voxtral Mini 4B を、バッチ処理に Voxtral Small 24B を使用します。",
       "docsLink": "ドキュメントを見る"
-    }
+    },
+    "apiKeyEnvHelp": "任意。空欄なら CUSTOM_TRANSCRIPTION_API_KEY を使います。$OPENAI_API_KEY と入力すると別変数を再利用します。~/.zshrc などの shell export は起動時に読み込みます。"
   },
   "hooks": {
     "audioRecording": {
@@ -3458,14 +3459,16 @@
     "remindLater": "後で通知"
   },
   "apiKeyInput": {
-    "placeholder": "API キーを入力",
+    "placeholder": "API キーまたは $ENV_VAR を貼り付け",
     "label": "API キー",
     "save": "保存",
     "cancelEdit": "編集をキャンセル",
     "edit": "編集",
     "add": "追加",
     "editButton": "編集",
-    "addButton": "追加"
+    "addButton": "追加",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "GPU で文字起こしを高速化",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -701,7 +701,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "Chave API (opcional)",
-      "apiKeyHelp": "Opcional. Enviada como token Bearer para autenticação. Separada da sua chave API da OpenAI.",
+      "apiKeyHelp": "Opcional. Deixe em branco para usar a variável de ambiente, ou digite $OPENAI_API_KEY. Exports do shell (ex.: ~/.zshrc) são lidos na inicialização.",
       "applyAndRefresh": "Aplicar e atualizar",
       "queryPrefix": "Vamos consultar",
       "querySuffix": "para modelos disponíveis.",
@@ -841,7 +841,8 @@
     "tinfoil": {
       "transportNote": "O Tinfoil transmite com o Voxtral Mini 4B e processa em lote com o Voxtral Small 24B.",
       "docsLink": "Ver a documentação"
-    }
+    },
+    "apiKeyEnvHelp": "Opcional. Deixe em branco para CUSTOM_TRANSCRIPTION_API_KEY, ou digite $OPENAI_API_KEY. Exports do shell (ex.: ~/.zshrc) são lidos na inicialização."
   },
   "hooks": {
     "audioRecording": {
@@ -3458,14 +3459,16 @@
     "remindLater": "Lembrar-me mais tarde"
   },
   "apiKeyInput": {
-    "placeholder": "Cole sua chave API",
+    "placeholder": "Cole a chave API ou $ENV_VAR",
     "label": "Chave API",
     "save": "Salvar",
     "cancelEdit": "Cancelar edição",
     "edit": "Editar",
     "add": "Adicionar",
     "editButton": "Editar",
-    "addButton": "Adicionar"
+    "addButton": "Adicionar",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Acelere a transcrição com GPU",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -722,7 +722,7 @@
       "ollama": "(Ollama)",
       "localAi": "(LocalAI)",
       "apiKeyOptional": "API-ключ (необязательно)",
-      "apiKeyHelp": "Необязательно. Отправляется как Bearer-токен для аутентификации. Это не ваш API-ключ OpenAI.",
+      "apiKeyHelp": "Необязательно. Оставьте пустым, чтобы взять переменную окружения, или введите $OPENAI_API_KEY. Экспорты из shell (например ~/.zshrc) подхватываются при запуске.",
       "applyAndRefresh": "Применить и обновить",
       "queryPrefix": "Мы запросим",
       "querySuffix": "для получения списка доступных моделей.",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil использует Voxtral Mini 4B для потоковой обработки и Voxtral Small 24B для пакетной.",
       "docsLink": "Открыть документацию"
-    }
+    },
+    "apiKeyEnvHelp": "Необязательно. Оставьте пустым для CUSTOM_TRANSCRIPTION_API_KEY или введите $OPENAI_API_KEY. Экспорты из shell (например ~/.zshrc) подхватываются при запуске."
   },
   "hooks": {
     "audioRecording": {
@@ -3504,14 +3505,16 @@
     "remindLater": "Напомнить позже"
   },
   "apiKeyInput": {
-    "placeholder": "Введите ваш API-ключ",
+    "placeholder": "Вставьте API-ключ или $ENV_VAR",
     "label": "API-ключ",
     "save": "Сохранить",
     "cancelEdit": "Отменить редактирование",
     "edit": "Изменить",
     "add": "Добавить",
     "editButton": "Изменить ключ",
-    "addButton": "Добавить ключ"
+    "addButton": "Добавить ключ",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "Ускорьте транскрипцию с помощью GPU",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -722,7 +722,7 @@
       "ollama": "（Ollama）",
       "localAi": "（LocalAI）",
       "apiKeyOptional": "API Key（可选）",
-      "apiKeyHelp": "可选。作为 Bearer token 用于身份验证，与 OpenAI API Key 无关。",
+      "apiKeyHelp": "可选。留空则使用对应环境变量，或填写 $OPENAI_API_KEY 以复用。启动时会导入 shell 导出的变量（如 ~/.zshrc）。",
       "applyAndRefresh": "应用并刷新",
       "queryPrefix": "我们将查询",
       "querySuffix": "获取可用模型。",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil 流式转录使用 Voxtral Mini 4B，批量转录使用 Voxtral Small 24B。",
       "docsLink": "查看文档"
-    }
+    },
+    "apiKeyEnvHelp": "可选。留空则使用 CUSTOM_TRANSCRIPTION_API_KEY，或填写 $OPENAI_API_KEY。启动时会导入 shell 导出的变量（如 ~/.zshrc）。"
   },
   "hooks": {
     "audioRecording": {
@@ -3458,14 +3459,16 @@
     "remindLater": "稍后提醒我"
   },
   "apiKeyInput": {
-    "placeholder": "输入你的 API Key",
+    "placeholder": "粘贴 API Key 或 $ENV_VAR",
     "label": "API Key",
     "save": "保存",
     "cancelEdit": "取消编辑",
     "edit": "编辑",
     "add": "添加",
     "editButton": "编辑密钥",
-    "addButton": "添加密钥"
+    "addButton": "添加密钥",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "使用 GPU 加速转录",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -722,7 +722,7 @@
       "ollama": "（Ollama）",
       "localAi": "（LocalAI）",
       "apiKeyOptional": "API Key（選填）",
-      "apiKeyHelp": "選填。作為 Bearer token 傳送以進行驗證。這與你的 OpenAI API Key 無關。",
+      "apiKeyHelp": "選填。留空則使用對應環境變數，或輸入 $OPENAI_API_KEY。啟動時會匯入 shell 匯出的變數（例如 ~/.zshrc）。",
       "applyAndRefresh": "套用並重新整理",
       "queryPrefix": "我們將查詢",
       "querySuffix": "以取得可用模型。",
@@ -862,7 +862,8 @@
     "tinfoil": {
       "transportNote": "Tinfoil 串流轉錄使用 Voxtral Mini 4B，批次轉錄使用 Voxtral Small 24B。",
       "docsLink": "查看文件"
-    }
+    },
+    "apiKeyEnvHelp": "選填。留空則使用 CUSTOM_TRANSCRIPTION_API_KEY，或輸入 $OPENAI_API_KEY。啟動時會匯入 shell 匯出的變數（例如 ~/.zshrc）。"
   },
   "hooks": {
     "audioRecording": {
@@ -3458,14 +3459,16 @@
     "remindLater": "稍後提醒我"
   },
   "apiKeyInput": {
-    "placeholder": "輸入你的 API Key",
+    "placeholder": "貼上 API Key 或 $ENV_VAR",
     "label": "API Key",
     "save": "儲存",
     "cancelEdit": "取消編輯",
     "edit": "編輯",
     "add": "新增",
     "editButton": "編輯金鑰",
-    "addButton": "新增金鑰"
+    "addButton": "新增金鑰",
+    "selfReference": "Use a different variable name here, or leave this field empty.",
+    "unknownRef": "Only OpenWhispr secret names can be referenced (for example $OPENAI_API_KEY)."
   },
   "gpu": {
     "transcriptionBanner": "使用 GPU 加速轉錄",

--- a/src/services/ReasoningService.ts
+++ b/src/services/ReasoningService.ts
@@ -11,6 +11,8 @@ import { SecureCache } from "../utils/SecureCache";
 import { withRetry, createApiRetryStrategy, httpError } from "../utils/retry";
 import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, ensureV1Suffix } from "../config/constants";
 import logger from "../utils/logger";
+import { resolveApiKey } from "../utils/resolveApiKey";
+import { usableSecret } from "../helpers/envRef";
 import { getSettings, isCloudCleanupMode } from "../stores/settingsStore";
 import { wrapCleanupTranscript } from "../config/prompts";
 import { stripThinkingTags } from "../helpers/stripThinking.js";
@@ -183,18 +185,17 @@ class ReasoningService extends BaseReasoningService {
       } catch (err) {
         logger.logReasoning("CUSTOM_KEY_IPC_FALLBACK", { error: (err as Error)?.message });
       }
-      if (!customKey || !customKey.trim()) {
-        customKey = getSettings().cleanupCustomApiKey || "";
-      }
-      const trimmedKey = customKey.trim();
+      customKey =
+        (await resolveApiKey(customKey)) ||
+        (await resolveApiKey(getSettings().cleanupCustomApiKey || ""));
 
       logger.logReasoning("CUSTOM_KEY_RETRIEVAL", {
         provider,
-        hasKey: !!trimmedKey,
-        keyLength: trimmedKey.length,
+        hasKey: !!customKey,
+        keyLength: customKey.length,
       });
 
-      return trimmedKey;
+      return customKey;
     }
 
     let apiKey = this.apiKeyCache.get(provider);
@@ -217,6 +218,7 @@ class ReasoningService extends BaseReasoningService {
           corti: () => window.electronAPI.getCortiKey?.(),
         };
         apiKey = (await keyGetters[provider]()) ?? undefined;
+        if (apiKey) apiKey = await resolveApiKey(apiKey);
 
         logger.logReasoning(`${provider.toUpperCase()}_KEY_FETCHED`, {
           provider,
@@ -260,7 +262,8 @@ class ReasoningService extends BaseReasoningService {
     config: Pick<ReasoningConfig, "baseUrl" | "customApiKey">
   ): Promise<{ apiKey: string; baseURL?: string }> {
     const providerKey = toByokStreamProvider(provider);
-    const overrideKey = providerKey === "custom" ? config.customApiKey?.trim() || "" : "";
+    const overrideKey =
+      providerKey === "custom" ? await resolveApiKey(config.customApiKey) : "";
     const canFallBackToSharedKey =
       providerKey !== "custom" || canBorrowCleanupCustomKey(config.baseUrl);
     const apiKey = overrideKey || (canFallBackToSharedKey ? await this.getApiKey(providerKey) : "");
@@ -332,8 +335,8 @@ class ReasoningService extends BaseReasoningService {
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
         };
-        if (apiKey) {
-          headers["Authorization"] = `Bearer ${apiKey}`;
+        if (usableSecret(apiKey)) {
+          headers["Authorization"] = `Bearer ${usableSecret(apiKey)}`;
         }
 
         const res = await fetchWithParamFallback(
@@ -564,7 +567,7 @@ class ReasoningService extends BaseReasoningService {
     if (isLanChat) {
       const baseUrl = resolveSelfHostedOpenAIBase(route.baseUrl);
       endpoint = buildApiUrl(baseUrl, "/chat/completions");
-      apiKey = route.apiKey;
+      apiKey = await resolveApiKey(route.apiKey);
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);
       if (!serverResult.success || !serverResult.port) {
@@ -622,8 +625,8 @@ class ReasoningService extends BaseReasoningService {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
+    if (usableSecret(apiKey)) {
+      headers["Authorization"] = `Bearer ${usableSecret(apiKey)}`;
     }
 
     const timeoutSeconds = getLlmRequestTimeoutSeconds({ streaming: true });
@@ -806,7 +809,7 @@ class ReasoningService extends BaseReasoningService {
       // Enterprise SDKs run in the main process; the model below proxies
       // doStream over IPC, so no key or base URL is resolved here.
     } else if (isLanChat) {
-      apiKey = route.apiKey;
+      apiKey = await resolveApiKey(route.apiKey);
       baseURL = resolveSelfHostedOpenAIBase(route.baseUrl);
     } else if (isLocalProvider) {
       const serverResult = await window.electronAPI.llamaServerStart(model);

--- a/src/services/ai/enterpriseSettings.ts
+++ b/src/services/ai/enterpriseSettings.ts
@@ -16,8 +16,10 @@ export type EnterpriseCallSettings = {
   bedrockSessionToken: string;
   azureEndpoint: string;
   azureApiVersion: string;
+  azureApiKey: string;
   vertexProject: string;
   vertexLocation: string;
+  vertexApiKey: string;
   managedContext?: ManagedEnterpriseRequestContext;
 };
 
@@ -60,8 +62,10 @@ export function getEnterpriseCallSettings(
     bedrockSessionToken: s.bedrockSessionToken,
     azureEndpoint: s.azureEndpoint,
     azureApiVersion: s.azureApiVersion,
+    azureApiKey: s.azureApiKey,
     vertexProject: s.vertexProject,
     vertexLocation: s.vertexLocation,
+    vertexApiKey: s.vertexApiKey,
     managedContext,
   };
 }

--- a/src/services/ai/inferenceProviders/lan.ts
+++ b/src/services/ai/inferenceProviders/lan.ts
@@ -3,6 +3,7 @@ import { buildApiUrl } from "../../../config/constants";
 import { getSettings } from "../../../stores/settingsStore";
 import logger from "../../../utils/logger";
 import { resolveSelfHostedOpenAIBase } from "../openaiBase";
+import { resolveApiKey } from "../../../utils/resolveApiKey";
 
 export const lanProvider: InferenceProvider = {
   id: "lan",
@@ -16,8 +17,8 @@ export const lanProvider: InferenceProvider = {
       const baseUrl = resolveSelfHostedOpenAIBase(lanUrl);
       const endpoint = buildApiUrl(baseUrl, "/chat/completions");
       const apiKey =
-        config.customApiKey?.trim() ||
-        (isAgentCall ? "" : settings.cleanupCustomApiKey?.trim()) ||
+        (await resolveApiKey(config.customApiKey)) ||
+        (isAgentCall ? "" : await resolveApiKey(settings.cleanupCustomApiKey)) ||
         "";
       const resolvedModel = model?.trim() || "default";
       return await ctx.callChatCompletionsApi(

--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -14,6 +14,8 @@ import { detectEndpointDialect } from "../thinkingSuppressionDialects";
 import { getLlmRequestTimeoutSeconds } from "../../../helpers/llmRequestTimeout.js";
 import { extractApiErrorMessage } from "../apiErrorMessage";
 import { wrapCleanupTranscript } from "../../../config/prompts";
+import { resolveApiKey } from "../../../utils/resolveApiKey";
+import { usableSecret } from "../../../helpers/envRef";
 
 const OPENAI_ENDPOINT_PREF_STORAGE_KEY = "openAiEndpointPreference";
 const PROBE_TIMEOUT_MS = 2_000;
@@ -139,12 +141,14 @@ export const openaiProvider: InferenceProvider = {
       isCustomProvider,
     });
 
-    const overrideKey = isCustomProvider ? config.customApiKey?.trim() : "";
+    const overrideKey = isCustomProvider ? await resolveApiKey(config.customApiKey) : "";
     const canFallBackToSharedKey = !isCustomProvider || canBorrowCleanupCustomKey(config.baseUrl);
     const apiKey =
       overrideKey ||
       (canFallBackToSharedKey
-        ? await ctx.getApiKey(isCustomProvider ? "custom" : isOpenRouter ? "openrouter" : "openai")
+        ? await resolveApiKey(
+            await ctx.getApiKey(isCustomProvider ? "custom" : isOpenRouter ? "openrouter" : "openai")
+          )
         : "");
 
     logger.logReasoning("OPENAI_API_KEY", {
@@ -260,7 +264,7 @@ export const openaiProvider: InferenceProvider = {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",
-                  ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+                  ...(usableSecret(apiKey) ? { Authorization: `Bearer ${usableSecret(apiKey)}` } : {}),
                 },
                 body: JSON.stringify(requestBody),
                 signal: controller.signal,

--- a/src/services/fileTranscription.ts
+++ b/src/services/fileTranscription.ts
@@ -10,6 +10,7 @@ import {
 } from "./managedTranscription";
 import { getTranscriptionProviders } from "../models/ModelRegistry";
 import type { LocalTranscriptionProvider } from "../types/electron";
+import { resolveApiKey } from "../utils/resolveApiKey";
 
 export interface FileTranscriptionResult {
   success: boolean;
@@ -184,7 +185,7 @@ export async function transcribeFile(
   return window.electronAPI.transcribeAudioFileByok!({
     filePath,
     managed: managed?.kind === "managed" ? managed : undefined,
-    apiKey: cfg.getApiKey(),
+    apiKey: await resolveApiKey(cfg.getApiKey()),
     baseUrl: cfg.cloudTranscriptionBaseUrl,
     model: cfg.cloudTranscriptionModel,
     diarize: diarize || undefined,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import i18n, { normalizeUiLanguage } from "../i18n";
 import { ensureAgentNameInDictionary } from "../utils/agentName";
 import { chooseDictionaryStartupAction } from "../helpers/dictionaryStartup";
 import logger from "../utils/logger";
+import { classifySecretInput } from "../helpers/envRef";
 import whisperVadConstants from "../constants/whisperVad.json";
 import type {
   ChineseScriptPreference,
@@ -1351,22 +1352,96 @@ const SECRET_IPC_SAVERS = {
 
 type SecretProvider = keyof typeof SECRET_IPC_SAVERS;
 
+// The env var each secret setter writes to, used to reject a field that
+// references itself (`$OPENAI_API_KEY` in the OpenAI field resolves to nothing
+// once saved). `Record<SecretProvider, string>` makes a new entry in
+// SECRET_IPC_SAVERS a type error until its env name is listed here.
+const SAVER_ENV: Record<SecretProvider, string> = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  gemini: "GEMINI_API_KEY",
+  groq: "GROQ_API_KEY",
+  xai: "XAI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  cortiClientId: "CORTI_CLIENT_ID",
+  cortiClientSecret: "CORTI_CLIENT_SECRET",
+  cortiApiKey: "CORTI_API_KEY",
+  tinfoil: "TINFOIL_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  assemblyai: "ASSEMBLYAI_API_KEY",
+  customTranscription: "CUSTOM_TRANSCRIPTION_API_KEY",
+  cleanupCustom: "CUSTOM_CLEANUP_API_KEY",
+  noteFormattingCustom: "NOTE_FORMATTING_CUSTOM_API_KEY",
+  translationCustom: "TRANSLATION_CUSTOM_API_KEY",
+  dictationAgentCustom: "DICTATION_AGENT_CUSTOM_API_KEY",
+  dictationAgentVisionCustom: "DICTATION_AGENT_VISION_CUSTOM_API_KEY",
+  chatAgentCustom: "CHAT_AGENT_CUSTOM_API_KEY",
+  bedrockAccessKeyId: "BEDROCK_ACCESS_KEY_ID",
+  bedrockSecretAccessKey: "BEDROCK_SECRET_ACCESS_KEY",
+  bedrockSessionToken: "BEDROCK_SESSION_TOKEN",
+  azureApiKey: "AZURE_OPENAI_API_KEY",
+  vertexApiKey: "VERTEX_API_KEY",
+};
+// The names a $VAR field may point at. Object.values(SAVER_ENV) covers every
+// provider the store can save; CUSTOM_REASONING_API_KEY is the legacy alias of
+// CUSTOM_CLEANUP_API_KEY that environment.js still reads but no setter writes.
+// Keep in lockstep with SECRET_ENV_NAMES in src/config/secretKeys.js.
+const SECRET_ENV_SET = new Set<string>([...Object.values(SAVER_ENV), "CUSTOM_REASONING_API_KEY"]);
+
+function assertSavableSecret(saver: SecretProvider, key: string, current?: string): string {
+  const trimmed = key.trim();
+  const reason = classifySecretInput(trimmed, SAVER_ENV[saver], SECRET_ENV_SET);
+  // Re-saving the $NAME already shown in the field (login-shell import) is a
+  // no-op. An empty field + `$OPENAI_API_KEY` is a user self-reference and
+  // must throw — hydration writes imported refs via setState, not setters.
+  if (reason === "self-reference" && current === trimmed) return trimmed;
+  if (reason) {
+    const err = new Error(reason) as Error & { code: string };
+    err.code = reason;
+    throw err;
+  }
+  return trimmed;
+}
+
+type SecretSaveResult = { success?: boolean; reason?: string } | void | null;
+
 const secretSaveTimers: Partial<Record<SecretProvider, ReturnType<typeof setTimeout>>> = {};
-function debouncedSaveSecret(provider: SecretProvider, key: string) {
+function debouncedSaveSecret(
+  provider: SecretProvider,
+  key: string,
+  rollback?: { storeKey: string; previous: string }
+) {
   if (!isBrowser) return;
   const timer = secretSaveTimers[provider];
   if (timer) clearTimeout(timer);
   secretSaveTimers[provider] = setTimeout(() => {
     const api = window.electronAPI;
     const save = api?.[SECRET_IPC_SAVERS[provider]] as
-      ((k: string) => Promise<unknown>) | undefined;
-    save?.(key)?.catch((err) => {
-      logger.warn(
-        "Failed to persist secret",
-        { provider, error: (err as Error).message },
-        "settings"
-      );
-    });
+      ((k: string) => Promise<SecretSaveResult>) | undefined;
+    if (!save) return;
+    save(key)
+      .then((result) => {
+        if (!result || result.success !== false) return;
+        if (rollback) {
+          const current = String(useSettingsStore.getState()[rollback.storeKey] ?? "");
+          if (current === key) {
+            useSettingsStore.setState({ [rollback.storeKey]: rollback.previous });
+          }
+        }
+        logger.warn(
+          "Rejected secret persist",
+          { provider, reason: result.reason },
+          "settings"
+        );
+      })
+      .catch((err) => {
+        logger.warn(
+          "Failed to persist secret",
+          { provider, error: (err as Error).message },
+          "settings"
+        );
+      });
   }, 250);
 }
 
@@ -1436,8 +1511,10 @@ function createSecretSetter(
   cacheProvider?: Parameters<typeof invalidateApiKeyCaches>[0]
 ) {
   return (key: string) => {
-    useSettingsStore.setState({ [storeKey]: key });
-    debouncedSaveSecret(saver, key);
+    const current = String(useSettingsStore.getState()[storeKey] ?? "");
+    const trimmed = assertSavableSecret(saver, key, current);
+    useSettingsStore.setState({ [storeKey]: trimmed });
+    debouncedSaveSecret(saver, trimmed, { storeKey, previous: current });
     invalidateApiKeyCaches(cacheProvider);
   };
 }
@@ -2137,13 +2214,17 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setMistralApiKey: createSecretSetter("mistralApiKey", "mistral", "mistral"),
   setOpenrouterApiKey: createSecretSetter("openrouterApiKey", "openrouter", "openrouter"),
   setCortiClientId: (key: string) => {
-    set({ cortiClientId: key });
-    debouncedSaveSecret("cortiClientId", key);
+    const previous = useSettingsStore.getState().cortiClientId;
+    const trimmed = assertSavableSecret("cortiClientId", key, previous);
+    set({ cortiClientId: trimmed });
+    debouncedSaveSecret("cortiClientId", trimmed, { storeKey: "cortiClientId", previous });
     invalidateApiKeyCaches("corti");
   },
   setCortiClientSecret: (key: string) => {
-    set({ cortiClientSecret: key });
-    debouncedSaveSecret("cortiClientSecret", key);
+    const previous = useSettingsStore.getState().cortiClientSecret;
+    const trimmed = assertSavableSecret("cortiClientSecret", key, previous);
+    set({ cortiClientSecret: trimmed });
+    debouncedSaveSecret("cortiClientSecret", trimmed, { storeKey: "cortiClientSecret", previous });
     invalidateApiKeyCaches("corti");
   },
   setCortiApiKey: createSecretSetter("cortiApiKey", "cortiApiKey", "corti"),
@@ -2154,13 +2235,23 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   setDeepgramApiKey: createSecretSetter("deepgramApiKey", "deepgram"),
   setAssemblyaiApiKey: createSecretSetter("assemblyaiApiKey", "assemblyai"),
   setCustomTranscriptionApiKey: (key: string) => {
-    set({ customTranscriptionApiKey: key });
-    debouncedSaveSecret("customTranscription", key);
+    const previous = useSettingsStore.getState().customTranscriptionApiKey;
+    const trimmed = assertSavableSecret("customTranscription", key, previous);
+    set({ customTranscriptionApiKey: trimmed });
+    debouncedSaveSecret("customTranscription", trimmed, {
+      storeKey: "customTranscriptionApiKey",
+      previous,
+    });
     invalidateApiKeyCaches("custom");
   },
   setCleanupCustomApiKey: (key: string) => {
-    set({ cleanupCustomApiKey: key });
-    debouncedSaveSecret("cleanupCustom", key);
+    const previous = useSettingsStore.getState().cleanupCustomApiKey;
+    const trimmed = assertSavableSecret("cleanupCustom", key, previous);
+    set({ cleanupCustomApiKey: trimmed });
+    debouncedSaveSecret("cleanupCustom", trimmed, {
+      storeKey: "cleanupCustomApiKey",
+      previous,
+    });
     invalidateApiKeyCaches("custom");
   },
 
@@ -2188,18 +2279,33 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     debouncedPersistToEnv();
   },
   setBedrockAccessKeyId: (key: string) => {
-    set({ bedrockAccessKeyId: key });
-    debouncedSaveSecret("bedrockAccessKeyId", key);
+    const previous = useSettingsStore.getState().bedrockAccessKeyId;
+    const trimmed = assertSavableSecret("bedrockAccessKeyId", key, previous);
+    set({ bedrockAccessKeyId: trimmed });
+    debouncedSaveSecret("bedrockAccessKeyId", trimmed, {
+      storeKey: "bedrockAccessKeyId",
+      previous,
+    });
     debouncedPersistToEnv();
   },
   setBedrockSecretAccessKey: (key: string) => {
-    set({ bedrockSecretAccessKey: key });
-    debouncedSaveSecret("bedrockSecretAccessKey", key);
+    const previous = useSettingsStore.getState().bedrockSecretAccessKey;
+    const trimmed = assertSavableSecret("bedrockSecretAccessKey", key, previous);
+    set({ bedrockSecretAccessKey: trimmed });
+    debouncedSaveSecret("bedrockSecretAccessKey", trimmed, {
+      storeKey: "bedrockSecretAccessKey",
+      previous,
+    });
     debouncedPersistToEnv();
   },
   setBedrockSessionToken: (key: string) => {
-    set({ bedrockSessionToken: key });
-    debouncedSaveSecret("bedrockSessionToken", key);
+    const previous = useSettingsStore.getState().bedrockSessionToken;
+    const trimmed = assertSavableSecret("bedrockSessionToken", key, previous);
+    set({ bedrockSessionToken: trimmed });
+    debouncedSaveSecret("bedrockSessionToken", trimmed, {
+      storeKey: "bedrockSessionToken",
+      previous,
+    });
     debouncedPersistToEnv();
   },
   setAzureEndpoint: (value: string) => {
@@ -2209,8 +2315,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     debouncedPersistToEnv();
   },
   setAzureApiKey: (key: string) => {
-    set({ azureApiKey: key });
-    debouncedSaveSecret("azureApiKey", key);
+    const previous = useSettingsStore.getState().azureApiKey;
+    const trimmed = assertSavableSecret("azureApiKey", key, previous);
+    set({ azureApiKey: trimmed });
+    debouncedSaveSecret("azureApiKey", trimmed, { storeKey: "azureApiKey", previous });
     debouncedPersistToEnv();
   },
   setAzureDeploymentName: (value: string) => {
@@ -2242,8 +2350,10 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     debouncedPersistToEnv();
   },
   setVertexApiKey: (key: string) => {
-    set({ vertexApiKey: key });
-    debouncedSaveSecret("vertexApiKey", key);
+    const previous = useSettingsStore.getState().vertexApiKey;
+    const trimmed = assertSavableSecret("vertexApiKey", key, previous);
+    set({ vertexApiKey: trimmed });
+    debouncedSaveSecret("vertexApiKey", trimmed, { storeKey: "vertexApiKey", previous });
     debouncedPersistToEnv();
   },
 
@@ -2640,22 +2750,35 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
 
   updateApiKeys: (keys: Partial<ApiKeySettings>) => {
     const s = useSettingsStore.getState();
-    if (keys.openaiApiKey !== undefined) s.setOpenaiApiKey(keys.openaiApiKey);
-    if (keys.anthropicApiKey !== undefined) s.setAnthropicApiKey(keys.anthropicApiKey);
-    if (keys.geminiApiKey !== undefined) s.setGeminiApiKey(keys.geminiApiKey);
-    if (keys.groqApiKey !== undefined) s.setGroqApiKey(keys.groqApiKey);
-    if (keys.xaiApiKey !== undefined) s.setXaiApiKey(keys.xaiApiKey);
-    if (keys.mistralApiKey !== undefined) s.setMistralApiKey(keys.mistralApiKey);
-    if (keys.openrouterApiKey !== undefined) s.setOpenrouterApiKey(keys.openrouterApiKey);
-    if (keys.cortiClientId !== undefined) s.setCortiClientId(keys.cortiClientId);
-    if (keys.cortiClientSecret !== undefined) s.setCortiClientSecret(keys.cortiClientSecret);
-    if (keys.cortiApiKey !== undefined) s.setCortiApiKey(keys.cortiApiKey);
-    if (keys.tinfoilApiKey !== undefined) s.setTinfoilApiKey(keys.tinfoilApiKey);
-    if (keys.deepgramApiKey !== undefined) s.setDeepgramApiKey(keys.deepgramApiKey);
-    if (keys.assemblyaiApiKey !== undefined) s.setAssemblyaiApiKey(keys.assemblyaiApiKey);
-    if (keys.customTranscriptionApiKey !== undefined)
-      s.setCustomTranscriptionApiKey(keys.customTranscriptionApiKey);
-    if (keys.cleanupCustomApiKey !== undefined) s.setCleanupCustomApiKey(keys.cleanupCustomApiKey);
+    // Secret setters throw on a rejected $VAR (self-reference / unknown name).
+    // A bulk update must not abort halfway, so each key is applied on its own.
+    const apply = (fn: (value: string) => void, value: string | undefined) => {
+      if (value === undefined) return;
+      try {
+        fn(value);
+      } catch (error) {
+        logger.warn(
+          "Skipped invalid API key update",
+          { error: error instanceof Error ? error.message : String(error) },
+          "settings"
+        );
+      }
+    };
+    apply(s.setOpenaiApiKey, keys.openaiApiKey);
+    apply(s.setAnthropicApiKey, keys.anthropicApiKey);
+    apply(s.setGeminiApiKey, keys.geminiApiKey);
+    apply(s.setGroqApiKey, keys.groqApiKey);
+    apply(s.setXaiApiKey, keys.xaiApiKey);
+    apply(s.setMistralApiKey, keys.mistralApiKey);
+    apply(s.setOpenrouterApiKey, keys.openrouterApiKey);
+    apply(s.setCortiClientId, keys.cortiClientId);
+    apply(s.setCortiClientSecret, keys.cortiClientSecret);
+    apply(s.setCortiApiKey, keys.cortiApiKey);
+    apply(s.setTinfoilApiKey, keys.tinfoilApiKey);
+    apply(s.setDeepgramApiKey, keys.deepgramApiKey);
+    apply(s.setAssemblyaiApiKey, keys.assemblyaiApiKey);
+    apply(s.setCustomTranscriptionApiKey, keys.customTranscriptionApiKey);
+    apply(s.setCleanupCustomApiKey, keys.cleanupCustomApiKey);
   },
 
   updateChatAgentSettings: (settings: Partial<ChatAgentSettings>) => {

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1666,6 +1666,7 @@ declare global {
       // API key management
       getOpenAIKey: () => Promise<string>;
       saveOpenAIKey: (key: string) => Promise<{ success: boolean }>;
+      resolveSecretRef?: (value: string) => Promise<string>;
       getAnthropicKey: () => Promise<string | null>;
       saveAnthropicKey: (key: string) => Promise<void>;
       getUiLanguage: () => Promise<string>;

--- a/src/utils/resolveApiKey.ts
+++ b/src/utils/resolveApiKey.ts
@@ -1,0 +1,17 @@
+/** Expand `$VAR` / `${VAR}` API-key fields via the main process. */
+import { isEnvRef, usableSecret } from "../helpers/envRef";
+
+export { isEnvRef, usableSecret };
+
+export async function resolveApiKey(value?: string | null): Promise<string> {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) return "";
+  if (!isEnvRef(raw)) return raw;
+  try {
+    const resolved = await window.electronAPI?.resolveSecretRef?.(raw);
+    if (typeof resolved === "string") return usableSecret(resolved);
+  } catch {
+    // IPC unavailable — never send an unexpanded $VAR to a provider.
+  }
+  return "";
+}

--- a/test/helpers/enterpriseRuntimeResolve.test.js
+++ b/test/helpers/enterpriseRuntimeResolve.test.js
@@ -1,0 +1,84 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const Module = require("module");
+
+const origLoad = Module._load;
+Module._load = function (request, ...rest) {
+  if (request === "electron") {
+    return { app: { getPath: () => "/tmp", getVersion: () => "0.0.0" } };
+  }
+  return origLoad.call(this, request, ...rest);
+};
+
+const { resolveManualEnterpriseRuntime } = require("../../src/helpers/enterpriseProviderErrors");
+
+function resolveFromEnv(env) {
+  return (value) => {
+    const raw = typeof value === "string" ? value.trim() : "";
+    const match = raw.match(/^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$|^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+    if (!match) return raw;
+    const name = match[1] || match[2];
+    const resolved = env[name];
+    if (resolved == null) return "";
+    const trimmed = String(resolved).trim();
+    return /^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(trimmed) ? "" : trimmed;
+  };
+}
+
+test("azure $AZURE_OPENAI_API_KEY expands and never emits a leftover $VAR", () => {
+  const resolve = resolveFromEnv({ AZURE_OPENAI_API_KEY: "az-live" });
+  const runtime = resolveManualEnterpriseRuntime(
+    { azureApiKey: "$AZURE_OPENAI_API_KEY", azureEndpoint: "https://example.openai.azure.com" },
+    "azure",
+    "gpt-4o",
+    resolve
+  );
+  assert.equal(runtime.apiKey, "az-live");
+  assert.equal(runtime.enterprise.azureApiKey, "az-live");
+  assert.equal(runtime.apiKey.includes("$"), false);
+});
+
+test("unset azure ref becomes empty instead of Bearer $VAR", () => {
+  const runtime = resolveManualEnterpriseRuntime(
+    { azureApiKey: "$AZURE_OPENAI_API_KEY" },
+    "azure",
+    "gpt-4o",
+    resolveFromEnv({})
+  );
+  assert.equal(runtime.apiKey, "");
+  assert.equal(runtime.enterprise.azureApiKey, "");
+});
+
+test("vertex key does not fill azure apiKey", () => {
+  const runtime = resolveManualEnterpriseRuntime(
+    { vertexApiKey: "vertex-secret", azureApiKey: "" },
+    "azure",
+    "gpt-4o",
+    (value) => value || ""
+  );
+  assert.equal(runtime.apiKey, "");
+  assert.equal(runtime.enterprise.vertexApiKey, "vertex-secret");
+});
+
+test("config.apiKey is resolved without mutating the caller object", () => {
+  const config = { apiKey: "$AZURE_OPENAI_API_KEY", azureApiKey: "$AZURE_OPENAI_API_KEY" };
+  const runtime = resolveManualEnterpriseRuntime(
+    config,
+    "azure",
+    "gpt-4o",
+    resolveFromEnv({ AZURE_OPENAI_API_KEY: "az-live" })
+  );
+  assert.equal(runtime.apiKey, "az-live");
+  assert.equal(config.apiKey, "$AZURE_OPENAI_API_KEY");
+  assert.equal(config.azureApiKey, "$AZURE_OPENAI_API_KEY");
+});
+
+test("missing resolver strips leftover $VAR but keeps literals", () => {
+  const runtime = resolveManualEnterpriseRuntime(
+    { apiKey: "sk-literal", azureApiKey: "$AZURE_OPENAI_API_KEY" },
+    "azure",
+    "gpt-4o"
+  );
+  assert.equal(runtime.apiKey, "sk-literal");
+  assert.equal(runtime.enterprise.azureApiKey, "");
+});

--- a/test/helpers/envKeyResolve.test.js
+++ b/test/helpers/envKeyResolve.test.js
@@ -1,0 +1,277 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isEnvRef,
+  envRefName,
+  resolveEnvRef,
+  parseExportP,
+  isTrustedLoginShell,
+  resolveLoginShell,
+  coalesceResolvedSecret,
+  usableSecret,
+  classifySecretInput,
+  ENV_EXPORT_SENTINEL,
+  importMissingSecretsFromLoginShell,
+} = require("../../src/helpers/envKeyResolve");
+
+function exportDump(body) {
+  return `${ENV_EXPORT_SENTINEL}\n${body}`;
+}
+
+test("detects $VAR and ${VAR} references", () => {
+  assert.equal(isEnvRef("$OPENAI_API_KEY"), true);
+  assert.equal(isEnvRef(" ${OPENAI_API_KEY} "), true);
+  assert.equal(isEnvRef("sk-abc"), false);
+  assert.equal(isEnvRef("$1INVALID"), false);
+  assert.equal(isEnvRef(""), false);
+  assert.equal(envRefName("$OPENAI_API_KEY"), "OPENAI_API_KEY");
+  assert.equal(envRefName("${CUSTOM_TRANSCRIPTION_API_KEY}"), "CUSTOM_TRANSCRIPTION_API_KEY");
+});
+
+test("resolves a single env-ref hop and leaves literals alone", () => {
+  const env = { OPENAI_API_KEY: "sk-from-shell", EMPTY: "" };
+  assert.equal(resolveEnvRef("$OPENAI_API_KEY", env), "sk-from-shell");
+  assert.equal(resolveEnvRef("${OPENAI_API_KEY}", env), "sk-from-shell");
+  assert.equal(resolveEnvRef("sk-hardcoded", env), "sk-hardcoded");
+  assert.equal(resolveEnvRef("$MISSING", env), "");
+  assert.equal(resolveEnvRef("$EMPTY", env), "");
+});
+
+test("does not recursively expand a resolved value", () => {
+  const env = { OUTER: "$INNER", INNER: "secret" };
+  assert.equal(resolveEnvRef("$OUTER", env), "$INNER");
+});
+
+test("parses bash declare -x and zsh export -p lines", () => {
+  const parsed = parseExportP(`
+declare -x OPENAI_API_KEY="sk-openai"
+export GROQ_API_KEY='gsk-groq'
+export CUSTOM_TRANSCRIPTION_API_KEY=plain-custom
+export WITH_SPACE="hello world"
+declare -x EMPTY=""
+not an assignment
+`);
+  assert.equal(parsed.OPENAI_API_KEY, "sk-openai");
+  assert.equal(parsed.GROQ_API_KEY, "gsk-groq");
+  assert.equal(parsed.CUSTOM_TRANSCRIPTION_API_KEY, "plain-custom");
+  assert.equal(parsed.WITH_SPACE, "hello world");
+  assert.equal(parsed.EMPTY, "");
+  assert.equal(parsed.not, undefined);
+});
+
+test("trusted shells are exact system paths, not basenames", () => {
+  assert.equal(isTrustedLoginShell("/bin/zsh"), true);
+  assert.equal(isTrustedLoginShell("/usr/bin/bash"), true);
+  assert.equal(isTrustedLoginShell("/tmp/zsh"), false);
+  assert.equal(isTrustedLoginShell("/tmp/evil"), false);
+});
+
+test("login-shell import fills only missing secret names", async () => {
+  const env = {
+    SHELL: "/bin/zsh",
+    OPENAI_API_KEY: "already-set",
+  };
+  const execFileSync = (file, args) => {
+    assert.equal(args[0], "-ilc");
+    return exportDump(
+      `export OPENAI_API_KEY='from-zsh-should-lose'\nexport GROQ_API_KEY='from-zsh'\nexport UNRELATED='nope'\n`
+    );
+  };
+
+  const { imported, reason } = await importMissingSecretsFromLoginShell({
+    secretNames: ["OPENAI_API_KEY", "GROQ_API_KEY", "CUSTOM_TRANSCRIPTION_API_KEY"],
+    env,
+    platform: "linux",
+    execFileSync,
+    existsSync: (p) => p === "/bin/zsh",
+  });
+
+  assert.equal(reason, "ok");
+  assert.deepEqual(imported, ["GROQ_API_KEY"]);
+  assert.equal(env.OPENAI_API_KEY, "already-set");
+  assert.equal(env.GROQ_API_KEY, "from-zsh");
+  assert.equal(env.CUSTOM_TRANSCRIPTION_API_KEY, undefined);
+  assert.equal(env.UNRELATED, undefined);
+});
+
+test("login-shell import does not execute /tmp/zsh", async () => {
+  const called = [];
+  const env = { SHELL: "/tmp/zsh" };
+  const { imported, reason } = await importMissingSecretsFromLoginShell({
+    secretNames: ["OPENAI_API_KEY"],
+    env,
+    platform: "linux",
+    existsSync: (p) => p === "/tmp/zsh" || p === "/bin/bash",
+    execFileSync: (file) => {
+      called.push(file);
+      return "export OPENAI_API_KEY='from-bash'\n";
+    },
+  });
+  assert.deepEqual(called, []);
+  assert.equal(reason, "no-trusted-shell");
+  assert.deepEqual(imported, []);
+  assert.equal(env.OPENAI_API_KEY, undefined);
+});
+
+test("login-shell child env does not receive app secrets", async () => {
+  let childEnv;
+  const env = {
+    SHELL: "/bin/zsh",
+    HOME: "/home/u",
+    PATH: "/bin",
+    USER: "u",
+    OPENAI_API_KEY: "sk-should-not-leak",
+    ANTHROPIC_API_KEY: "sk-nope",
+  };
+  await importMissingSecretsFromLoginShell({
+    secretNames: ["GROQ_API_KEY"],
+    env,
+    platform: "linux",
+    existsSync: (p) => p === "/bin/zsh",
+    execFileSync: (_file, _args, opts) => {
+      childEnv = opts.env;
+      return exportDump("export GROQ_API_KEY='gsk'\n");
+    },
+  });
+  assert.equal(childEnv.OPENAI_API_KEY, undefined);
+  assert.equal(childEnv.ANTHROPIC_API_KEY, undefined);
+  assert.equal(childEnv.HOME, "/home/u");
+  assert.equal(childEnv.SHELL, "/bin/zsh");
+  assert.equal(childEnv.TERM, "dumb");
+});
+
+test("coalesceResolvedSecret never emits an unexpanded ref", () => {
+  assert.equal(coalesceResolvedSecret("$OPENAI_API_KEY", ""), "");
+  assert.equal(coalesceResolvedSecret("$OPENAI_API_KEY", "sk-live"), "sk-live");
+  assert.equal(coalesceResolvedSecret("$OPENAI_API_KEY", "$OPENAI_API_KEY"), "");
+  assert.equal(coalesceResolvedSecret("$OPENAI_API_KEY", undefined), "");
+  assert.equal(coalesceResolvedSecret("sk-hardcoded", undefined), "sk-hardcoded");
+});
+
+test("parseExportP ignores rc noise before the sentinel", () => {
+  const parsed = parseExportP(
+    `Powerlevel10k noise FOO=bar\n${ENV_EXPORT_SENTINEL}\nexport GROQ_API_KEY='gsk'\n`,
+    ENV_EXPORT_SENTINEL
+  );
+  assert.equal(parsed.FOO, undefined);
+  assert.equal(parsed.GROQ_API_KEY, "gsk");
+});
+
+test("login-shell import skips when no trusted shell exists", async () => {
+  const { imported, reason } = await importMissingSecretsFromLoginShell({
+    secretNames: ["OPENAI_API_KEY"],
+    env: { SHELL: "/tmp/zsh" },
+    platform: "linux",
+    existsSync: () => false,
+    execFileSync: () => {
+      throw new Error("should not run");
+    },
+  });
+  assert.equal(reason, "no-trusted-shell");
+  assert.deepEqual(imported, []);
+});
+
+test("resolveLoginShell uses SHELL when trusted, else passwd, and does not probe zsh", () => {
+  assert.equal(
+    resolveLoginShell({ SHELL: "/usr/bin/bash" }, (p) => p === "/usr/bin/bash", ""),
+    "/usr/bin/bash"
+  );
+  assert.equal(resolveLoginShell({ SHELL: "/tmp/zsh" }, (p) => p === "/bin/bash", "/bin/bash"), null);
+  assert.equal(resolveLoginShell({}, (p) => p === "/bin/bash", "/bin/bash"), "/bin/bash");
+  assert.equal(resolveLoginShell({}, (p) => p === "/bin/zsh", ""), null);
+  assert.equal(resolveLoginShell({}, () => false, ""), null);
+});
+
+test("login-shell import records names before mutating env", async () => {
+  const env = { SHELL: "/bin/zsh" };
+  const importedSet = new Set();
+  await importMissingSecretsFromLoginShell({
+    secretNames: ["GROQ_API_KEY"],
+    env,
+    platform: "linux",
+    importedSet,
+    existsSync: (p) => p === "/bin/zsh",
+    execFileSync: () => exportDump("export GROQ_API_KEY='gsk'\n"),
+  });
+  assert.equal(importedSet.has("GROQ_API_KEY"), true);
+  assert.equal(env.GROQ_API_KEY, "gsk");
+});
+
+test("login-shell import async execFile path parses sentinel output", async () => {
+  const env = { SHELL: "/bin/zsh" };
+  const { imported, reason } = await importMissingSecretsFromLoginShell({
+    secretNames: ["GROQ_API_KEY"],
+    env,
+    platform: "linux",
+    existsSync: (p) => p === "/bin/zsh",
+    execFile: async () => ({ stdout: exportDump("export GROQ_API_KEY='gsk'\n") }),
+  });
+  assert.equal(reason, "ok");
+  assert.deepEqual(imported, ["GROQ_API_KEY"]);
+  assert.equal(env.GROQ_API_KEY, "gsk");
+});
+
+test("login-shell import is a no-op on Windows and on exec failure", async () => {
+  const env = {};
+  assert.deepEqual(
+    await importMissingSecretsFromLoginShell({
+      secretNames: ["OPENAI_API_KEY"],
+      env,
+      platform: "win32",
+      execFileSync: () => {
+        throw new Error("should not run");
+      },
+    }),
+    { imported: [], reason: "win32" }
+  );
+  assert.deepEqual(
+    await importMissingSecretsFromLoginShell({
+      secretNames: ["OPENAI_API_KEY"],
+      env: { SHELL: "/bin/zsh" },
+      platform: "linux",
+      existsSync: (p) => p === "/bin/zsh",
+      execFileSync: () => {
+        throw new Error("zsh hung");
+      },
+    }),
+    { imported: [], reason: "exec-failed" }
+  );
+});
+
+test("usableSecret never returns a leftover $VAR", () => {
+  assert.equal(usableSecret("$OPENAI_API_KEY"), "");
+  assert.equal(usableSecret("${GROQ_API_KEY}"), "");
+  assert.equal(usableSecret("sk-live"), "sk-live");
+  assert.equal(usableSecret(""), "");
+});
+
+test("classifySecretInput rejects self-refs and unknown names", () => {
+  const allowed = new Set(["OPENAI_API_KEY", "GROQ_API_KEY"]);
+  assert.equal(classifySecretInput("$OPENAI_API_KEY", "OPENAI_API_KEY", allowed), "self-reference");
+  assert.equal(classifySecretInput("$PATH", "OPENAI_API_KEY", allowed), "unknown-ref");
+  assert.equal(classifySecretInput("$GROQ_API_KEY", "OPENAI_API_KEY", allowed), null);
+  assert.equal(classifySecretInput("sk-live", "OPENAI_API_KEY", allowed), null);
+});
+
+test("chat-agent and scope custom refs are not usable as Authorization secrets", () => {
+  assert.equal(usableSecret("$CHAT_AGENT_CUSTOM_API_KEY"), "");
+  assert.equal(usableSecret("$NOTE_FORMATTING_CUSTOM_API_KEY"), "");
+  assert.equal(usableSecret("$TRANSLATION_CUSTOM_API_KEY"), "");
+  assert.equal(usableSecret("$DICTATION_AGENT_CUSTOM_API_KEY"), "");
+  assert.equal(usableSecret("sk-chat"), "sk-chat");
+});
+
+test("resolved env ref is a usable Authorization secret, leftover $VAR is not", () => {
+  const resolved = resolveEnvRef("$OPENAI_API_KEY", { OPENAI_API_KEY: "sk-live" });
+  assert.equal(usableSecret(resolved), "sk-live");
+  assert.equal(usableSecret("$OPENAI_API_KEY"), "");
+});
+
+test("envRef.ts and envRef.cjs share the same ENV_REF_RE", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const ts = fs.readFileSync(path.join(__dirname, "../../src/helpers/envRef.ts"), "utf8");
+  const cjs = fs.readFileSync(path.join(__dirname, "../../src/helpers/envRef.cjs"), "utf8");
+  const re = /ENV_REF_RE = (\/.+\/);/;
+  assert.equal(ts.match(re)[1], cjs.match(re)[1]);
+});

--- a/test/helpers/secretKeys.test.js
+++ b/test/helpers/secretKeys.test.js
@@ -1,4 +1,5 @@
 const test = require("node:test");
+const { beforeEach } = test;
 const assert = require("node:assert");
 const os = require("os");
 const path = require("path");
@@ -18,11 +19,19 @@ const origLoad = Module._load;
 Module._load = function (request, ...rest) {
   if (request === "electron") return fakeElectron;
   if (request === "@napi-rs/keyring") throw new Error("keyring disabled in tests");
+  if (request === "dotenv") return { config: () => ({}) };
+  if (request === "./i18nMain" || request.endsWith("/i18nMain")) {
+    return { normalizeUiLanguage: (v) => v || "en" };
+  }
   return origLoad.call(this, request, ...rest);
 };
 
-const { BYOK_API_KEYS } = require("../../src/config/secretKeys");
+const { BYOK_API_KEYS, SECRET_ENV_NAMES } = require("../../src/config/secretKeys");
 const EnvironmentManager = require("../../src/helpers/environment");
+
+beforeEach(() => {
+  EnvironmentManager._resetShellImportedSecrets();
+});
 
 test("manifest entries are unique and complete", () => {
   const seen = { base: new Set(), env: new Set(), storeKey: new Set() };
@@ -34,6 +43,20 @@ test("manifest entries are unique and complete", () => {
       assert.ok(!seen[field].has(k[field]), `duplicate ${field}: ${k[field]}`);
       seen[field].add(k[field]);
     }
+  }
+});
+
+test("SECRET_ENV_NAMES includes BYOK custom keys and the cleanup alias", () => {
+  for (const name of [
+    "CHAT_AGENT_CUSTOM_API_KEY",
+    "NOTE_FORMATTING_CUSTOM_API_KEY",
+    "TRANSLATION_CUSTOM_API_KEY",
+    "DICTATION_AGENT_CUSTOM_API_KEY",
+    "DICTATION_AGENT_VISION_CUSTOM_API_KEY",
+    "CUSTOM_CLEANUP_API_KEY",
+    "CUSTOM_REASONING_API_KEY",
+  ]) {
+    assert.ok(SECRET_ENV_NAMES.includes(name), name);
   }
 });
 
@@ -52,6 +75,85 @@ test("every BYOK key round-trips through the generated accessors", () => {
     assert.equal(env[k.get](), "", `${k.base} clears`);
     assert.equal(process.env[k.env], undefined, `${k.base} env var removed on clear`);
   }
+});
+
+test("custom transcription key can reference $OPENAI_API_KEY", () => {
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  const previousCustom = process.env.CUSTOM_TRANSCRIPTION_API_KEY;
+  const env = new EnvironmentManager();
+  process.env.OPENAI_API_KEY = "sk-from-shell";
+  env.saveCustomTranscriptionKey("$OPENAI_API_KEY");
+  assert.equal(env.getRawKey("CUSTOM_TRANSCRIPTION_API_KEY"), "$OPENAI_API_KEY");
+  assert.equal(env.getCustomTranscriptionKey(), "sk-from-shell");
+  env.saveCustomTranscriptionKey("");
+  if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = previousOpenAI;
+  if (previousCustom === undefined) delete process.env.CUSTOM_TRANSCRIPTION_API_KEY;
+  else process.env.CUSTOM_TRANSCRIPTION_API_KEY = previousCustom;
+});
+
+test("shell-imported secrets are not written to plaintext .env", async () => {
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  const env = new EnvironmentManager();
+  process.env.OPENAI_API_KEY = "sk-imported-shell";
+  env._shellImportedSecrets.add("OPENAI_API_KEY");
+  const result = await env.saveAllKeysToEnvFile();
+  const content = fs.readFileSync(result.path, "utf8");
+  assert.equal(content.includes("sk-imported-shell"), false);
+  assert.equal(content.includes("OPENAI_API_KEY="), false);
+  if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = previousOpenAI;
+});
+
+test("getRawKey returns $NAME for shell-imported secrets and saving that ref does not persist", async () => {
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  const env = new EnvironmentManager();
+  process.env.OPENAI_API_KEY = "sk-imported-shell";
+  env._shellImportedSecrets.add("OPENAI_API_KEY");
+  assert.equal(env.getRawKey("OPENAI_API_KEY"), "$OPENAI_API_KEY");
+  assert.equal(env.getOpenAIKey(), "sk-imported-shell");
+  env.saveOpenAIKey("$OPENAI_API_KEY");
+  assert.equal(process.env.OPENAI_API_KEY, "sk-imported-shell");
+  assert.equal(env._shellImportedSecrets.has("OPENAI_API_KEY"), true);
+  const result = await env.saveAllKeysToEnvFile();
+  const content = fs.readFileSync(result.path, "utf8");
+  assert.equal(content.includes("sk-imported-shell"), false);
+  if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = previousOpenAI;
+});
+
+test("resolveSecretRef only expands known secret names", () => {
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  const env = new EnvironmentManager();
+  process.env.OPENAI_API_KEY = "sk-ok";
+  assert.equal(env.resolveSecretRef("$PATH"), "");
+  assert.equal(env.resolveSecretRef("$OPENAI_API_KEY"), "sk-ok");
+  if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = previousOpenAI;
+});
+
+test("self-referential $OPENAI_API_KEY is rejected and does not become a bearer token", () => {
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  const env = new EnvironmentManager();
+  const saved = env.saveOpenAIKey("$OPENAI_API_KEY");
+  assert.equal(saved.success, false);
+  assert.equal(saved.reason, "self-reference");
+  assert.equal(process.env.OPENAI_API_KEY, undefined);
+  assert.equal(env.getOpenAIKey(), "");
+  env.saveOpenAIKey("${OPENAI_API_KEY}");
+  assert.equal(process.env.OPENAI_API_KEY, undefined);
+  if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = previousOpenAI;
+});
+
+test("_getKey does not expand non-secret env names", () => {
+  const previous = process.env.CUSTOM_TRANSCRIPTION_API_KEY;
+  const env = new EnvironmentManager();
+  process.env.CUSTOM_TRANSCRIPTION_API_KEY = "$PATH";
+  assert.equal(env.getCustomTranscriptionKey(), "");
+  if (previous === undefined) delete process.env.CUSTOM_TRANSCRIPTION_API_KEY;
+  else process.env.CUSTOM_TRANSCRIPTION_API_KEY = previous;
 });
 
 test("openrouter is a first-class secret", () => {
@@ -88,4 +190,11 @@ test("preload BYOK_KEY_BRIDGES mirror the manifest exactly", () => {
   }
   const bridgeCount = (block[1].match(/base:/g) || []).length;
   assert.equal(bridgeCount, BYOK_API_KEYS.length, "no extra/missing preload bridges");
+});
+
+test("settingsStore allowlist mentions every SECRET_ENV_NAMES entry", () => {
+  const src = fs.readFileSync(path.join(__dirname, "../../src/stores/settingsStore.ts"), "utf8");
+  for (const name of SECRET_ENV_NAMES) {
+    assert.ok(src.includes(`"${name}"`), `${name} missing from settingsStore.ts`);
+  }
 });


### PR DESCRIPTION
## Why

Custom (and other BYOK) providers require an API key next to the endpoint URL. Today that key has to be pasted into Settings. People who already export keys in `~/.zshrc` / `~/.bashrc` should be able to reference them instead of duplicating the secret in the app.

## What

API key fields accept a whole-field `$VAR` / `${VAR}` instead of the secret.

- Settings and IPC keep the raw reference. It is expanded only on the request path.
- Only OpenWhispr secret names are expanded (`OPENAI_API_KEY`, `GROQ_API_KEY`, `CUSTOM_TRANSCRIPTION_API_KEY`, …). `$PATH` and arbitrary names like `$KEY_TEST` resolve to empty, so they are never sent as `Authorization: Bearer $VAR`.
- `$OPENAI_API_KEY` in the OpenAI field itself is a self-reference and is not stored as a working key. Use it in a *different* field (custom endpoint), or leave the OpenAI field empty.
- On Unix, empty known secrets are filled from a trusted login shell (`/bin/zsh`, `/usr/bin/zsh`, `/bin/bash`, `/usr/bin/bash`) so dock launches see `~/.zshrc` / `~/.bashrc` exports. Untrusted `SHELL` paths (e.g. `/tmp/zsh`) are not executed. Imports are never written to Settings or `.env`.
- Windows is unchanged (no shell import).

Custom provider is the original case: set the endpoint URL, put `$OPENAI_API_KEY` in the custom key field (or leave it empty and `export CUSTOM_TRANSCRIPTION_API_KEY` in zsh).

## Verification

- `node --test test/helpers/envKeyResolve.test.js test/helpers/enterpriseRuntimeResolve.test.js test/helpers/secretKeys.test.js` — 37 pass
- i18n keys added in all 10 locale files

## Still owed

Manual smoke: custom endpoint with `$OPENAI_API_KEY`, empty field + zsh export, confirm the import does not appear as a saved Settings secret.
