### PR TITLE
fix(macos): arm64 ONNX Runtime slice from the hoid-ai build tuned for the Parakeet/Orukeet encoder

### DIFF
--- a/scripts/download-sherpa-onnx.js
+++ b/scripts/download-sherpa-onnx.js
@@ -32,15 +32,15 @@ const WINDOWS_ONNXRUNTIME_UPSTREAM_NAME = "onnxruntime.dll";
 const WINDOWS_ONNXRUNTIME_PRIVATE_NAME = "ow-onnxrt.dll";
 
 // sherpa-onnx's macOS archives bundle a universal2 libonnxruntime whose arm64
-// slice runs INT8 models ~3x slower than the arm64-only build of the same
-// version from the same maintainer (the zip sherpa-onnx's own
-// cmake/onnxruntime-osx-arm64.cmake pins). On macOS hosts we swap that slice
-// in and keep the x86_64 slice, so the file stays universal2.
+// slice runs INT8 models ~3x slower than an arm64-only build of the same
+// version. On macOS hosts we swap that slice in and keep the x86_64 slice, so
+// the file stays universal2. The slice is hoid-ai/onnxruntime: upstream 1.27.0
+// plus MLAS kernel/scheduling changes for the Parakeet encoder on Apple silicon.
 const MACOS_ARM64_ONNXRUNTIME = {
-  url: "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v1.27.0/onnxruntime-osx-arm64-1.27.0.zip",
-  sha256: "5f05b2653eb0af852dab46c85778f0e012c514ed2e71a6dbb9c9550434b0a514",
+  url: "https://github.com/hoid-ai/onnxruntime/releases/download/hoid-v1.27.0-1/onnxruntime-osx-arm64-1.27.0-hoid-v1.27.0-1.zip",
+  sha256: "8d0151ea22fff1ffe985bdd7d72b0c300a597e460f365c65894510fece3fa65d",
   libraryName: "libonnxruntime.1.27.0.dylib",
-  marker: "arm64-1.27.0", // recorded in the install marker so older installs re-extract
+  marker: "arm64-1.27.0-hoid.1", // recorded in the install marker so older installs re-extract
 };
 
 // Binary configurations for each platform


### PR DESCRIPTION
> **Not ready to merge yet.** This PR only pays off together with the new Orukeet export ([Oruk-AI/orukeet#2](https://github.com/Oruk-AI/orukeet/pull/2)). That one needs to land first and the re-exported model needs to be published on Hugging Face and picked up in the registry; then this can go in. On the current model it is still a safe, WER-neutral improvement (171 → 156 ms), but the point of it is the combination below.

## What it does

Follow-up to #2116. The arm64 ONNX Runtime slice spliced into `libonnxruntime.1.27.0.dylib` now comes from a build maintained at [hoid-ai/onnxruntime](https://github.com/hoid-ai/onnxruntime/releases/tag/hoid-v1.27.0-1): upstream 1.27.0 plus three MLAS changes for the Parakeet/Orukeet encoder on Apple silicon. Same soname, same C API, same deployment target (15.5). One constant edited: URL, hash, and the install-marker string (so existing dev installs re-extract).

Changes in that build vs upstream (branch `hoid/apple-mlas`, 3 focused commits):
- **KleidiAI int8 GEMM scheduling** (SME on M4/M5): activation packing per thread in a single parallel section instead of a serial pack phase plus thread-count slivers along N. Bit-identical output; 10,608 MLAS quantized-GEMM unit tests pass.
- **NEON LayerNormalization kernel** for ARM64 (MLAS only had one for RISC-V; ARM64 used a scalar loop). 14x on the op.
- **I8MM GEMM kernels enabled on Apple** (upstream kernels used the Apple-reserved `x18` register). Bit-exact; this is the path M2/M3 take.

## The point: 171 → 110 ms

With this runtime **and** the new Orukeet export, transcribing an 11 s clip on an Apple M5 goes from **171 ms to 110 ms** (warm app-level median; the encoder alone 150 → 96 ms). Neither half gets there alone: runtime only 156 ms, new model on the stock runtime 149 ms.

## Other hardware

- Other Apple silicon: the code paths M1 (UDOT), M2/M3 (I8MM) and M4/M5 (SME) take were all exercised on the M5 by forcing them; they agree within int8 noise and the non-SME paths are also faster with this build (5–8%), so improvements are expected across the arm64 Macs, not only M5. Real M1–M4 measurements are still to come.
- Everything else (Intel Macs, Windows, Linux) is untouched: the x86_64 slice and the other archives are exactly what they were.

## Correctness

Tested a lot and nothing changed for the worse: 120-clip LibriSpeech WER 2.49% with this slice vs 2.54% with the previous one on the shipped model; 420 clips with the new export 2.60% vs 2.61%; identical transcripts on the JFK fixture across all combinations; all MLAS quantized-GEMM unit tests pass.

## Verification
- `node scripts/download-sherpa-onnx.js --current --force`: arm64 slice sha matches the release zip's library, `minos 15.5`, marker `arm64-1.27.0-hoid.1`; `test/scripts/downloadSherpaOnnx.test.js` 10/10; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So8qajb1NRMPLKYoJRLstZ
