### PR TITLE
fix(ai): key custom OpenAI endpoint preference by model and preserve fallback (#2041)

### DIFF
--- a/src/services/ai/inferenceProviders/openai.ts
+++ b/src/services/ai/inferenceProviders/openai.ts
@@ -1,5 +1,5 @@
 import type { InferenceProvider } from "./types";
-import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl } from "../../../config/constants";
+import { API_ENDPOINTS, TOKEN_LIMITS, buildApiUrl, normalizeBaseUrl } from "../../../config/constants";
 import { getOpenAiApiConfig } from "../../../models/ModelRegistry";
 import { getSettings } from "../../../stores/settingsStore";
 import { withRetry, createApiRetryStrategy, httpError } from "../../../utils/retry";
@@ -21,7 +21,22 @@ const PROBE_TIMEOUT_MS = 2_000;
 const endpointPreferenceCache = new Map<string, "responses" | "chat">();
 const probedBases = new Set<string>();
 
-function readStoredPreference(base: string): "responses" | "chat" | undefined {
+function getPreferenceStorageKey(base: string, model?: string): string {
+  const normalizedBase = normalizeBaseUrl(base) || base.trim().replace(/\/+$/, "");
+  const trimmedModel = model?.trim();
+  return trimmedModel ? `${normalizedBase}#${trimmedModel}` : normalizedBase;
+}
+
+function readStoredPreference(base: string, model?: string): "responses" | "chat" | undefined {
+  const normalizedBase = normalizeBaseUrl(base) || base.trim().replace(/\/+$/, "");
+  const modelKey = model ? getPreferenceStorageKey(base, model) : undefined;
+
+  if (modelKey && endpointPreferenceCache.has(modelKey)) {
+    return endpointPreferenceCache.get(modelKey);
+  }
+  if (endpointPreferenceCache.has(normalizedBase)) {
+    return endpointPreferenceCache.get(normalizedBase);
+  }
   if (endpointPreferenceCache.has(base)) {
     return endpointPreferenceCache.get(base);
   }
@@ -35,10 +50,16 @@ function readStoredPreference(base: string): "responses" | "chat" | undefined {
     if (!raw) return undefined;
     const parsed = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return undefined;
-    const value = parsed[base];
-    if (value === "responses" || value === "chat") {
-      endpointPreferenceCache.set(base, value);
-      return value;
+
+    if (modelKey && (parsed[modelKey] === "responses" || parsed[modelKey] === "chat")) {
+      endpointPreferenceCache.set(modelKey, parsed[modelKey]);
+      return parsed[modelKey];
+    }
+
+    const baseValue = parsed[normalizedBase] ?? parsed[base];
+    if (baseValue === "responses" || baseValue === "chat") {
+      endpointPreferenceCache.set(normalizedBase, baseValue);
+      return baseValue;
     }
   } catch {
     return undefined;
@@ -47,8 +68,11 @@ function readStoredPreference(base: string): "responses" | "chat" | undefined {
   return undefined;
 }
 
-function rememberPreference(base: string, preference: "responses" | "chat"): void {
-  endpointPreferenceCache.set(base, preference);
+function rememberPreference(base: string, preference: "responses" | "chat", model?: string): void {
+  const normalizedBase = normalizeBaseUrl(base) || base.trim().replace(/\/+$/, "");
+  const key = getPreferenceStorageKey(base, model);
+
+  endpointPreferenceCache.set(key, preference);
 
   if (typeof window === "undefined" || !window.localStorage) {
     return;
@@ -58,12 +82,23 @@ function rememberPreference(base: string, preference: "responses" | "chat"): voi
     const raw = window.localStorage.getItem(OPENAI_ENDPOINT_PREF_STORAGE_KEY);
     const parsed = raw ? JSON.parse(raw) : {};
     const data = typeof parsed === "object" && parsed !== null ? parsed : {};
-    data[base] = preference;
+    data[key] = preference;
+    if (!model) {
+      data[normalizedBase] = preference;
+    }
     window.localStorage.setItem(OPENAI_ENDPOINT_PREF_STORAGE_KEY, JSON.stringify(data));
   } catch {}
 }
 
-function getEndpointCandidates(base: string): Array<{ url: string; type: "responses" | "chat" }> {
+function clearEndpointPreferenceCache(): void {
+  endpointPreferenceCache.clear();
+  probedBases.clear();
+}
+
+function getEndpointCandidates(
+  base: string,
+  model?: string
+): Array<{ url: string; type: "responses" | "chat" }> {
   const lower = base.toLowerCase();
 
   if (lower.endsWith("/responses") || lower.endsWith("/chat/completions")) {
@@ -71,9 +106,12 @@ function getEndpointCandidates(base: string): Array<{ url: string; type: "respon
     return [{ url: base, type }];
   }
 
-  const preference = readStoredPreference(base);
+  const preference = readStoredPreference(base, model);
   if (preference === "chat") {
-    return [{ url: buildApiUrl(base, "/chat/completions"), type: "chat" }];
+    return [
+      { url: buildApiUrl(base, "/chat/completions"), type: "chat" },
+      { url: buildApiUrl(base, "/responses"), type: "responses" },
+    ];
   }
 
   return [
@@ -189,7 +227,7 @@ export const openaiProvider: InferenceProvider = {
       endpointCandidates = [{ url: buildApiUrl(openAiBase, "/chat/completions"), type: "chat" }];
     } else {
       await detectServerType(openAiBase);
-      endpointCandidates = getEndpointCandidates(openAiBase);
+      endpointCandidates = getEndpointCandidates(openAiBase, model);
     }
     const isCustomEndpoint = openAiBase !== API_ENDPOINTS.OPENAI_BASE;
 
@@ -197,7 +235,7 @@ export const openaiProvider: InferenceProvider = {
       base: openAiBase,
       isCustomEndpoint,
       candidates: endpointCandidates.map((candidate) => candidate.url),
-      preference: readStoredPreference(openAiBase) || null,
+      preference: readStoredPreference(openAiBase, model) || null,
     });
 
     if (isCustomEndpoint) {
@@ -215,7 +253,9 @@ export const openaiProvider: InferenceProvider = {
       let lastError: Error | null = null;
       let lastRetryableError: Error | null = null;
 
-      for (const { url: endpoint, type } of endpointCandidates) {
+      for (let i = 0; i < endpointCandidates.length; i++) {
+        const { url: endpoint, type } = endpointCandidates[i];
+        const hasAlternativeCandidate = i < endpointCandidates.length - 1;
         const controller = new AbortController();
         const timeoutSeconds = getLlmRequestTimeoutSeconds();
         const timeoutId = setTimeout(() => controller.abort(), timeoutSeconds * 1000);
@@ -277,13 +317,16 @@ export const openaiProvider: InferenceProvider = {
             );
 
             const isUnsupportedEndpoint =
-              (res.status === 404 || res.status === 405) && type === "responses";
+              (res.status === 404 || res.status === 405) && hasAlternativeCandidate;
 
             if (isUnsupportedEndpoint) {
               lastError = httpError(errorMessage, res.status);
-              rememberPreference(openAiBase, "chat");
+              const fallbackType = type === "responses" ? "chat" : "responses";
+              rememberPreference(openAiBase, fallbackType, model);
               logger.logReasoning("OPENAI_ENDPOINT_FALLBACK", {
                 attemptedEndpoint: endpoint,
+                fallbackType,
+                model,
                 error: errorMessage,
               });
               continue;
@@ -292,7 +335,7 @@ export const openaiProvider: InferenceProvider = {
             throw httpError(errorMessage, res.status);
           }
 
-          rememberPreference(openAiBase, type);
+          rememberPreference(openAiBase, type, model);
           return res.json();
         } catch (error) {
           if ((error as Error).name === "AbortError") {
@@ -302,9 +345,10 @@ export const openaiProvider: InferenceProvider = {
           if (retryStrategy.shouldRetry(lastError)) {
             lastRetryableError = lastError;
           }
-          if (type === "responses") {
+          if (hasAlternativeCandidate) {
             logger.logReasoning("OPENAI_ENDPOINT_FALLBACK", {
               attemptedEndpoint: endpoint,
+              model,
               error: (error as Error).message,
             });
             continue;
@@ -414,4 +458,11 @@ export const openaiProvider: InferenceProvider = {
 
     return responseText;
   },
+};
+
+export {
+  getEndpointCandidates,
+  readStoredPreference,
+  rememberPreference,
+  clearEndpointPreferenceCache,
 };

--- a/test/services/openaiEndpointPreference.test.js
+++ b/test/services/openaiEndpointPreference.test.js
@@ -1,0 +1,224 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = async () => {
+  const mod = await import("../../src/services/ai/inferenceProviders/openai.ts");
+  return mod.default || mod;
+};
+
+test.beforeEach(async () => {
+  const { clearEndpointPreferenceCache } = await load();
+  clearEndpointPreferenceCache();
+  if (typeof globalThis.window === "undefined") {
+    globalThis.window = {};
+  }
+  const store = new Map();
+  globalThis.window.localStorage = {
+    getItem: (key) => store.get(key) || null,
+    setItem: (key, val) => store.set(key, String(val)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear(),
+  };
+});
+
+test("default endpoint candidates include responses first and chat second", async () => {
+  const { getEndpointCandidates } = await load();
+  const candidates = getEndpointCandidates("https://opencode.ai/zen/go/v1", "gpt-5.6-luna");
+
+  assert.deepEqual(candidates, [
+    { url: "https://opencode.ai/zen/go/v1/responses", type: "responses" },
+    { url: "https://opencode.ai/zen/go/v1/chat/completions", type: "chat" },
+  ]);
+});
+
+test("explicit URL suffixes are preserved as single candidate", async () => {
+  const { getEndpointCandidates } = await load();
+  const respCandidates = getEndpointCandidates("https://opencode.ai/zen/go/v1/responses");
+  assert.deepEqual(respCandidates, [
+    { url: "https://opencode.ai/zen/go/v1/responses", type: "responses" },
+  ]);
+
+  const chatCandidates = getEndpointCandidates("https://opencode.ai/zen/go/v1/chat/completions");
+  assert.deepEqual(chatCandidates, [
+    { url: "https://opencode.ai/zen/go/v1/chat/completions", type: "chat" },
+  ]);
+});
+
+test("preferences are isolated per model on the same base URL", async () => {
+  const { getEndpointCandidates, readStoredPreference, rememberPreference } = await load();
+  const base = "https://opencode.ai/zen/go/v1";
+
+  // Remember 'chat' for grok-4.5
+  rememberPreference(base, "chat", "grok-4.5");
+
+  assert.equal(readStoredPreference(base, "grok-4.5"), "chat");
+  assert.equal(readStoredPreference(base, "gpt-5.6-luna"), undefined);
+
+  // grok-4.5 candidates start with chat
+  const grokCandidates = getEndpointCandidates(base, "grok-4.5");
+  assert.deepEqual(grokCandidates, [
+    { url: "https://opencode.ai/zen/go/v1/chat/completions", type: "chat" },
+    { url: "https://opencode.ai/zen/go/v1/responses", type: "responses" },
+  ]);
+
+  // gpt-5.6-luna candidates still start with responses
+  const lunaCandidates = getEndpointCandidates(base, "gpt-5.6-luna");
+  assert.deepEqual(lunaCandidates, [
+    { url: "https://opencode.ai/zen/go/v1/responses", type: "responses" },
+    { url: "https://opencode.ai/zen/go/v1/chat/completions", type: "chat" },
+  ]);
+
+  // Now remember 'responses' for gpt-5.6-luna
+  rememberPreference(base, "responses", "gpt-5.6-luna");
+  assert.equal(readStoredPreference(base, "gpt-5.6-luna"), "responses");
+  assert.equal(readStoredPreference(base, "grok-4.5"), "chat");
+});
+
+test("falls back from Chat to Responses when Chat returns 404", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestedEndpoints = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const endpoint = String(input);
+    const method = init.method || "GET";
+    requestedEndpoints.push(`${method} ${endpoint}`);
+
+    if (method === "GET" && endpoint.endsWith("/models")) {
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (endpoint.endsWith("/chat/completions")) {
+      return new Response(JSON.stringify({ error: { message: "Chat not supported for this model" } }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (endpoint.endsWith("/responses")) {
+      return new Response(
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: "Responses output" }],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    throw new Error(`Unexpected request: ${method} ${endpoint}`);
+  };
+
+  const { openaiProvider, rememberPreference, readStoredPreference } = await load();
+  const base = "https://opencode.ai/zen/go/v1";
+
+  // Simulate a base-level preference of 'chat' from another model
+  rememberPreference(base, "chat");
+
+  const result = await openaiProvider.call({
+    text: "Clean this text",
+    model: "gpt-5.6-luna",
+    agentName: null,
+    config: {
+      provider: "custom",
+      baseUrl: base,
+      customApiKey: "test-key",
+      systemPrompt: "Clean the transcript",
+    },
+    ctx: {
+      getApiKey: async () => "test-key",
+      getSystemPrompt: () => "Clean the transcript",
+      getCustomDictionary: () => [],
+      getPreferredLanguage: () => "en",
+      getUiLanguage: () => "en",
+      callChatCompletionsApi: async () => {
+        throw new Error("Unexpected chat completions delegation");
+      },
+      calculateMaxTokens: () => 4096,
+    },
+  });
+
+  assert.equal(result, "Responses output");
+  // Verified chat was attempted first, then responses succeeded
+  assert.ok(requestedEndpoints.includes("POST https://opencode.ai/zen/go/v1/chat/completions"));
+  assert.ok(requestedEndpoints.includes("POST https://opencode.ai/zen/go/v1/responses"));
+
+  // Subsequent call for gpt-5.6-luna now has 'responses' remembered
+  assert.equal(readStoredPreference(base, "gpt-5.6-luna"), "responses");
+});
+
+test("falls back from Responses to Chat when Responses returns 404", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const requestedEndpoints = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const endpoint = String(input);
+    const method = init.method || "GET";
+    requestedEndpoints.push(`${method} ${endpoint}`);
+
+    if (method === "GET" && endpoint.endsWith("/models")) {
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (endpoint.endsWith("/responses")) {
+      return new Response(JSON.stringify({ error: { message: "Responses unsupported" } }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (endpoint.endsWith("/chat/completions")) {
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "Chat output" } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    throw new Error(`Unexpected request: ${method} ${endpoint}`);
+  };
+
+  const { openaiProvider, readStoredPreference } = await load();
+  const base = "https://opencode.ai/zen/go/v1";
+
+  const result = await openaiProvider.call({
+    text: "Clean this text",
+    model: "grok-4.5",
+    agentName: null,
+    config: {
+      provider: "custom",
+      baseUrl: base,
+      customApiKey: "test-key",
+      systemPrompt: "Clean the transcript",
+    },
+    ctx: {
+      getApiKey: async () => "test-key",
+      getSystemPrompt: () => "Clean the transcript",
+      getCustomDictionary: () => [],
+      getPreferredLanguage: () => "en",
+      getUiLanguage: () => "en",
+      callChatCompletionsApi: async () => {
+        throw new Error("Unexpected chat completions delegation");
+      },
+      calculateMaxTokens: () => 4096,
+    },
+  });
+
+  assert.equal(result, "Chat output");
+  assert.equal(readStoredPreference(base, "grok-4.5"), "chat");
+});

--- a/test/services/openaiEndpointRetry.test.js
+++ b/test/services/openaiEndpointRetry.test.js
@@ -1,7 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const load = () => import("../../src/services/ai/inferenceProviders/openai.ts");
+const load = async () => {
+  const mod = await import("../../src/services/ai/inferenceProviders/openai.ts");
+  return mod.default || mod;
+};
 
 test("Responses retries when a permanent Chat fallback follows a transient failure", async (t) => {
   t.mock.timers.enable({ apis: ["setTimeout"] });


### PR DESCRIPTION
Fixes #2041

## Problem

When using a custom OpenAI-compatible endpoint (such as a Bring-Your-Own-Model gateway or multi-model proxy like OpenCode Go or LiteLLM), different models served under the same base URL may require different transports (`/responses` vs `/chat/completions`).

Previously in `src/services/ai/inferenceProviders/openai.ts`:
1. `openAiEndpointPreference` in the in-memory cache and `localStorage` was keyed strictly by the base URL (`base`).
2. When any model successfully completed a request via `/chat/completions` (or triggered a `/responses` 404), `rememberPreference(openAiBase, "chat")` recorded `"chat"` for the whole base URL.
3. Subsequent requests for *any* model on that base URL called `getEndpointCandidates(base)`, which unconditionally dropped `/responses` and returned only `[{ url: .../chat/completions, type: "chat" }]`.
4. When the user then switched to a model requiring the Responses API (such as `gpt-5.6-luna`), OpenWhispr sent the request to `/chat/completions`, received an error (e.g., 400 or 500 `Internal server error`), and aborted because no alternative candidate was available.
5. The endpoint fallback in the retry loop only handled fallback from `type === "responses"` to `"chat"`, and threw immediately on any error from `"chat"`.

## Fix

1. **Key endpoint preferences by `(base, model)`**:
   - Preferences in `endpointPreferenceCache` and `localStorage` are keyed by `${base}#${model}`, allowing each model on a shared base URL to retain its own successful transport route.
   - Preserves fallback to `base` when a model-specific preference is not yet recorded (e.g. server-wide llama.cpp detection via `detectServerType`).
2. **Retain candidate ordering with fallback**:
   - When preference is `"chat"`, return `[/chat/completions, /responses]`.
   - When preference is `"responses"` or unset, return `[/responses, /chat/completions]`.
   - When the preferred candidate succeeds (as expected), exactly 1 request is made with 0 extra overhead.
   - When an endpoint returns 404 or 405 (or fails with an unsupported endpoint error) and an alternative candidate exists, the retry loop records the alternate preference for that specific model and seamlessly falls back to the other candidate.
3. **Export helpers for deterministic testing**:
   - Exported `getEndpointCandidates`, `readStoredPreference`, `rememberPreference`, and `clearEndpointPreferenceCache`.

## Testing

- Added `test/services/openaiEndpointPreference.test.js` covering:
  - Default candidate ordering (`/responses` then `/chat/completions`).
  - Explicit URL suffix preservation (`/responses` or `/chat/completions`).
  - Preference isolation per model on the same base URL (e.g. `grok-4.5` on `chat` and `gpt-5.6-luna` on `responses`).
  - Fallback from `chat` to `responses` on 404.
  - Fallback from `responses` to `chat` on 404.
- Updated `test/services/openaiEndpointRetry.test.js` to handle CJS/ESM interop in the test loader.
- Verified test suite: `node --import tsx --test test/services/openaiEndpointPreference.test.js test/services/openaiEndpointRetry.test.js` passed (6/6 tests).
- Ran `npm run lint` and `npm run i18n:check` (clean).