### PR TITLE
test(updater): pin the platform so Linux runners exercise the checks

### DIFF
--- a/test/helpers/updater.test.js
+++ b/test/helpers/updater.test.js
@@ -74,6 +74,9 @@ function setPlatform(platform) {
 beforeEach((t) => {
   t.mock.method(console, "log", () => {});
   t.mock.method(console, "error", () => {});
+  // The updater is unsupported on Linux outside an AppImage, so a test that
+  // does not pick a platform would never check for updates on a Linux CI runner.
+  setPlatform("darwin");
 });
 
 afterEach(() => {


### PR DESCRIPTION
## What this does

Two tests in `test/helpers/updater.test.js` never chose a platform. The updater reports itself unsupported on Linux outside an AppImage, so on the ubuntu CI runner the startup check never fired and both tests failed. They pass on a Mac, which is how #2120 went green locally.

Every test now starts on `darwin` via `beforeEach`; the Linux AppImage test still sets its own platform.

## Verification

Reproduced the failure locally by forcing `process.platform` to `linux` before loading the test file (2 fail), then re-ran with the fix under the same forced platform (8 pass) and natively (8 pass).

Every branch's `pr-quality` check has been red since #2120 merged; this unblocks them.