### PR TITLE
fix(linux): align push-to-talk watchdog with 5-minute platform ceiling (#2047)

### DIFF
--- a/src/helpers/linuxKeyManager.js
+++ b/src/helpers/linuxKeyManager.js
@@ -6,14 +6,16 @@ const debugLogger = require("./debugLogger");
 
 // Force a key-up if the native listener never reports one (e.g. a missed release
 // while another window had focus), so a held key can't get stuck recording.
-const WATCHDOG_MS = 30000;
+// Aligned with Windows and macOS push-to-talk maximum duration (5 minutes, #1594, #2047).
+const WATCHDOG_MS = 300000;
 
 class LinuxKeyManager extends EventEmitter {
-  constructor() {
+  constructor(options = {}) {
     super();
-    this.isSupported = process.platform === "linux";
+    this.isSupported = options.isSupported ?? process.platform === "linux";
     this.hasReportedError = false;
     this.hasReportedUnavailable = false;
+    this.watchdogMs = typeof options.watchdogMs === "number" ? options.watchdogMs : WATCHDOG_MS;
     this.listeners = new Map(); // key string -> { child, watchdog }
   }
 
@@ -110,7 +112,7 @@ class LinuxKeyManager extends EventEmitter {
     if (entry.watchdog) clearTimeout(entry.watchdog);
     debugLogger.debug("[LinuxKeyManager] Stopping key listener", { key });
     try {
-      entry.child.kill();
+      entry.child?.kill?.();
     } catch {
       // Already gone
     }
@@ -135,12 +137,13 @@ class LinuxKeyManager extends EventEmitter {
       if (entry) {
         if (entry.watchdog) clearTimeout(entry.watchdog);
         entry.watchdog = setTimeout(() => {
-          debugLogger.warn("[LinuxKeyManager] Watchdog: no KEY_UP within 30s, forcing release", {
-            key,
-          });
+          debugLogger.warn(
+            `[LinuxKeyManager] Watchdog: no KEY_UP within ${Math.round(this.watchdogMs / 1000)}s, forcing release`,
+            { key }
+          );
           entry.watchdog = null;
           this.emit("key-up", key);
-        }, WATCHDOG_MS);
+        }, this.watchdogMs);
       }
       this.emit("key-down", key);
       return;
@@ -230,5 +233,8 @@ class LinuxKeyManager extends EventEmitter {
     return null;
   }
 }
+
+LinuxKeyManager.WATCHDOG_MS = WATCHDOG_MS;
+LinuxKeyManager.DEFAULT_WATCHDOG_MS = WATCHDOG_MS;
 
 module.exports = LinuxKeyManager;

--- a/test/helpers/linuxKeyManager.test.js
+++ b/test/helpers/linuxKeyManager.test.js
@@ -1,0 +1,108 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("module");
+
+const originalLoad = Module._load;
+Module._load = function loadWithMocks(request, parent, isMain) {
+  if (request === "./debugLogger" || request.endsWith("/debugLogger")) {
+    return { info() {}, warn() {}, debug() {}, error() {} };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const LinuxKeyManager = require("../../src/helpers/linuxKeyManager");
+
+test("LinuxKeyManager exports 5-minute platform ceiling", () => {
+  assert.equal(LinuxKeyManager.WATCHDOG_MS, 300000);
+  assert.equal(LinuxKeyManager.DEFAULT_WATCHDOG_MS, 300000);
+
+  const manager = new LinuxKeyManager();
+  assert.equal(manager.watchdogMs, 300000);
+});
+
+test("LinuxKeyManager accepts custom watchdog duration in constructor options", () => {
+  const manager = new LinuxKeyManager({ watchdogMs: 15000 });
+  assert.equal(manager.watchdogMs, 15000);
+});
+
+test("watchdog does not prematurely release at 30 seconds under 5-minute ceiling", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(() => {
+    t.mock.timers.reset();
+  });
+
+  const manager = new LinuxKeyManager({ isSupported: true });
+  manager.listeners.set("Control+Space", { child: null, watchdog: null });
+
+  let keyUpEmitted = false;
+  manager.on("key-up", () => {
+    keyUpEmitted = true;
+  });
+
+  manager.handleOutputLine("KEY_DOWN", "Control+Space");
+
+  // Advance 30 seconds (old premature timeout)
+  t.mock.timers.tick(30000);
+  assert.equal(keyUpEmitted, false, "Should not emit key-up at 30s");
+
+  // Advance 60 seconds (1.5 minutes total)
+  t.mock.timers.tick(60000);
+  assert.equal(keyUpEmitted, false, "Should not emit key-up at 90s");
+
+  // Advance to 300,000 ms (5 minutes total)
+  t.mock.timers.tick(210000);
+  assert.equal(keyUpEmitted, true, "Should emit key-up at 5-minute ceiling");
+});
+
+test("watchdog is cleared when KEY_UP is received before timeout", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(() => {
+    t.mock.timers.reset();
+  });
+
+  const manager = new LinuxKeyManager({ isSupported: true, watchdogMs: 300000 });
+  manager.listeners.set("Control+Space", { child: null, watchdog: null });
+
+  const events = [];
+  manager.on("key-down", (k) => events.push(`down:${k}`));
+  manager.on("key-up", (k) => events.push(`up:${k}`));
+
+  manager.handleOutputLine("KEY_DOWN", "Control+Space");
+  assert.deepEqual(events, ["down:Control+Space"]);
+
+  // User speaks for 45 seconds and releases key
+  t.mock.timers.tick(45000);
+  manager.handleOutputLine("KEY_UP", "Control+Space");
+  assert.deepEqual(events, ["down:Control+Space", "up:Control+Space"]);
+
+  const entry = manager.listeners.get("Control+Space");
+  assert.equal(entry.watchdog, null, "Watchdog timer should be cleared");
+
+  // Advance past 5 minutes to verify no extra synthetic key-up fires
+  t.mock.timers.tick(300000);
+  assert.deepEqual(events, ["down:Control+Space", "up:Control+Space"]);
+});
+
+test("stopping a key cancels any active watchdog", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(() => {
+    t.mock.timers.reset();
+  });
+
+  const manager = new LinuxKeyManager({ isSupported: true });
+  manager.listeners.set("Control+Space", { child: { kill: () => {} }, watchdog: null });
+
+  let keyUpFired = false;
+  manager.on("key-up", () => {
+    keyUpFired = true;
+  });
+
+  manager.handleOutputLine("KEY_DOWN", "Control+Space");
+  assert.ok(manager.listeners.get("Control+Space").watchdog !== null);
+
+  manager._stopKey("Control+Space");
+  assert.equal(manager.listeners.has("Control+Space"), false);
+
+  t.mock.timers.tick(350000);
+  assert.equal(keyUpFired, false, "Cancelled watchdog should not fire after stop");
+});


### PR DESCRIPTION
Refs #2047
Refs #1594

## Problem

In push-to-talk (Hold) mode on Linux, `LinuxKeyManager` hardcoded a 30-second watchdog timer (`WATCHDOG_MS = 30000`). When a user held the hotkey for longer than 30 seconds:
1. The watchdog fired and synthesized a `key-up` event after 30s, stopping the dictation while the hotkey was still physically held down.
2. In `windowManager.js`, macOS and Windows already define `MAX_PUSH_DURATION_MS = 300000` (5 minutes) as the protective ceiling for stuck recordings. Linux was given 10x less headroom.
3. Because the user was still physically holding the trigger modifier keys (e.g. `Control+Space`), the subsequent auto-paste step injected a synthetic paste shortcut into the still-held modifiers, causing the paste to fail or corrupt, and the transcription to be silently lost.

## Fix

1. Align `WATCHDOG_MS` in `src/helpers/linuxKeyManager.js` to `300000` (5 minutes / 300 seconds), matching `MAX_PUSH_DURATION_MS` across platforms in `windowManager.js`.
2. Allow `watchdogMs` to be configured via constructor options (defaulting to `WATCHDOG_MS`), improving testability and flexibility.
3. Accurately reflect the watchdog duration in seconds in debug logs.
4. Export `LinuxKeyManager.WATCHDOG_MS` and `LinuxKeyManager.DEFAULT_WATCHDOG_MS` static constants.

## Testing

- Added `test/helpers/linuxKeyManager.test.js` covering:
  - 5-minute default ceiling export and instance initialization.
  - Custom watchdog duration configuration via constructor options.
  - Verified that holding beyond 30 seconds does not trigger premature `key-up` release under the 5-minute ceiling.
  - Verified watchdog is armed and fires at 300,000 ms when `KEY_UP` is missing.
  - Verified watchdog is cancelled immediately when physical `KEY_UP` is received.
  - Verified `_stopKey` cancels any pending watchdog timer.
- Ran test suite: `node --import tsx --test test/helpers/linuxKeyManager.test.js` passed (5/5 tests).
- Ran `npm run lint` and `npm run i18n:check` (clean).
