### PR TITLE
fix(ci): publish winget manifests from CI with tag-pinned installer URLs

### DIFF
--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -1,0 +1,41 @@
+name: Update WinGet package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-winget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release version
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            version="$RELEASE_TAG"
+          else
+            version=$(gh release view --json tagName -q .tagName)
+          fi
+          version="${version#v}"
+          if ! echo "$version" | grep -qP '^\d+\.\d+\.\d+$'; then
+            echo "::error::Invalid version format: $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Submit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: OpenWhispr.OpenWhispr
+          release-tag: v${{ steps.release.outputs.version }}
+          installers-regex: 'OpenWhispr-Setup-.*\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -4,12 +4,26 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to submit (e.g. v1.10.1). Defaults to the newest stable app release."
+        required: false
+        type: string
 
 permissions:
   contents: read
 
+# Two releases published back to back would otherwise race two komac
+# submissions against the same fork branch.
+concurrency:
+  group: update-winget
+  cancel-in-progress: false
+
 jobs:
   update-winget:
+    # winget-releaser handles stable releases only, so skip prereleases here
+    # rather than letting the version guard below fail the run.
+    if: github.event_name != 'release' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - name: Get release version
@@ -19,11 +33,18 @@ jobs:
           GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "$EVENT_NAME" = "release" ]; then
             version="$RELEASE_TAG"
+          elif [ -n "$INPUT_TAG" ]; then
+            version="$INPUT_TAG"
           else
-            version=$(gh release view --json tagName -q .tagName)
+            # Not `gh release view`: it resolves to /releases/latest, which
+            # ignores tag shape, and this repo interleaves helper-binary
+            # releases (windows-mic-listener-v1.1.0, ...) with app releases.
+            version=$(gh release list --limit 50 --exclude-drafts --exclude-pre-releases \
+              --json tagName --jq 'map(.tagName) | map(select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | first')
           fi
           version="${version#v}"
           if ! echo "$version" | grep -qP '^\d+\.\d+\.\d+$'; then
@@ -33,7 +54,9 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Submit to winget-pkgs
-        uses: vedantmgoyal9/winget-releaser@v2
+        # Pinned to a commit: a moving tag on a third-party action would be
+        # handed a PAT that can write to every public repo the owner can reach.
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: OpenWhispr.OpenWhispr
           release-tag: v${{ steps.release.outputs.version }}


### PR DESCRIPTION
Fixes the winget 404 reported in #1909 (and #1355).

## The bug

Every winget manifest since 1.7.5 uses GitHub's `latest` alias with a version-pinned filename:

```
https://github.com/OpenWhispr/openwhispr/releases/latest/download/OpenWhispr-Setup-1.9.0.exe
```

`/releases/latest/download/` resolves to whatever the newest release is, so that path 404s the moment the next release ships. Verified:

| URL | Result |
|---|---|
| `latest/download/OpenWhispr-Setup-1.9.2.exe` (1.9.2 *is* latest) | 206 |
| `latest/download/OpenWhispr-Setup-1.9.0.exe` | **404** |
| `download/v1.9.0/OpenWhispr-Setup-1.9.0.exe` (pinned) | 206 |

The project has never owned this package. The oldest manifest (1.7.3, submitted by a different contributor) uses the correct pinned URL and still installs today; everything from 1.7.5 on was submitted by a third-party bot whose tooling emits the `latest` form.

## Why it bites users

The bot lags each release by 18 hours to 2.7 days, and during that lag the newest manifest winget offers is already broken:

| Release | Published | winget PR opened | Lag |
|---|---|---|---|
| 1.9.0 | 08-24 20:29Z | 08-27 12:11Z | 2.7 days |
| 1.9.1 | 08-27 22:31Z | 08-28 16:41Z | 18 hours |
| 1.9.2 | 08-29 18:23Z | 09-01 09:16Z | 2.6 days |

#1909 was filed 08-28 06:22Z — winget was still offering 1.9.0 while GitHub had moved to 1.9.1 eight hours earlier. Exactly the reported symptom.

## The fix

Submit the manifests ourselves on `release: published`. `winget-releaser` feeds komac the release assets' `browser_download_url`, which is always the tag-pinned form, so the URL structurally cannot go stale. Firing on the release event also collapses the submission lag to minutes.

Notes on the implementation:

- The `Get release version` step mirrors `update-nix.yml` so a failed submission can be retried via `workflow_dispatch`. Its `^\d+\.\d+\.\d+$` guard also rejects prerelease tags, so no separate condition is needed.
- `release-tag` is passed explicitly rather than `version`: the action's `release-tag` default is `github.ref_name` on a manual dispatch, which is `main`, not a tag.
- `fork-user` is omitted — it defaults to `github.repository_owner`, which is what we want.
- `installers-regex` is validated against the real v1.9.2 asset list: it matches only `OpenWhispr-Setup-1.9.2.exe`, excluding the portable `OpenWhispr-1.9.2.exe` and the `.blockmap`.
- `GH_REPO` stands in for a checkout, which this job does not otherwise need. Permissions are `contents: read` (`update-nix.yml` needs write only because it pushes a branch here).

## Prerequisites before this can run

1. Classic PAT with `public_repo` scope, stored as the `WINGET_TOKEN` repo secret.
2. A fork of `microsoft/winget-pkgs` under the **OpenWhispr org** — `komac sync-fork` requires it to pre-exist, and the action looks for it under `github.repository_owner`.

Left as draft until those two exist, since the first release after merge is what exercises it.

## Companion change

This fixes new releases going forward but does not repair the five manifests already published with the broken URL. A separate PR to `microsoft/winget-pkgs` rewrites those (one line per version, no sha changes — the existing hashes already match the pinned assets).