### PR TITLE
fix(macos): use the arm64-native ONNX Runtime slice for sherpa-onnx on Apple silicon (~3x faster Parakeet/Orukeet)

### DIFF
--- a/scripts/download-sherpa-onnx.js
+++ b/scripts/download-sherpa-onnx.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
+const crypto = require("crypto");
 const {
   cleanupFiles,
   downloadFile,
@@ -29,6 +30,18 @@ const GITHUB_RELEASE_URL = `https://github.com/k2-fsa/sherpa-onnx/releases/downl
 // and sherpa-onnx picks them up.
 const WINDOWS_ONNXRUNTIME_UPSTREAM_NAME = "onnxruntime.dll";
 const WINDOWS_ONNXRUNTIME_PRIVATE_NAME = "ow-onnxrt.dll";
+
+// sherpa-onnx's macOS archives bundle a universal2 libonnxruntime whose arm64
+// slice runs INT8 models ~3x slower than the arm64-only build of the same
+// version from the same maintainer (the zip sherpa-onnx's own
+// cmake/onnxruntime-osx-arm64.cmake pins). On macOS hosts we swap that slice
+// in and keep the x86_64 slice, so the file stays universal2.
+const MACOS_ARM64_ONNXRUNTIME = {
+  url: "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.0/onnxruntime-osx-arm64-1.27.0.zip",
+  sha256: "5f05b2653eb0af852dab46c85778f0e012c514ed2e71a6dbb9c9550434b0a514",
+  libraryName: "libonnxruntime.1.27.0.dylib",
+  marker: "arm64-1.27.0", // recorded in the install marker so older installs re-extract
+};
 
 // Binary configurations for each platform
 // Note: macOS uses universal2 builds that work on both arm64 and x64
@@ -81,10 +94,45 @@ const BIN_DIR = path.join(__dirname, "..", "resources", "bin");
 const VERSIONED_LIB_PATTERN = /^(lib.+?)\.(\d+\.\d+\.\d+)\.(dylib|so|dll)$/;
 const REQUIRED_MACOS_ARCHITECTURES = ["x86_64", "arm64"];
 
+// Both macOS targets install the same libonnxruntime file; lipo needs a macOS host.
+function isMacosHostTarget(platformArch) {
+  return process.platform === "darwin" && platformArch.startsWith("darwin");
+}
+
 // Upstream 1.13.4 ships an invalid arm64 signature on libonnxruntime; dyld SIGKILLs unsigned loads.
 function adhocSign(filePath, platformArch) {
   if (process.platform !== "darwin" || !platformArch.startsWith("darwin")) return;
   execFileSync("codesign", ["--force", "--sign", "-", filePath], { stdio: "ignore" });
+}
+
+async function replaceMacosArm64OnnxRuntime(libraryPath, platformArch) {
+  const { url, sha256, libraryName } = MACOS_ARM64_ONNXRUNTIME;
+  if (path.basename(libraryPath) !== libraryName) {
+    throw new Error(
+      `sherpa-onnx ships ${path.basename(libraryPath)}; update MACOS_ARM64_ONNXRUNTIME to match`
+    );
+  }
+  const zipPath = `${libraryPath}.arm64.zip`;
+  const extractDir = `${libraryPath}.arm64`;
+  const x86Path = `${libraryPath}.x86_64`;
+  try {
+    console.log(`  ${platformArch}: Downloading arm64 ONNX Runtime from ${url}`);
+    await downloadFile(url, zipPath);
+    const actual = crypto.createHash("sha256").update(fs.readFileSync(zipPath)).digest("hex");
+    if (actual !== sha256) throw new Error(`arm64 ONNX Runtime sha256 mismatch: ${actual}`);
+    execFileSync("unzip", ["-q", "-o", zipPath, "-d", extractDir], { stdio: "ignore" });
+    const arm64Path = findLibrariesInDir(extractDir, "*.dylib").find(
+      (file) => path.basename(file) === libraryName
+    );
+    if (!arm64Path) throw new Error(`${libraryName} missing from arm64 ONNX Runtime zip`);
+    execFileSync("lipo", ["-thin", "x86_64", libraryPath, "-output", x86Path]);
+    execFileSync("lipo", ["-create", x86Path, arm64Path, "-output", libraryPath]);
+    console.log(`  ${platformArch}: Replaced arm64 slice of ${libraryName}`);
+  } finally {
+    for (const file of [zipPath, extractDir, x86Path]) {
+      fs.rmSync(file, { recursive: true, force: true });
+    }
+  }
 }
 
 function getDownloadUrl(archiveName) {
@@ -250,8 +298,12 @@ function isCompleteInstall(markerPath, binaryPaths, { platformArch, binDir = BIN
     if (marker.libraries.some((lib) => !fs.existsSync(path.join(binDir, lib)))) return false;
     // A win32 marker without this field predates the rename: the exes on disk
     // still import onnxruntime.dll and must be re-extracted.
+    if (platformArch.startsWith("win32")) {
+      return marker.onnxRuntime === WINDOWS_ONNXRUNTIME_PRIVATE_NAME;
+    }
+    // A macOS marker without this field still holds the slow universal2 slice.
     return (
-      !platformArch.startsWith("win32") || marker.onnxRuntime === WINDOWS_ONNXRUNTIME_PRIVATE_NAME
+      !isMacosHostTarget(platformArch) || marker.onnxRuntime === MACOS_ARM64_ONNXRUNTIME.marker
     );
   } catch {
     return false;
@@ -325,6 +377,9 @@ async function downloadBinary(platformArch, config, isForce = false) {
         fs.rmSync(destPath, { force: true });
         fs.copyFileSync(libPath, destPath);
         setExecutable(destPath);
+        if (isMacosHostTarget(platformArch) && versionMatch?.[1] === "libonnxruntime") {
+          await replaceMacosArm64OnnxRuntime(destPath, platformArch);
+        }
         adhocSign(destPath, platformArch);
         copiedLibraries.push(libName);
         console.log(`  ${platformArch}: Copied library ${libName}`);
@@ -364,6 +419,7 @@ async function downloadBinary(platformArch, config, isForce = false) {
         version: SHERPA_ONNX_VERSION,
         libraries: shippedLibraries,
         ...(isWindowsTarget ? { onnxRuntime: WINDOWS_ONNXRUNTIME_PRIVATE_NAME } : {}),
+        ...(isMacosHostTarget(platformArch) ? { onnxRuntime: MACOS_ARM64_ONNXRUNTIME.marker } : {}),
       })
     );
     return true;
@@ -443,6 +499,7 @@ async function main() {
 // Export config for potential imports
 module.exports = {
   SHERPA_ONNX_VERSION,
+  MACOS_ARM64_ONNXRUNTIME,
   BINARIES,
   BIN_DIR,
   WINDOWS_ONNXRUNTIME_PRIVATE_NAME,

--- a/test/scripts/downloadSherpaOnnx.test.js
+++ b/test/scripts/downloadSherpaOnnx.test.js
@@ -10,6 +10,7 @@ const { listImportedModules } = require("../../scripts/lib/pe-imports");
 const { buildPeImage } = require("../helpers/harness/peFixture");
 const {
   BINARIES,
+  MACOS_ARM64_ONNXRUNTIME,
   SHERPA_ONNX_VERSION,
   WINDOWS_ONNXRUNTIME_PRIVATE_NAME,
   WINDOWS_ONNXRUNTIME_UPSTREAM_NAME,
@@ -181,17 +182,42 @@ test("a win32 marker written before the rename is not a complete install", (t) =
   assert.equal(isCompleteInstall(marker, [exe], options), true);
 });
 
-test("non-Windows markers do not need the onnxRuntime field", (t) => {
+test("Linux markers do not need the onnxRuntime field", (t) => {
   const dir = makeBinDir(t);
-  const binary = path.join(dir, "sherpa-onnx-ws-darwin-arm64");
+  const binary = path.join(dir, "sherpa-onnx-ws-linux-x64");
   fs.writeFileSync(binary, "");
-  const marker = path.join(dir, ".sherpa-onnx-darwin-arm64.json");
+  const marker = path.join(dir, ".sherpa-onnx-linux-x64.json");
   fs.writeFileSync(marker, JSON.stringify({ version: SHERPA_ONNX_VERSION, libraries: [] }));
   assert.equal(
-    isCompleteInstall(marker, [binary], { platformArch: "darwin-arm64", binDir: dir }),
+    isCompleteInstall(marker, [binary], { platformArch: "linux-x64", binDir: dir }),
     true
   );
 });
+
+test(
+  "a macOS marker written before the arm64 ONNX Runtime slice is not a complete install",
+  { skip: process.platform !== "darwin" && "the slice is only replaced on macOS hosts" },
+  (t) => {
+    const dir = makeBinDir(t);
+    const binary = path.join(dir, "sherpa-onnx-ws-darwin-arm64");
+    fs.writeFileSync(binary, "");
+    const marker = path.join(dir, ".sherpa-onnx-darwin-arm64.json");
+    const options = { platformArch: "darwin-arm64", binDir: dir };
+
+    fs.writeFileSync(marker, JSON.stringify({ version: SHERPA_ONNX_VERSION, libraries: [] }));
+    assert.equal(isCompleteInstall(marker, [binary], options), false);
+
+    fs.writeFileSync(
+      marker,
+      JSON.stringify({
+        version: SHERPA_ONNX_VERSION,
+        libraries: [],
+        onnxRuntime: MACOS_ARM64_ONNXRUNTIME.marker,
+      })
+    );
+    assert.equal(isCompleteInstall(marker, [binary], options), true);
+  }
+);
 
 test("a failed automatic Windows repair stays incomplete and retries DLL patching", async (t) => {
   const root = makeBinDir(t);


### PR DESCRIPTION
## Summary

On Apple silicon, every Parakeet-family model in OpenWhispr (Orukeet, Parakeet TDT v3, Nemotron, Cohere) runs ~3x slower than it should. The sherpa-onnx macOS archive we download bundles `libonnxruntime.1.27.0.dylib` as a universal2 build, and that build's arm64 slice runs INT8 kernels far slower than the arm64-only build of the **same ONNX Runtime version** from the same maintainer ([csukuangfj/onnxruntime-libs v1.27.0](https://github.com/csukuangfj/onnxruntime-libs/releases/tag/v1.27.0), the zip sherpa-onnx's own `cmake/onnxruntime-osx-arm64.cmake` pins). sherpa-onnx's `osx-arm64` archive is lipo-thinned from the universal2 build and is equally slow, so switching archives does not help.

On a macOS host, `scripts/download-sherpa-onnx.js` now downloads that zip, verifies its SHA-256, and rebuilds the bundled dylib with the arm64 slice from it. The x86_64 slice is kept byte-for-byte, so the file stays universal2 and Intel Macs are unchanged. Linux and Windows paths are untouched. The install marker records the new slice so existing dev installs re-extract instead of keeping the slow library.

## Measurements

Apple M5, OpenWhispr `main` @ 4b4f290c, 11 s JFK clip, real `ParakeetManager.transcribeLocalParakeet` under Electron, warm median of 10 calls, default thread count:

| Model | Shipped | This PR |
|---|---:|---:|
| `orukeet-v0.1.0` | 605 ms | 173 ms |
| `parakeet-tdt-0.6b-v3` | 665 ms | 230 ms |

Transcripts identical in every run. Encoder-only cross-check with the ONNX Runtime C++ API (Orukeet `encoder.int8.onnx`, 4 threads): universal2 dylib 583 ms, sherpa `osx-arm64` archive 601 ms, arm64-only zip 152 ms, pip `onnxruntime` 1.27.0 arm64 153 ms.

## Notes

- Runs for both macOS targets because they install the same file, so an `--all` run cannot overwrite the fix. Non-macOS hosts have no `lipo` and keep the upstream library.
- If a future sherpa-onnx bump ships a different ONNX Runtime version, the script fails asking for `MACOS_ARM64_ONNXRUNTIME` to be updated, rather than splicing mismatched versions.
- The arm64 zip library's deployment target is macOS 15.5, same as the bundled one.

## Verification

- `--current --force` and `--force`: library is `x86_64 arm64`; arm64 slice hash equals the zip's library; x86_64 slice `cmp`-identical to upstream; marker carries `onnxRuntime: "arm64-1.27.0"`; rerun without `--force` reports "Already exists".
- `test/scripts/downloadSherpaOnnx.test.js` 10/10. `npm test`: 3970 pass, one failure (`settingsStore imports without a bare localStorage global`) that fails identically on unmodified `main`. `npm run format:check` clean.

The long-term fix is for sherpa-onnx to bundle a properly built ONNX Runtime in its macOS archives; this step can be removed once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
