### PR TITLE
fix: keep retry bubble visible during recording

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -310,6 +310,7 @@ export default function App() {
     toastCount,
     isCommandMenuOpen,
     isCompactPill: windowFitsCompactPill,
+    hasLiveActivity: isVisuallyProcessing || isRecording,
     assistantOpen: assistant.open,
     assistantMounted: assistant.mounted,
     assistantOpenRef,

--- a/src/hooks/useMainWindowSizeOwner.js
+++ b/src/hooks/useMainWindowSizeOwner.js
@@ -23,6 +23,7 @@ export function useMainWindowSizeOwner({
   toastCount,
   isCommandMenuOpen,
   isCompactPill,
+  hasLiveActivity,
   assistantOpen,
   assistantMounted,
   assistantOpenRef,
@@ -32,6 +33,7 @@ export function useMainWindowSizeOwner({
 }) {
   const [handoffActive, setHandoffActive] = useState(false);
   const actionCountRef = useRef(dictationErrorActionCount);
+  const liveActivityRef = useRef(hasLiveActivity);
   const handoffRef = useRef(null);
   // Same masking for the panel-return shrink: snapping the native window from
   // panel bounds back to the pill box paints one compositor frame of the old
@@ -40,10 +42,14 @@ export function useMainWindowSizeOwner({
   const [panelReturnResizeActive, setPanelReturnResizeActive] = useState(false);
   const panelReturnSuppressedRef = useRef(false);
   const panelReturnHandoffRef = useRef(null);
+  useLayoutEffect(() => {
+    liveActivityRef.current = hasLiveActivity;
+  }, [hasLiveActivity]);
   useEffect(() => {
     const handoff = createPillVisibilityHandoff({
       onSuppressedChange: setHandoffActive,
-      shouldAutoHide: () => useSettingsStore.getState().floatingIconAutoHide,
+      shouldAutoHide: () =>
+        useSettingsStore.getState().floatingIconAutoHide && !liveActivityRef.current,
       hideWindow: () => window.electronAPI?.hideWindow?.(),
     });
     handoffRef.current = handoff;
@@ -173,6 +179,7 @@ export function useMainWindowSizeOwner({
     isCommandMenuOpen,
     toastCount,
     isCompactPill,
+    hasLiveActivity,
     dictationErrorActionCount,
     requestMainWindowSize,
   ]);

--- a/test/helpers/pillVisibilityHandoff.test.js
+++ b/test/helpers/pillVisibilityHandoff.test.js
@@ -148,3 +148,24 @@ test("auto-hide closes the native window before releasing DOM suppression", asyn
 
   assert.deepEqual(order, ["suppress", "bounds", "hide", "release"]);
 });
+
+test("active work vetoes auto-hide while releasing a retry error", async () => {
+  const { createPillVisibilityHandoff } =
+    await import("../../src/utils/pillVisibilityHandoff.ts");
+  let active = true;
+  const order = [];
+  const handoff = createPillVisibilityHandoff({
+    onSuppressedChange: (suppressed) => order.push(suppressed ? "suppress" : "release"),
+    shouldAutoHide: () => !active,
+    hideWindow: async () => order.push("hide"),
+    waitForFrames: async () => order.push("frames"),
+  });
+
+  handoff.suppress();
+  await handoff.releaseAfter(async () => order.push("bounds"));
+
+  assert.deepEqual(order, ["suppress", "bounds", "frames", "release"]);
+  active = false;
+  await handoff.releaseAfter(async () => order.push("bounds-again"));
+  assert.deepEqual(order, ["suppress", "bounds", "frames", "release", "bounds-again", "hide"]);
+});


### PR DESCRIPTION
## Summary

Fixes #2141 by keeping the error-to-pill handoff from auto-hiding the native window while recording or processing is active. This preserves the floating bubble when Retry starts a new recording.

## Validation

- 
ode --import tsx --test test/helpers/dictationErrorPillHandoff.test.js
- 
pm run lint
- 
pm run typecheck
- git diff --check

The KDE Wayland reproduction was not available on this host; the regression is covered at the handoff boundary.