### PR TITLE
fix(transcription): repair BYOK Deepgram and AssemblyAI streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Transcription
+
+- **Your own Deepgram key works again.** Every Deepgram connection failed with `Unexpected server response: 401`, even though the same key tested fine in Settings and worked against Deepgram directly. Deepgram accepts a raw API key only under its `Token` authorization scheme and reserves `Bearer` for the short-lived tokens OpenWhispr Cloud mints on your behalf — and the app was presenting your key as a `Bearer`. This broke bring-your-own-key dictation as well as Note Recording. (#2140, thanks @nikhilmaddirala)
+
 ## [1.10.0] - 2026-09-11
 
 The desktop app gets a new look: an inset content container with a top bar and ⌘K search, a redesigned Home and note editor, the Yowza brand font and Nucleo icons, and one brand-blue glass surface for every primary action, onboarding included. Notes start recording the moment you create them, offer an AI summary when a recording ends, and gain Detailed Notes and Follow-up email as built-in actions. Orukeet arrives as the recommended local speech-to-text model and local models run up to three times faster on Apple silicon. Managed enterprise speech-to-text lands for workspaces on Azure OpenAI or AI Foundry, transcription gains streaming from Deepgram, AssemblyAI and Gemini Live plus Cohere Transcribe as a local engine, gpt-transcribe becomes the OpenAI default, onboarding was rebuilt and reordered, Insights gains an opt-in leaderboard and backfilled history, updates install themselves, Arabic joins as the eleventh UI language, and Astra and Fable 5.1 join the reasoning models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Transcription
 
 - **Your own Deepgram key works again.** Every Deepgram connection failed with `Unexpected server response: 401`, even though the same key tested fine in Settings and worked against Deepgram directly. Deepgram accepts a raw API key only under its `Token` authorization scheme and reserves `Bearer` for the short-lived tokens OpenWhispr Cloud mints on your behalf — and the app was presenting your key as a `Bearer`. This broke bring-your-own-key dictation as well as Note Recording. (#2140, thanks @nikhilmaddirala)
+- **Your own AssemblyAI key works in Note Recording again.** Recordings died seconds in with `Input Duration Violation: 40.0 ms`, followed by a cascade of reconnect errors. AssemblyAI accepts audio in 50-1000 ms frames, and the app measured those frames against dictation's 16 kHz — but Note Recording streams at 24 kHz, where the same frame lasts only 33-40 ms. The frame size now follows the rate each session actually opened at, and an oversized burst — which a busy moment can produce on the system-audio channel — is split instead of being sent as one frame that trips the same limit from the other end. Dictation was never affected. (#2140, thanks @nikhilmaddirala)
 
 ## [1.10.0] - 2026-09-11
 

--- a/scripts/stt-canary.mjs
+++ b/scripts/stt-canary.mjs
@@ -29,6 +29,7 @@ import audioUtils from "../src/utils/audioUtils.js";
 import geminiTranscription from "../src/helpers/geminiTranscription.js";
 import geminiLive from "../src/helpers/geminiLiveStreaming.js";
 import AssemblyAiStreaming from "../src/helpers/assemblyAiStreaming.js";
+import DeepgramStreaming from "../src/helpers/deepgramStreaming.js";
 import modelRegistryData from "../src/models/modelRegistryData.json" with { type: "json" };
 
 const { fetchRealtimeTokenForProvider } = tokenProviders;
@@ -48,19 +49,28 @@ const HANDSHAKE_TIMEOUT_MS = 15000;
 const SILENT_WAV = () => pcm16ToWav(Buffer.alloc(16000));
 
 // Mirrors the app's dial: openaiRealtimeStreaming.js connects with a bare
-// Bearer header; deepgramStreaming.js passes the key as the bearer token; a
-// null token means the credential already rides in the URL (AssemblyAI).
+// Bearer header; a null token means the credential already rides in the URL
+// (AssemblyAI). `authorization` wins over `token` when both are passed, and is
+// how a provider whose scheme is not Bearer hands over the client's own header,
+// so the probe cannot drift from what ships. Note this did NOT hide #2140: the
+// old probe sent the same wrong header the client did and Deepgram would have
+// rejected it — that row has simply never run, for want of a configured key.
 // `awaitServerEvent` is for providers that authenticate AFTER the upgrade:
 // OpenAI opens the socket for any key and only then sends an `error` event
 // for a bad one, so resolving on `open` validates nothing (#1624 class).
 // `verifyServerEvent` inspects that first event and returns a failure detail,
 // or null to accept — for servers that acknowledge the requested configuration
 // rather than reject a bad one.
-function probeWebSocket(url, token, { awaitServerEvent = false, verifyServerEvent = null } = {}) {
+function probeWebSocket(
+  url,
+  token,
+  { awaitServerEvent = false, verifyServerEvent = null, authorization = null } = {}
+) {
   return new Promise((resolve) => {
+    const credential = authorization ?? (token ? `Bearer ${token}` : null);
     const ws = new WebSocket(
       url,
-      token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+      credential ? { headers: { Authorization: credential } } : undefined
     );
     const timer = setTimeout(() => {
       ws.terminate();
@@ -259,10 +269,16 @@ const PROBES = [
       const token = await fetchRealtimeTokenForProvider("deepgram-realtime", tokenDeps(key), {
         mode: "byok",
       });
-      return probeWebSocket(
-        "wss://api.deepgram.com/v1/listen?model=nova-3&encoding=linear16&sample_rate=16000",
-        token
-      );
+      // Dials the exact URL the client builds, like the AssemblyAI probe below,
+      // so punctuate/interim_results/channels and the keyterm parameter nova-3
+      // renamed are all exercised rather than assumed.
+      const url = new DeepgramStreaming().buildWebSocketUrl({
+        sampleRate: 16000,
+        keyterms: ["OpenWhispr"],
+      });
+      return probeWebSocket(url, null, {
+        authorization: DeepgramStreaming.authorizationHeader("byok", token),
+      });
     },
   },
   {

--- a/scripts/stt-canary.mjs
+++ b/scripts/stt-canary.mjs
@@ -50,11 +50,8 @@ const SILENT_WAV = () => pcm16ToWav(Buffer.alloc(16000));
 
 // Mirrors the app's dial: openaiRealtimeStreaming.js connects with a bare
 // Bearer header; a null token means the credential already rides in the URL
-// (AssemblyAI). `authorization` wins over `token` when both are passed, and is
-// how a provider whose scheme is not Bearer hands over the client's own header,
-// so the probe cannot drift from what ships. Note this did NOT hide #2140: the
-// old probe sent the same wrong header the client did and Deepgram would have
-// rejected it — that row has simply never run, for want of a configured key.
+// (AssemblyAI). `authorization` overrides both, for a provider whose scheme is
+// not Bearer; passing the client's own header keeps the probe from drifting.
 // `awaitServerEvent` is for providers that authenticate AFTER the upgrade:
 // OpenAI opens the socket for any key and only then sends an `error` event
 // for a bad one, so resolving on `open` validates nothing (#1624 class).
@@ -269,9 +266,6 @@ const PROBES = [
       const token = await fetchRealtimeTokenForProvider("deepgram-realtime", tokenDeps(key), {
         mode: "byok",
       });
-      // Dials the exact URL the client builds, like the AssemblyAI probe below,
-      // so punctuate/interim_results/channels and the keyterm parameter nova-3
-      // renamed are all exercised rather than assumed.
       const url = new DeepgramStreaming().buildWebSocketUrl({
         sampleRate: 16000,
         keyterms: ["OpenWhispr"],

--- a/src/helpers/assemblyAiStreaming.js
+++ b/src/helpers/assemblyAiStreaming.js
@@ -11,10 +11,9 @@ const MAX_REWARM_ATTEMPTS = 10;
 const KEEPALIVE_INTERVAL_MS = 15000;
 const MIN_FRAME_MS = 50;
 const MAX_FRAME_MS = 1000;
-// AssemblyAI rejects any frame outside 50-1000 ms and closes the session, so both
-// bounds have to follow the rate the socket was opened at: Note Recording streams
-// at 24 kHz, where a frame sized against this module's 16 kHz default lasts only
-// 33 ms (#2140). Round the floor up and the ceiling down so neither can undershoot.
+// AssemblyAI closes the session on any frame outside 50-1000 ms, so both bounds
+// follow the rate the socket opened at: Note Recording streams at 24 kHz, where a
+// frame sized against this module's 16 kHz default lasts only 33 ms (#2140).
 const minFrameBytes = (sampleRate) => Math.ceil((sampleRate * 2 * MIN_FRAME_MS) / 1000);
 const maxFrameBytes = (sampleRate) => Math.floor((sampleRate * 2 * MAX_FRAME_MS) / 1000);
 
@@ -596,10 +595,9 @@ class AssemblyAiStreaming {
     this.pendingAudio = [];
     this.pendingAudioBytes = 0;
 
-    // The macOS tap and the Windows/Linux loopback helpers forward raw stdout
-    // chunks, so one read can carry far more than the nominal 100 ms when the
-    // main process stalls and the pipe coalesces. Slice to the ceiling and carry
-    // any sub-floor remainder into the next frame rather than sending it short.
+    // The native system-audio helpers forward raw stdout chunks, so one read can
+    // far exceed the nominal 100 ms when a stalled main process lets the pipe
+    // coalesce. Carry a sub-floor remainder forward rather than sending it short.
     const maxBytes = maxFrameBytes(this.sessionSampleRate);
     let offset = 0;
     while (frame.length - offset >= minBytes) {

--- a/src/helpers/assemblyAiStreaming.js
+++ b/src/helpers/assemblyAiStreaming.js
@@ -10,10 +10,13 @@ const REWARM_DELAY_MS = 2000;
 const MAX_REWARM_ATTEMPTS = 10;
 const KEEPALIVE_INTERVAL_MS = 15000;
 const MIN_FRAME_MS = 50;
-const MAX_FRAME_MS = 1000;
-// AssemblyAI closes the session on any frame outside 50-1000 ms, so both bounds
-// follow the rate the socket opened at: Note Recording streams at 24 kHz, where a
-// frame sized against this module's 16 kHz default lasts only 33 ms (#2140).
+// AssemblyAI hard-closes the session outside 50-1000 ms but documents 50-250 ms
+// as the supported shape, so the split targets the recommended ceiling: 1000 would
+// put the first slice of a coalesced read exactly on the limit it exists to avoid.
+const MAX_FRAME_MS = 250;
+// Both bounds follow the rate the socket opened at: Note Recording streams at
+// 24 kHz, where a frame sized against this module's 16 kHz default lasts only
+// 33 ms (#2140).
 const minFrameBytes = (sampleRate) => Math.ceil((sampleRate * 2 * MIN_FRAME_MS) / 1000);
 const maxFrameBytes = (sampleRate) => Math.floor((sampleRate * 2 * MAX_FRAME_MS) / 1000);
 

--- a/src/helpers/assemblyAiStreaming.js
+++ b/src/helpers/assemblyAiStreaming.js
@@ -10,7 +10,13 @@ const REWARM_DELAY_MS = 2000;
 const MAX_REWARM_ATTEMPTS = 10;
 const KEEPALIVE_INTERVAL_MS = 15000;
 const MIN_FRAME_MS = 50;
-const MIN_FRAME_BYTES = (SAMPLE_RATE * 2 * MIN_FRAME_MS) / 1000;
+const MAX_FRAME_MS = 1000;
+// AssemblyAI rejects any frame outside 50-1000 ms and closes the session, so both
+// bounds have to follow the rate the socket was opened at: Note Recording streams
+// at 24 kHz, where a frame sized against this module's 16 kHz default lasts only
+// 33 ms (#2140). Round the floor up and the ceiling down so neither can undershoot.
+const minFrameBytes = (sampleRate) => Math.ceil((sampleRate * 2 * MIN_FRAME_MS) / 1000);
+const maxFrameBytes = (sampleRate) => Math.floor((sampleRate * 2 * MAX_FRAME_MS) / 1000);
 
 class AssemblyAiStreaming {
   constructor() {
@@ -38,6 +44,7 @@ class AssemblyAiStreaming {
     this.warmConnectionOptions = null;
     this.warmSessionId = null;
     this.requestedModel = null;
+    this.sessionSampleRate = SAMPLE_RATE;
     this.rewarmAttempts = 0;
     this.rewarmTimer = null;
     this.keepAliveInterval = null;
@@ -50,6 +57,7 @@ class AssemblyAiStreaming {
 
   buildWebSocketUrl(options) {
     const sampleRate = options.sampleRate || SAMPLE_RATE;
+    this.sessionSampleRate = sampleRate;
     const params = new URLSearchParams({
       sample_rate: String(sampleRate),
       encoding: "pcm_s16le",
@@ -351,11 +359,15 @@ class AssemblyAiStreaming {
     // warning could never fire for the model actually requested.
     if (
       this.hasWarmConnection() &&
-      (this.warmConnectionOptions.model || null) !== (options.model || null)
+      ((this.warmConnectionOptions.model || null) !== (options.model || null) ||
+        (this.warmConnectionOptions.sampleRate || SAMPLE_RATE) !==
+          (options.sampleRate || SAMPLE_RATE))
     ) {
-      debugLogger.debug("AssemblyAI warm connection model differs, cold-starting", {
+      debugLogger.debug("AssemblyAI warm connection differs, cold-starting", {
         warm: this.warmConnectionOptions.model || null,
         requested: options.model || null,
+        warmSampleRate: this.warmConnectionOptions.sampleRate || SAMPLE_RATE,
+        requestedSampleRate: options.sampleRate || SAMPLE_RATE,
       });
       this.cleanupWarmConnection();
     }
@@ -575,14 +587,31 @@ class AssemblyAiStreaming {
 
     this.pendingAudio.push(pcmBuffer);
     this.pendingAudioBytes += pcmBuffer.length;
-    if (this.pendingAudioBytes < MIN_FRAME_BYTES) {
+    const minBytes = minFrameBytes(this.sessionSampleRate);
+    if (this.pendingAudioBytes < minBytes) {
       return true;
     }
 
     const frame = Buffer.concat(this.pendingAudio, this.pendingAudioBytes);
     this.pendingAudio = [];
     this.pendingAudioBytes = 0;
-    this.ws.send(frame);
+
+    // The macOS tap and the Windows/Linux loopback helpers forward raw stdout
+    // chunks, so one read can carry far more than the nominal 100 ms when the
+    // main process stalls and the pipe coalesces. Slice to the ceiling and carry
+    // any sub-floor remainder into the next frame rather than sending it short.
+    const maxBytes = maxFrameBytes(this.sessionSampleRate);
+    let offset = 0;
+    while (frame.length - offset >= minBytes) {
+      const end = Math.min(offset + maxBytes, frame.length);
+      this.ws.send(frame.subarray(offset, end));
+      offset = end;
+    }
+    if (offset < frame.length) {
+      const remainder = frame.subarray(offset);
+      this.pendingAudio.push(remainder);
+      this.pendingAudioBytes = remainder.length;
+    }
     return true;
   }
 

--- a/src/helpers/deepgramStreaming.js
+++ b/src/helpers/deepgramStreaming.js
@@ -72,6 +72,17 @@ const SILENCE_FRAME = Buffer.alloc((SAMPLE_RATE / 10) * 2);
 // only as `Token`, `Bearer` only for what /v1/auth/grant mints (managed). #2140
 const authorizationHeader = (mode, token) => `${mode === "byok" ? "Token" : "Bearer"} ${token}`;
 
+// Everything buildWebSocketUrl pins on the socket, folded the way it folds it, so
+// a warm connection can be compared against the session that wants to ride it.
+// Dictation warms on the UI language before it can know a translation wants the
+// source language, and the dictionary can be edited between the two.
+const urlIdentity = (options) =>
+  JSON.stringify([
+    options.sampleRate || SAMPLE_RATE,
+    options.language && options.language !== "auto" ? options.language : null,
+    (options.keyterms || []).filter(Boolean),
+  ]);
+
 class DeepgramStreaming {
   constructor() {
     this.ws = null;
@@ -614,6 +625,20 @@ class DeepgramStreaming {
     } else {
       this.coldStartBuffer = [];
       this.coldStartBufferSize = 0;
+    }
+
+    // The socket carries these for its whole life, so riding a warm one opened
+    // for other values transcribes the session under them — silently, since
+    // Deepgram has no reason to object to the audio.
+    if (
+      this.hasWarmConnection() &&
+      urlIdentity(this.warmConnectionOptions) !== urlIdentity(options)
+    ) {
+      debugLogger.debug("Deepgram warm connection differs, cold-starting", {
+        warm: urlIdentity(this.warmConnectionOptions),
+        requested: urlIdentity(options),
+      });
+      this.cleanupWarmConnection();
     }
 
     if (!forceNew && this.hasWarmConnection()) {

--- a/src/helpers/deepgramStreaming.js
+++ b/src/helpers/deepgramStreaming.js
@@ -68,6 +68,13 @@ const NOVA3_LANGUAGES = new Set([
 // Deepgram's net0001 idle timeout (which only resets on audio data, not KeepAlive).
 const SILENCE_FRAME = Buffer.alloc((SAMPLE_RATE / 10) * 2);
 
+// Deepgram binds the Authorization scheme to the kind of credential: a raw API
+// key — what BYOK holds — is only accepted as `Token`, while `Bearer` is for the
+// short-lived credential /v1/auth/grant mints, which is what the managed path
+// receives from the OpenWhispr API. Presenting either under the other's scheme
+// fails the handshake with 401 (#2140).
+const authorizationHeader = (mode, token) => `${mode === "byok" ? "Token" : "Bearer"} ${token}`;
+
 class DeepgramStreaming {
   constructor() {
     this.ws = null;
@@ -286,7 +293,7 @@ class DeepgramStreaming {
       }, WEBSOCKET_TIMEOUT_MS);
 
       this.warmConnection = new WebSocket(url, {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: authorizationHeader(this.mode, token) },
       });
 
       this.warmConnection.on("open", () => {
@@ -371,6 +378,15 @@ class DeepgramStreaming {
       this.rewarmTimer = null;
       if (this.hasWarmConnection() || this.isConnected) return;
 
+      // cleanupWarmConnection() drops the saved options without cancelling this
+      // timer, and spreading a null one loses `mode` — which re-warms a BYOK key
+      // as a Bearer and 401s. scheduleProactiveRefresh snapshots for the same reason.
+      const savedOptions = this.warmConnectionOptions;
+      if (!savedOptions) {
+        debugLogger.debug("Deepgram cannot re-warm: options dropped before the timer fired");
+        return;
+      }
+
       let token = this.getCachedToken();
       if (!token && this.tokenRefreshFn) {
         try {
@@ -387,7 +403,7 @@ class DeepgramStreaming {
         return;
       }
 
-      this.warmup({ ...this.warmConnectionOptions, token }).catch((err) => {
+      this.warmup({ ...savedOptions, token }).catch((err) => {
         debugLogger.debug("Deepgram auto re-warm failed", { error: err.message });
       });
     }, delay);
@@ -625,7 +641,7 @@ class DeepgramStreaming {
       }, WEBSOCKET_TIMEOUT_MS);
 
       this.ws = new WebSocket(url, {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: authorizationHeader(this.mode, token) },
       });
 
       this.ws.on("open", () => {
@@ -929,3 +945,4 @@ class DeepgramStreaming {
 }
 
 module.exports = DeepgramStreaming;
+module.exports.authorizationHeader = authorizationHeader;

--- a/src/helpers/deepgramStreaming.js
+++ b/src/helpers/deepgramStreaming.js
@@ -68,11 +68,8 @@ const NOVA3_LANGUAGES = new Set([
 // Deepgram's net0001 idle timeout (which only resets on audio data, not KeepAlive).
 const SILENCE_FRAME = Buffer.alloc((SAMPLE_RATE / 10) * 2);
 
-// Deepgram binds the Authorization scheme to the kind of credential: a raw API
-// key — what BYOK holds — is only accepted as `Token`, while `Bearer` is for the
-// short-lived credential /v1/auth/grant mints, which is what the managed path
-// receives from the OpenWhispr API. Presenting either under the other's scheme
-// fails the handshake with 401 (#2140).
+// Deepgram binds the scheme to the credential: a raw API key (BYOK) is accepted
+// only as `Token`, `Bearer` only for what /v1/auth/grant mints (managed). #2140
 const authorizationHeader = (mode, token) => `${mode === "byok" ? "Token" : "Bearer"} ${token}`;
 
 class DeepgramStreaming {
@@ -378,9 +375,8 @@ class DeepgramStreaming {
       this.rewarmTimer = null;
       if (this.hasWarmConnection() || this.isConnected) return;
 
-      // cleanupWarmConnection() drops the saved options without cancelling this
-      // timer, and spreading a null one loses `mode` — which re-warms a BYOK key
-      // as a Bearer and 401s. scheduleProactiveRefresh snapshots for the same reason.
+      // cleanupWarmConnection() drops these without cancelling this timer, and
+      // spreading a null one loses `mode`, re-warming a BYOK key as a Bearer.
       const savedOptions = this.warmConnectionOptions;
       if (!savedOptions) {
         debugLogger.debug("Deepgram cannot re-warm: options dropped before the timer fired");

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -7039,6 +7039,7 @@ class IPCHandlers {
           const connectOpts = {
             model: options.model,
             language: options.language,
+            mode: options.mode,
             preconfigured: options.mode !== "byok",
             environment: options.environment,
             tenant: options.tenant,
@@ -7249,6 +7250,7 @@ class IPCHandlers {
       const connectOpts = {
         model: options.model,
         language: options.language,
+        mode: options.mode,
         preconfigured: options.mode !== "byok",
         environment: options.environment,
         tenant: options.tenant,

--- a/test/helpers/assemblyAiStreaming.test.js
+++ b/test/helpers/assemblyAiStreaming.test.js
@@ -20,8 +20,8 @@ async function withPrematureCloseServer(run) {
 }
 
 // `connections` collects each accepted request URL so a test can count sockets
-// and read the query the client actually sent. `onAudioFrame` reports every
-// binary frame as the server receives it, for tests that assert on framing.
+// and read the query the client actually sent. `onAudioFrame` reports each
+// binary frame the server receives.
 async function withBeginServer(run, { onAudioFrame } = {}) {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((resolve) => server.once("listening", resolve));
@@ -183,15 +183,12 @@ test("a warm connection opened for another speech model is not reused", async ()
   });
 });
 
-// Note Recording streams at MEETING_STREAM_SAMPLE_RATE (24 kHz), where a frame
-// sized against the module's 16 kHz default lasts only 33 ms — under the 50 ms
-// floor AssemblyAI enforces, which closes the socket mid-meeting (#2140).
+// Note Recording's MEETING_STREAM_SAMPLE_RATE (#2140).
 const MEETING_SAMPLE_RATE = 24000;
 const frameDurationMs = (bytes) => (bytes / 2 / MEETING_SAMPLE_RATE) * 1000;
 
-// Collects the frames the server receives, failing rather than hanging when the
-// client withholds audio: node:test has no default timeout, so a bare await on a
-// byte count would stall CI for hours instead of going red.
+// node:test has no default timeout, so the wait is bounded here: withheld audio
+// must fail the run rather than hang it.
 async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
   const frames = [];
   let receivedBytes = 0;
@@ -201,8 +198,7 @@ async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
   await withBeginServer(
     async (url, connections) => {
       const streaming = new AssemblyAiStreaming();
-      // The real builder is what pins the session's sample rate, so this test
-      // must not stub it out.
+      // The real builder is what pins the session's sample rate: do not stub it.
       dialLoopback(streaming, url);
 
       try {
@@ -246,9 +242,7 @@ async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
 }
 
 test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate", async () => {
-  // meeting-aec-helper emits one frame per mic chunk, sized to the whole 10 ms
-  // frames it had ready — 1440 or 1680 bytes for the renderer's 800-sample input.
-  // 480 bytes (a single 10 ms frame) is the smallest it can hand over.
+  // 480 bytes is the smallest meeting-aec-helper can hand over (one 10 ms frame).
   await collectFrames({ chunkBytes: 480, chunkCount: 20 }, (frames) => {
     assert.ok(frames.length > 0, "no audio reached the server");
     for (const bytes of frames) {
@@ -261,9 +255,8 @@ test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate",
 });
 
 test("a coalesced system-audio read is split under AssemblyAI's 1000 ms ceiling", async () => {
-  // audioTapManager and the Windows/Linux loopback helpers forward raw stdout
-  // chunks, so a stalled main process gets one 64 KB pipe read — 1365 ms at
-  // 24 kHz, which AssemblyAI rejects exactly like an undersized frame.
+  // A stalled main process gets one 64 KB pipe read off the system-audio helper:
+  // 1365 ms at 24 kHz, which AssemblyAI rejects like an undersized frame.
   await collectFrames({ chunkBytes: 65536, chunkCount: 1 }, (frames) => {
     assert.ok(frames.length > 1, "a 1365 ms read must be split, not sent whole");
     for (const bytes of frames) {

--- a/test/helpers/assemblyAiStreaming.test.js
+++ b/test/helpers/assemblyAiStreaming.test.js
@@ -254,15 +254,16 @@ test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate",
   });
 });
 
-test("a coalesced system-audio read is split under AssemblyAI's 1000 ms ceiling", async () => {
+test("a coalesced system-audio read is split inside AssemblyAI's frame window", async () => {
   // A stalled main process gets one 64 KB pipe read off the system-audio helper:
-  // 1365 ms at 24 kHz, which AssemblyAI rejects like an undersized frame.
+  // 1365 ms at 24 kHz, which AssemblyAI rejects like an undersized frame. The
+  // slices target the documented 250 ms ceiling, not the 1000 ms hard limit.
   await collectFrames([65536], (frames) => {
     assert.ok(frames.length > 1, "a 1365 ms read must be split, not sent whole");
     for (const bytes of frames) {
       assert.ok(
-        frameDurationMs(bytes) >= 50 && frameDurationMs(bytes) <= 1000,
-        `sent a ${frameDurationMs(bytes).toFixed(1)} ms frame; AssemblyAI accepts 50-1000 ms`
+        frameDurationMs(bytes) >= 50 && frameDurationMs(bytes) <= 250,
+        `sent a ${frameDurationMs(bytes).toFixed(1)} ms frame; AssemblyAI documents 50-250 ms`
       );
     }
   });

--- a/test/helpers/assemblyAiStreaming.test.js
+++ b/test/helpers/assemblyAiStreaming.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const { WebSocketServer } = require("ws");
 
 const AssemblyAiStreaming = require("../../src/helpers/assemblyAiStreaming");
+const { deferred } = require("./harness/deferred");
 
 async function withPrematureCloseServer(run) {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
@@ -19,13 +20,17 @@ async function withPrematureCloseServer(run) {
 }
 
 // `connections` collects each accepted request URL so a test can count sockets
-// and read the query the client actually sent.
-async function withBeginServer(run) {
+// and read the query the client actually sent. `onAudioFrame` reports every
+// binary frame as the server receives it, for tests that assert on framing.
+async function withBeginServer(run, { onAudioFrame } = {}) {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((resolve) => server.once("listening", resolve));
   const connections = [];
   server.on("connection", (socket, request) => {
     connections.push(request.url);
+    socket.on("message", (data, isBinary) => {
+      if (isBinary) onAudioFrame?.(data);
+    });
     socket.send(JSON.stringify({ type: "Begin", id: "test-session" }));
   });
 
@@ -174,6 +179,98 @@ test("a warm connection opened for another speech model is not reused", async ()
       assert.equal(connections.length, 1, "same model rides the warm socket");
     } finally {
       streaming.cleanupAll();
+    }
+  });
+});
+
+// Note Recording streams at MEETING_STREAM_SAMPLE_RATE (24 kHz), where a frame
+// sized against the module's 16 kHz default lasts only 33 ms — under the 50 ms
+// floor AssemblyAI enforces, which closes the socket mid-meeting (#2140).
+const MEETING_SAMPLE_RATE = 24000;
+const frameDurationMs = (bytes) => (bytes / 2 / MEETING_SAMPLE_RATE) * 1000;
+
+// Collects the frames the server receives, failing rather than hanging when the
+// client withholds audio: node:test has no default timeout, so a bare await on a
+// byte count would stall CI for hours instead of going red.
+async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
+  const frames = [];
+  let receivedBytes = 0;
+  const allReceived = deferred();
+  const expectedBytes = chunkBytes * chunkCount;
+
+  await withBeginServer(
+    async (url, connections) => {
+      const streaming = new AssemblyAiStreaming();
+      // The real builder is what pins the session's sample rate, so this test
+      // must not stub it out.
+      dialLoopback(streaming, url);
+
+      try {
+        await streaming.connect({
+          token: "byok-key",
+          mode: "byok",
+          sampleRate: MEETING_SAMPLE_RATE,
+        });
+        for (let i = 0; i < chunkCount; i++) streaming.sendAudio(Buffer.alloc(chunkBytes));
+        await Promise.race([
+          allReceived.promise,
+          new Promise((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(`only ${receivedBytes} of ${expectedBytes} bytes reached the server`)
+                ),
+              2000
+            ).unref()
+          ),
+        ]);
+
+        assert.match(
+          connections[0],
+          /sample_rate=24000/,
+          "the session must open at the meeting rate for the frame maths to mean anything"
+        );
+        assertFrames(frames);
+      } finally {
+        streaming.cleanupAll();
+      }
+    },
+    {
+      onAudioFrame: (data) => {
+        frames.push(data.length);
+        receivedBytes += data.length;
+        if (receivedBytes >= expectedBytes) allReceived.resolve();
+      },
+    }
+  );
+}
+
+test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate", async () => {
+  // meeting-aec-helper emits one frame per mic chunk, sized to the whole 10 ms
+  // frames it had ready — 1440 or 1680 bytes for the renderer's 800-sample input.
+  // 480 bytes (a single 10 ms frame) is the smallest it can hand over.
+  await collectFrames({ chunkBytes: 480, chunkCount: 20 }, (frames) => {
+    assert.ok(frames.length > 0, "no audio reached the server");
+    for (const bytes of frames) {
+      assert.ok(
+        frameDurationMs(bytes) >= 50,
+        `sent a ${frameDurationMs(bytes).toFixed(1)} ms frame; AssemblyAI's floor is 50 ms`
+      );
+    }
+  });
+});
+
+test("a coalesced system-audio read is split under AssemblyAI's 1000 ms ceiling", async () => {
+  // audioTapManager and the Windows/Linux loopback helpers forward raw stdout
+  // chunks, so a stalled main process gets one 64 KB pipe read — 1365 ms at
+  // 24 kHz, which AssemblyAI rejects exactly like an undersized frame.
+  await collectFrames({ chunkBytes: 65536, chunkCount: 1 }, (frames) => {
+    assert.ok(frames.length > 1, "a 1365 ms read must be split, not sent whole");
+    for (const bytes of frames) {
+      assert.ok(
+        frameDurationMs(bytes) >= 50 && frameDurationMs(bytes) <= 1000,
+        `sent a ${frameDurationMs(bytes).toFixed(1)} ms frame; AssemblyAI accepts 50-1000 ms`
+      );
     }
   });
 });

--- a/test/helpers/assemblyAiStreaming.test.js
+++ b/test/helpers/assemblyAiStreaming.test.js
@@ -189,11 +189,11 @@ const frameDurationMs = (bytes) => (bytes / 2 / MEETING_SAMPLE_RATE) * 1000;
 
 // node:test has no default timeout, so the wait is bounded here: withheld audio
 // must fail the run rather than hang it.
-async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
+async function collectFrames(chunks, assertFrames) {
   const frames = [];
   let receivedBytes = 0;
   const allReceived = deferred();
-  const expectedBytes = chunkBytes * chunkCount;
+  const expectedBytes = chunks.reduce((total, bytes) => total + bytes, 0);
 
   await withBeginServer(
     async (url, connections) => {
@@ -207,7 +207,7 @@ async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
           mode: "byok",
           sampleRate: MEETING_SAMPLE_RATE,
         });
-        for (let i = 0; i < chunkCount; i++) streaming.sendAudio(Buffer.alloc(chunkBytes));
+        for (const bytes of chunks) streaming.sendAudio(Buffer.alloc(bytes));
         await Promise.race([
           allReceived.promise,
           new Promise((_, reject) =>
@@ -243,7 +243,7 @@ async function collectFrames({ chunkBytes, chunkCount }, assertFrames) {
 
 test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate", async () => {
   // 480 bytes is the smallest meeting-aec-helper can hand over (one 10 ms frame).
-  await collectFrames({ chunkBytes: 480, chunkCount: 20 }, (frames) => {
+  await collectFrames(Array(20).fill(480), (frames) => {
     assert.ok(frames.length > 0, "no audio reached the server");
     for (const bytes of frames) {
       assert.ok(
@@ -257,13 +257,64 @@ test("audio frames respect AssemblyAI's 50 ms floor at the meeting sample rate",
 test("a coalesced system-audio read is split under AssemblyAI's 1000 ms ceiling", async () => {
   // A stalled main process gets one 64 KB pipe read off the system-audio helper:
   // 1365 ms at 24 kHz, which AssemblyAI rejects like an undersized frame.
-  await collectFrames({ chunkBytes: 65536, chunkCount: 1 }, (frames) => {
+  await collectFrames([65536], (frames) => {
     assert.ok(frames.length > 1, "a 1365 ms read must be split, not sent whole");
     for (const bytes of frames) {
       assert.ok(
         frameDurationMs(bytes) >= 50 && frameDurationMs(bytes) <= 1000,
         `sent a ${frameDurationMs(bytes).toFixed(1)} ms frame; AssemblyAI accepts 50-1000 ms`
       );
+    }
+  });
+});
+
+test("a sub-floor remainder is carried into the next frame, not dropped", async () => {
+  // 50000 B leaves 2000 B after the slices — under the 2400 B floor at 24 kHz, so
+  // it can only go out once the next chunk lifts it over. Without the carry it is
+  // silently discarded and 2000 B of speech never reaches the transcript, which
+  // collectFrames catches as bytes that never arrive. Asserting the tail rather
+  // than the whole shape keeps this independent of MAX_FRAME_MS.
+  await collectFrames([50000, 2400], (frames) => {
+    assert.equal(frames.at(-1), 4400, "the 2000 B tail must ride out on the next frame");
+  });
+});
+
+test("a warm connection opened at another sample rate is not reused", async () => {
+  await withBeginServer(async (url, connections) => {
+    const streaming = new AssemblyAiStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      await streaming.warmup({ token: "byok-key", mode: "byok" });
+      // The rate is pinned at open, so riding a 16 kHz warm socket with 24 kHz PCM
+      // garbles the transcript silently and re-frames audio against the wrong rate.
+      await streaming.connect({
+        token: "byok-key",
+        mode: "byok",
+        sampleRate: MEETING_SAMPLE_RATE,
+      });
+
+      assert.equal(connections.length, 2);
+      assert.match(connections[0], /sample_rate=16000/);
+      assert.match(connections[1], /sample_rate=24000/);
+      assert.equal(streaming.sessionSampleRate, MEETING_SAMPLE_RATE);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+
+  await withBeginServer(async (url, connections) => {
+    const streaming = new AssemblyAiStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      const options = { token: "byok-key", mode: "byok", sampleRate: MEETING_SAMPLE_RATE };
+      await streaming.warmup(options);
+      await streaming.connect(options);
+
+      assert.equal(connections.length, 1, "same rate rides the warm socket");
+    } finally {
+      streaming.cleanupAll();
     }
   });
 });

--- a/test/helpers/deepgramStreaming.test.js
+++ b/test/helpers/deepgramStreaming.test.js
@@ -6,8 +6,6 @@ const DeepgramStreaming = require("../../src/helpers/deepgramStreaming");
 
 // Loopback Deepgram: warmup resolves on the socket opening, connect on the
 // first server message, so every accepted socket answers with Metadata.
-// `authHeaders` mirrors `connections` so a test can read the credential the
-// client presented at the handshake.
 async function withMetadataServer(run) {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((resolve) => server.once("listening", resolve));
@@ -88,10 +86,6 @@ test("adopting a different mode before a warmup drops the other mode's token", a
   });
 });
 
-// Deepgram binds the Authorization scheme to the kind of credential, not to the
-// endpoint: a raw API key is a `Token`, and only the short-lived credential
-// /v1/auth/grant mints is a `Bearer`. BYOK hands over the raw key, so sending it
-// as a Bearer 401s the handshake (#2140).
 test("a BYOK key authenticates under Deepgram's Token scheme", async () => {
   await withMetadataServer(async (url, connections, authHeaders) => {
     const streaming = new DeepgramStreaming();
@@ -137,8 +131,8 @@ test("warmup presents the same scheme the session will connect with", async () =
   });
 });
 
-// stt-canary.mjs is the only consumer, and it runs weekly rather than in PR CI —
-// so without this, deleting the export stays green for a week.
+// Its only consumer is the weekly canary, not PR CI: without this, deleting the
+// export stays green for a week.
 test("the authorization scheme is exported for the canary to reuse", () => {
   assert.equal(DeepgramStreaming.authorizationHeader("byok", "k"), "Token k");
   assert.equal(DeepgramStreaming.authorizationHeader("openwhispr", "k"), "Bearer k");

--- a/test/helpers/deepgramStreaming.test.js
+++ b/test/helpers/deepgramStreaming.test.js
@@ -6,17 +6,21 @@ const DeepgramStreaming = require("../../src/helpers/deepgramStreaming");
 
 // Loopback Deepgram: warmup resolves on the socket opening, connect on the
 // first server message, so every accepted socket answers with Metadata.
+// `authHeaders` mirrors `connections` so a test can read the credential the
+// client presented at the handshake.
 async function withMetadataServer(run) {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((resolve) => server.once("listening", resolve));
   const connections = [];
+  const authHeaders = [];
   server.on("connection", (socket, request) => {
     connections.push(request.url);
+    authHeaders.push(request.headers.authorization);
     socket.send(JSON.stringify({ type: "Metadata", request_id: `req-${connections.length}` }));
   });
 
   try {
-    await run(`ws://127.0.0.1:${server.address().port}`, connections);
+    await run(`ws://127.0.0.1:${server.address().port}`, connections, authHeaders);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -82,4 +86,60 @@ test("adopting a different mode before a warmup drops the other mode's token", a
       streaming.cleanupAll();
     }
   });
+});
+
+// Deepgram binds the Authorization scheme to the kind of credential, not to the
+// endpoint: a raw API key is a `Token`, and only the short-lived credential
+// /v1/auth/grant mints is a `Bearer`. BYOK hands over the raw key, so sending it
+// as a Bearer 401s the handshake (#2140).
+test("a BYOK key authenticates under Deepgram's Token scheme", async () => {
+  await withMetadataServer(async (url, connections, authHeaders) => {
+    const streaming = new DeepgramStreaming();
+    streaming.buildWebSocketUrl = () => url;
+
+    try {
+      await streaming.connect({ token: "byok-key", mode: "byok" });
+
+      assert.deepEqual(authHeaders, ["Token byok-key"]);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
+test("a managed grant token authenticates under the Bearer scheme", async () => {
+  await withMetadataServer(async (url, connections, authHeaders) => {
+    const streaming = new DeepgramStreaming();
+    streaming.buildWebSocketUrl = () => url;
+
+    try {
+      await streaming.connect({ token: "grant-token", mode: "openwhispr" });
+
+      assert.deepEqual(authHeaders, ["Bearer grant-token"]);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
+test("warmup presents the same scheme the session will connect with", async () => {
+  await withMetadataServer(async (url, connections, authHeaders) => {
+    const streaming = new DeepgramStreaming();
+    streaming.buildWebSocketUrl = () => url;
+
+    try {
+      await streaming.warmup({ token: "byok-key", mode: "byok" });
+
+      assert.deepEqual(authHeaders, ["Token byok-key"]);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
+// stt-canary.mjs is the only consumer, and it runs weekly rather than in PR CI —
+// so without this, deleting the export stays green for a week.
+test("the authorization scheme is exported for the canary to reuse", () => {
+  assert.equal(DeepgramStreaming.authorizationHeader("byok", "k"), "Token k");
+  assert.equal(DeepgramStreaming.authorizationHeader("openwhispr", "k"), "Bearer k");
 });

--- a/test/helpers/deepgramStreaming.test.js
+++ b/test/helpers/deepgramStreaming.test.js
@@ -67,6 +67,86 @@ test("a warm connection is reused only within the same credential mode", async (
   });
 });
 
+// Keeps the real query string (language, keyterms) while dialing the loopback server.
+function dialLoopback(streaming, url) {
+  const buildRealUrl = streaming.buildWebSocketUrl.bind(streaming);
+  streaming.buildWebSocketUrl = (options) =>
+    buildRealUrl(options).replace("wss://api.deepgram.com/v1/listen", url);
+}
+
+test("a warm connection opened for another language is not reused", async () => {
+  await withMetadataServer(async (url, connections) => {
+    const streaming = new DeepgramStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      // Dictation warms on the UI language: warmupStreamingConnection() runs at
+      // startup and after each transcription, before setTranslationRequested()
+      // can say a translation wants the source language instead. The URL pins
+      // that language — and with it nova-3 vs nova-2 — for the whole session.
+      await streaming.warmup({ token: "byok-key", mode: "byok", language: "en" });
+      await streaming.connect({ token: "byok-key", mode: "byok", language: "fr" });
+
+      assert.equal(connections.length, 2, "the English warm socket was reused for French");
+      assert.match(connections[0], /language=en/);
+      assert.match(connections[1], /language=fr/);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+
+  await withMetadataServer(async (url, connections) => {
+    const streaming = new DeepgramStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      const options = { token: "byok-key", mode: "byok", language: "en" };
+      await streaming.warmup(options);
+      await streaming.connect(options);
+
+      assert.equal(connections.length, 1, "same language rides the warm socket");
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
+test("a warm connection opened for other keyterms is not reused", async () => {
+  await withMetadataServer(async (url, connections) => {
+    const streaming = new DeepgramStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      await streaming.warmup({ token: "byok-key", mode: "byok", keyterms: ["Whispr"] });
+      await streaming.connect({ token: "byok-key", mode: "byok", keyterms: ["Whispr", "Qdrant"] });
+
+      assert.equal(connections.length, 2, "a dictionary edit must reach the socket");
+      assert.match(connections[1], /keyterm=Qdrant/);
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
+test("a warm connection is reused when the two option sets build the same URL", async () => {
+  // buildWebSocketUrl folds "auto" into no language and skips empty keyterms, so
+  // the guard has to fold them the same way — otherwise every dictation cold
+  // starts and the warm socket stops buying anything.
+  await withMetadataServer(async (url, connections) => {
+    const streaming = new DeepgramStreaming();
+    dialLoopback(streaming, url);
+
+    try {
+      await streaming.warmup({ token: "byok-key", mode: "byok", language: "auto" });
+      await streaming.connect({ token: "byok-key", mode: "byok", keyterms: [] });
+
+      assert.equal(connections.length, 1, "an identical URL must ride the warm socket");
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
 test("adopting a different mode before a warmup drops the other mode's token", async () => {
   await withMetadataServer(async (url) => {
     const streaming = new DeepgramStreaming();

--- a/test/helpers/deepgramStreaming.test.js
+++ b/test/helpers/deepgramStreaming.test.js
@@ -131,6 +131,49 @@ test("warmup presents the same scheme the session will connect with", async () =
   });
 });
 
+// Runs `schedule` with setTimeout stubbed out and hands back its callback, so a
+// timer-gated branch can be exercised at once. Scoped to the one synchronous
+// call: mocking setTimeout for any longer deadlocks the ws server's teardown.
+function captureScheduledCallback(schedule) {
+  const realSetTimeout = global.setTimeout;
+  let scheduled = null;
+  global.setTimeout = (callback) => {
+    scheduled = callback;
+    return { unref() {} };
+  };
+  try {
+    schedule();
+  } finally {
+    global.setTimeout = realSetTimeout;
+  }
+  assert.ok(scheduled, "nothing was scheduled");
+  return scheduled;
+}
+
+test("a re-warm whose options were dropped does not re-authenticate as managed", async () => {
+  await withMetadataServer(async (url, connections, authHeaders) => {
+    const streaming = new DeepgramStreaming();
+    streaming.buildWebSocketUrl = () => url;
+
+    try {
+      await streaming.warmup({ token: "byok-key", mode: "byok" });
+      assert.deepEqual(authHeaders, ["Token byok-key"]);
+
+      const rewarm = captureScheduledCallback(() => streaming.scheduleRewarm());
+      // cleanupWarmConnection() drops the saved options without cancelling the
+      // timer, and the cached token outlives them — so the re-warm still has a
+      // credential to present, just no longer any record of which kind it is.
+      streaming.cleanupWarmConnection();
+      await rewarm();
+
+      assert.equal(streaming.mode, "byok", "the re-warm renegotiated the credential mode");
+      assert.equal(streaming.warmConnection, null, "a socket was opened without a known mode");
+    } finally {
+      streaming.cleanupAll();
+    }
+  });
+});
+
 // Its only consumer is the weekly canary, not PR CI: without this, deleting the
 // export stays green for a week.
 test("the authorization scheme is exported for the canary to reuse", () => {

--- a/test/helpers/meetingStreamingWiring.test.js
+++ b/test/helpers/meetingStreamingWiring.test.js
@@ -159,19 +159,15 @@ test("the watchdog sees every system chunk and the helper's device warning", () 
 });
 
 test("meeting connects forward the credential mode", () => {
-  // Deepgram authenticates a raw BYOK key and a managed grant token under
-  // different Authorization schemes, and the client reads which it holds from
-  // `mode`. Both meeting connectOpts are built by hand, so omitting it here
-  // silently re-authenticates Note Recording as managed (#2140).
-  // Scoped by the meeting sample rate so an unrelated connectOpts elsewhere in
-  // this file cannot drag the assertion off target, and matched without crossing
-  // a `}` so a nested literal cannot truncate the block.
+  // The Deepgram client picks its Authorization scheme from `mode`; both meeting
+  // connectOpts are built by hand, so omitting it re-authenticates Note Recording
+  // as managed (#2140). Scoped by sample rate so an unrelated connectOpts cannot
+  // drag the assertion off target.
   const connectOptsBlocks =
     source.match(/const connectOpts = \{[^}]*sampleRate: MEETING_STREAM_SAMPLE_RATE,\s*\};/g) ?? [];
   assert.equal(connectOptsBlocks.length, 2, "initial connect and reconnect each build connectOpts");
   for (const block of connectOptsBlocks) {
-    // Anchored to its own line: an unanchored match also accepts the key sitting
-    // commented out, which is exactly how this would regress during debugging.
+    // Anchored: an unanchored match also accepts the key commented out.
     assert.match(block, /^\s*mode: options\.mode,$/m);
   }
 });

--- a/test/helpers/meetingStreamingWiring.test.js
+++ b/test/helpers/meetingStreamingWiring.test.js
@@ -157,3 +157,21 @@ test("the watchdog sees every system chunk and the helper's device warning", () 
   // user watching a recording that has stopped hearing the call.
   assert.match(source, /send\("meeting-system-audio-interrupted", payload\)/);
 });
+
+test("meeting connects forward the credential mode", () => {
+  // Deepgram authenticates a raw BYOK key and a managed grant token under
+  // different Authorization schemes, and the client reads which it holds from
+  // `mode`. Both meeting connectOpts are built by hand, so omitting it here
+  // silently re-authenticates Note Recording as managed (#2140).
+  // Scoped by the meeting sample rate so an unrelated connectOpts elsewhere in
+  // this file cannot drag the assertion off target, and matched without crossing
+  // a `}` so a nested literal cannot truncate the block.
+  const connectOptsBlocks =
+    source.match(/const connectOpts = \{[^}]*sampleRate: MEETING_STREAM_SAMPLE_RATE,\s*\};/g) ?? [];
+  assert.equal(connectOptsBlocks.length, 2, "initial connect and reconnect each build connectOpts");
+  for (const block of connectOptsBlocks) {
+    // Anchored to its own line: an unanchored match also accepts the key sitting
+    // commented out, which is exactly how this would regress during debugging.
+    assert.match(block, /^\s*mode: options\.mode,$/m);
+  }
+});


### PR DESCRIPTION
Fixes #2140.

Both BYOK streaming providers added in #2063 were broken in 1.10.0, for two
unrelated reasons. Each is reproduced by a test that fails without its fix.

## 1. Deepgram — raw key sent under the wrong scheme

Deepgram binds the Authorization scheme to the *kind* of credential: a raw API
key is only accepted as `Token`, and `Bearer` is reserved for the short-lived
credential `/v1/auth/grant` mints. `deepgramStreaming.js` sent every credential
as a `Bearer`, so BYOK failed the handshake with `Unexpected server response:
401` while OpenWhispr Cloud — which receives a real grant token from
`/api/deepgram-streaming-token` — kept working. `providerConnectionTest.js`
already used `Token`, which is exactly why the reporter's key tested green in
Settings while streaming 401'd.

This affected **BYOK dictation as well as Note Recording**, not just Note
Recording as reported.

Two supporting fixes were needed for the scheme to actually reach every socket:

- Both meeting `connectOpts` carried `preconfigured` but not `mode`, so Note
  Recording would have re-authenticated as managed.
- `scheduleRewarm()` re-read `warmConnectionOptions` at timer-fire time.
  `cleanupWarmConnection()` nulls that field without cancelling the timer, so
  `{...null, token}` lost the mode and re-warmed a BYOK key as a `Bearer`. It now
  snapshots, as `scheduleProactiveRefresh()` already did.

## 2. AssemblyAI — frames sized for the wrong sample rate

AssemblyAI accepts 50–1000 ms per frame. The floor was derived from the module's
hardcoded 16 kHz, but Note Recording opens at `MEETING_STREAM_SAMPLE_RATE`
(24 kHz), where 1600 bytes is 33 ms. With the AEC helper's 10 ms frames the gate
emitted exactly **40.0 ms** — the figure in the report — and the session died
seconds in, taking the reconnect cascade with it. Dictation, pinned to 16 kHz,
was never affected.

Both bounds now follow the rate the socket was opened at. The **ceiling** turned
out to matter: `audioTapManager` and the Windows/Linux loopback helpers forward
raw stdout chunks, so a stalled main process yields a 64 KB pipe read = 1365 ms
at 24 kHz. These sessions never previously survived long enough to reach that, so
fixing the floor would have exposed it for the first time. Oversized frames are
sliced and any sub-floor remainder carried forward.

Measured against every real cadence at 24 kHz:

| producer | frame | |
|---|---|---|
| aec-helper 10 ms frame (480 B) | 50 ms | in window |
| aec-helper real frame (1440 B) | 60 ms | in window |
| meeting worklet (1600 B) | 66.7 ms | in window |
| macOS tap `--chunk-ms 100` (4800 B) | 100 ms | in window |
| coalesced 64 KB pipe read | 1000 + 365.3 ms | in window |

## Not fixed here

- **`STT_CANARY_DEEPGRAM_KEY` and `STT_CANARY_ASSEMBLYAI_KEY` do not exist as repo
  secrets.** This is the actual reason #2140 shipped: those canary rows have been
  silently skipped in every run, and the job only fails when *every* probe is
  skipped. The probe in this PR is correct but still will not run until the
  secrets are added. Worth a `--require-all` flag so unprobed providers go red.
- The meeting reconnect is make-before-break, so it transiently doubles live
  provider sessions and trips per-account concurrency caps. That produced the
  "Too many concurrent sessions" toast in the report, as a cascade of the framing
  failure rather than an independent cause.
- No workflow sets `timeout-minutes`, and `node --test` has no default timeout.
- `buildMeetingConnectOpts()` as a pure seam would replace the source-grep wiring
  test with a behavioural one and remove the `mode`/`preconfigured` duplication.

## Verification

4301 tests, 0 failures (219 known DB-ABI skips). eslint 0 errors, prettier clean.
Every new test was watched failing first; the AssemblyAI one reproduces `40.0 ms`
character-for-character, and the ceiling test fails with `a 1365 ms read must be
split, not sent whole` when the slice is reverted.
