### PR TITLE
Count Orukeet downloads via an optional pinned manifest

### DIFF
--- a/src/helpers/downloadUtils.js
+++ b/src/helpers/downloadUtils.js
@@ -248,11 +248,12 @@ function downloadAttempt(url, tempPath, options) {
 }
 
 async function fetchJson(url, options = {}) {
-  const headers = { "User-Agent": USER_AGENT, ...(options.headers || {}) };
+  const { headers, ...init } = options;
   const response = await net.fetch(url, {
     method: "GET",
-    headers,
     useSessionCookies: false,
+    ...init,
+    headers: { "User-Agent": USER_AGENT, ...(headers || {}) },
   });
   if (!response.ok) {
     const err = new Error(`HTTP ${response.status} fetching ${url}`);

--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -1,12 +1,12 @@
 const fs = require("fs");
 const fsPromises = require("fs").promises;
 const path = require("path");
-const { net } = require("electron");
 const { pipeline } = require("stream/promises");
 const debugLogger = require("./debugLogger");
 const { runSystemTar } = require("./systemTar");
 const {
   downloadFile,
+  fetchJson,
   createDownloadSignal,
   createDownloadInProgressError,
   cleanupStaleDownloads,
@@ -30,6 +30,7 @@ function getParakeetModelConfig(modelName) {
     url: modelInfo.downloadUrl,
     manifestUrl: modelInfo.manifestUrl,
     size: modelInfo.expectedSizeBytes || modelInfo.sizeMb * 1_000_000,
+    expectedSizeBytes: modelInfo.expectedSizeBytes,
     language: modelInfo.language,
     supportedLanguages: modelInfo.supportedLanguages || [],
     extractDir: modelInfo.extractDir,
@@ -473,19 +474,19 @@ class ParakeetManager {
   }
 
   async _saveModelManifest(modelConfig, modelPath) {
-    const response = await net.fetch(modelConfig.manifestUrl, {
-      headers: { "User-Agent": "OpenWhispr/1.0" },
+    const manifest = await fetchJson(modelConfig.manifestUrl, {
+      // Keep the default session's cookies off a third-party host, and make sure
+      // the request reaches the network — a cache hit would not be counted.
       credentials: "omit",
-      useSessionCookies: false,
       cache: "no-store",
       signal: AbortSignal.timeout(3000),
     });
-    if (!response.ok) throw new Error(`Manifest HTTP ${response.status}`);
-    const manifest = await response.json();
     if (
       manifest?.archive !== path.posix.basename(new URL(modelConfig.url).pathname) ||
       manifest.extract_dir !== modelConfig.extractDir ||
-      manifest.archive_bytes !== modelConfig.size ||
+      // Only `expectedSizeBytes` is the archive's true size; `sizeMb` describes the
+      // extracted model, so a model without it simply skips this comparison.
+      (modelConfig.expectedSizeBytes && manifest.archive_bytes !== modelConfig.expectedSizeBytes) ||
       !/^[a-f0-9]{64}$/.test(manifest.archive_sha256)
     ) {
       throw new Error("Manifest does not match the installed model");

--- a/src/helpers/parakeet.js
+++ b/src/helpers/parakeet.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const fsPromises = require("fs").promises;
 const path = require("path");
+const { net } = require("electron");
 const { pipeline } = require("stream/promises");
 const debugLogger = require("./debugLogger");
 const { runSystemTar } = require("./systemTar");
@@ -27,6 +28,7 @@ function getParakeetModelConfig(modelName) {
   if (!modelInfo) return null;
   return {
     url: modelInfo.downloadUrl,
+    manifestUrl: modelInfo.manifestUrl,
     size: modelInfo.expectedSizeBytes || modelInfo.sizeMb * 1_000_000,
     language: modelInfo.language,
     supportedLanguages: modelInfo.supportedLanguages || [],
@@ -443,6 +445,17 @@ class ParakeetManager {
         });
       }
 
+      // Optional provenance: one request after a fresh install, never on model load.
+      // Hugging Face counts this JSON request for NeMo repositories.
+      if (!archiveReady && !signal.aborted && modelConfig.manifestUrl) {
+        this._saveModelManifest(modelConfig, modelPath).catch((error) => {
+          debugLogger.debug("Optional model manifest unavailable", {
+            modelName,
+            error: error.message,
+          });
+        });
+      }
+
       return { model: modelName, downloaded: true, path: modelPath, success: true };
     } catch (error) {
       if (error.isAbort) {
@@ -457,6 +470,32 @@ class ParakeetManager {
         this.currentDownloadProcess = null;
       }
     }
+  }
+
+  async _saveModelManifest(modelConfig, modelPath) {
+    const response = await net.fetch(modelConfig.manifestUrl, {
+      headers: { "User-Agent": "OpenWhispr/1.0" },
+      credentials: "omit",
+      useSessionCookies: false,
+      cache: "no-store",
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) throw new Error(`Manifest HTTP ${response.status}`);
+    const manifest = await response.json();
+    if (
+      manifest?.archive !== path.posix.basename(new URL(modelConfig.url).pathname) ||
+      manifest.extract_dir !== modelConfig.extractDir ||
+      manifest.archive_bytes !== modelConfig.size ||
+      !/^[a-f0-9]{64}$/.test(manifest.archive_sha256)
+    ) {
+      throw new Error("Manifest does not match the installed model");
+    }
+    // Never recreate a deleted model directory or overwrite an existing sidecar.
+    await fsPromises.writeFile(
+      path.join(modelPath, "download-manifest.json"),
+      JSON.stringify(manifest, null, 2) + "\n",
+      { flag: "wx" }
+    );
   }
 
   async _extractModel(archivePath, modelName) {

--- a/src/models/ModelRegistry.ts
+++ b/src/models/ModelRegistry.ts
@@ -105,6 +105,7 @@ export interface ParakeetModelInfo {
   size: string;
   sizeMb: number;
   expectedSizeBytes?: number;
+  manifestUrl?: string;
   language: string;
   supportedLanguages: string[];
   runtime?: "offline" | "online";

--- a/src/models/modelRegistryData.json
+++ b/src/models/modelRegistryData.json
@@ -157,6 +157,7 @@
       "recommended": true,
       "extractDir": "sherpa-onnx-orukeet-v0.1.0-int8",
       "downloadUrl": "https://huggingface.co/oruk/orukeet/resolve/55a984d46f68323301837194ce647c702f55facc/onnx/sherpa-onnx-orukeet-v0.1.0-int8.tar.bz2",
+      "manifestUrl": "https://huggingface.co/oruk/orukeet/resolve/55a984d46f68323301837194ce647c702f55facc/onnx/manifest.json",
       "license": "CC-BY-SA-4.0",
       "organization": {
         "id": "oruk",

--- a/test/helpers/downloadUtils.test.js
+++ b/test/helpers/downloadUtils.test.js
@@ -21,6 +21,79 @@ function createElectronMock(response) {
   };
 }
 
+function loadWithNetFetch(fetchImpl) {
+  const electronPath = require.resolve("electron");
+  const downloadUtilsPath = require.resolve("../../src/helpers/downloadUtils.js");
+  const originalElectronCache = require.cache[electronPath];
+  require.cache[electronPath] = {
+    exports: { app: { isReady: () => false }, net: { fetch: fetchImpl } },
+  };
+  delete require.cache[downloadUtilsPath];
+  return {
+    downloadUtils: require(downloadUtilsPath),
+    restore() {
+      delete require.cache[downloadUtilsPath];
+      if (originalElectronCache) require.cache[electronPath] = originalElectronCache;
+      else delete require.cache[electronPath];
+    },
+  };
+}
+
+test("fetchJson sends the app User-Agent and returns the parsed body", async (t) => {
+  const calls = [];
+  const { downloadUtils, restore } = loadWithNetFetch(async (url, init) => {
+    calls.push({ url, init });
+    return Response.json({ tag_name: "v1" });
+  });
+  t.after(restore);
+
+  assert.deepEqual(await downloadUtils.fetchJson("https://example.com/release.json"), {
+    tag_name: "v1",
+  });
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(calls[0].init.headers["User-Agent"], "OpenWhispr/1.0");
+});
+
+// The status is the only thing standing between an error page and a caller that
+// would otherwise treat a valid-looking JSON body as a successful response.
+test("fetchJson rejects a non-2xx response even when its body is valid JSON", async (t) => {
+  const { downloadUtils, restore } = loadWithNetFetch(async () =>
+    Response.json({ error: "Entry not found" }, { status: 404 })
+  );
+  t.after(restore);
+
+  await assert.rejects(
+    () => downloadUtils.fetchJson("https://example.com/missing.json"),
+    (error) => error.isHttpError === true && error.statusCode === 404
+  );
+});
+
+test("fetchJson forwards caller init and keeps the User-Agent alongside caller headers", async (t) => {
+  const calls = [];
+  const { downloadUtils, restore } = loadWithNetFetch(async (url, init) => {
+    calls.push({ url, init });
+    return Response.json({});
+  });
+  t.after(restore);
+  const signal = new AbortController().signal;
+
+  await downloadUtils.fetchJson("https://example.com/pinned.json", {
+    headers: { Accept: "application/vnd.github+json" },
+    credentials: "omit",
+    cache: "no-store",
+    signal,
+  });
+
+  const { init } = calls[0];
+  assert.equal(init.credentials, "omit");
+  assert.equal(init.cache, "no-store");
+  assert.equal(init.signal, signal);
+  assert.deepEqual(init.headers, {
+    "User-Agent": "OpenWhispr/1.0",
+    Accept: "application/vnd.github+json",
+  });
+});
+
 test("downloadFile waits for a cancelled write stream to close before removing its temp file", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "downloadUtils-test-"));
   const destination = path.join(tempDir, "model.bin");

--- a/test/helpers/parakeetModelManifest.test.js
+++ b/test/helpers/parakeetModelManifest.test.js
@@ -1,0 +1,315 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const { createRequire } = require("node:module");
+const registry = require("../../src/models/modelRegistryData.json");
+const { getRequiredModelFiles } = require("../../src/helpers/parakeetModelInfo");
+
+const MODEL = "orukeet-v0.1.0";
+const info = registry.parakeetModels[MODEL];
+const manifest = {
+  archive: path.posix.basename(new URL(info.downloadUrl).pathname),
+  extract_dir: info.extractDir,
+  archive_bytes: info.expectedSizeBytes,
+  archive_sha256: "a".repeat(64),
+};
+const managerFile = path.resolve(__dirname, "../../src/helpers/parakeet.js");
+
+function setup(t, options = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "parakeet-manifest-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const calls = { downloads: [], manifests: [], events: [], errors: [], warms: 0 };
+  const realRequire = createRequire(managerFile);
+  const timeout = new AbortController();
+  const fakeFs = options.writeError
+    ? {
+        ...fs,
+        promises: {
+          ...fs.promises,
+          writeFile: async () => {
+            throw new Error("disk full");
+          },
+        },
+      }
+    : fs;
+  const stubs = {
+    fs: fakeFs,
+    electron: {
+      net: {
+        fetch: async (url, init) => {
+          calls.manifests.push({ url, init });
+          calls.events.push("manifest");
+          return options.fetch ? options.fetch(url, init) : Response.json(manifest);
+        },
+      },
+    },
+    "./debugLogger": {
+      info() {},
+      warn() {},
+      debug(message, data) {
+        if (message === "Optional model manifest unavailable") calls.errors.push(data);
+      },
+    },
+    "./modelDirUtils": { getModelsDirForService: () => root },
+    "./parakeetCapability": { assertParakeetSupported() {} },
+    "./parakeetServer": class {
+      isModelDownloaded(name) {
+        return fs.existsSync(path.join(root, name, "tokens.txt"));
+      }
+      getServerStatus() {
+        return { running: !!options.running, starting: false };
+      }
+      isAvailable() {
+        return true;
+      }
+      async startServer() {
+        calls.warms++;
+        calls.events.push("warm");
+      }
+    },
+    "./downloadUtils": {
+      async downloadFile(url, target, { signal }) {
+        calls.downloads.push(url);
+        if (options.cancel) {
+          signal.aborted = true;
+          throw Object.assign(new Error("cancelled"), { isAbort: true });
+        }
+        if (options.downloadError) throw new Error("download failed");
+        fs.writeFileSync(target, "archive fixture");
+        calls.events.push("downloaded");
+      },
+      createDownloadSignal() {
+        const signal = { aborted: false };
+        return {
+          signal,
+          abort: () => {
+            signal.aborted = true;
+          },
+        };
+      },
+      createDownloadInProgressError: () => new Error("download already running"),
+      checkDiskSpace: async () => ({ ok: true }),
+    },
+  };
+  const exports = { exports: {} };
+  vm.runInNewContext(
+    fs.readFileSync(managerFile, "utf8"),
+    {
+      require: (name) => stubs[name] || realRequire(name),
+      module: exports,
+      URL,
+      AbortSignal: {
+        timeout(ms) {
+          assert.equal(ms, 3000);
+          return timeout.signal;
+        },
+      },
+      process,
+      Buffer,
+      console,
+    },
+    { filename: managerFile }
+  );
+  const manager = new exports.exports();
+  let extracts = 0;
+  manager._runTarExtract = async (_archive, destination) => {
+    extracts++;
+    if (options.extractionError || (options.retryExtraction && extracts === 1))
+      throw new Error("bad archive");
+    const name = options.model || MODEL;
+    const dir = path.join(destination, registry.parakeetModels[name].extractDir);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const file of getRequiredModelFiles(name))
+      fs.writeFileSync(path.join(dir, file), "model fixture");
+    calls.events.push("extracted");
+  };
+  let manifestTask;
+  const save = manager._saveModelManifest.bind(manager);
+  manager._saveModelManifest = (...args) => {
+    manifestTask = save(...args);
+    return manifestTask;
+  };
+  return {
+    manager,
+    root,
+    calls,
+    timeout,
+    sidecar: path.join(root, MODEL, "download-manifest.json"),
+    async settled() {
+      await manifestTask?.catch(() => {});
+    },
+  };
+}
+
+test("Orukeet manifest is pinned beside its existing archive; other models are not opted in", () => {
+  assert.equal(info.manifestUrl, new URL("manifest.json", info.downloadUrl).href);
+  assert.match(info.manifestUrl, /\/resolve\/[a-f0-9]{40}\/onnx\/manifest\.json$/);
+  assert.deepEqual(
+    Object.keys(registry.parakeetModels).filter((id) => registry.parakeetModels[id].manifestUrl),
+    [MODEL]
+  );
+});
+
+test("fresh install fetches one manifest after extraction and warmup, then saves optional provenance", async (t) => {
+  const h = setup(t);
+  assert.equal((await h.manager.downloadParakeetModel(MODEL)).success, true);
+  await h.settled();
+  assert.deepEqual(h.calls.events, ["downloaded", "extracted", "warm", "manifest"]);
+  assert.equal(h.calls.manifests.length, 1);
+  const { url, init } = h.calls.manifests[0];
+  assert.equal(url, info.manifestUrl);
+  assert.equal(init.credentials, "omit");
+  assert.equal(init.useSessionCookies, false);
+  assert.equal(init.cache, "no-store");
+  assert.equal(h.manager.currentDownloadProcess, null);
+  assert.deepEqual(JSON.parse(fs.readFileSync(h.sidecar)), manifest);
+  for (const file of getRequiredModelFiles(MODEL))
+    assert.equal(fs.readFileSync(path.join(h.root, MODEL, file), "utf8"), "model fixture");
+  await h.manager.downloadParakeetModel(MODEL);
+  assert.equal(h.calls.manifests.length, 1);
+  assert.equal(h.calls.downloads.length, 1);
+});
+
+for (const kind of ["installed", "cached archive", "other model"]) {
+  test(`${kind} does not fetch a manifest`, async (t) => {
+    const model = kind === "other model" ? "parakeet-tdt-0.6b-v3" : MODEL;
+    const h = setup(t, { model });
+    if (kind === "installed") {
+      fs.mkdirSync(path.join(h.root, MODEL));
+      fs.writeFileSync(path.join(h.root, MODEL, "tokens.txt"), "installed");
+    }
+    if (kind === "cached archive") {
+      const archive = path.join(h.root, `${MODEL}.tar.bz2`);
+      fs.writeFileSync(archive, "");
+      fs.truncateSync(archive, info.expectedSizeBytes);
+    }
+    assert.equal((await h.manager.downloadParakeetModel(model)).success, true);
+    assert.equal(h.calls.manifests.length, 0);
+    if (kind !== "other model") assert.equal(h.calls.downloads.length, 0);
+  });
+}
+
+for (const option of ["cancel", "downloadError", "extractionError"]) {
+  test(`${option} does not fetch a manifest or leave the download locked`, async (t) => {
+    const h = setup(t, { [option]: true });
+    await assert.rejects(h.manager.downloadParakeetModel(MODEL));
+    assert.equal(h.calls.manifests.length, 0);
+    assert.equal(h.manager.currentDownloadProcess, null);
+  });
+}
+
+test("an extraction retry fetches only one manifest", async (t) => {
+  const h = setup(t, { retryExtraction: true });
+  assert.equal((await h.manager.downloadParakeetModel(MODEL)).success, true);
+  await h.settled();
+  assert.equal(h.calls.manifests.length, 1);
+});
+
+test("a truncated cached archive is downloaded again and gets one manifest", async (t) => {
+  const h = setup(t);
+  fs.writeFileSync(path.join(h.root, `${MODEL}.tar.bz2`), "incomplete");
+  await h.manager.downloadParakeetModel(MODEL);
+  await h.settled();
+  assert.equal(h.calls.downloads.length, 1);
+  assert.equal(h.calls.manifests.length, 1);
+});
+
+test(
+  "a stalled manifest cannot delay successful installation or warmup",
+  { timeout: 2000 },
+  async (t) => {
+    const h = setup(t, {
+      fetch: (_url, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    });
+    t.after(() => h.timeout.abort());
+    const result = await h.manager.downloadParakeetModel(MODEL);
+    assert.equal(result.success, true);
+    assert.equal(h.calls.warms, 1);
+    assert.equal(h.manager.currentDownloadProcess, null);
+    h.timeout.abort(new Error("timeout"));
+    await h.settled();
+    assert.equal(h.calls.manifests.length, 1);
+    assert.equal(h.calls.errors.length, 1);
+    assert.equal(fs.existsSync(h.sidecar), false);
+  }
+);
+
+const failures = [
+  [
+    "network rejection",
+    {
+      fetch: async () => {
+        throw new Error("offline");
+      },
+    },
+  ],
+  ["HTTP 404", { fetch: async () => new Response("missing", { status: 404 }) }],
+  ["invalid JSON", { fetch: async () => new Response("not json") }],
+  ["null manifest", { fetch: async () => Response.json(null) }],
+  [
+    "wrong archive",
+    { fetch: async () => Response.json({ ...manifest, archive: "other.tar.bz2" }) },
+  ],
+  ["wrong directory", { fetch: async () => Response.json({ ...manifest, extract_dir: "other" }) }],
+  ["wrong size", { fetch: async () => Response.json({ ...manifest, archive_bytes: 1 }) }],
+  ["invalid digest", { fetch: async () => Response.json({ ...manifest, archive_sha256: "bad" }) }],
+  ["sidecar write failure", { writeError: true }],
+];
+for (const [label, options] of failures) {
+  test(`${label} leaves the installed model usable`, async (t) => {
+    const h = setup(t, options);
+    assert.equal((await h.manager.downloadParakeetModel(MODEL)).success, true);
+    await h.settled();
+    assert.equal(h.calls.manifests.length, 1);
+    assert.equal(h.calls.errors.length, 1);
+    assert.equal(h.calls.warms, 1);
+    assert.equal(h.manager.serverManager.isModelDownloaded(MODEL), true);
+    assert.equal(fs.existsSync(h.sidecar), false);
+    assert.equal(h.manager.currentDownloadProcess, null);
+  });
+}
+
+test("a late manifest never recreates a deleted model directory", async (t) => {
+  let finish;
+  const h = setup(t, {
+    fetch: () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  });
+  await h.manager.downloadParakeetModel(MODEL);
+  fs.rmSync(path.join(h.root, MODEL), { recursive: true });
+  finish(Response.json(manifest));
+  await h.settled();
+  assert.equal(fs.existsSync(path.join(h.root, MODEL)), false);
+  assert.equal(h.calls.errors.length, 1);
+});
+
+test("a late manifest never overwrites an existing sidecar", async (t) => {
+  let finish;
+  const h = setup(t, {
+    fetch: () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  });
+  await h.manager.downloadParakeetModel(MODEL);
+  fs.writeFileSync(h.sidecar, "existing provenance");
+  finish(Response.json(manifest));
+  await h.settled();
+  assert.equal(fs.readFileSync(h.sidecar, "utf8"), "existing provenance");
+});
+
+test("manifest collection does not hijack a running model server", async (t) => {
+  const h = setup(t, { running: true });
+  await h.manager.downloadParakeetModel(MODEL);
+  await h.settled();
+  assert.equal(h.calls.warms, 0);
+  assert.equal(h.calls.manifests.length, 1);
+});

--- a/test/helpers/parakeetModelManifest.test.js
+++ b/test/helpers/parakeetModelManifest.test.js
@@ -21,9 +21,10 @@ const managerFile = path.resolve(__dirname, "../../src/helpers/parakeet.js");
 function setup(t, options = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "parakeet-manifest-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const calls = { downloads: [], manifests: [], events: [], errors: [], warms: 0 };
+  const calls = { downloads: [], manifests: [], events: [], errors: [], warms: 0, timeouts: [] };
   const realRequire = createRequire(managerFile);
   const timeout = new AbortController();
+  let downloadControl;
   const fakeFs = options.writeError
     ? {
         ...fs,
@@ -37,15 +38,6 @@ function setup(t, options = {}) {
     : fs;
   const stubs = {
     fs: fakeFs,
-    electron: {
-      net: {
-        fetch: async (url, init) => {
-          calls.manifests.push({ url, init });
-          calls.events.push("manifest");
-          return options.fetch ? options.fetch(url, init) : Response.json(manifest);
-        },
-      },
-    },
     "./debugLogger": {
       info() {},
       warn() {},
@@ -83,15 +75,30 @@ function setup(t, options = {}) {
       },
       createDownloadSignal() {
         const signal = { aborted: false };
-        return {
+        downloadControl = {
           signal,
           abort: () => {
             signal.aborted = true;
           },
         };
+        return downloadControl;
       },
       createDownloadInProgressError: () => new Error("download already running"),
       checkDiskSpace: async () => ({ ok: true }),
+      // Mirrors the real helper's contract (test/helpers/downloadUtils.test.js):
+      // non-2xx rejects, otherwise the parsed body comes back.
+      async fetchJson(url, init) {
+        calls.manifests.push({ url, init });
+        calls.events.push("manifest");
+        const response = options.fetch ? await options.fetch(url, init) : Response.json(manifest);
+        if (!response.ok) {
+          throw Object.assign(new Error(`HTTP ${response.status} fetching ${url}`), {
+            isHttpError: true,
+            statusCode: response.status,
+          });
+        }
+        return response.json();
+      },
     },
   };
   const exports = { exports: {} };
@@ -103,7 +110,7 @@ function setup(t, options = {}) {
       URL,
       AbortSignal: {
         timeout(ms) {
-          assert.equal(ms, 3000);
+          calls.timeouts.push(ms);
           return timeout.signal;
         },
       },
@@ -124,6 +131,7 @@ function setup(t, options = {}) {
     fs.mkdirSync(dir, { recursive: true });
     for (const file of getRequiredModelFiles(name))
       fs.writeFileSync(path.join(dir, file), "model fixture");
+    if (options.abortDuringInstall) downloadControl.abort();
     calls.events.push("extracted");
   };
   let manifestTask;
@@ -161,9 +169,12 @@ test("fresh install fetches one manifest after extraction and warmup, then saves
   assert.equal(h.calls.manifests.length, 1);
   const { url, init } = h.calls.manifests[0];
   assert.equal(url, info.manifestUrl);
+  // `credentials` is what actually keeps the default session's cookies off this
+  // third-party host; net.fetch ignores `useSessionCookies` and sends them without it.
   assert.equal(init.credentials, "omit");
-  assert.equal(init.useSessionCookies, false);
   assert.equal(init.cache, "no-store");
+  assert.equal(init.signal, h.timeout.signal);
+  assert.deepEqual(h.calls.timeouts, [3000]);
   assert.equal(h.manager.currentDownloadProcess, null);
   assert.deepEqual(JSON.parse(fs.readFileSync(h.sidecar)), manifest);
   for (const file of getRequiredModelFiles(MODEL))
@@ -200,6 +211,18 @@ for (const option of ["cancel", "downloadError", "extractionError"]) {
     assert.equal(h.manager.currentDownloadProcess, null);
   });
 }
+
+// downloadFile only checks the signal between retry attempts, so a cancel that
+// lands after the last byte (during the archive's cross-device move, say)
+// resolves normally and still installs. The install stands; the ping does not.
+test("a cancel landing after the download does not fetch a manifest", async (t) => {
+  const h = setup(t, { abortDuringInstall: true });
+  assert.equal((await h.manager.downloadParakeetModel(MODEL)).success, true);
+  await h.settled();
+  assert.equal(h.calls.manifests.length, 0);
+  assert.equal(fs.existsSync(h.sidecar), false);
+  assert.equal(h.manager.serverManager.isModelDownloaded(MODEL), true);
+});
 
 test("an extraction retry fetches only one manifest", async (t) => {
   const h = setup(t, { retryExtraction: true });
@@ -249,7 +272,9 @@ const failures = [
       },
     },
   ],
-  ["HTTP 404", { fetch: async () => new Response("missing", { status: 404 }) }],
+  // Body is a valid manifest on purpose: the status alone has to stop the write,
+  // or a JSON error page served with a 4xx would be saved as provenance.
+  ["HTTP 404", { fetch: async () => Response.json(manifest, { status: 404 }) }],
   ["invalid JSON", { fetch: async () => new Response("not json") }],
   ["null manifest", { fetch: async () => Response.json(null) }],
   [
@@ -274,6 +299,21 @@ for (const [label, options] of failures) {
     assert.equal(h.manager.currentDownloadProcess, null);
   });
 }
+
+// `sizeMb` describes the extracted model, not the archive, so a model whose entry
+// omits `expectedSizeBytes` has nothing to compare and must still save provenance.
+test("a model without expectedSizeBytes skips the archive-size check", async (t) => {
+  const h = setup(t, { fetch: async () => Response.json({ ...manifest, archive_bytes: 1 }) });
+  const modelDir = path.join(h.root, MODEL);
+  fs.mkdirSync(modelDir, { recursive: true });
+
+  await h.manager._saveModelManifest(
+    { url: info.downloadUrl, extractDir: info.extractDir, manifestUrl: info.manifestUrl },
+    modelDir
+  );
+
+  assert.equal(JSON.parse(fs.readFileSync(h.sidecar)).archive_bytes, 1);
+});
 
 test("a late manifest never recreates a deleted model directory", async (t) => {
   let finish;


### PR DESCRIPTION
Supersedes #2148 — same work, plus review follow-ups. Nathan's commit `f8613625` is preserved unchanged; `cd4c1b4f` adds the review fixes.

## Review follow-ups in cd4c1b4f

Four mutations survived the suite added in #2148 — removing the non-2xx throw, the abort guard, the timeout, or the User-Agent each left it green. The 404 fixture now returns a valid manifest body so only the status can stop the write, the request init is asserted, and a cancel landing after the last byte is covered.

`archive_bytes` is compared against `expectedSizeBytes` rather than the derived `size`: `sizeMb` describes the extracted model, not the archive, so the four Parakeet models without `expectedSizeBytes` would have failed validation silently.

The manifest is fetched through the shared `downloadUtils.fetchJson`, which already sends the app User-Agent and throws on non-2xx. `fetchJson` now forwards caller init (`credentials`, `cache`, `signal`) with its defaults unchanged — the GitHub release lookup in `gpuBinaryManager` is byte-identical — and it gains its first tests.

## Validation

- Suite: 4322 tests, 4102 passing, 0 failing, 219 skipped (unchanged), 1 todo.
- `quality-check`, `typecheck`, `i18n:check` and `prettier --check` all clean.
- Mutation matrix: 13/13 killed, including reverting each of the three changes above.

Closes #2148
