### PR TITLE
fix(transcription): normalize underscore, casing, and whitespace in base language resolution

### DIFF
--- a/src/helpers/transcriptionRoute.ts
+++ b/src/helpers/transcriptionRoute.ts
@@ -27,6 +27,7 @@ import {
   type TranscriptionProviderBaseUrl,
 } from "../services/transcriptionBaseUrl.ts";
 import type { ManagedEnterpriseRequestContext } from "../types/enterpriseIdentity.ts";
+import { getBaseLanguageCode } from "../utils/languageSupport.ts";
 
 const BYOK_FILE_SIZE_LIMIT = 25 * 1024 * 1024;
 
@@ -212,11 +213,7 @@ export function resolveTranscriptionRoute({
 }: TranscriptionRouteInput): TranscriptionRoute {
   const s = settings || {};
   const managed = policy?.status === "managed";
-  const language =
-    request?.effectiveLanguage ??
-    (!s.preferredLanguage || s.preferredLanguage === "auto"
-      ? undefined
-      : s.preferredLanguage.split("-")[0]);
+  const language = getBaseLanguageCode(request?.effectiveLanguage ?? s.preferredLanguage);
 
   // Managed enterprise STT outranks every personal setting; the resolution is
   // already policy-checked where it was computed (enterpriseIdentityStore /

--- a/src/utils/languageSupport.ts
+++ b/src/utils/languageSupport.ts
@@ -1,4 +1,4 @@
-import registry from "../config/languageRegistry.json";
+import registry from "../config/languageRegistry.json" with { type: "json" };
 
 function buildLanguageSet(key: "whisper" | "assemblyai"): Set<string> {
   const set = new Set<string>();
@@ -25,8 +25,11 @@ const LANGUAGE_INSTRUCTIONS: Record<string, string> = Object.fromEntries(
 );
 
 export function getBaseLanguageCode(language: string | null | undefined): string | undefined {
-  if (!language || language === "auto") return undefined;
-  return language.split("-")[0];
+  if (typeof language !== "string") return undefined;
+  const trimmed = language.trim().replace(/_/g, "-");
+  if (!trimmed || trimmed.toLowerCase() === "auto") return undefined;
+  const base = trimmed.split("-")[0].toLowerCase();
+  return base || undefined;
 }
 
 export function getLanguageInstruction(language: string | undefined): string {

--- a/test/helpers/transcriptionRoute.test.js
+++ b/test/helpers/transcriptionRoute.test.js
@@ -1,7 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const load = () => import("../../src/helpers/transcriptionRoute.ts");
+const load = async () => {
+  const mod = await import("../../src/helpers/transcriptionRoute.ts");
+  return mod.resolveTranscriptionRoute ? mod : mod.default;
+};
 
 const resolve = async (settings, extra = {}) => {
   const { resolveTranscriptionRoute } = await load();
@@ -284,6 +287,26 @@ test("request overrides win: explicit model and effective language", async () =>
   );
   assert.equal(route.model, "whisper-large-v3");
   assert.equal(route.language, "ja");
+});
+
+test("normalizes underscore-separated and padded locales for route language and xAI support", async () => {
+  const xaiRoute = await resolve({
+    cloudTranscriptionProvider: "xai",
+    preferredLanguage: "pt_BR",
+  });
+  assert.equal(xaiRoute.language, "pt");
+
+  const groqRoute = await resolve(
+    { cloudTranscriptionProvider: "groq", preferredLanguage: "en-US" },
+    { request: { effectiveLanguage: "  zh_CN  " } }
+  );
+  assert.equal(groqRoute.language, "zh");
+
+  const autoRoute = await resolve({
+    cloudTranscriptionProvider: "openai",
+    preferredLanguage: "auto",
+  });
+  assert.equal(autoRoute.language, undefined);
 });
 
 const MANAGED_STT = {

--- a/test/utils/languageSupport.test.js
+++ b/test/utils/languageSupport.test.js
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = async () => {
+  const mod = await import("../../src/utils/languageSupport.ts");
+  return mod.getBaseLanguageCode ? mod : mod.default;
+};
+
+test("getBaseLanguageCode extracts primary subtag from simple codes", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("en"), "en");
+  assert.equal(getBaseLanguageCode("es"), "es");
+  assert.equal(getBaseLanguageCode("zh"), "zh");
+  assert.equal(getBaseLanguageCode("pt"), "pt");
+});
+
+test("getBaseLanguageCode normalizes hyphen-separated language tags", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("en-US"), "en");
+  assert.equal(getBaseLanguageCode("zh-CN"), "zh");
+  assert.equal(getBaseLanguageCode("pt-BR"), "pt");
+  assert.equal(getBaseLanguageCode("es-419"), "es");
+});
+
+test("getBaseLanguageCode normalizes underscore-separated locales", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("zh_CN"), "zh");
+  assert.equal(getBaseLanguageCode("pt_BR"), "pt");
+  assert.equal(getBaseLanguageCode("de_DE"), "de");
+  assert.equal(getBaseLanguageCode("es_ES"), "es");
+  assert.equal(getBaseLanguageCode("fr_FR"), "fr");
+  assert.equal(getBaseLanguageCode("en_GB"), "en");
+});
+
+test("getBaseLanguageCode lowercases uppercase and mixed-case inputs", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("EN"), "en");
+  assert.equal(getBaseLanguageCode("EN-US"), "en");
+  assert.equal(getBaseLanguageCode("ZH_CN"), "zh");
+  assert.equal(getBaseLanguageCode("Pt-Br"), "pt");
+});
+
+test("getBaseLanguageCode trims leading and trailing whitespace", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("  en  "), "en");
+  assert.equal(getBaseLanguageCode("  zh_CN  "), "zh");
+  assert.equal(getBaseLanguageCode("\tes-ES\n"), "es");
+  assert.equal(getBaseLanguageCode("  pt-BR  "), "pt");
+});
+
+test("getBaseLanguageCode returns undefined for auto, empty, or non-string inputs", async () => {
+  const { getBaseLanguageCode } = await load();
+
+  assert.equal(getBaseLanguageCode("auto"), undefined);
+  assert.equal(getBaseLanguageCode("AUTO"), undefined);
+  assert.equal(getBaseLanguageCode("  auto  "), undefined);
+  assert.equal(getBaseLanguageCode(""), undefined);
+  assert.equal(getBaseLanguageCode("   "), undefined);
+  assert.equal(getBaseLanguageCode(null), undefined);
+  assert.equal(getBaseLanguageCode(undefined), undefined);
+  assert.equal(getBaseLanguageCode(123), undefined);
+});


