### PR TITLE
ci: only require brand fonts when the build can read them

### DIFF
--- a/.github/workflows/build-and-notarize.yml
+++ b/.github/workflows/build-and-notarize.yml
@@ -130,7 +130,8 @@ jobs:
         run: npm run build:linux -- --publish never
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          BRAND_FONTS_REQUIRED: "1"
+          # Forks and Dependabot get no GH_TOKEN; github.token can't read the private font release.
+          BRAND_FONTS_REQUIRED: ${{ secrets.GH_TOKEN && '1' || '0' }}
           VITE_AUTH_URL: ${{ vars.VITE_AUTH_URL || 'https://auth.openwhispr.com' }}
           VITE_OPENWHISPR_API_URL: ${{ vars.VITE_OPENWHISPR_API_URL }}
           VITE_OPENWHISPR_OAUTH_CALLBACK_URL: ${{ vars.VITE_OPENWHISPR_OAUTH_CALLBACK_URL }}
@@ -372,7 +373,8 @@ jobs:
         env:
           TARGET_ARCH: ${{ matrix.arch }}
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          BRAND_FONTS_REQUIRED: "1"
+          # Forks and Dependabot get no GH_TOKEN; github.token can't read the private font release.
+          BRAND_FONTS_REQUIRED: ${{ secrets.GH_TOKEN && '1' || '0' }}
           VITE_AUTH_URL: ${{ vars.VITE_AUTH_URL || 'https://auth.openwhispr.com' }}
           VITE_OPENWHISPR_API_URL: ${{ vars.VITE_OPENWHISPR_API_URL }}
           VITE_OPENWHISPR_OAUTH_CALLBACK_URL: ${{ vars.VITE_OPENWHISPR_OAUTH_CALLBACK_URL }}


### PR DESCRIPTION
## Summary

Since #2117, every fork PR's `build-macos` and `build-linux` jobs fail at `download:brand-fonts` with "Cannot read OpenWhispr/brand-assets release yowza-v1 (no access?)". #2134 is one example.

Both steps set `BRAND_FONTS_REQUIRED: "1"` on every run. Fork and Dependabot PRs get no `secrets.GH_TOKEN`, so the step falls back to `github.token`, which can't read the private font release.

This PR requires the fonts only when `GH_TOKEN` is available, mirroring the step's own `secrets.GH_TOKEN || github.token` fallback:

- Main and same-repo PR builds still fail if the fonts can't be fetched.
- Fork and Dependabot builds fall back to Noto Sans, as `download-brand-fonts.js` already does without the flag.

`release.yml` still requires the fonts. The Windows build step never set the flag.

## Test plan

- [ ] This PR comes from a fork, so its own `build-macos` ×2 and `build-linux` jobs run the edited workflow. They should log the "no access" skip and get past `download:brand-fonts`.
- [ ] After merge, a push to main still downloads the fonts: the log shows the download, not the skip.
