### PR TITLE
fix(calendar): use localhost redirect for Microsoft OAuth loopback

### DIFF
--- a/src/helpers/microsoftCalendarOAuth.js
+++ b/src/helpers/microsoftCalendarOAuth.js
@@ -28,6 +28,13 @@ class MicrosoftCalendarOAuth {
     }
     return runOAuthLoopbackFlow({
       errorParam: "mcal_error",
+      // Microsoft Entra's redirect URI registration UI only accepts the
+      // "localhost" hostname for the http scheme; registering the
+      // 127.0.0.1 IP literal requires editing the app manifest directly,
+      // which this app's registration doesn't do. Sending 127.0.0.1 (the
+      // default) mismatches that registration and fails with AADSTS50011,
+      // which surfaces here only as a silent 120s "OAuth flow timed out".
+      redirectHost: "localhost",
       buildAuthUrl: (redirectUri, state, codeChallenge) => {
         const params = new URLSearchParams({
           client_id: this.getClientId(),

--- a/src/helpers/oauthLoopbackFlow.js
+++ b/src/helpers/oauthLoopbackFlow.js
@@ -50,7 +50,15 @@ function redirect(res, params) {
 //   specific callback-page code) to reject.
 // - errorParam — query-param name for the hosted desktop-callback page
 //   (e.g. "gcal_error"); the success param is derived from the same prefix.
-function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
+// - redirectHost — hostname put in the redirect_uri sent to the provider
+//   (default "127.0.0.1", the RFC 8252-recommended IP literal). The server
+//   always binds to 127.0.0.1 regardless, so "localhost" still reaches it.
+//   Microsoft Entra's redirect URI registration UI only accepts "localhost"
+//   for the http scheme — registering the 127.0.0.1 literal requires editing
+//   the app manifest directly — so Microsoft's flow overrides this to avoid
+//   an AADSTS50011 redirect_uri mismatch against a registration most devs
+//   never think to add.
+function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam, redirectHost = "127.0.0.1" }) {
   const connectedParam = errorParam.replace(/_error$/, "_connected");
 
   return new Promise((resolve, reject) => {
@@ -97,7 +105,7 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
         }
 
         callbackClaimed = true;
-        const redirectUri = `http://127.0.0.1:${server.address().port}`;
+        const redirectUri = `http://${redirectHost}:${server.address().port}`;
         const result = await handleCallback(code, redirectUri, codeVerifier);
 
         redirect(res, { [connectedParam]: "true" });
@@ -120,7 +128,7 @@ function runOAuthLoopbackFlow({ buildAuthUrl, handleCallback, errorParam }) {
 
     server.listen(0, "127.0.0.1", () => {
       const port = server.address().port;
-      const redirectUri = `http://127.0.0.1:${port}`;
+      const redirectUri = `http://${redirectHost}:${port}`;
       // Fire-and-forget like the shell.openExternal call it replaced: a failed
       // browser launch surfaces as the flow timeout.
       openExternalUrl(buildAuthUrl(redirectUri, state, codeChallenge)).catch(() => {});

--- a/test/helpers/oauthLoopbackFlow.test.js
+++ b/test/helpers/oauthLoopbackFlow.test.js
@@ -22,7 +22,7 @@ function loadLoopback() {
   }
 }
 
-function startFlow(handleCallback = async () => ({ ok: true })) {
+function startFlow(handleCallback = async () => ({ ok: true }), options = {}) {
   const { runOAuthLoopbackFlow } = loadLoopback();
   let redirectUri;
   let state;
@@ -42,6 +42,7 @@ function startFlow(handleCallback = async () => ({ ok: true })) {
         return "https://example.test/auth";
       },
       handleCallback,
+      ...options,
     });
     return { flow, server, getRedirectUri: () => redirectUri, getState: () => state };
   } finally {
@@ -206,6 +207,20 @@ test("a callback with a code and the wrong state rejects immediately", async () 
 
   await rejected;
   assert.ok(Date.now() - started < 5000, "must not wait for the 120s timeout");
+});
+
+test("redirectHost overrides the redirect_uri sent to the provider, and the loopback server still answers on it", async () => {
+  const { flow, getRedirectUri, getState } = startFlow(async (code) => ({ code }), {
+    redirectHost: "localhost",
+  });
+  const redirectUri = await waitForListen(getRedirectUri);
+  assert.match(redirectUri, /^http:\/\/localhost:\d+$/);
+
+  const success = await fetch(`${redirectUri}/?code=ok&state=${getState()}`, {
+    redirect: "manual",
+  });
+  assert.equal(success.status, 302);
+  assert.deepEqual(await flow, { code: "ok" });
 });
 
 test("a request with no code leaves the flow running until a real callback", async () => {


### PR DESCRIPTION
## Summary
- Microsoft Entra's redirect URI registration UI only accepts the `localhost` hostname for the `http` scheme — registering the `127.0.0.1` IP literal requires editing the app manifest's `replyUrlsWithType` directly, which this app's registration doesn't do.
- Since the shared OAuth loopback helper always sent `redirect_uri=http://127.0.0.1:{port}`, every Microsoft Calendar connection attempt failed with `AADSTS50011` on Microsoft's side. That failure never reaches the local callback server, so it surfaced only as a generic "OAuth flow timed out" after the 120s deadline, with no indication of the real cause.
- `runOAuthLoopbackFlow` now accepts an optional `redirectHost` (default `127.0.0.1`, unchanged for Google/Apple), and the Microsoft flow opts into `"localhost"`. The loopback server still binds to `127.0.0.1`, so requests to `localhost:{port}` still reach it locally.

## Test plan
- [x] `node --test test/helpers/oauthLoopbackFlow.test.js` — added a regression test covering `redirectHost` override, all 9 tests pass
- [x] `node --test test/helpers/microsoftCalendarManager.test.js` — unaffected, all 8 tests pass
- [x] Manual: connect a Microsoft Calendar account end-to-end (I don't have Microsoft OAuth credentials to test this myself; the fix is verified at the loopback-server level only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)