### PR TITLE
fix(audio): guard nullish and empty labels in microphone detection and resolution

### DIFF
--- a/src/helpers/microphoneSelection.js
+++ b/src/helpers/microphoneSelection.js
@@ -1,5 +1,5 @@
-import { isBuiltInMicrophone } from "../utils/audioDeviceUtils";
-import { resolveMicDeviceSelection } from "./micDeviceSelection";
+import { isBuiltInMicrophone } from "../utils/audioDeviceUtils.ts";
+import { resolveMicDeviceSelection } from "./micDeviceSelection.js";
 
 export const MICROPHONE_SELECTION_MODES = ["system", "built-in", "specific"];
 
@@ -14,6 +14,9 @@ export function getMicrophoneSelectionMode(settings = {}) {
 }
 
 export function normalizeMicrophoneLabel(label = "") {
+  if (typeof label !== "string" || !label) {
+    return "";
+  }
   return String(label)
     .normalize("NFKC")
     .replace(/^\s*(?:default|communications)\s*-\s*/i, "")

--- a/src/utils/audioDeviceUtils.ts
+++ b/src/utils/audioDeviceUtils.ts
@@ -7,7 +7,10 @@
  * Determines if a microphone device is a built-in device based on its label.
  * Works across macOS, Windows, and Linux platforms.
  */
-export function isBuiltInMicrophone(label: string): boolean {
+export function isBuiltInMicrophone(label?: string | null): boolean {
+  if (typeof label !== "string" || !label.trim()) {
+    return false;
+  }
   const lowerLabel = label.toLowerCase();
 
   // Direct built-in indicators

--- a/test/helpers/microphoneSelection.test.js
+++ b/test/helpers/microphoneSelection.test.js
@@ -3,8 +3,13 @@ const assert = require("node:assert/strict");
 
 const mic = (deviceId, label) => ({ kind: "audioinput", deviceId, label });
 
+const load = async () => {
+  const mod = await import("../../src/helpers/microphoneSelection.js");
+  return mod.resolveMicrophoneSelection ? mod : mod.default;
+};
+
 test("system mode maps the native default name to an exact Chromium input", async () => {
-  const { resolveMicrophoneSelection } = await import("../../src/helpers/microphoneSelection.js");
+  const { resolveMicrophoneSelection } = await load();
   const expected = mic("macbook", "MacBook Pro Microphone (Built-in)");
   const result = resolveMicrophoneSelection(
     [mic("default", "Default - MacBook Pro Microphone (Built-in)"), expected],
@@ -17,8 +22,7 @@ test("system mode maps the native default name to an exact Chromium input", asyn
 });
 
 test("system mode uses Chromium's explicit default device when native mapping is unavailable", async () => {
-  const { isCacheableMicrophoneResolution, resolveMicrophoneSelection } =
-    await import("../../src/helpers/microphoneSelection.js");
+  const { isCacheableMicrophoneResolution, resolveMicrophoneSelection } = await load();
   const expected = mic("default", "Default - Microphone Array");
   const result = resolveMicrophoneSelection([expected, mic("continuity", "Joshua P Microphone")], {
     microphoneSelectionMode: "system",
@@ -30,8 +34,7 @@ test("system mode uses Chromium's explicit default device when native mapping is
 });
 
 test("a resolved physical microphone can be cached", async () => {
-  const { isCacheableMicrophoneResolution, resolveMicrophoneSelection } =
-    await import("../../src/helpers/microphoneSelection.js");
+  const { isCacheableMicrophoneResolution, resolveMicrophoneSelection } = await load();
   const result = resolveMicrophoneSelection(
     [mic("default", "Default - USB Microphone"), mic("usb", "USB Microphone")],
     { microphoneSelectionMode: "system" },
@@ -42,7 +45,7 @@ test("a resolved physical microphone can be cached", async () => {
 });
 
 test("system mode never guesses the first physical microphone", async () => {
-  const { resolveMicrophoneSelection } = await import("../../src/helpers/microphoneSelection.js");
+  const { resolveMicrophoneSelection } = await load();
   const result = resolveMicrophoneSelection(
     [mic("continuity", "Joshua P Microphone"), mic("usb", "USB Microphone")],
     { microphoneSelectionMode: "system" },
@@ -54,7 +57,7 @@ test("system mode never guesses the first physical microphone", async () => {
 });
 
 test("legacy microphone preferences retain their behavior", async () => {
-  const { getMicrophoneSelectionMode } = await import("../../src/helpers/microphoneSelection.js");
+  const { getMicrophoneSelectionMode } = await load();
 
   assert.equal(getMicrophoneSelectionMode({ preferBuiltInMic: true }), "built-in");
   assert.equal(
@@ -62,4 +65,45 @@ test("legacy microphone preferences retain their behavior", async () => {
     "specific"
   );
   assert.equal(getMicrophoneSelectionMode({ preferBuiltInMic: false }), "system");
+});
+
+test("built-in mode safely skips devices with null, undefined, or empty labels without throwing", async () => {
+  const { resolveMicrophoneSelection } = await load();
+  const unlabeled = { kind: "audioinput", deviceId: "raw-mic-1" };
+  const nullLabel = { kind: "audioinput", deviceId: "raw-mic-2", label: null };
+  const emptyLabel = { kind: "audioinput", deviceId: "raw-mic-3", label: "" };
+
+  const result = resolveMicrophoneSelection([unlabeled, nullLabel, emptyLabel], {
+    microphoneSelectionMode: "built-in",
+  });
+
+  assert.equal(result.device, null);
+  assert.equal(result.status, "unavailable");
+});
+
+test("built-in mode finds real built-in mic even among unlabeled devices", async () => {
+  const { resolveMicrophoneSelection } = await load();
+  const unlabeled = { kind: "audioinput", deviceId: "raw-mic-1" };
+  const nullLabel = { kind: "audioinput", deviceId: "raw-mic-2", label: null };
+  const builtIn = mic("macbook", "MacBook Pro Microphone");
+
+  const result = resolveMicrophoneSelection([unlabeled, nullLabel, builtIn], {
+    microphoneSelectionMode: "built-in",
+  });
+
+  assert.equal(result.device, builtIn);
+  assert.equal(result.status, "built-in");
+});
+
+test("normalizeMicrophoneLabel handles null, undefined, and non-string inputs safely", async () => {
+  const { normalizeMicrophoneLabel } = await load();
+
+  assert.equal(normalizeMicrophoneLabel(null), "");
+  assert.equal(normalizeMicrophoneLabel(undefined), "");
+  assert.equal(normalizeMicrophoneLabel(""), "");
+  assert.equal(normalizeMicrophoneLabel(123), "");
+  assert.equal(
+    normalizeMicrophoneLabel("  Default - Built-in Microphone (Built-in)  "),
+    "built-in microphone"
+  );
 });

--- a/test/utils/audioDeviceUtils.test.js
+++ b/test/utils/audioDeviceUtils.test.js
@@ -3,7 +3,10 @@ const assert = require("node:assert/strict");
 
 // Requires Node's native TypeScript type-stripping (Node >= 22.6 with
 // --experimental-strip-types, on by default in Node 23.6+/24). CI runs Node 24.
-const load = () => import("../../src/utils/audioDeviceUtils.ts");
+const load = async () => {
+  const mod = await import("../../src/utils/audioDeviceUtils.ts");
+  return mod.isBuiltInMicrophone ? mod : mod.default;
+};
 
 test("a phone microphone is never classified as built-in", async () => {
   const { isBuiltInMicrophone } = await load();
@@ -40,4 +43,14 @@ test("headphone and headset microphones are external", async () => {
   assert.equal(isBuiltInMicrophone("Wired Headphones Microphone"), false);
   assert.equal(isBuiltInMicrophone("USB Headset Microphone"), false);
   assert.equal(isBuiltInMicrophone("AirPods Pro"), false);
+});
+
+test("nullish, empty, or non-string labels are never classified as built-in and do not throw", async () => {
+  const { isBuiltInMicrophone } = await load();
+
+  assert.equal(isBuiltInMicrophone(undefined), false);
+  assert.equal(isBuiltInMicrophone(null), false);
+  assert.equal(isBuiltInMicrophone(""), false);
+  assert.equal(isBuiltInMicrophone("   "), false);
+  assert.equal(isBuiltInMicrophone(123), false);
 });


### PR DESCRIPTION
## Problem

In `src/utils/audioDeviceUtils.ts`:

```ts
export function isBuiltInMicrophone(label: string): boolean {
  const lowerLabel = label.toLowerCase();
```

And in `src/helpers/microphoneSelection.js`:

```js
export function normalizeMicrophoneLabel(label = "") {
  return String(label)...
```

1. **Uncaught TypeError on devices without labels**:
   `isBuiltInMicrophone(candidate.label)` is called across `src/helpers/microphoneSelection.js` (line 83) during built-in microphone resolution and in `src/components/ui/MicrophoneSettings.tsx` (line 65). When audio permissions have not yet been granted, or when virtual/USB/headless audio devices enumerate with `label: ""` or without a `label` property (`undefined` or `null`), passing `candidate.label` throws an unhandled:
   `TypeError: Cannot read properties of undefined (reading 'toLowerCase\)`
   This crashes microphone resolution and aborts settings initialization.
2. **String coercion of `null`**:
   `normalizeMicrophoneLabel(null)` defaulted only for `undefined` via ES6 default parameters, coercing `null` via `String(null)` to `"null"`, which compares as a literal device name rather than an empty string.

## Fix

1. **Nullish & Empty Safety in `src/utils/audioDeviceUtils.ts`**:
   - Guard `isBuiltInMicrophone(label?: string | null)`: return `false` immediately if `label` is not a non-empty string.
2. **Safe Label Normalization in `src/helpers/microphoneSelection.js`**:
   - Check `typeof label !== "string" || !label` and return `""` immediately in `normalizeMicrophoneLabel`.
   - Add explicit module extensions on internal imports (`.ts` and `.js`) so the module loads cleanly across both bundled and Node test environments.

## Testing

- Updated `test/utils/audioDeviceUtils.test.js`:
  - Added test case verifying `isBuiltInMicrophone` returns `false` and does not throw for `undefined`, `null`, `""`, `"   "`, and non-string values.
- Extended `test/helpers/microphoneSelection.test.js`:
  - Verified built-in mode safely skips devices with `null`, `undefined`, or empty labels without throwing.
  - Verified built-in mode finds the real built-in microphone in the presence of unlabeled devices.
  - Verified `normalizeMicrophoneLabel` safely returns `""` for `null`, `undefined`, `""`, and non-string inputs.
  - Verified all 12 tests pass under both `node --test` and `node --import tsx --test`.
- Passed `npm run lint` and `npm run i18n:check`.