### PR DESCRIPTION
## Problem

In `src/utils/languageSupport.ts` and `src/helpers/transcriptionRoute.ts`, language resolution relied on splitting solely by hyphen:

```ts
export function getBaseLanguageCode(language: string | null | undefined): string | undefined {
  if (!language || language === "auto") return undefined;
  return language.split("-")[0];
}
```

And in `src/helpers/transcriptionRoute.ts`:

```ts
const language =
  request?.effectiveLanguage ??
  (!s.preferredLanguage || s.preferredLanguage === "auto"
    ? undefined
    : s.preferredLanguage.split("-")[0]);
```

When system locales, environment variables, or user settings format languages with underscores (e.g. `zh_CN`, `pt_BR`, `de_DE`, `es_ES`, `fr_FR`—the standard POSIX/Linux format and common in Windows exports), with whitespace (`"  es_ES  "`), or uppercase (`"EN-US"`):
1. `getBaseLanguageCode("pt_BR")` and `getBaseLanguageCode("zh_CN")` return `"pt_BR"` and `"zh_CN"`, failing to extract the base language code (`"pt"`, `"zh"`).
2. In `transcriptionRoute.ts`, `XAI_STT_LANGUAGES.has(language)` check fails because `XAI_STT_LANGUAGES` only contains 2-letter codes (`"pt"`, `"zh"`, etc.). As a result, xAI drops the language parameter entirely and disables language-specific text normalization (ITN).
3. `getBaseLanguageCode` passes `"pt_BR"` or `"zh_CN"` directly to cloud STT APIs (OpenAI, Groq, Mistral, Corti, Gemini), which require standard 2-letter ISO 639-1 language codes, resulting in 400 Bad Request errors or degraded transcription.
4. If `request?.effectiveLanguage` is provided to `resolveTranscriptionRoute`, it was passed through raw without extracting the primary subtag or trimming.

## Fix

1. **Robust base language code resolution in `src/utils/languageSupport.ts`**:
   - Trim whitespace and normalize underscores to hyphens before splitting.
   - Lowercase the extracted base language subtag so mixed/uppercase inputs (`"EN-US"`, `"ZH_CN"`) produce valid ISO 639-1 codes (`"en"`, `"zh"`).
   - Add `with { type: "json" }` attribute to `languageRegistry.json` import so the utility can be cleanly loaded across renderer and Node/main-process ESM contexts.
2. **Standardize language resolution in `src/helpers/transcriptionRoute.ts`**:
   - Use `getBaseLanguageCode(request?.effectiveLanguage ?? s.preferredLanguage)` so both effective language overrides and preferred language settings are uniformly normalized.
   - Retains proper language passing for xAI, OpenAI, Groq, Mistral, Corti, Gemini, self-hosted, and managed enterprise routes.

## Testing

- Added `test/utils/languageSupport.test.js`:
  - Verified simple codes (`en`, `es`, `zh`, `pt`).
  - Verified hyphenated tags (`en-US`, `zh-CN`, `pt-BR`, `es-419`).
  - Verified underscore-separated locales (`zh_CN`, `pt_BR`, `de_DE`, `es_ES`, `fr_FR`, `en_GB`).
  - Verified case normalization (`EN`, `EN-US`, `ZH_CN`, `Pt-Br`).
  - Verified whitespace trimming (`"  en  "`, `"  zh_CN  "`, `"\tes-ES\n"`).
  - Verified empty, null, undefined, auto, and non-string inputs return `undefined`.
- Extended `test/helpers/transcriptionRoute.test.js`:
  - Verified underscore and padded locale normalization for route language and xAI support (`pt_BR` -> `pt` retained for xAI; `  zh_CN  ` -> `zh` for Groq; `auto` -> `undefined`).
  - Verified all 19 tests pass under both `node --test` and `node --import tsx --test`.
- Passed `npm run lint` and `npm run i18n:check`.