### PR TITLE
feat: New note button, pill and tray quick actions, and settings polish

### DIFF
--- a/main.js
+++ b/main.js
@@ -1161,10 +1161,11 @@ async function startApp() {
 
   // Set up meeting mode hotkey
   const isMeetingPress = createHotkeyRepeatGate();
+  // Through the renderer, like the tray's item: it owns the meeting policy the
+  // main process cannot see, so both entries refuse the same way.
   const meetingHotkeyCallback = () => {
     if (!isMeetingPress()) return;
-    debugLogger.info("Meeting hotkey triggered", {}, "meeting");
-    windowManager.startManualMeeting();
+    windowManager.sendStartMeeting();
   };
 
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";
@@ -1728,7 +1729,7 @@ async function startApp() {
       } else if (hotkeyManager.slotHasHotkey("translation", key)) {
         windowManager.sendToggleTranslation();
       } else if (hotkeyManager.slotHasHotkey("meeting", key)) {
-        windowManager.startManualMeeting();
+        windowManager.sendStartMeeting();
       }
     };
 

--- a/main.js
+++ b/main.js
@@ -1331,6 +1331,9 @@ async function startApp() {
 
   trayManager.setWindows(windowManager.mainWindow, windowManager.controlPanelWindow);
   trayManager.setWindowManager(windowManager);
+  // The tray's listen item is a toggle, so it has to rebuild when dictation
+  // starts or stops.
+  windowManager.onDictationStateChanged = () => trayManager.updateTrayMenu();
   trayManager.setCreateControlPanelCallback(() => windowManager.createControlPanelWindow());
   await trayManager.createTray();
 

--- a/main.js
+++ b/main.js
@@ -1163,11 +1163,8 @@ async function startApp() {
   const isMeetingPress = createHotkeyRepeatGate();
   const meetingHotkeyCallback = () => {
     if (!isMeetingPress()) return;
-    if (hotkeyManager.isInListeningMode()) return;
-    // Fail closed during onboarding, like every other hotkey slot.
-    if (!windowManager.isMeetingInputAllowed()) return;
     debugLogger.info("Meeting hotkey triggered", {}, "meeting");
-    meetingDetectionEngine?.startManualMeeting();
+    windowManager.startManualMeeting();
   };
 
   const savedMeetingKey = environmentManager.getMeetingKey?.() || "";
@@ -1728,9 +1725,7 @@ async function startApp() {
       } else if (hotkeyManager.slotHasHotkey("translation", key)) {
         windowManager.sendToggleTranslation();
       } else if (hotkeyManager.slotHasHotkey("meeting", key)) {
-        if (!hotkeyManager.isInListeningMode() && windowManager.isMeetingInputAllowed()) {
-          meetingDetectionEngine?.startManualMeeting();
-        }
+        windowManager.startManualMeeting();
       }
     };
 

--- a/preload.js
+++ b/preload.js
@@ -91,6 +91,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onToggleVoiceAgent: registerListener("toggle-voice-agent", (callback) => () => callback()),
   onToggleTranslation: registerListener("toggle-translation", (callback) => () => callback()),
   onOpenAssistantPanel: registerListener("open-assistant-panel", (callback) => () => callback()),
+  onStartMeeting: registerListener("start-meeting", (callback) => () => callback()),
   onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
   onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
   onPrepareDictation: registerListener(

--- a/preload.js
+++ b/preload.js
@@ -92,6 +92,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onToggleTranslation: registerListener("toggle-translation", (callback) => () => callback()),
   onOpenAssistantPanel: registerListener("open-assistant-panel", (callback) => () => callback()),
   onStartMeeting: registerListener("start-meeting", (callback) => () => callback()),
+  onTrayActionRefused: registerListener(
+    "tray-action-refused",
+    (callback) => (_event, data) => callback(data)
+  ),
   onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
   onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
   onPrepareDictation: registerListener(

--- a/preload.js
+++ b/preload.js
@@ -90,6 +90,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onToggleDictation: registerListener("toggle-dictation", (callback) => () => callback()),
   onToggleVoiceAgent: registerListener("toggle-voice-agent", (callback) => () => callback()),
   onToggleTranslation: registerListener("toggle-translation", (callback) => () => callback()),
+  onOpenAssistantPanel: registerListener("open-assistant-panel", (callback) => () => callback()),
   onStartDictation: registerListener("start-dictation", (callback) => () => callback()),
   onStopDictation: registerListener("stop-dictation", (callback) => () => callback()),
   onPrepareDictation: registerListener(
@@ -1340,6 +1341,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   meetingNotificationRespond: (detectionId, action) =>
     ipcRenderer.invoke("meeting-notification-respond", detectionId, action),
   joinCalendarMeeting: (eventId) => ipcRenderer.invoke("join-calendar-meeting", eventId),
+  startManualMeeting: () => ipcRenderer.invoke("start-manual-meeting"),
   getPendingMeetingNoteNavigation: () => ipcRenderer.invoke("get-pending-meeting-note-navigation"),
   onMeetingNoteNavigationPending: registerListener(
     "meeting-note-navigation-pending",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -383,10 +383,26 @@ export default function App() {
     const unsubscribe = window.electronAPI?.onOpenAssistantPanel?.(() => {
       if (!agentAllowed || isRecording || assistant.mounted || liveTranscript.mounted) return;
       setIsCommandMenuOpen(false);
-      openAssistantPanel();
+      void openAssistantPanel();
     });
     return () => unsubscribe?.();
   }, [agentAllowed, isRecording, assistant.mounted, liveTranscript.mounted, openAssistantPanel]);
+
+  // The tray's Start meeting recording. The pill menu hides the item when policy
+  // blocks meeting transcription; the tray can't, so the refusal happens here —
+  // before a note exists — with the pill surfaced so the explanation is visible.
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onStartMeeting?.(() => {
+      setIsCommandMenuOpen(false);
+      if (!meetingAllowed) {
+        void window.electronAPI?.showDictationPanel?.();
+        toast({ title: t("notes.meeting.restrictedByOrg"), variant: "default" });
+        return;
+      }
+      void window.electronAPI.startManualMeeting?.();
+    });
+    return () => unsubscribe?.();
+  }, [meetingAllowed, toast, t]);
 
   // Auto-hide the floating icon when idle (setting enabled or dictation cycle completed)
   useEffect(() => {
@@ -747,11 +763,11 @@ export default function App() {
               }}
               onAskAssistant={() => {
                 setIsCommandMenuOpen(false);
-                openAssistantPanel();
+                void openAssistantPanel();
               }}
               onStartMeeting={() => {
                 setIsCommandMenuOpen(false);
-                window.electronAPI.startManualMeeting();
+                void window.electronAPI.startManualMeeting?.();
               }}
               onHide={() => {
                 setIsCommandMenuOpen(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -377,32 +377,47 @@ export default function App() {
     return () => unsubscribe?.();
   }, [isRecording, isPreparing, isProcessing, cancelRecording, cancelProcessing]);
 
-  // The tray's Ask Assistant is the pill menu's action, so it follows the pill
-  // menu's availability: agent allowed, not recording, no panel mounted.
+  // The tray's Ask Assistant and Start meeting recording. The pill menu hides
+  // those items when policy or a live recording rules them out; the tray always
+  // shows them, so the refusal happens here — before a panel opens or a note
+  // exists. A policy refusal says why, with the pill surfaced so it is visible.
+  const refuseByPolicy = useCallback(
+    (messageKey) => {
+      void window.electronAPI?.showDictationPanel?.();
+      toast({ title: t(messageKey), variant: "default" });
+    },
+    [toast, t]
+  );
+
   useEffect(() => {
     const unsubscribe = window.electronAPI?.onOpenAssistantPanel?.(() => {
-      if (!agentAllowed || isRecording || assistant.mounted || liveTranscript.mounted) return;
       setIsCommandMenuOpen(false);
+      if (!agentAllowed) {
+        refuseByPolicy("common.policyAgentRestricted");
+        return;
+      }
+      // A recording or the transcript panel owns the pill; openPanel itself is a
+      // no-op once the assistant panel is up.
+      if (isRecording || liveTranscript.mounted) return;
       void openAssistantPanel();
     });
     return () => unsubscribe?.();
-  }, [agentAllowed, isRecording, assistant.mounted, liveTranscript.mounted, openAssistantPanel]);
+  }, [agentAllowed, isRecording, liveTranscript.mounted, openAssistantPanel, refuseByPolicy]);
 
-  // The tray's Start meeting recording. The pill menu hides the item when policy
-  // blocks meeting transcription; the tray can't, so the refusal happens here —
-  // before a note exists — with the pill surfaced so the explanation is visible.
   useEffect(() => {
     const unsubscribe = window.electronAPI?.onStartMeeting?.(() => {
       setIsCommandMenuOpen(false);
       if (!meetingAllowed) {
-        void window.electronAPI?.showDictationPanel?.();
-        toast({ title: t("notes.meeting.restrictedByOrg"), variant: "default" });
+        refuseByPolicy("notes.meeting.restrictedByOrg");
         return;
       }
+      // The pill menu hides this while dictating: a meeting would capture the
+      // microphone the live dictation is already holding.
+      if (isRecording) return;
       void window.electronAPI.startManualMeeting?.();
     });
     return () => unsubscribe?.();
-  }, [meetingAllowed, toast, t]);
+  }, [meetingAllowed, isRecording, refuseByPolicy]);
 
   // Auto-hide the floating icon when idle (setting enabled or dictation cycle completed)
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import { useWindowResizeCompensation } from "./hooks/useWindowResizeCompensation
 import { useSettingsStore } from "./stores/settingsStore";
 import { isAgentAllowed } from "./stores/policyRules";
 import { usePolicyStore } from "./stores/policyStore";
+import { useTranscriptionContextAllowed } from "./hooks/usePolicy";
 import { VoicePill } from "./components/dictation/VoicePill";
 import { AssistantPanel } from "./components/dictation/AssistantPanel";
 import { LiveTranscriptPanel } from "./components/dictation/LiveTranscriptPanel";
@@ -112,6 +113,7 @@ export default function App() {
   useMainProcessNotifications({ toast, dismiss, t });
 
   const agentAllowed = usePolicyStore(isAgentAllowed);
+  const meetingAllowed = useTranscriptionContextAllowed("meeting");
 
   const mainWindowResizeCoordinatorRef = useRef(null);
   useEffect(() => {
@@ -172,7 +174,11 @@ export default function App() {
     recordingControlsRef,
     onPanelOpened,
   });
-  const { noteDictationError, openRef: assistantOpenRef } = assistant;
+  const {
+    noteDictationError,
+    openRef: assistantOpenRef,
+    openPanel: openAssistantPanel,
+  } = assistant;
 
   const handleDictationError = React.useCallback(
     (options = {}) => {
@@ -370,6 +376,17 @@ export default function App() {
     });
     return () => unsubscribe?.();
   }, [isRecording, isPreparing, isProcessing, cancelRecording, cancelProcessing]);
+
+  // The tray's Ask Assistant is the pill menu's action, so it follows the pill
+  // menu's availability: agent allowed, not recording, no panel mounted.
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onOpenAssistantPanel?.(() => {
+      if (!agentAllowed || isRecording || assistant.mounted || liveTranscript.mounted) return;
+      setIsCommandMenuOpen(false);
+      openAssistantPanel();
+    });
+    return () => unsubscribe?.();
+  }, [agentAllowed, isRecording, assistant.mounted, liveTranscript.mounted, openAssistantPanel]);
 
   // Auto-hide the floating icon when idle (setting enabled or dictation cycle completed)
   useEffect(() => {
@@ -722,6 +739,7 @@ export default function App() {
               buttonRef={buttonRef}
               isRecording={isRecording}
               agentAllowed={agentAllowed}
+              meetingAllowed={meetingAllowed}
               isHovered={isHovered}
               setWindowInteractivity={setWindowInteractivity}
               onToggleListening={() => {
@@ -729,7 +747,11 @@ export default function App() {
               }}
               onAskAssistant={() => {
                 setIsCommandMenuOpen(false);
-                assistant.openPanel();
+                openAssistantPanel();
+              }}
+              onStartMeeting={() => {
+                setIsCommandMenuOpen(false);
+                window.electronAPI.startManualMeeting();
               }}
               onHide={() => {
                 setIsCommandMenuOpen(false);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import { useSettingsStore } from "./stores/settingsStore";
 import { isAgentAllowed } from "./stores/policyRules";
 import { usePolicyStore } from "./stores/policyStore";
 import { useTranscriptionContextAllowed } from "./hooks/usePolicy";
+import { resolveTrayAssistantAction, resolveTrayMeetingAction } from "./helpers/trayActionPolicy";
 import { VoicePill } from "./components/dictation/VoicePill";
 import { AssistantPanel } from "./components/dictation/AssistantPanel";
 import { LiveTranscriptPanel } from "./components/dictation/LiveTranscriptPanel";
@@ -381,7 +382,8 @@ export default function App() {
   // those items when policy or a live recording rules them out; the tray always
   // shows them, so the refusal happens here — before a panel opens or a note
   // exists. A policy refusal says why, with the pill surfaced so it is visible.
-  const refuseByPolicy = useCallback(
+  // Surfaced with the pill, so the message is visible even when it was hidden.
+  const refuse = useCallback(
     (messageKey) => {
       void window.electronAPI?.showDictationPanel?.();
       toast({ title: t(messageKey), variant: "default" });
@@ -392,32 +394,41 @@ export default function App() {
   useEffect(() => {
     const unsubscribe = window.electronAPI?.onOpenAssistantPanel?.(() => {
       setIsCommandMenuOpen(false);
-      if (!agentAllowed) {
-        refuseByPolicy("common.policyAgentRestricted");
+      const decision = resolveTrayAssistantAction({
+        agentAllowed,
+        isRecording,
+        liveTranscriptMounted: liveTranscript.mounted,
+      });
+      if (decision.action === "refuse") {
+        refuse(decision.messageKey);
         return;
       }
-      // A recording or the transcript panel owns the pill; openPanel itself is a
-      // no-op once the assistant panel is up.
-      if (isRecording || liveTranscript.mounted) return;
       void openAssistantPanel();
     });
     return () => unsubscribe?.();
-  }, [agentAllowed, isRecording, liveTranscript.mounted, openAssistantPanel, refuseByPolicy]);
+  }, [agentAllowed, isRecording, liveTranscript.mounted, openAssistantPanel, refuse]);
 
   useEffect(() => {
     const unsubscribe = window.electronAPI?.onStartMeeting?.(() => {
       setIsCommandMenuOpen(false);
-      if (!meetingAllowed) {
-        refuseByPolicy("notes.meeting.restrictedByOrg");
+      const decision = resolveTrayMeetingAction({ meetingAllowed, isRecording });
+      if (decision.action === "refuse") {
+        refuse(decision.messageKey);
         return;
       }
-      // The pill menu hides this while dictating: a meeting would capture the
-      // microphone the live dictation is already holding.
-      if (isRecording) return;
-      void window.electronAPI.startManualMeeting?.();
+      void window.electronAPI?.startManualMeeting?.();
     });
     return () => unsubscribe?.();
-  }, [meetingAllowed, isRecording, refuseByPolicy]);
+  }, [meetingAllowed, isRecording, refuse]);
+
+  // Main refuses the tray's listen item on gates only it can see (a panel owning
+  // the pill, a transcription still settling), and says so through here.
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onTrayActionRefused?.((data) => {
+      if (data?.messageKey) refuse(data.messageKey);
+    });
+    return () => unsubscribe?.();
+  }, [refuse]);
 
   // Auto-hide the floating icon when idle (setting enabled or dictation cycle completed)
   useEffect(() => {
@@ -782,7 +793,7 @@ export default function App() {
               }}
               onStartMeeting={() => {
                 setIsCommandMenuOpen(false);
-                void window.electronAPI.startManualMeeting?.();
+                void window.electronAPI?.startManualMeeting?.();
               }}
               onHide={() => {
                 setIsCommandMenuOpen(false);

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1162,6 +1162,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                     invitationEntry={invitationNotesEntry}
                     onInvitationEntryHandled={() => setInvitationNotesEntry(null)}
                     topBarActions={topBarActions}
+                    onNewChat={agentAllowedByPolicy ? () => setActiveView("chat") : undefined}
                   />
                 </Suspense>
               )}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1162,7 +1162,6 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                     invitationEntry={invitationNotesEntry}
                     onInvitationEntryHandled={() => setInvitationNotesEntry(null)}
                     topBarActions={topBarActions}
-                    onNewChat={agentAllowedByPolicy ? () => setActiveView("chat") : undefined}
                   />
                 </Suspense>
               )}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -150,6 +150,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
     folderId: number;
     event: any;
   } | null>(null);
+  const [topBarActions, setTopBarActions] = useState<HTMLDivElement | null>(null);
   const [gpuBannerDismissed, setGpuBannerDismissed] = useState(
     () => localStorage.getItem("gpuBannerDismissedUnified") === "true"
   );
@@ -1003,6 +1004,7 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
               onOpenSearch={() => setShowSearch(true)}
               isSidePanelLayout={isSidePanelLayout}
               onExitSidePanel={handleExitSidePanel}
+              actionsSlotRef={setTopBarActions}
             />
             <div className="scrollbar-hidden flex-1 overflow-y-auto">
               {updateRequiredByOrg && (
@@ -1159,6 +1161,8 @@ export default function ControlPanel({ initialSettingsSection }: ControlPanelPro
                     onMeetingRecordingRequestHandled={handleMeetingRecordingRequestHandled}
                     invitationEntry={invitationNotesEntry}
                     onInvitationEntryHandled={() => setInvitationNotesEntry(null)}
+                    topBarActions={topBarActions}
+                    onNewChat={agentAllowedByPolicy ? () => setActiveView("chat") : undefined}
                   />
                 </Suspense>
               )}

--- a/src/components/ControlPanelTopBar.tsx
+++ b/src/components/ControlPanelTopBar.tsx
@@ -120,7 +120,9 @@ export default function ControlPanelTopBar({
             ref={actionsSlotRef}
             data-no-window-drag=""
             style={noDragStyle}
-            className="flex items-center"
+            // macOS keeps no window controls here, so page actions take the far
+            // end; elsewhere they sit beside the search, left of the controls.
+            className={cn("flex items-center", platform === "darwin" && "ms-auto")}
           />
         )}
         {platform !== "darwin" && (

--- a/src/components/ControlPanelTopBar.tsx
+++ b/src/components/ControlPanelTopBar.tsx
@@ -24,6 +24,8 @@ interface ControlPanelTopBarProps {
   /** Meeting mode or a narrow window with an open note: sidebar hidden, back button shown. */
   isSidePanelLayout: boolean;
   onExitSidePanel: () => void;
+  /** Receives the slot, right of the search bar, that the active page portals its actions into. */
+  actionsSlotRef?: React.Ref<HTMLDivElement>;
 }
 
 export default function ControlPanelTopBar({
@@ -35,6 +37,7 @@ export default function ControlPanelTopBar({
   onOpenSearch,
   isSidePanelLayout,
   onExitSidePanel,
+  actionsSlotRef,
 }: ControlPanelTopBarProps) {
   const { t } = useTranslation();
   // With the sidebar out of the way the container's start edge sits under the
@@ -44,7 +47,8 @@ export default function ControlPanelTopBar({
   return (
     <header
       className={cn(
-        "grid h-12 shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,340px)_minmax(0,1fr)] items-center gap-4 border-b border-border px-3 dark:border-white/10",
+        // The trailing column never shrinks past its actions and window controls.
+        "grid h-12 shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,340px)_minmax(max-content,1fr)] items-center gap-4 border-b border-border px-3 dark:border-white/10",
         // Eased with the sidebar spacer so the toggle glides instead of jumping when the
         // clearance switches; a jump would drag it back under the cursor and re-trigger peek.
         "transition-[padding] duration-300 ease-out",
@@ -110,9 +114,17 @@ export default function ControlPanelTopBar({
         </button>
       )}
 
-      <div className="col-start-3 flex items-center justify-self-end">
+      <div className="col-start-3 flex items-center gap-2">
+        {!isSidePanelLayout && (
+          <div
+            ref={actionsSlotRef}
+            data-no-window-drag=""
+            style={noDragStyle}
+            className="flex items-center"
+          />
+        )}
         {platform !== "darwin" && (
-          <div data-no-window-drag="" style={noDragStyle}>
+          <div data-no-window-drag="" style={noDragStyle} className="ms-auto">
             <WindowControls />
           </div>
         )}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   Keyboard,
   CreditCard,
   Shield,
+  ShieldCheck,
   Users,
 } from "./icons";
 import SidebarModal, { type SidebarItem } from "./ui/SidebarModal";
@@ -179,12 +180,15 @@ export default function SettingsModal({ open, onOpenChange, initialSection }: Se
           </div>
         ) : undefined
       }
+      notice={
+        policyManaged ? (
+          <>
+            <ShieldCheck className="h-4 w-4 shrink-0" />
+            {t("settingsModal.managedByOrg")}
+          </>
+        ) : undefined
+      }
     >
-      {policyManaged && (
-        <div className="mx-4 mt-4 rounded-lg border border-primary/20 bg-primary/8 px-3 py-2 text-sm text-primary dark:border-primary/30 dark:bg-primary/15">
-          {t("settingsModal.managedByOrg")}
-        </div>
-      )}
       <SettingsPage
         activeSection={activeSection}
         onNavigateToSection={handleSectionChange}

--- a/src/components/dictation/PillCommandMenu.tsx
+++ b/src/components/dictation/PillCommandMenu.tsx
@@ -6,10 +6,12 @@ interface PillCommandMenuProps {
   buttonRef: React.RefObject<HTMLDivElement | null>;
   isRecording: boolean;
   agentAllowed: boolean;
+  meetingAllowed: boolean;
   isHovered: boolean;
   setWindowInteractivity: (capture: boolean) => void;
   onToggleListening: () => void;
   onAskAssistant: () => void;
+  onStartMeeting: () => void;
   onHide: () => void;
   onClose: () => void;
 }
@@ -22,10 +24,12 @@ export function PillCommandMenu({
   buttonRef,
   isRecording,
   agentAllowed,
+  meetingAllowed,
   isHovered,
   setWindowInteractivity,
   onToggleListening,
   onAskAssistant,
+  onStartMeeting,
   onHide,
   onClose,
 }: PillCommandMenuProps): React.JSX.Element {
@@ -80,6 +84,17 @@ export function PillCommandMenu({
             onClick={onAskAssistant}
           >
             {t("app.commandMenu.askAssistant")}
+          </button>
+        </>
+      )}
+      {meetingAllowed && !isRecording && (
+        <>
+          <div className="h-px bg-border" />
+          <button
+            className="w-full px-3 py-2 text-start text-sm hover:bg-muted focus:bg-muted focus:outline-none"
+            onClick={onStartMeeting}
+          >
+            {t("app.commandMenu.startMeetingRecording")}
           </button>
         </>
       )}

--- a/src/components/notes/NewNoteMenu.tsx
+++ b/src/components/notes/NewNoteMenu.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, MessageSquare, NotebookPen, Plus, Users } from "../icons";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import {
+  SPLIT_BUTTON_DIVIDER_CLASS,
+  SPLIT_BUTTON_GROUP_CLASS,
+  SPLIT_BUTTON_SEGMENT_CLASS,
+} from "../ui/splitButton";
+import { cn } from "../lib/utils";
+import { useCanCreateTeamSpace } from "../../hooks/useCanCreateTeamSpace";
+import CreateSpaceDialog from "./CreateSpaceDialog";
+
+interface NewNoteMenuProps {
+  onNewNote: () => void;
+  /** Omitted when the organization's policy turns the assistant off. */
+  onNewChat?: () => void;
+}
+
+/** The Notes topbar's split "New note" button; the chevron offers the other things to create. */
+export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) {
+  const { t } = useTranslation();
+  const canCreateTeamSpace = useCanCreateTeamSpace();
+  const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
+
+  return (
+    <>
+      <div className={cn(SPLIT_BUTTON_GROUP_CLASS, "h-8")}>
+        <button
+          type="button"
+          onClick={onNewNote}
+          className={cn(SPLIT_BUTTON_SEGMENT_CLASS, "gap-1.5 whitespace-nowrap ps-3 pe-3.5")}
+        >
+          <Plus size={14} />
+          {t("notes.list.newNote")}
+        </button>
+        <span aria-hidden="true" className={SPLIT_BUTTON_DIVIDER_CLASS} />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label={t("notes.createMenu.chooseType")}
+              className={cn(SPLIT_BUTTON_SEGMENT_CLASS, "w-8 justify-center")}
+            >
+              <ChevronDown size={14} />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" sideOffset={6} className="min-w-44">
+            <DropdownMenuItem onSelect={onNewNote} className="gap-2.5">
+              <NotebookPen className="h-4 w-4" />
+              {t("notes.createMenu.note")}
+            </DropdownMenuItem>
+            {onNewChat && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={onNewChat} className="gap-2.5">
+                  <MessageSquare className="h-4 w-4" />
+                  {t("notes.createMenu.assistantChat")}
+                </DropdownMenuItem>
+              </>
+            )}
+            {canCreateTeamSpace && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={() => setCreateSpaceOpen(true)} className="gap-2.5">
+                  <Users className="h-4 w-4" />
+                  {t("notes.createMenu.sharedSpace")}
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <CreateSpaceDialog open={createSpaceOpen} onOpenChange={setCreateSpaceOpen} />
+    </>
+  );
+}

--- a/src/components/notes/NewNoteMenu.tsx
+++ b/src/components/notes/NewNoteMenu.tsx
@@ -19,8 +19,8 @@ import CreateSpaceDialog from "./CreateSpaceDialog";
 
 interface NewNoteMenuProps {
   onNewNote: () => void;
-  /** Opens a fresh assistant chat in Notes: the open note's, or the overview's. */
-  onNewChat: () => void;
+  /** Opens a new chat in the Chat tab; omitted when policy turns the assistant off. */
+  onNewChat?: () => void;
 }
 
 /** The Notes topbar's split "New note" button; the chevron offers the other things to create. */
@@ -74,11 +74,15 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
               <NotebookPen className="h-4 w-4" />
               {t("notes.createMenu.note")}
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={keepFocus(onNewChat)} className="gap-2.5">
-              <MessageSquare className="h-4 w-4" />
-              {t("notes.createMenu.assistantChat")}
-            </DropdownMenuItem>
+            {onNewChat && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onSelect={keepFocus(onNewChat)} className="gap-2.5">
+                  <MessageSquare className="h-4 w-4" />
+                  {t("notes.createMenu.assistantChat")}
+                </DropdownMenuItem>
+              </>
+            )}
             {canCreateTeamSpace && (
               <>
                 <DropdownMenuSeparator />

--- a/src/components/notes/NewNoteMenu.tsx
+++ b/src/components/notes/NewNoteMenu.tsx
@@ -30,9 +30,10 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
   const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
   const itemChosenRef = useRef(false);
 
-  // Each item hands focus to what it opens (the chat input, the space dialog), so only
-  // those closes keep it; dismissing the menu still returns focus to the chevron.
-  const chooseItem = (action: () => void) => () => {
+  // The chat input and the space dialog take focus themselves, so those closes
+  // keep it. A new note focuses nothing (the editor mounts fresh), and dismissing
+  // the menu returns focus to the chevron, as Radix does by default.
+  const keepFocus = (action: () => void) => () => {
     itemChosenRef.current = true;
     action();
   };
@@ -69,12 +70,12 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
               event.preventDefault();
             }}
           >
-            <DropdownMenuItem onSelect={chooseItem(onNewNote)} className="gap-2.5">
+            <DropdownMenuItem onSelect={onNewNote} className="gap-2.5">
               <NotebookPen className="h-4 w-4" />
               {t("notes.createMenu.note")}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={chooseItem(onNewChat)} className="gap-2.5">
+            <DropdownMenuItem onSelect={keepFocus(onNewChat)} className="gap-2.5">
               <MessageSquare className="h-4 w-4" />
               {t("notes.createMenu.assistantChat")}
             </DropdownMenuItem>
@@ -82,7 +83,7 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
-                  onSelect={chooseItem(() => setCreateSpaceOpen(true))}
+                  onSelect={keepFocus(() => setCreateSpaceOpen(true))}
                   className="gap-2.5"
                 >
                   <Users className="h-4 w-4" />

--- a/src/components/notes/NewNoteMenu.tsx
+++ b/src/components/notes/NewNoteMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, MessageSquare, NotebookPen, Plus, Users } from "../icons";
 import {
@@ -28,6 +28,14 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
   const { t } = useTranslation();
   const canCreateTeamSpace = useCanCreateTeamSpace();
   const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
+  const itemChosenRef = useRef(false);
+
+  // Each item hands focus to what it opens (the chat input, the space dialog), so only
+  // those closes keep it; dismissing the menu still returns focus to the chevron.
+  const chooseItem = (action: () => void) => () => {
+    itemChosenRef.current = true;
+    action();
+  };
 
   return (
     <>
@@ -55,25 +63,30 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
             align="end"
             sideOffset={6}
             className="min-w-44"
-            // Each item hands focus to what it opens (the chat input, the space dialog);
-            // don't pull it back to the chevron.
-            onCloseAutoFocus={(event) => event.preventDefault()}
+            onCloseAutoFocus={(event) => {
+              if (!itemChosenRef.current) return;
+              itemChosenRef.current = false;
+              event.preventDefault();
+            }}
           >
-            <DropdownMenuItem onSelect={onNewNote} className="gap-2.5">
+            <DropdownMenuItem onSelect={chooseItem(onNewNote)} className="gap-2.5">
               <NotebookPen className="h-4 w-4" />
               {t("notes.createMenu.note")}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={onNewChat} className="gap-2.5">
+            <DropdownMenuItem onSelect={chooseItem(onNewChat)} className="gap-2.5">
               <MessageSquare className="h-4 w-4" />
               {t("notes.createMenu.assistantChat")}
             </DropdownMenuItem>
             {canCreateTeamSpace && (
               <>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={() => setCreateSpaceOpen(true)} className="gap-2.5">
+                <DropdownMenuItem
+                  onSelect={chooseItem(() => setCreateSpaceOpen(true))}
+                  className="gap-2.5"
+                >
                   <Users className="h-4 w-4" />
-                  {t("notes.createMenu.sharedSpace")}
+                  {t("notes.createMenu.teamSpace")}
                 </DropdownMenuItem>
               </>
             )}

--- a/src/components/notes/NewNoteMenu.tsx
+++ b/src/components/notes/NewNoteMenu.tsx
@@ -19,8 +19,8 @@ import CreateSpaceDialog from "./CreateSpaceDialog";
 
 interface NewNoteMenuProps {
   onNewNote: () => void;
-  /** Omitted when the organization's policy turns the assistant off. */
-  onNewChat?: () => void;
+  /** Opens a fresh assistant chat in Notes: the open note's, or the overview's. */
+  onNewChat: () => void;
 }
 
 /** The Notes topbar's split "New note" button; the chevron offers the other things to create. */
@@ -51,20 +51,23 @@ export default function NewNoteMenu({ onNewNote, onNewChat }: NewNoteMenuProps) 
               <ChevronDown size={14} />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" sideOffset={6} className="min-w-44">
+          <DropdownMenuContent
+            align="end"
+            sideOffset={6}
+            className="min-w-44"
+            // Each item hands focus to what it opens (the chat input, the space dialog);
+            // don't pull it back to the chevron.
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
             <DropdownMenuItem onSelect={onNewNote} className="gap-2.5">
               <NotebookPen className="h-4 w-4" />
               {t("notes.createMenu.note")}
             </DropdownMenuItem>
-            {onNewChat && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={onNewChat} className="gap-2.5">
-                  <MessageSquare className="h-4 w-4" />
-                  {t("notes.createMenu.assistantChat")}
-                </DropdownMenuItem>
-              </>
-            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onNewChat} className="gap-2.5">
+              <MessageSquare className="h-4 w-4" />
+              {t("notes.createMenu.assistantChat")}
+            </DropdownMenuItem>
             {canCreateTeamSpace && (
               <>
                 <DropdownMenuSeparator />

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -1055,7 +1055,7 @@ export default function NoteEditor({
                     )}
                   >
                     <Sparkles size={12} />
-                    {t("notes.editor.enhanced")}
+                    {t("notes.editor.aiSummary")}
                     {enhancement.isStale && (
                       <span
                         className="h-1 w-1 rounded-full bg-amber-400/60"

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -189,6 +189,9 @@ interface NoteEditorProps {
   actionPicker?: React.ReactNode;
   /** Runs the built-in Generate Notes action; enables the post-recording summary pill. */
   onGenerateSummary?: () => void;
+  /** Set by the Notes topbar's Assistant chat: open a fresh chat about this note. */
+  newChatRequested?: boolean;
+  onNewChatRequestHandled?: () => void;
   actionProcessingState?: ActionProcessingState;
   actionName?: string | null;
   diarizationSessionId?: string | null;
@@ -222,6 +225,8 @@ export default function NoteEditor({
   enhancement,
   actionPicker,
   onGenerateSummary,
+  newChatRequested,
+  onNewChatRequestHandled,
   actionProcessingState,
   actionName,
   diarizationSessionId,
@@ -373,6 +378,16 @@ export default function NoteEditor({
     noteContent: note.content,
     noteTranscript: note.transcript ?? undefined,
   });
+  const { startNewChat: startNewEmbeddedChat } = embeddedChat;
+  // Remounting the panel for a requested chat replays its entrance and refocuses its input.
+  const [chatSession, setChatSession] = useState(0);
+  useEffect(() => {
+    if (!newChatRequested) return;
+    startNewEmbeddedChat();
+    setChatSession((session) => session + 1);
+    setChatMode((mode) => (mode === "hidden" ? "floating" : mode));
+    onNewChatRequestHandled?.();
+  }, [newChatRequested, startNewEmbeddedChat, onNewChatRequestHandled]);
   const titleRef = useRef<HTMLDivElement>(null);
   const prevNoteIdRef = useRef<number>(note.id);
 
@@ -1249,6 +1264,7 @@ export default function NoteEditor({
           />
           {chatMode === "floating" && (
             <EmbeddedChat
+              key={chatSession}
               mode="floating"
               floatingPanelRef={floatingChatPanelRef}
               onModeChange={setChatMode}
@@ -1266,6 +1282,7 @@ export default function NoteEditor({
       </div>
       {chatMode === "sidebar" && (
         <EmbeddedChat
+          key={chatSession}
           mode="sidebar"
           onModeChange={setChatMode}
           messages={embeddedChat.messages}

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -54,6 +54,11 @@ import {
   DropdownMenuSeparator,
 } from "../ui/dropdown-menu";
 import { cn } from "../lib/utils";
+import {
+  SPLIT_BUTTON_DIVIDER_CLASS,
+  SPLIT_BUTTON_GROUP_CLASS,
+  SPLIT_BUTTON_SEGMENT_CLASS,
+} from "../ui/splitButton";
 import type { NoteItem, FolderItem } from "../../types/electron";
 import type { ActionProcessingState } from "../../hooks/useActionProcessing";
 import ActionProcessingOverlay from "./ActionProcessingOverlay";
@@ -78,10 +83,6 @@ import { NOTE_META_CHIP_CLASS, defaultFolderDisplayName, folderMatchesQuery } fr
 
 const SEGMENT_BUTTON_CLASS =
   "relative z-1 flex h-[26px] items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors duration-150";
-const SHARE_GROUP_CLASS =
-  "flex h-[30px] items-stretch overflow-hidden rounded-full border border-border bg-surface-3 dark:border-white/10 dark:bg-surface-2";
-const SHARE_SEGMENT_CLASS =
-  "flex items-center text-xs font-medium text-foreground/80 outline-none transition-colors duration-150 hover:bg-surface-raised hover:text-foreground focus-visible:bg-surface-raised dark:hover:bg-surface-3";
 
 const TRANSCRIPT_EXPORT_LABEL_KEYS = {
   txt: "notes.editor.asTranscriptText",
@@ -1076,21 +1077,21 @@ export default function NoteEditor({
                   onStop={onStopRecording}
                 />
               )}
-              <div className={SHARE_GROUP_CLASS}>
+              <div className={cn(SPLIT_BUTTON_GROUP_CLASS, "h-[30px]")}>
                 <button
                   type="button"
                   onClick={() => openShare("open")}
-                  className={cn(SHARE_SEGMENT_CLASS, "gap-1.5 ps-2.5 pe-3")}
+                  className={cn(SPLIT_BUTTON_SEGMENT_CLASS, "gap-1.5 ps-2.5 pe-3")}
                 >
                   <Lock size={13} className={isShared ? "text-primary" : "text-foreground/60"} />
                   {t("noteEditor.share.button")}
                 </button>
-                <span aria-hidden="true" className="my-1.5 w-px bg-border dark:bg-white/10" />
+                <span aria-hidden="true" className={SPLIT_BUTTON_DIVIDER_CLASS} />
                 <button
                   type="button"
                   onClick={() => openShare("copy-link")}
                   aria-label={t("noteEditor.share.dialog.copyLink")}
-                  className={cn(SHARE_SEGMENT_CLASS, "w-[30px] justify-center")}
+                  className={cn(SPLIT_BUTTON_SEGMENT_CLASS, "w-[30px] justify-center")}
                 >
                   <Link2 size={13} className="text-foreground/60" />
                 </button>

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -189,9 +189,6 @@ interface NoteEditorProps {
   actionPicker?: React.ReactNode;
   /** Runs the built-in Generate Notes action; enables the post-recording summary pill. */
   onGenerateSummary?: () => void;
-  /** Set by the Notes topbar's Assistant chat: open a fresh chat about this note. */
-  newChatRequested?: boolean;
-  onNewChatRequestHandled?: () => void;
   actionProcessingState?: ActionProcessingState;
   actionName?: string | null;
   diarizationSessionId?: string | null;
@@ -225,8 +222,6 @@ export default function NoteEditor({
   enhancement,
   actionPicker,
   onGenerateSummary,
-  newChatRequested,
-  onNewChatRequestHandled,
   actionProcessingState,
   actionName,
   diarizationSessionId,
@@ -378,16 +373,6 @@ export default function NoteEditor({
     noteContent: note.content,
     noteTranscript: note.transcript ?? undefined,
   });
-  const { startNewChat: startNewEmbeddedChat } = embeddedChat;
-  // Remounting the panel for a requested chat replays its entrance and refocuses its input.
-  const [chatSession, setChatSession] = useState(0);
-  useEffect(() => {
-    if (!newChatRequested) return;
-    startNewEmbeddedChat();
-    setChatSession((session) => session + 1);
-    setChatMode((mode) => (mode === "hidden" ? "floating" : mode));
-    onNewChatRequestHandled?.();
-  }, [newChatRequested, startNewEmbeddedChat, onNewChatRequestHandled]);
   const titleRef = useRef<HTMLDivElement>(null);
   const prevNoteIdRef = useRef<number>(note.id);
 
@@ -1264,7 +1249,6 @@ export default function NoteEditor({
           />
           {chatMode === "floating" && (
             <EmbeddedChat
-              key={chatSession}
               mode="floating"
               floatingPanelRef={floatingChatPanelRef}
               onModeChange={setChatMode}
@@ -1282,7 +1266,6 @@ export default function NoteEditor({
       </div>
       {chatMode === "sidebar" && (
         <EmbeddedChat
-          key={chatSession}
           mode="sidebar"
           onModeChange={setChatMode}
           messages={embeddedChat.messages}

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -129,8 +129,6 @@ interface PersonalNotesViewProps {
   onInvitationEntryHandled?: () => void;
   /** The topbar slot the New note button portals into; null while the topbar hides it. */
   topBarActions?: HTMLElement | null;
-  /** Omitted when the organization's policy turns the assistant off. */
-  onNewChat?: () => void;
 }
 
 export default function PersonalNotesView({
@@ -140,7 +138,6 @@ export default function PersonalNotesView({
   invitationEntry,
   onInvitationEntryHandled,
   topBarActions,
-  onNewChat,
 }: PersonalNotesViewProps) {
   const isMeetingMode = useIsMeetingMode();
   const isNarrowWindow = useIsNarrowWindow();
@@ -552,6 +549,18 @@ export default function PersonalNotesView({
     else handleNewNoteInPrivate();
   }, [activeContext, handleNewNoteIn, handleNewNoteInPrivate]);
 
+  // The topbar's Assistant chat opens the chat already in Notes: the open note's, or the
+  // space/folder overview's (the private space's when nothing is selected).
+  const [newChatRequested, setNewChatRequested] = useState(false);
+  const clearNewChatRequest = useCallback(() => setNewChatRequested(false), []);
+  const handleNewChat = useCallback(() => {
+    if (!activeNote && !overviewSpace) {
+      if (privateSpaceId == null) return;
+      setActiveContext(privateSpaceId, null);
+    }
+    setNewChatRequested(true);
+  }, [activeNote, overviewSpace, privateSpaceId]);
+
   const handleNotesAdded = useCallback(async () => {
     if (activeFolderId) {
       await initializeNotes(null, 50, activeFolderId);
@@ -775,7 +784,7 @@ export default function PersonalNotesView({
     <div className="flex h-full">
       {topBarActions &&
         createPortal(
-          <NewNoteMenu onNewNote={handleNewNote} onNewChat={onNewChat} />,
+          <NewNoteMenu onNewNote={handleNewNote} onNewChat={handleNewChat} />,
           topBarActions
         )}
       <div
@@ -849,6 +858,8 @@ export default function PersonalNotesView({
               actionProcessingState={actionProcessingState}
               actionName={actionName}
               onGenerateSummary={generateSummary}
+              newChatRequested={newChatRequested}
+              onNewChatRequestHandled={clearNewChatRequest}
               actionPicker={
                 <ActionPicker
                   onRunAction={runNoteAction}
@@ -876,6 +887,8 @@ export default function PersonalNotesView({
             onOpenNote={setActiveNoteId}
             onNewNote={handleNewNote}
             onAddExisting={activeFolderId != null ? () => setShowAddNotesDialog(true) : undefined}
+            newChatRequested={newChatRequested}
+            onNewChatRequestHandled={clearNewChatRequest}
           />
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center -mt-6">

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
 import { Plus, Sparkles } from "../icons";
 import { useToast } from "../ui/useToast";
 import NoteEditor from "./NoteEditor";
+import NewNoteMenu from "./NewNoteMenu";
 import SpacesTree from "./SpacesTree";
 import { ContainerOverview } from "./overview/ContainerOverview";
 import NotesStructureIntroDialog from "./NotesStructureIntroDialog";
@@ -125,6 +127,10 @@ interface PersonalNotesViewProps {
   onMeetingRecordingRequestHandled?: () => void;
   invitationEntry?: { workspaceId: string; teamIds: string[] } | null;
   onInvitationEntryHandled?: () => void;
+  /** The topbar slot the New note button portals into; null while the topbar hides it. */
+  topBarActions?: HTMLElement | null;
+  /** Omitted when the organization's policy turns the assistant off. */
+  onNewChat?: () => void;
 }
 
 export default function PersonalNotesView({
@@ -133,6 +139,8 @@ export default function PersonalNotesView({
   onMeetingRecordingRequestHandled,
   invitationEntry,
   onInvitationEntryHandled,
+  topBarActions,
+  onNewChat,
 }: PersonalNotesViewProps) {
   const isMeetingMode = useIsMeetingMode();
   const isNarrowWindow = useIsNarrowWindow();
@@ -765,6 +773,11 @@ export default function PersonalNotesView({
 
   return (
     <div className="flex h-full">
+      {topBarActions &&
+        createPortal(
+          <NewNoteMenu onNewNote={handleNewNote} onNewChat={onNewChat} />,
+          topBarActions
+        )}
       <div
         className="shrink-0 overflow-hidden transition-[width] duration-300 ease-out"
         style={{ width: isSidePanelLayout ? 0 : "13rem" }}

--- a/src/components/notes/PersonalNotesView.tsx
+++ b/src/components/notes/PersonalNotesView.tsx
@@ -129,6 +129,8 @@ interface PersonalNotesViewProps {
   onInvitationEntryHandled?: () => void;
   /** The topbar slot the New note button portals into; null while the topbar hides it. */
   topBarActions?: HTMLElement | null;
+  /** Opens a new chat in the Chat tab; omitted when policy turns the assistant off. */
+  onNewChat?: () => void;
 }
 
 export default function PersonalNotesView({
@@ -138,6 +140,7 @@ export default function PersonalNotesView({
   invitationEntry,
   onInvitationEntryHandled,
   topBarActions,
+  onNewChat,
 }: PersonalNotesViewProps) {
   const isMeetingMode = useIsMeetingMode();
   const isNarrowWindow = useIsNarrowWindow();
@@ -549,18 +552,6 @@ export default function PersonalNotesView({
     else handleNewNoteInPrivate();
   }, [activeContext, handleNewNoteIn, handleNewNoteInPrivate]);
 
-  // The topbar's Assistant chat opens the chat already in Notes: the open note's, or the
-  // space/folder overview's (the private space's when nothing is selected).
-  const [newChatRequested, setNewChatRequested] = useState(false);
-  const clearNewChatRequest = useCallback(() => setNewChatRequested(false), []);
-  const handleNewChat = useCallback(() => {
-    if (!activeNote && !overviewSpace) {
-      if (privateSpaceId == null) return;
-      setActiveContext(privateSpaceId, null);
-    }
-    setNewChatRequested(true);
-  }, [activeNote, overviewSpace, privateSpaceId]);
-
   const handleNotesAdded = useCallback(async () => {
     if (activeFolderId) {
       await initializeNotes(null, 50, activeFolderId);
@@ -784,7 +775,7 @@ export default function PersonalNotesView({
     <div className="flex h-full">
       {topBarActions &&
         createPortal(
-          <NewNoteMenu onNewNote={handleNewNote} onNewChat={handleNewChat} />,
+          <NewNoteMenu onNewNote={handleNewNote} onNewChat={onNewChat} />,
           topBarActions
         )}
       <div
@@ -858,8 +849,6 @@ export default function PersonalNotesView({
               actionProcessingState={actionProcessingState}
               actionName={actionName}
               onGenerateSummary={generateSummary}
-              newChatRequested={newChatRequested}
-              onNewChatRequestHandled={clearNewChatRequest}
               actionPicker={
                 <ActionPicker
                   onRunAction={runNoteAction}
@@ -887,8 +876,6 @@ export default function PersonalNotesView({
             onOpenNote={setActiveNoteId}
             onNewNote={handleNewNote}
             onAddExisting={activeFolderId != null ? () => setShowAddNotesDialog(true) : undefined}
-            newChatRequested={newChatRequested}
-            onNewChatRequestHandled={clearNewChatRequest}
           />
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center -mt-6">

--- a/src/components/notes/SpacesTree.tsx
+++ b/src/components/notes/SpacesTree.tsx
@@ -35,6 +35,7 @@ import { useDialogs } from "../../hooks/useDialogs";
 import { useToast } from "../ui/useToast";
 import { useNoteDragAndDrop, type NoteMoveTarget } from "../../hooks/useNoteDragAndDrop";
 import { useTeamSpacesCapability } from "../../hooks/useTeamSpacesCapability";
+import { useCanCreateTeamSpace } from "../../hooks/useCanCreateTeamSpace";
 import { useAuth } from "../../hooks/useAuth";
 import { useWorkspace } from "../../hooks/useWorkspace";
 import { EmojiPickerInput } from "./EmojiPickerInput";
@@ -1175,6 +1176,7 @@ export default function SpacesTree({
   const isTreeLoading = useIsTreeLoading();
   const { isSignedIn, user } = useAuth();
   const teamCapability = useTeamSpacesCapability(isSignedIn);
+  const canCreateTeamSpace = useCanCreateTeamSpace();
   const { workspaces, loaded: workspacesLoaded } = useWorkspace();
   const noteFilesEnabled = useSettingsStore((s) => s.noteFilesEnabled);
   const shareByCloudId = useShareCache();
@@ -1235,12 +1237,6 @@ export default function SpacesTree({
   // Signed-out users never load workspaces (mirrored team spaces render flat);
   // errors still flip `loaded`, so this can't skeleton forever.
   const workspacesPending = isSignedIn && !workspacesLoaded;
-
-  // The server 403s team creation for plain members; no-workspace users get the create funnel.
-  const canCreateTeamSpace =
-    isSignedIn &&
-    workspacesLoaded &&
-    (workspaces.length === 0 || workspaces.some((w) => canManageWorkspace(w.role)));
 
   const currentUserId = user?.id ?? null;
   const workspaceRoleFor = (space: SpaceItem | undefined): WorkspaceRole | null =>

--- a/src/components/notes/overview/ContainerOverview.tsx
+++ b/src/components/notes/overview/ContainerOverview.tsx
@@ -27,6 +27,9 @@ interface ContainerOverviewProps {
   onOpenNote: (noteId: number) => void;
   onNewNote: () => void;
   onAddExisting?: () => void;
+  /** Set by the Notes topbar's Assistant chat: start a fresh chat in the ask box. */
+  newChatRequested?: boolean;
+  onNewChatRequestHandled?: () => void;
 }
 
 export function ContainerOverview({
@@ -35,6 +38,8 @@ export function ContainerOverview({
   onOpenNote,
   onNewNote,
   onAddExisting,
+  newChatRequested,
+  onNewChatRequestHandled,
 }: ContainerOverviewProps) {
   const { t } = useTranslation();
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -68,6 +73,15 @@ export function ContainerOverview({
   const notes = folder ? containerNotes : (spaceNotes ?? []);
 
   const chat = useContainerChat({ space, folder, notes });
+  const { startNewChat } = chat;
+  // Remounting the ask box for a requested chat leaves its input empty and focused.
+  const [chatSession, setChatSession] = useState(0);
+  useEffect(() => {
+    if (!newChatRequested) return;
+    startNewChat();
+    setChatSession((session) => session + 1);
+    onNewChatRequestHandled?.();
+  }, [newChatRequested, startNewChat, onNewChatRequestHandled]);
 
   const workspace = space.workspace_id
     ? workspaces.find((w) => w.id === space.workspace_id)
@@ -141,6 +155,7 @@ export function ContainerOverview({
         <OverviewExplainerBanner kind={space.kind === "team" ? "team" : "private"} />
 
         <OverviewAskSection
+          key={chatSession}
           messages={chat.messages}
           agentState={chat.agentState}
           onTextSubmit={chat.sendMessage}

--- a/src/components/notes/overview/ContainerOverview.tsx
+++ b/src/components/notes/overview/ContainerOverview.tsx
@@ -27,9 +27,6 @@ interface ContainerOverviewProps {
   onOpenNote: (noteId: number) => void;
   onNewNote: () => void;
   onAddExisting?: () => void;
-  /** Set by the Notes topbar's Assistant chat: start a fresh chat in the ask box. */
-  newChatRequested?: boolean;
-  onNewChatRequestHandled?: () => void;
 }
 
 export function ContainerOverview({
@@ -38,8 +35,6 @@ export function ContainerOverview({
   onOpenNote,
   onNewNote,
   onAddExisting,
-  newChatRequested,
-  onNewChatRequestHandled,
 }: ContainerOverviewProps) {
   const { t } = useTranslation();
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -73,15 +68,6 @@ export function ContainerOverview({
   const notes = folder ? containerNotes : (spaceNotes ?? []);
 
   const chat = useContainerChat({ space, folder, notes });
-  const { startNewChat } = chat;
-  // Remounting the ask box for a requested chat leaves its input empty and focused.
-  const [chatSession, setChatSession] = useState(0);
-  useEffect(() => {
-    if (!newChatRequested) return;
-    startNewChat();
-    setChatSession((session) => session + 1);
-    onNewChatRequestHandled?.();
-  }, [newChatRequested, startNewChat, onNewChatRequestHandled]);
 
   const workspace = space.workspace_id
     ? workspaces.find((w) => w.id === space.workspace_id)
@@ -155,7 +141,6 @@ export function ContainerOverview({
         <OverviewExplainerBanner kind={space.kind === "team" ? "team" : "private"} />
 
         <OverviewAskSection
-          key={chatSession}
           messages={chat.messages}
           agentState={chat.agentState}
           onTextSubmit={chat.sendMessage}

--- a/src/components/ui/SidebarModal.tsx
+++ b/src/components/ui/SidebarModal.tsx
@@ -110,6 +110,12 @@ export default function SidebarModal<T extends string>({
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
           ref={registerContent}
+          // Radix focuses the first tabbable on open, which is the close button;
+          // focus the dialog itself so the X doesn't open wearing a focus ring.
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            (e.currentTarget as HTMLElement).focus();
+          }}
           onEscapeKeyDown={(e) => {
             if (document.querySelector("[data-capturing]")) e.preventDefault();
           }}
@@ -119,10 +125,10 @@ export default function SidebarModal<T extends string>({
             // otherwise take the whole settings modal with it.
             if (shouldBlockDismiss(e)) e.preventDefault();
           }}
-          className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-4xl translate-x-[-50%] translate-y-[-50%] rounded-xl p-0 overflow-hidden bg-background border border-border shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:bg-surface-1 dark:border-border-subtle dark:shadow-[0_25px_60px_-12px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98"
+          className="fixed left-[50%] top-[50%] z-50 max-h-[85vh] w-[90vw] max-w-4xl translate-x-[-50%] translate-y-[-50%] rounded-xl p-0 overflow-hidden outline-none bg-background border border-border shadow-[0_25px_50px_-12px_rgba(0,0,0,0.25)] dark:bg-surface-1 dark:border-border-subtle dark:shadow-[0_25px_60px_-12px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98"
         >
           <div className="relative h-full max-h-[85vh] overflow-hidden">
-            <DialogPrimitive.Close className="absolute end-4 top-4 z-10 rounded-md p-1.5 opacity-40 ring-offset-background transition-[opacity,background-color] hover:opacity-100 bg-transparent hover:bg-muted dark:hover:bg-surface-raised focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-1">
+            <DialogPrimitive.Close className="absolute end-4 top-4 z-10 rounded-md p-1.5 opacity-40 ring-offset-background transition-[opacity,background-color] hover:opacity-100 bg-transparent hover:bg-muted dark:hover:bg-surface-raised outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-1">
               <X className="h-3.5 w-3.5 text-muted-foreground" />
               <span className="sr-only">{t("common.close")}</span>
             </DialogPrimitive.Close>

--- a/src/components/ui/SidebarModal.tsx
+++ b/src/components/ui/SidebarModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "../icons";
+import { InfoBox } from "./InfoBox";
 import { SettingsLayoutProvider } from "./useSettingsLayout";
 import { useDismissGuard } from "./useDismissGuard";
 
@@ -28,6 +29,8 @@ interface SidebarModalProps<T extends string> {
   version?: string;
   /** Rendered above the nav (hidden in compact mode), e.g. account identity. */
   header?: React.ReactNode;
+  /** Full-width banner above every section, e.g. an organization-managed notice. */
+  notice?: React.ReactNode;
 }
 
 export default function SidebarModal<T extends string>({
@@ -41,6 +44,7 @@ export default function SidebarModal<T extends string>({
   sidebarWidth = "w-52",
   version,
   header,
+  notice,
 }: SidebarModalProps<T>) {
   const { t } = useTranslation();
   const { registerContent, shouldBlockDismiss } = useDismissGuard<HTMLDivElement>();
@@ -238,7 +242,19 @@ export default function SidebarModal<T extends string>({
               {/* Main Content */}
               <div className="flex-1 overflow-y-auto bg-background dark:bg-surface-1">
                 <SettingsLayoutProvider value={{ isCompact }}>
-                  <div className={isCompact ? "p-4" : "p-6"}>{children}</div>
+                  <div className={isCompact ? "p-4" : "p-6"}>
+                    {/* Starts just below the close button, which floats over this column's top corner. */}
+                    {notice && (
+                      <InfoBox
+                        className={`mb-6 flex items-center gap-2.5 rounded-lg px-4 py-3 text-sm text-primary ${
+                          isCompact ? "mt-8" : "mt-6"
+                        }`}
+                      >
+                        {notice}
+                      </InfoBox>
+                    )}
+                    {children}
+                  </div>
                 </SettingsLayoutProvider>
               </div>
             </div>

--- a/src/components/ui/splitButton.ts
+++ b/src/components/ui/splitButton.ts
@@ -1,0 +1,7 @@
+// Two actions in one pill, split by a hairline (the note's Share control, the
+// Notes topbar's New note). Callers set the height to match their row.
+export const SPLIT_BUTTON_GROUP_CLASS =
+  "flex items-stretch overflow-hidden rounded-full border border-border bg-surface-3 dark:border-white/10 dark:bg-surface-2";
+export const SPLIT_BUTTON_SEGMENT_CLASS =
+  "flex items-center text-xs font-medium text-foreground/80 outline-none transition-colors duration-150 hover:bg-surface-raised hover:text-foreground focus-visible:bg-surface-raised dark:hover:bg-surface-3";
+export const SPLIT_BUTTON_DIVIDER_CLASS = "my-1.5 w-px bg-border dark:bg-white/10";

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -2,6 +2,7 @@ const { ipcMain, app, shell, BrowserWindow, systemPreferences, net, session } = 
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const { isRestorablePasteTarget } = require("./windowsPasteTarget");
 const crypto = require("crypto");
 const debugLogger = require("./debugLogger");
 const { ANALYTICS_HISTORY_BACKFILL_VERSION } = require("./analytics");
@@ -590,25 +591,6 @@ async function chunkedCloudTranscribe({
       debugLogger.warn("Failed to cleanup chunk dir", { error: cleanupErr.message });
     }
   }
-}
-
-// Windows only: whether an HWND captured at record start is one of our own
-// BrowserWindows. The tray's menu-owner window is ours but is not one of them,
-// and restoring it at paste time would pull the foreground onto OpenWhispr and
-// drop the keystroke.
-function isOwnBrowserWindowHandle(hwndHex) {
-  let handle;
-  try {
-    handle = BigInt(`0x${String(hwndHex).replace(/^0x/i, "")}`);
-  } catch {
-    return false;
-  }
-  return BrowserWindow.getAllWindows().some((win) => {
-    if (win.isDestroyed()) return false;
-    const buffer = win.getNativeWindowHandle();
-    const value = buffer.length >= 8 ? buffer.readBigUInt64LE(0) : BigInt(buffer.readUInt32LE(0));
-    return value === handle;
-  });
 }
 
 class IPCHandlers {
@@ -3073,14 +3055,17 @@ class IPCHandlers {
         process.platform === "win32"
           ? ((await this.selectionManager?.getWinTarget?.()) ?? null)
           : null;
-      // A dictation started from the tray captures our own menu-owner window, and
-      // restoring that would pull the foreground onto OpenWhispr and drop the
-      // keystroke. Our real windows stay valid targets.
-      const ownWindowCapture =
-        !!winTarget &&
-        (winTarget.exeName || "").toLowerCase() === path.basename(process.execPath).toLowerCase() &&
-        !isOwnBrowserWindowHandle(winTarget.id);
-      const targetWindow = winTarget && !ownWindowCapture ? winTarget.id : null;
+      const targetWindow =
+        winTarget &&
+        isRestorablePasteTarget({
+          target: winTarget,
+          ownExeName: path.basename(process.execPath),
+          ownWindowHandles: BrowserWindow.getAllWindows()
+            .filter((win) => !win.isDestroyed())
+            .map((win) => win.getNativeWindowHandle()),
+        })
+          ? winTarget.id
+          : null;
 
       const pasteResult = await this.clipboardManager.pasteText(textToPaste, {
         ...options,

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -11479,6 +11479,8 @@ class IPCHandlers {
       }
     });
 
+    ipcMain.handle("start-manual-meeting", () => this.windowManager.startManualMeeting());
+
     ipcMain.handle("get-meeting-notification-data", async () => {
       return this.windowManager?._pendingNotificationData ?? null;
     });

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -592,6 +592,25 @@ async function chunkedCloudTranscribe({
   }
 }
 
+// Windows only: whether an HWND captured at record start is one of our own
+// BrowserWindows. The tray's menu-owner window is ours but is not one of them,
+// and restoring it at paste time would pull the foreground onto OpenWhispr and
+// drop the keystroke.
+function isOwnBrowserWindowHandle(hwndHex) {
+  let handle;
+  try {
+    handle = BigInt(`0x${String(hwndHex).replace(/^0x/i, "")}`);
+  } catch {
+    return false;
+  }
+  return BrowserWindow.getAllWindows().some((win) => {
+    if (win.isDestroyed()) return false;
+    const buffer = win.getNativeWindowHandle();
+    const value = buffer.length >= 8 ? buffer.readBigUInt64LE(0) : BigInt(buffer.readUInt32LE(0));
+    return value === handle;
+  });
+}
+
 class IPCHandlers {
   constructor(managers) {
     this.environmentManager = managers.environmentManager;
@@ -3050,10 +3069,18 @@ class IPCHandlers {
       // paste lands in the field the user was dictating into, not wherever focus
       // drifted during transcription (#859). macOS handles this via
       // activateTargetPid above; Linux re-detects the target inside pasteLinux.
-      const targetWindow =
+      const winTarget =
         process.platform === "win32"
-          ? ((await this.selectionManager?.getWinTargetHwnd?.()) ?? null)
+          ? ((await this.selectionManager?.getWinTarget?.()) ?? null)
           : null;
+      // A dictation started from the tray captures our own menu-owner window, and
+      // restoring that would pull the foreground onto OpenWhispr and drop the
+      // keystroke. Our real windows stay valid targets.
+      const ownWindowCapture =
+        !!winTarget &&
+        (winTarget.exeName || "").toLowerCase() === path.basename(process.execPath).toLowerCase() &&
+        !isOwnBrowserWindowHandle(winTarget.id);
+      const targetWindow = winTarget && !ownWindowCapture ? winTarget.id : null;
 
       const pasteResult = await this.clipboardManager.pasteText(textToPaste, {
         ...options,
@@ -8426,6 +8453,7 @@ class IPCHandlers {
           sessionId: recordingSessionId,
           autoEndEligible: options.autoEndEligible === true,
           ownerWebContents: event.sender,
+          noteId: options.noteId ?? null,
           // Renderer loopback may still fail after main chooses its strategy.
           // Auto-end stays fail-safe until the renderer confirms a real source.
           systemAudioAvailable: false,

--- a/src/helpers/meetingDetectionEngine.js
+++ b/src/helpers/meetingDetectionEngine.js
@@ -385,6 +385,7 @@ class MeetingDetectionEngine {
     autoEndEligible,
     ownerWebContents,
     systemAudioAvailable = false,
+    noteId = null,
   }) {
     this._clearAutoEndRecovery();
     if (this._recordingSession) this._deactivateAutoEnd();
@@ -394,6 +395,9 @@ class MeetingDetectionEngine {
       autoEndEligible: autoEndEligible === true,
       ownerWebContents,
       systemAudioAvailable: systemAudioAvailable === true,
+      // Lets a second manual start surface this recording instead of opening a
+      // new note over it.
+      noteId,
     };
     this._syncMeetingProcessDetector();
 
@@ -674,6 +678,15 @@ class MeetingDetectionEngine {
 
   async startManualMeeting() {
     debugLogger.info("Starting manual meeting", {}, "meeting");
+
+    // A live meeting already owns a note: a second start would leave the recording
+    // running in it behind a new, empty one. Surface the live note instead.
+    if (this._recordingSession) {
+      const { noteId } = this._recordingSession;
+      debugLogger.info("Manual meeting ignored — a recording is live", { noteId }, "meeting");
+      if (noteId != null) await this.windowManager.queueNoteNavigation({ noteId });
+      return;
+    }
 
     const activeEvents = this.databaseManager.getActiveEvents();
     if (activeEvents?.length > 0) {

--- a/src/helpers/selectionManager.js
+++ b/src/helpers/selectionManager.js
@@ -143,13 +143,8 @@ class SelectionManager {
   // The Windows foreground window captured at record start, for the paste path
   // to restore before Ctrl+V lands (#859). Waits out an in-flight probe for the
   // same reason captureSelectedText does: the stop-press probe can still be
-  // running when fast transcription reaches the paste.
-  async getWinTargetHwnd() {
-    return (await this.getWinTarget())?.id ?? null;
-  }
-
-  // The same capture with its window identity, for callers that must judge
-  // whether the captured window is a sensible paste target.
+  // running when fast transcription reaches the paste. Carries the window's
+  // identity so the paste can judge whether restoring it makes sense.
   async getWinTarget() {
     while (this._captureTargetPromise) {
       await this._captureTargetPromise;

--- a/src/helpers/selectionManager.js
+++ b/src/helpers/selectionManager.js
@@ -145,10 +145,16 @@ class SelectionManager {
   // same reason captureSelectedText does: the stop-press probe can still be
   // running when fast transcription reaches the paste.
   async getWinTargetHwnd() {
+    return (await this.getWinTarget())?.id ?? null;
+  }
+
+  // The same capture with its window identity, for callers that must judge
+  // whether the captured window is a sensible paste target.
+  async getWinTarget() {
     while (this._captureTargetPromise) {
       await this._captureTargetPromise;
     }
-    return this.lastTarget?.kind === "win-hwnd" ? this.lastTarget.id : null;
+    return this.lastTarget?.kind === "win-hwnd" ? this.lastTarget : null;
   }
 
   async captureSelectedText(options = {}) {

--- a/src/helpers/tray.js
+++ b/src/helpers/tray.js
@@ -256,6 +256,19 @@ class TrayManager {
 
     return [
       {
+        label: i18nMain.t("app.commandMenu.startListening"),
+        click: () => this.windowManager?.sendStartDictation(),
+      },
+      {
+        label: i18nMain.t("app.commandMenu.askAssistant"),
+        click: () => this.windowManager?.sendOpenAssistantPanel(),
+      },
+      {
+        label: i18nMain.t("app.commandMenu.startMeetingRecording"),
+        click: () => void this.windowManager?.startManualMeeting(),
+      },
+      { type: "separator" },
+      {
         label: dictationVisible
           ? i18nMain.t("tray.toggleDictation.hide")
           : i18nMain.t("tray.toggleDictation.show"),

--- a/src/helpers/tray.js
+++ b/src/helpers/tray.js
@@ -263,7 +263,7 @@ class TrayManager {
         click: () =>
           dictating
             ? this.windowManager?.sendStopDictation()
-            : this.windowManager?.sendStartDictation(),
+            : this.windowManager?.sendStartListening(),
       },
       {
         label: i18nMain.t("app.commandMenu.askAssistant"),

--- a/src/helpers/tray.js
+++ b/src/helpers/tray.js
@@ -253,11 +253,17 @@ class TrayManager {
 
   buildContextMenuTemplate() {
     const dictationVisible = this.windowManager?.isDictationPanelVisible?.() ?? false;
+    const dictating = this.windowManager?.isDictating?.() ?? false;
 
     return [
       {
-        label: i18nMain.t("app.commandMenu.startListening"),
-        click: () => this.windowManager?.sendStartDictation(),
+        label: dictating
+          ? i18nMain.t("app.commandMenu.stopListening")
+          : i18nMain.t("app.commandMenu.startListening"),
+        click: () =>
+          dictating
+            ? this.windowManager?.sendStopDictation()
+            : this.windowManager?.sendStartDictation(),
       },
       {
         label: i18nMain.t("app.commandMenu.askAssistant"),
@@ -265,7 +271,7 @@ class TrayManager {
       },
       {
         label: i18nMain.t("app.commandMenu.startMeetingRecording"),
-        click: () => void this.windowManager?.startManualMeeting(),
+        click: () => this.windowManager?.sendStartMeeting(),
       },
       { type: "separator" },
       {

--- a/src/helpers/trayActionPolicy.js
+++ b/src/helpers/trayActionPolicy.js
@@ -1,0 +1,26 @@
+// The pill's command menu hides quick actions that cannot run; the tray always
+// shows them, so a tray click needs an answer instead of silence. These decide
+// what the dictation renderer does with one, and the message it explains a
+// refusal with. Keys resolve through i18n in the renderer.
+export const TRAY_REFUSAL_KEYS = Object.freeze({
+  agentRestricted: "common.policyAgentRestricted",
+  meetingRestricted: "notes.meeting.restrictedByOrg",
+  busy: "app.commandMenu.busyRecording",
+});
+
+const run = Object.freeze({ action: "run" });
+const refuse = (messageKey) => Object.freeze({ action: "refuse", messageKey });
+
+/** The pill menu hides Ask Assistant without the agent, and while a panel owns the pill. */
+export function resolveTrayAssistantAction({ agentAllowed, isRecording, liveTranscriptMounted }) {
+  if (!agentAllowed) return refuse(TRAY_REFUSAL_KEYS.agentRestricted);
+  if (isRecording || liveTranscriptMounted) return refuse(TRAY_REFUSAL_KEYS.busy);
+  return run;
+}
+
+/** A meeting would capture the microphone a live dictation already holds. */
+export function resolveTrayMeetingAction({ meetingAllowed, isRecording }) {
+  if (!meetingAllowed) return refuse(TRAY_REFUSAL_KEYS.meetingRestricted);
+  if (isRecording) return refuse(TRAY_REFUSAL_KEYS.busy);
+  return run;
+}

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -837,11 +837,21 @@ class WindowManager {
     return isOnboardingInputAllowed(this._onboardingActive, this._onboardingDemoKind, inputKind);
   }
 
-  // Public gate for main.js's meeting hotkey call sites, which invoke the
-  // detection engine directly rather than routing through a send method here.
   // "meeting" is never a demo kind, so this is simply "not during onboarding".
   isMeetingInputAllowed() {
     return this._isOnboardingInputAllowed("meeting");
+  }
+
+  // The one entry for starting a meeting by hand: the meeting hotkey, the pill's
+  // command menu, and the tray. Fails closed during onboarding and while a
+  // hotkey is being captured, like every hotkey slot.
+  async startManualMeeting() {
+    if (this.hotkeyManager.isInListeningMode() || !this.isMeetingInputAllowed()) return;
+    try {
+      await this.meetingDetectionEngine?.startManualMeeting();
+    } catch (error) {
+      debugLogger.error("Failed to start manual meeting", { error: error.message }, "meeting");
+    }
   }
 
   // Visibility is part of "available": a ready pill that is merely hidden
@@ -986,6 +996,15 @@ class WindowManager {
 
   sendToggleTranslation() {
     this._sendDictationToggle("toggle-translation", "translation");
+  }
+
+  // The pill's Ask Assistant for surfaces outside the pill (the tray); the
+  // renderer applies the pill menu's availability rules on arrival.
+  sendOpenAssistantPanel() {
+    if (!this._isOnboardingInputAllowed("assistant")) return;
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+    this.showDictationPanel({ focus: true });
+    this.mainWindow.webContents.send("open-assistant-panel");
   }
 
   sendStartDictation() {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -949,6 +949,12 @@ class WindowManager {
     this._isDictatingToggle = isDictationRecording(nextState);
     this.meetingDetectionEngine?.setUserRecording(this._isDictatingToggle);
     this._sendAgentDictationPillState();
+    this.onDictationStateChanged?.();
+  }
+
+  // The tray's listen item is a toggle over this state, like the pill's.
+  isDictating() {
+    return this._isDictatingToggle;
   }
 
   _sendAgentDictationPillState() {
@@ -998,13 +1004,21 @@ class WindowManager {
     this._sendDictationToggle("toggle-translation", "translation");
   }
 
-  // The pill's Ask Assistant for surfaces outside the pill (the tray); the
-  // renderer applies the pill menu's availability rules on arrival.
+  // The pill's Ask Assistant and Start meeting recording for surfaces outside the
+  // pill (the tray). Only the renderer knows the policy and recording state the
+  // pill menu gates those items on, so it decides; nothing is shown or created
+  // here. An accepted assistant command surfaces the pill itself through
+  // setAssistantPanelOpen, and a meeting comes back through start-manual-meeting.
   sendOpenAssistantPanel() {
     if (!this._isOnboardingInputAllowed("assistant")) return;
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
-    this.showDictationPanel({ focus: true });
     this.mainWindow.webContents.send("open-assistant-panel");
+  }
+
+  sendStartMeeting() {
+    if (this.hotkeyManager.isInListeningMode() || !this.isMeetingInputAllowed()) return;
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+    this.mainWindow.webContents.send("start-meeting");
   }
 
   sendStartDictation() {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -61,6 +61,8 @@ class WindowManager {
     // Set by IPCHandlers so its demo session dies with the demo kind on every
     // teardown path (id-matched end, onboarding exit, control panel closed).
     this.onOnboardingDemoTeardown = null;
+    // Set by main.js so the tray's listen item rebuilds with dictation state.
+    this.onDictationStateChanged = null;
     this.notificationWindow = null;
     this.agentDictationPillWindow = null;
     this._agentDictationPillReady = false;
@@ -1009,9 +1011,10 @@ class WindowManager {
   // pill menu gates those items on, so it decides; nothing is shown or created
   // here. An accepted assistant command surfaces the pill itself through
   // setAssistantPanelOpen, and a meeting comes back through start-manual-meeting.
+  // Onboarding blocks these outright rather than through the demo-aware gate:
+  // the tray and the meeting hotkey are never part of the scripted demo.
   sendOpenAssistantPanel() {
-    if (this.hotkeyManager.isInListeningMode()) return;
-    if (!this._isOnboardingInputAllowed("assistant")) return;
+    if (this.hotkeyManager.isInListeningMode() || this._onboardingActive) return;
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     this.mainWindow.webContents.send("open-assistant-panel");
   }
@@ -1019,7 +1022,27 @@ class WindowManager {
   sendStartMeeting() {
     if (this.hotkeyManager.isInListeningMode() || !this.isMeetingInputAllowed()) return;
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+    debugLogger.info("Manual meeting requested", {}, "meeting");
     this.mainWindow.webContents.send("start-meeting");
+  }
+
+  // The tray's listen item, unlike the hotkey, is visible whatever the state, so
+  // the gates only this process can see explain themselves instead of going quiet.
+  sendStartListening() {
+    if (this.hotkeyManager.isInListeningMode() || this._onboardingActive) return;
+    if (
+      this._shouldBlockDictationInput("dictation") ||
+      shouldIgnoreDictationHotkey(this._dictationLifecycleState)
+    ) {
+      this._sendTrayActionRefused("app.commandMenu.busyRecording");
+      return;
+    }
+    this.sendStartDictation();
+  }
+
+  _sendTrayActionRefused(messageKey) {
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+    this.mainWindow.webContents.send("tray-action-refused", { messageKey });
   }
 
   sendStartDictation() {

--- a/src/helpers/windowManager.js
+++ b/src/helpers/windowManager.js
@@ -1010,6 +1010,7 @@ class WindowManager {
   // here. An accepted assistant command surfaces the pill itself through
   // setAssistantPanelOpen, and a meeting comes back through start-manual-meeting.
   sendOpenAssistantPanel() {
+    if (this.hotkeyManager.isInListeningMode()) return;
     if (!this._isOnboardingInputAllowed("assistant")) return;
     if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
     this.mainWindow.webContents.send("open-assistant-panel");

--- a/src/helpers/windowsPasteTarget.js
+++ b/src/helpers/windowsPasteTarget.js
@@ -1,0 +1,35 @@
+// Whether a Windows paste may restore the window captured at record start
+// (#859). The predicate is "ours and not one of our windows", not "ours and
+// editable": a tray-menu start leaves the menu's owner window foreground, and
+// force-activating that at paste time would pull the foreground onto OpenWhispr
+// and drop the keystroke. Our real windows — the control panel's note editor —
+// stay valid targets, so dictating into a note still pastes there.
+
+/** "TARGET %p" prints hex, with or without an 0x prefix. */
+function parseWindowHandle(value) {
+  try {
+    return BigInt(`0x${String(value).replace(/^0x/i, "")}`);
+  } catch {
+    return null;
+  }
+}
+
+// Win64 hands back an 8-byte pointer, Win32 a 4-byte one.
+function readWindowHandle(buffer) {
+  return buffer.length >= 8 ? buffer.readBigUInt64LE(0) : BigInt(buffer.readUInt32LE(0));
+}
+
+function isRestorablePasteTarget({ target, ownExeName, ownWindowHandles = [] }) {
+  if (!target?.id) return false;
+
+  // An unreadable exe name reads as someone else's window, keeping the pre-#859
+  // behaviour rather than dropping a target that was probably legitimate.
+  const exeName = String(target.exeName || "").toLowerCase();
+  if (!exeName || exeName !== String(ownExeName || "").toLowerCase()) return true;
+
+  const handle = parseWindowHandle(target.id);
+  if (handle === null) return false;
+  return ownWindowHandles.some((buffer) => readWindowHandle(buffer) === handle);
+}
+
+module.exports = { isRestorablePasteTarget, parseWindowHandle };

--- a/src/hooks/useCanCreateTeamSpace.ts
+++ b/src/hooks/useCanCreateTeamSpace.ts
@@ -1,0 +1,19 @@
+import { useAuth } from "./useAuth";
+import { useTeamSpacesCapability } from "./useTeamSpacesCapability";
+import { useWorkspace } from "./useWorkspace";
+import { canManageWorkspace } from "../lib/spacePermissions";
+
+/**
+ * Whether to offer "new team space". The server 403s team creation for plain
+ * members; users with no workspace yet get the create funnel in the dialog.
+ */
+export function useCanCreateTeamSpace(): boolean {
+  const { isSignedIn } = useAuth();
+  const teamSpacesAvailable = useTeamSpacesCapability(isSignedIn);
+  const { workspaces, loaded } = useWorkspace();
+  return (
+    teamSpacesAvailable &&
+    loaded &&
+    (workspaces.length === 0 || workspaces.some((w) => canManageWorkspace(w.role)))
+  );
+}

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -1584,7 +1584,7 @@
       "asJson": "بصيغة JSON (.json)",
       "asTranscriptMarkdown": "بصيغة Markdown (.md)",
       "raw": "خام",
-      "enhanced": "مُحسّن",
+      "aiSummary": "ملخص بالذكاء الاصطناعي",
       "saving": "جاري الحفظ",
       "transcriptEmptyTitle": "لم يتم تسجيل أي شيء بعد",
       "transcriptEmptyDescription": "اضغط على تسجيل لبدء النسخ. كل ما يُقال يظهر هنا لحظيًا.",

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -1574,7 +1574,7 @@
     "createMenu": {
       "note": "ملاحظة",
       "assistantChat": "دردشة مع المساعد",
-      "sharedSpace": "مساحة مشتركة",
+      "teamSpace": "مساحة فريق",
       "chooseType": "اختر ما تريد إنشاءه"
     },
     "editor": {

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -1350,7 +1350,8 @@
       "stopListening": "إيقاف الاستماع",
       "startListening": "بدء الاستماع",
       "hideForNow": "إخفاء الآن",
-      "askAssistant": "اسأل المساعد"
+      "askAssistant": "اسأل المساعد",
+      "startMeetingRecording": "بدء تسجيل الاجتماع"
     }
   },
   "calendar": {

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -1351,6 +1351,7 @@
       "startListening": "بدء الاستماع",
       "hideForNow": "إخفاء الآن",
       "askAssistant": "اسأل المساعد",
+      "busyRecording": "أنهِ التسجيل الحالي أولاً",
       "startMeetingRecording": "بدء تسجيل الاجتماع"
     }
   },

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -1571,6 +1571,12 @@
       "hoursAgo": "منذ {{count}} س",
       "daysAgo": "منذ {{count}} ي"
     },
+    "createMenu": {
+      "note": "ملاحظة",
+      "assistantChat": "دردشة مع المساعد",
+      "sharedSpace": "مساحة مشتركة",
+      "chooseType": "اختر ما تريد إنشاءه"
+    },
     "editor": {
       "untitled": "بدون عنوان",
       "noteTitle": "عنوان الملاحظة",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -3229,6 +3229,12 @@
       "hoursAgo": "vor {{count}}h",
       "daysAgo": "vor {{count}}T"
     },
+    "createMenu": {
+      "note": "Notiz",
+      "assistantChat": "Assistent-Chat",
+      "sharedSpace": "Geteilter Bereich",
+      "chooseType": "Auswählen, was erstellt werden soll"
+    },
     "editor": {
       "untitled": "Unbenannt",
       "noteTitle": "Notiztitel",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -3243,7 +3243,7 @@
       "asJson": "Als JSON (.json)",
       "asTranscriptMarkdown": "Als Markdown (.md)",
       "raw": "Roh",
-      "enhanced": "Verbessert",
+      "aiSummary": "KI-Zusammenfassung",
       "saving": "Wird gespeichert",
       "transcriptEmptyTitle": "Noch nichts aufgenommen",
       "transcriptEmptyDescription": "Drücke auf Aufnahme, um mit der Transkription zu beginnen. Alles Gesagte erscheint hier in Echtzeit.",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -3696,7 +3696,8 @@
       "stopListening": "Aufnahme beenden",
       "startListening": "Aufnahme starten",
       "hideForNow": "Vorerst ausblenden",
-      "askAssistant": "Assistent fragen"
+      "askAssistant": "Assistent fragen",
+      "startMeetingRecording": "Meeting-Aufnahme starten"
     }
   },
   "dictationAgent": {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -3703,6 +3703,7 @@
       "startListening": "Aufnahme starten",
       "hideForNow": "Vorerst ausblenden",
       "askAssistant": "Assistent fragen",
+      "busyRecording": "Beende zuerst die laufende Aufnahme",
       "startMeetingRecording": "Meeting-Aufnahme starten"
     }
   },

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -3232,7 +3232,7 @@
     "createMenu": {
       "note": "Notiz",
       "assistantChat": "Assistent-Chat",
-      "sharedSpace": "Geteilter Bereich",
+      "teamSpace": "Team-Bereich",
       "chooseType": "Auswählen, was erstellt werden soll"
     },
     "editor": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3243,7 +3243,7 @@
       "asJson": "As JSON (.json)",
       "asTranscriptMarkdown": "As Markdown (.md)",
       "raw": "Raw",
-      "enhanced": "Enhanced",
+      "aiSummary": "AI Summary",
       "saving": "Saving",
       "transcriptEmptyTitle": "Nothing recorded yet",
       "transcriptEmptyDescription": "Hit record to start transcribing. Everything said shows up here as it happens.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3232,7 +3232,7 @@
     "createMenu": {
       "note": "Note",
       "assistantChat": "Assistant chat",
-      "sharedSpace": "Shared space",
+      "teamSpace": "Team space",
       "chooseType": "Choose what to create"
     },
     "editor": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3703,6 +3703,7 @@
       "startListening": "Start listening",
       "hideForNow": "Hide for now",
       "askAssistant": "Ask assistant",
+      "busyRecording": "Finish the current dictation first",
       "startMeetingRecording": "Start meeting recording"
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3702,7 +3702,7 @@
       "stopListening": "Stop listening",
       "startListening": "Start listening",
       "hideForNow": "Hide for now",
-      "askAssistant": "Ask Assistant",
+      "askAssistant": "Ask assistant",
       "startMeetingRecording": "Start meeting recording"
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3229,6 +3229,12 @@
       "hoursAgo": "{{count}}h",
       "daysAgo": "{{count}}d"
     },
+    "createMenu": {
+      "note": "Note",
+      "assistantChat": "Assistant chat",
+      "sharedSpace": "Shared space",
+      "chooseType": "Choose what to create"
+    },
     "editor": {
       "untitled": "Untitled",
       "noteTitle": "Note title",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -3696,7 +3696,8 @@
       "stopListening": "Stop listening",
       "startListening": "Start listening",
       "hideForNow": "Hide for now",
-      "askAssistant": "Ask Assistant"
+      "askAssistant": "Ask Assistant",
+      "startMeetingRecording": "Start meeting recording"
     }
   },
   "dictationAgent": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2943,7 +2943,7 @@
     "createMenu": {
       "note": "Nota",
       "assistantChat": "Chat con el asistente",
-      "sharedSpace": "Espacio compartido",
+      "teamSpace": "Espacio de equipo",
       "chooseType": "Elegir qué crear"
     },
     "editor": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -3587,6 +3587,7 @@
       "startListening": "Empezar a escuchar",
       "hideForNow": "Ocultar por ahora",
       "askAssistant": "Preguntar al asistente",
+      "busyRecording": "Primero termina la grabación actual",
       "startMeetingRecording": "Iniciar grabación de reunión"
     }
   },

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2954,7 +2954,7 @@
       "asJson": "Como JSON (.json)",
       "asTranscriptMarkdown": "Como Markdown (.md)",
       "raw": "Sin procesar",
-      "enhanced": "Mejorado",
+      "aiSummary": "Resumen con IA",
       "saving": "Guardando",
       "transcriptEmptyTitle": "Aún no hay grabaciones",
       "transcriptEmptyDescription": "Pulsa grabar para empezar a transcribir. Todo lo que se diga aparecerá aquí en tiempo real.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -3580,7 +3580,8 @@
       "stopListening": "Dejar de escuchar",
       "startListening": "Empezar a escuchar",
       "hideForNow": "Ocultar por ahora",
-      "askAssistant": "Preguntar al asistente"
+      "askAssistant": "Preguntar al asistente",
+      "startMeetingRecording": "Iniciar grabación de reunión"
     }
   },
   "dictationAgent": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -2940,6 +2940,12 @@
       "hoursAgo": "hace {{count}}h",
       "daysAgo": "hace {{count}}d"
     },
+    "createMenu": {
+      "note": "Nota",
+      "assistantChat": "Chat con el asistente",
+      "sharedSpace": "Espacio compartido",
+      "chooseType": "Elegir qué crear"
+    },
     "editor": {
       "untitled": "Sin título",
       "noteTitle": "Título de la nota",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3232,7 +3232,7 @@
     "createMenu": {
       "note": "Note",
       "assistantChat": "Chat avec l'assistant",
-      "sharedSpace": "Espace partagé",
+      "teamSpace": "Espace d'équipe",
       "chooseType": "Choisir quoi créer"
     },
     "editor": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3703,6 +3703,7 @@
       "startListening": "Commencer l’écoute",
       "hideForNow": "Masquer pour l’instant",
       "askAssistant": "Demander à l'assistant",
+      "busyRecording": "Terminez d'abord l'enregistrement en cours",
       "startMeetingRecording": "Démarrer l’enregistrement de la réunion"
     }
   },

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3229,6 +3229,12 @@
       "hoursAgo": "il y a {{count}}h",
       "daysAgo": "il y a {{count}}j"
     },
+    "createMenu": {
+      "note": "Note",
+      "assistantChat": "Chat avec l'assistant",
+      "sharedSpace": "Espace partagé",
+      "chooseType": "Choisir quoi créer"
+    },
     "editor": {
       "untitled": "Sans titre",
       "noteTitle": "Titre de la note",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3243,7 +3243,7 @@
       "asJson": "En JSON (.json)",
       "asTranscriptMarkdown": "En Markdown (.md)",
       "raw": "Brut",
-      "enhanced": "Amélioré",
+      "aiSummary": "Résumé IA",
       "saving": "Enregistrement",
       "transcriptEmptyTitle": "Rien d'enregistré pour l'instant",
       "transcriptEmptyDescription": "Lancez l'enregistrement pour commencer la transcription. Tout ce qui est dit s'affiche ici en direct.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -3696,7 +3696,8 @@
       "stopListening": "Arrêter l’écoute",
       "startListening": "Commencer l’écoute",
       "hideForNow": "Masquer pour l’instant",
-      "askAssistant": "Demander à l'assistant"
+      "askAssistant": "Demander à l'assistant",
+      "startMeetingRecording": "Démarrer l’enregistrement de la réunion"
     }
   },
   "dictationAgent": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2901,7 +2901,7 @@
       "asJson": "Come JSON (.json)",
       "asTranscriptMarkdown": "Come Markdown (.md)",
       "raw": "Originale",
-      "enhanced": "Migliorato",
+      "aiSummary": "Riepilogo AI",
       "saving": "Salvataggio",
       "transcriptEmptyTitle": "Nessuna registrazione",
       "transcriptEmptyDescription": "Premi registra per iniziare a trascrivere. Tutto ciò che viene detto compare qui in tempo reale.",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2890,7 +2890,7 @@
     "createMenu": {
       "note": "Nota",
       "assistantChat": "Chat con l'assistente",
-      "sharedSpace": "Spazio condiviso",
+      "teamSpace": "Spazio del team",
       "chooseType": "Scegli cosa creare"
     },
     "editor": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -2887,6 +2887,12 @@
       "hoursAgo": "{{count}}h",
       "daysAgo": "{{count}}g"
     },
+    "createMenu": {
+      "note": "Nota",
+      "assistantChat": "Chat con l'assistente",
+      "sharedSpace": "Spazio condiviso",
+      "chooseType": "Scegli cosa creare"
+    },
     "editor": {
       "untitled": "Senza titolo",
       "noteTitle": "Titolo della nota",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -3534,6 +3534,7 @@
       "startListening": "Inizia ad ascoltare",
       "hideForNow": "Nascondi per ora",
       "askAssistant": "Chiedi all'assistente",
+      "busyRecording": "Prima termina la registrazione in corso",
       "startMeetingRecording": "Avvia registrazione meeting"
     }
   },

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -3527,7 +3527,8 @@
       "stopListening": "Smetti di ascoltare",
       "startListening": "Inizia ad ascoltare",
       "hideForNow": "Nascondi per ora",
-      "askAssistant": "Chiedi all'assistente"
+      "askAssistant": "Chiedi all'assistente",
+      "startMeetingRecording": "Avvia registrazione meeting"
     }
   },
   "dictationAgent": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -3527,7 +3527,8 @@
       "stopListening": "録音を停止",
       "startListening": "録音を開始",
       "hideForNow": "一時的に非表示",
-      "askAssistant": "アシスタントに質問"
+      "askAssistant": "アシスタントに質問",
+      "startMeetingRecording": "ミーティングの録音を開始"
     }
   },
   "dictationAgent": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2918,6 +2918,12 @@
       "hoursAgo": "{{count}}時間前",
       "daysAgo": "{{count}}日前"
     },
+    "createMenu": {
+      "note": "ノート",
+      "assistantChat": "アシスタントとのチャット",
+      "sharedSpace": "共有スペース",
+      "chooseType": "作成する項目を選択"
+    },
     "upload": {
       "title": "音声をアップロード",
       "using": "{{model}} を使用中",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2921,7 +2921,7 @@
     "createMenu": {
       "note": "ノート",
       "assistantChat": "アシスタントとのチャット",
-      "sharedSpace": "共有スペース",
+      "teamSpace": "チームスペース",
       "chooseType": "作成する項目を選択"
     },
     "upload": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -2809,7 +2809,7 @@
       "asJson": "JSON (.json)",
       "asTranscriptMarkdown": "Markdown (.md)",
       "raw": "元のテキスト",
-      "enhanced": "強化済み",
+      "aiSummary": "AI要約",
       "saving": "保存中",
       "transcriptEmptyTitle": "まだ録音がありません",
       "transcriptEmptyDescription": "録音ボタンを押すと文字起こしが始まります。話した内容がここにリアルタイムで表示されます。",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -3534,6 +3534,7 @@
       "startListening": "録音を開始",
       "hideForNow": "一時的に非表示",
       "askAssistant": "アシスタントに質問",
+      "busyRecording": "先に録音を終了してください",
       "startMeetingRecording": "ミーティングの録音を開始"
     }
   },

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2890,7 +2890,7 @@
     "createMenu": {
       "note": "Nota",
       "assistantChat": "Chat com o assistente",
-      "sharedSpace": "Espaço compartilhado",
+      "teamSpace": "Espaço de equipe",
       "chooseType": "Escolher o que criar"
     },
     "editor": {

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2901,7 +2901,7 @@
       "asJson": "Como JSON (.json)",
       "asTranscriptMarkdown": "Como Markdown (.md)",
       "raw": "Original",
-      "enhanced": "Aprimorado",
+      "aiSummary": "Resumo com IA",
       "saving": "Salvando",
       "transcriptEmptyTitle": "Nada gravado ainda",
       "transcriptEmptyDescription": "Toque em gravar para começar a transcrever. Tudo o que for dito aparece aqui em tempo real.",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -2887,6 +2887,12 @@
       "hoursAgo": "{{count}}h",
       "daysAgo": "{{count}}d"
     },
+    "createMenu": {
+      "note": "Nota",
+      "assistantChat": "Chat com o assistente",
+      "sharedSpace": "Espaço compartilhado",
+      "chooseType": "Escolher o que criar"
+    },
     "editor": {
       "untitled": "Sem título",
       "noteTitle": "Título da nota",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -3534,6 +3534,7 @@
       "startListening": "Começar a ouvir",
       "hideForNow": "Ocultar por agora",
       "askAssistant": "Perguntar ao assistente",
+      "busyRecording": "Termine primeiro a gravação atual",
       "startMeetingRecording": "Iniciar gravação da reunião"
     }
   },

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -3527,7 +3527,8 @@
       "stopListening": "Parar de ouvir",
       "startListening": "Começar a ouvir",
       "hideForNow": "Ocultar por agora",
-      "askAssistant": "Perguntar ao assistente"
+      "askAssistant": "Perguntar ao assistente",
+      "startMeetingRecording": "Iniciar gravação da reunião"
     }
   },
   "dictationAgent": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -3573,7 +3573,8 @@
       "stopListening": "Остановить запись",
       "startListening": "Начать запись",
       "hideForNow": "Скрыть",
-      "askAssistant": "Спросить помощника"
+      "askAssistant": "Спросить помощника",
+      "startMeetingRecording": "Начать запись встречи"
     }
   },
   "dictationAgent": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2923,7 +2923,7 @@
       "asJson": "Как JSON (.json)",
       "asTranscriptMarkdown": "Как Markdown (.md)",
       "raw": "Исходный",
-      "enhanced": "Улучшенный",
+      "aiSummary": "ИИ-сводка",
       "saving": "Сохранение",
       "transcriptEmptyTitle": "Пока ничего не записано",
       "transcriptEmptyDescription": "Нажмите «Запись», чтобы начать транскрипцию. Всё сказанное появится здесь в реальном времени.",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2909,6 +2909,12 @@
       "hoursAgo": "{{count}} ч. назад",
       "daysAgo": "{{count}} дн. назад"
     },
+    "createMenu": {
+      "note": "Заметка",
+      "assistantChat": "Чат с помощником",
+      "sharedSpace": "Общее пространство",
+      "chooseType": "Выбрать, что создать"
+    },
     "editor": {
       "untitled": "Без названия",
       "noteTitle": "Название заметки",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -3580,6 +3580,7 @@
       "startListening": "Начать запись",
       "hideForNow": "Скрыть",
       "askAssistant": "Спросить помощника",
+      "busyRecording": "Сначала завершите текущую запись",
       "startMeetingRecording": "Начать запись встречи"
     }
   },

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -2912,7 +2912,7 @@
     "createMenu": {
       "note": "Заметка",
       "assistantChat": "Чат с помощником",
-      "sharedSpace": "Общее пространство",
+      "teamSpace": "Командное пространство",
       "chooseType": "Выбрать, что создать"
     },
     "editor": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2887,6 +2887,12 @@
       "hoursAgo": "{{count}} 小时前",
       "daysAgo": "{{count}} 天前"
     },
+    "createMenu": {
+      "note": "笔记",
+      "assistantChat": "助手聊天",
+      "sharedSpace": "共享空间",
+      "chooseType": "选择要创建的内容"
+    },
     "editor": {
       "untitled": "无标题",
       "noteTitle": "笔记标题",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2901,7 +2901,7 @@
       "asJson": "导出为 JSON (.json)",
       "asTranscriptMarkdown": "导出为 Markdown (.md)",
       "raw": "原始内容",
-      "enhanced": "增强内容",
+      "aiSummary": "AI 摘要",
       "saving": "保存中",
       "transcriptEmptyTitle": "尚未录制任何内容",
       "transcriptEmptyDescription": "点击录制开始转写。所说的内容会实时显示在这里。",

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -2890,7 +2890,7 @@
     "createMenu": {
       "note": "笔记",
       "assistantChat": "助手聊天",
-      "sharedSpace": "共享空间",
+      "teamSpace": "团队空间",
       "chooseType": "选择要创建的内容"
     },
     "editor": {

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -3534,6 +3534,7 @@
       "startListening": "开始录音",
       "hideForNow": "暂时隐藏",
       "askAssistant": "询问助手",
+      "busyRecording": "请先结束当前录音",
       "startMeetingRecording": "开始会议录音"
     }
   },

--- a/src/locales/zh-CN/translation.json
+++ b/src/locales/zh-CN/translation.json
@@ -3527,7 +3527,8 @@
       "stopListening": "停止录音",
       "startListening": "开始录音",
       "hideForNow": "暂时隐藏",
-      "askAssistant": "询问助手"
+      "askAssistant": "询问助手",
+      "startMeetingRecording": "开始会议录音"
     }
   },
   "dictationAgent": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2887,6 +2887,12 @@
       "hoursAgo": "{{count}} 小時前",
       "daysAgo": "{{count}} 天前"
     },
+    "createMenu": {
+      "note": "筆記",
+      "assistantChat": "助理聊天",
+      "sharedSpace": "共用空間",
+      "chooseType": "選擇要建立的內容"
+    },
     "editor": {
       "untitled": "未命名",
       "noteTitle": "筆記標題",

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -3534,6 +3534,7 @@
       "startListening": "開始錄音",
       "hideForNow": "暫時隱藏",
       "askAssistant": "詢問助理",
+      "busyRecording": "請先結束目前的錄音",
       "startMeetingRecording": "開始會議錄音"
     }
   },

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -3527,7 +3527,8 @@
       "stopListening": "停止錄音",
       "startListening": "開始錄音",
       "hideForNow": "暫時隱藏",
-      "askAssistant": "詢問助理"
+      "askAssistant": "詢問助理",
+      "startMeetingRecording": "開始會議錄音"
     }
   },
   "dictationAgent": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2890,7 +2890,7 @@
     "createMenu": {
       "note": "筆記",
       "assistantChat": "助理聊天",
-      "sharedSpace": "共用空間",
+      "teamSpace": "團隊空間",
       "chooseType": "選擇要建立的內容"
     },
     "editor": {

--- a/src/locales/zh-TW/translation.json
+++ b/src/locales/zh-TW/translation.json
@@ -2901,7 +2901,7 @@
       "asJson": "匯出為 JSON (.json)",
       "asTranscriptMarkdown": "匯出為 Markdown (.md)",
       "raw": "原始",
-      "enhanced": "已增強",
+      "aiSummary": "AI 摘要",
       "saving": "儲存中",
       "transcriptEmptyTitle": "尚未錄製任何內容",
       "transcriptEmptyDescription": "點擊錄製開始轉錄。所說的內容會即時顯示在這裡。",

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1168,6 +1168,7 @@ declare global {
       onToggleVoiceAgent?: (callback: () => void) => () => void;
       onToggleTranslation?: (callback: () => void) => () => void;
       onOpenAssistantPanel?: (callback: () => void) => () => void;
+      onStartMeeting?: (callback: () => void) => () => void;
       onStartDictation?: (callback: () => void) => () => void;
       onStopDictation?: (callback: () => void) => () => void;
       onPrepareDictation?: (

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1169,6 +1169,7 @@ declare global {
       onToggleTranslation?: (callback: () => void) => () => void;
       onOpenAssistantPanel?: (callback: () => void) => () => void;
       onStartMeeting?: (callback: () => void) => () => void;
+      onTrayActionRefused?: (callback: (data: { messageKey: string }) => void) => () => void;
       onStartDictation?: (callback: () => void) => () => void;
       onStopDictation?: (callback: () => void) => () => void;
       onPrepareDictation?: (

--- a/src/types/electron.ts
+++ b/src/types/electron.ts
@@ -1167,6 +1167,7 @@ declare global {
       onToggleDictation: (callback: () => void) => () => void;
       onToggleVoiceAgent?: (callback: () => void) => () => void;
       onToggleTranslation?: (callback: () => void) => () => void;
+      onOpenAssistantPanel?: (callback: () => void) => () => void;
       onStartDictation?: (callback: () => void) => () => void;
       onStopDictation?: (callback: () => void) => () => void;
       onPrepareDictation?: (
@@ -3154,6 +3155,7 @@ declare global {
         action: string
       ) => Promise<{ success: boolean }>;
       joinCalendarMeeting?: (eventId: string) => Promise<{ success: boolean }>;
+      startManualMeeting?: () => Promise<void>;
       getPendingMeetingNoteNavigation?: () => Promise<{
         noteId: number;
         folderId: number;

--- a/test/components/newNoteMenu.test.js
+++ b/test/components/newNoteMenu.test.js
@@ -7,7 +7,7 @@ const { createRendererServer, installBrowserGlobals } = require("../lib/renderer
 // The harness renders i18n keys verbatim (no i18next instance is initialized), so
 // assertions match on the raw translation key rather than resolved copy. The dropdown
 // primitives are stubbed so the menu's items render inline instead of into a portal.
-async function renderMenu(t, { canCreateTeamSpace }) {
+async function renderMenu(t, { canCreateTeamSpace, withAssistant = true }) {
   installBrowserGlobals(t);
   const vite = await createRendererServer(t, {
     cachePrefix: "openwhispr-new-note-menu-test-",
@@ -35,7 +35,10 @@ async function renderMenu(t, { canCreateTeamSpace }) {
   });
   const mod = await vite.ssrLoadModule("/components/notes/NewNoteMenu.tsx");
   return renderToStaticMarkup(
-    createElement(mod.default, { onNewNote: () => {}, onNewChat: () => {} })
+    createElement(mod.default, {
+      onNewNote: () => {},
+      ...(withAssistant ? { onNewChat: () => {} } : {}),
+    })
   );
 }
 
@@ -53,4 +56,13 @@ test("the New note menu offers a team space only when the user can create one", 
 
   const withPermission = await renderMenu(t, { canCreateTeamSpace: true });
   assert.match(withPermission, /notes\.createMenu\.teamSpace/);
+});
+
+// The Chat tab disappears entirely when an org turns the assistant off, so the
+// item that navigates there goes with it.
+test("the New note menu hides the assistant chat when the assistant is off", async (t) => {
+  const markup = await renderMenu(t, { canCreateTeamSpace: false, withAssistant: false });
+
+  assert.doesNotMatch(markup, /notes\.createMenu\.assistantChat/);
+  assert.match(markup, /notes\.createMenu\.note/);
 });

--- a/test/components/newNoteMenu.test.js
+++ b/test/components/newNoteMenu.test.js
@@ -1,0 +1,56 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createElement } = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+const { createRendererServer, installBrowserGlobals } = require("../lib/rendererTestHarness");
+
+// The harness renders i18n keys verbatim (no i18next instance is initialized), so
+// assertions match on the raw translation key rather than resolved copy. The dropdown
+// primitives are stubbed so the menu's items render inline instead of into a portal.
+async function renderMenu(t, { canCreateTeamSpace }) {
+  installBrowserGlobals(t);
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-new-note-menu-test-",
+    mockModules: {
+      "/ui/dropdown-menu": `
+        import { createElement } from "react";
+        const passthrough = (props) => createElement("div", null, props.children);
+        export const DropdownMenu = passthrough;
+        export const DropdownMenuTrigger = passthrough;
+        export const DropdownMenuContent = passthrough;
+        export const DropdownMenuItem = passthrough;
+        export const DropdownMenuSeparator = () => createElement("div", null);
+      `,
+      "/hooks/useCanCreateTeamSpace": `
+        export const useCanCreateTeamSpace = () => globalThis.__canCreateTeamSpace === true;
+      `,
+      "/CreateSpaceDialog": `
+        export default function CreateSpaceDialog() { return null; }
+      `,
+    },
+  });
+  globalThis.__canCreateTeamSpace = canCreateTeamSpace;
+  t.after(() => {
+    delete globalThis.__canCreateTeamSpace;
+  });
+  const mod = await vite.ssrLoadModule("/components/notes/NewNoteMenu.tsx");
+  return renderToStaticMarkup(
+    createElement(mod.default, { onNewNote: () => {}, onNewChat: () => {} })
+  );
+}
+
+test("the New note menu always offers a note and an assistant chat", async (t) => {
+  const markup = await renderMenu(t, { canCreateTeamSpace: false });
+
+  assert.match(markup, /notes\.list\.newNote/);
+  assert.match(markup, /notes\.createMenu\.note/);
+  assert.match(markup, /notes\.createMenu\.assistantChat/);
+});
+
+test("the New note menu offers a team space only when the user can create one", async (t) => {
+  const withoutPermission = await renderMenu(t, { canCreateTeamSpace: false });
+  assert.doesNotMatch(withoutPermission, /notes\.createMenu\.teamSpace/);
+
+  const withPermission = await renderMenu(t, { canCreateTeamSpace: true });
+  assert.match(withPermission, /notes\.createMenu\.teamSpace/);
+});

--- a/test/components/pillCommandMenu.test.js
+++ b/test/components/pillCommandMenu.test.js
@@ -17,10 +17,12 @@ async function renderMenu(t, props) {
       buttonRef: { current: null },
       isRecording: false,
       agentAllowed: true,
+      meetingAllowed: true,
       isHovered: false,
       setWindowInteractivity: () => {},
       onToggleListening: () => {},
       onAskAssistant: () => {},
+      onStartMeeting: () => {},
       onHide: () => {},
       onClose: () => {},
       ...props,
@@ -34,4 +36,10 @@ test("the command menu hides Ask Assistant while a recording is active", async (
 
   const recordingMarkup = await renderMenu(t, { isRecording: true });
   assert.doesNotMatch(recordingMarkup, /askAssistant/);
+});
+
+test("the command menu offers a meeting recording only while idle and allowed", async (t) => {
+  assert.match(await renderMenu(t, {}), /startMeetingRecording/);
+  assert.doesNotMatch(await renderMenu(t, { isRecording: true }), /startMeetingRecording/);
+  assert.doesNotMatch(await renderMenu(t, { meetingAllowed: false }), /startMeetingRecording/);
 });

--- a/test/components/spacesTreeNoteActionClearance.test.js
+++ b/test/components/spacesTreeNoteActionClearance.test.js
@@ -80,6 +80,7 @@ async function renderTree(t, direction) {
       "/hooks/useAuth": "export const useAuth = () => ({ isSignedIn: false, user: null });",
       "/hooks/useWorkspace":
         "export const useWorkspace = () => ({ workspaces: [], loaded: true });",
+      "/hooks/useCanCreateTeamSpace": "export const useCanCreateTeamSpace = () => false;",
       "/hooks/useDialogs": `
         export const useDialogs = () => ({
           confirmDialog: { open: false },

--- a/test/helpers/meetingDetectionEngine.test.js
+++ b/test/helpers/meetingDetectionEngine.test.js
@@ -55,11 +55,14 @@ function createEngine() {
   audioDetector.stop = () => {};
 
   const shown = [];
+  const meetingNavigations = [];
+  const noteNavigations = [];
   const windowManager = {
     notificationPrefs: {},
     showMeetingNotification: (data) => shown.push(data),
     dismissMeetingNotification: () => {},
-    queueMeetingNoteNavigation: async () => {},
+    queueMeetingNoteNavigation: async (payload) => meetingNavigations.push(payload),
+    queueNoteNavigation: async (payload) => noteNavigations.push(payload),
   };
 
   const engine = new MeetingDetectionEngine(
@@ -70,7 +73,7 @@ function createEngine() {
     {}
   );
 
-  return { engine, audioDetector, processDetector, shown };
+  return { engine, audioDetector, processDetector, shown, meetingNavigations, noteNavigations };
 }
 
 test("an unanswered audio prompt expires without cooling down the mic detector", () => {
@@ -115,4 +118,24 @@ test("a meeting app appearing asks the mic detector to re-evaluate unattributed 
 
   assert.equal(audioDetector.meetingAppNotifications, 1);
   assert.equal(shown.length, 0, "a running meeting app alone stays context-only");
+});
+
+// The bare {} databaseManager is the assertion that no note was created: reaching
+// the note path at all would throw on getActiveEvents.
+test("a manual meeting start during a live recording surfaces that note, not a new one", async () => {
+  const { engine, noteNavigations } = createEngine();
+  engine._recordingSession = { sessionId: "s1", noteId: 42 };
+
+  await engine.startManualMeeting();
+
+  assert.deepEqual(noteNavigations, [{ noteId: 42 }]);
+});
+
+test("a live recording with no note id still blocks a second manual meeting", async () => {
+  const { engine, noteNavigations } = createEngine();
+  engine._recordingSession = { sessionId: "s2", noteId: null };
+
+  await engine.startManualMeeting();
+
+  assert.deepEqual(noteNavigations, []);
 });

--- a/test/helpers/selectionManager.test.js
+++ b/test/helpers/selectionManager.test.js
@@ -193,8 +193,7 @@ test("a Linux AT-SPI terminal pid never becomes a caret delivery target", async 
   const editor = { kind: "atspi-pid", id: "8765" };
 
   assert.equal(
-    (await manager._markEditableCaret({ status: "none", target: terminal }, terminal, true))
-      .status,
+    (await manager._markEditableCaret({ status: "none", target: terminal }, terminal, true)).status,
     "none"
   );
   assert.equal(probes.length, 0, "a terminal pid must be refused without probing");
@@ -458,9 +457,9 @@ test("a superseded probe never overwrites the newer probe's target", async () =>
 });
 
 // The Windows paste path restores the window captured at record start (#859).
-// getWinTargetHwnd hands the paste that HWND exactly as --detect-only printed
+// getWinTarget hands the paste that HWND exactly as --detect-only printed
 // it ("TARGET %p", hex) so the binary's base-16 --restore-window parse round-trips.
-test("getWinTargetHwnd returns the hex HWND a win32 probe captured (#859)", async () => {
+test("getWinTarget returns the hex HWND a win32 probe captured (#859)", async () => {
   const spawnCalls = [];
   const SpawningSelectionManager = loadSelectionManager({
     spawn: (command, args) => {
@@ -490,12 +489,12 @@ test("getWinTargetHwnd returns the hex HWND a win32 probe captured (#859)", asyn
   assert.deepEqual(spawnCalls, [
     { command: "/tmp/windows-fast-paste.exe", args: ["--detect-only"] },
   ]);
-  assert.equal(await manager.getWinTargetHwnd(), "00001A2B");
+  assert.equal((await manager.getWinTarget())?.id, "00001A2B");
 });
 
 // captureTarget() nulls lastTarget while its probe runs; a paste racing the
 // stop-press probe must wait for the answer instead of restoring nothing.
-test("getWinTargetHwnd waits for an in-flight probe before answering", async () => {
+test("getWinTarget waits for an in-flight probe before answering", async () => {
   const manager = new SelectionManager({
     clipboardManager: {},
     textEditMonitor: {},
@@ -506,24 +505,24 @@ test("getWinTargetHwnd waits for an in-flight probe before answering", async () 
   manager._probeTarget = () => new Promise((resolve) => (resolveProbe = resolve));
 
   const probe = manager.captureTarget();
-  const pending = manager.getWinTargetHwnd();
+  const pending = manager.getWinTarget();
   resolveProbe({ kind: "win-hwnd", id: "0000F00D" });
   await probe;
 
-  assert.equal(await pending, "0000F00D");
+  assert.equal((await pending)?.id, "0000F00D");
 });
 
-test("getWinTargetHwnd is null without a capture or with a non-Windows target", async () => {
+test("getWinTarget is null without a capture or with a non-Windows target", async () => {
   const manager = new SelectionManager({
     clipboardManager: {},
     textEditMonitor: {},
     platform: "linux",
     now: () => 1000,
   });
-  assert.equal(await manager.getWinTargetHwnd(), null);
+  assert.equal(await manager.getWinTarget(), null);
 
   manager.lastTarget = { kind: "x11-window", id: "7" };
-  assert.equal(await manager.getWinTargetHwnd(), null);
+  assert.equal(await manager.getWinTarget(), null);
 });
 
 test("caret delivery pins the captured Windows HWND into the paste helper", async () => {

--- a/test/helpers/trayActionPolicy.test.js
+++ b/test/helpers/trayActionPolicy.test.js
@@ -1,0 +1,55 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const load = () => import("../../src/helpers/trayActionPolicy.js");
+
+// The pill's command menu hides these items instead of refusing; the tray always
+// shows them, so every path here must answer rather than swallow the click.
+test("the tray's assistant action refuses policy and a busy pill, and runs otherwise", async () => {
+  const { resolveTrayAssistantAction, TRAY_REFUSAL_KEYS } = await load();
+  const idle = { agentAllowed: true, isRecording: false, liveTranscriptMounted: false };
+
+  assert.deepEqual(resolveTrayAssistantAction(idle), { action: "run" });
+  assert.deepEqual(resolveTrayAssistantAction({ ...idle, agentAllowed: false }), {
+    action: "refuse",
+    messageKey: TRAY_REFUSAL_KEYS.agentRestricted,
+  });
+  assert.deepEqual(resolveTrayAssistantAction({ ...idle, isRecording: true }), {
+    action: "refuse",
+    messageKey: TRAY_REFUSAL_KEYS.busy,
+  });
+  // The transcript panel owns the pill just as a live recording does.
+  assert.deepEqual(resolveTrayAssistantAction({ ...idle, liveTranscriptMounted: true }), {
+    action: "refuse",
+    messageKey: TRAY_REFUSAL_KEYS.busy,
+  });
+});
+
+test("the tray's meeting action refuses policy and a live dictation, and runs otherwise", async () => {
+  const { resolveTrayMeetingAction, TRAY_REFUSAL_KEYS } = await load();
+  const idle = { meetingAllowed: true, isRecording: false };
+
+  assert.deepEqual(resolveTrayMeetingAction(idle), { action: "run" });
+  assert.deepEqual(resolveTrayMeetingAction({ ...idle, meetingAllowed: false }), {
+    action: "refuse",
+    messageKey: TRAY_REFUSAL_KEYS.meetingRestricted,
+  });
+  assert.deepEqual(resolveTrayMeetingAction({ ...idle, isRecording: true }), {
+    action: "refuse",
+    messageKey: TRAY_REFUSAL_KEYS.busy,
+  });
+});
+
+// Policy outranks busy: an org refusal explains the real reason.
+test("a blocked policy is reported even while the pill is busy", async () => {
+  const { resolveTrayAssistantAction, resolveTrayMeetingAction, TRAY_REFUSAL_KEYS } = await load();
+
+  assert.equal(
+    resolveTrayAssistantAction({ agentAllowed: false, isRecording: true }).messageKey,
+    TRAY_REFUSAL_KEYS.agentRestricted
+  );
+  assert.equal(
+    resolveTrayMeetingAction({ meetingAllowed: false, isRecording: true }).messageKey,
+    TRAY_REFUSAL_KEYS.meetingRestricted
+  );
+});

--- a/test/helpers/trayQuickActions.test.js
+++ b/test/helpers/trayQuickActions.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+const originalLoad = Module._load;
+Module._load = function loadTrayWithStubs(request, parent, isMain) {
+  if (request === "electron") return { Tray: class {}, Menu: {}, nativeImage: {}, app: {} };
+  if (request === "./debugLogger") return { info: () => undefined, debug: () => undefined };
+  if (request === "./dockManager") return {};
+  if (request === "./i18nMain") return { i18nMain: { t: (key) => key } };
+  return originalLoad.call(this, request, parent, isMain);
+};
+const TrayManager = require("../../src/helpers/tray");
+Module._load = originalLoad;
+
+test("the tray menu leads with the dictation pill's quick actions", () => {
+  const calls = [];
+  const trayManager = new TrayManager();
+  trayManager.windowManager = {
+    isDictationPanelVisible: () => false,
+    sendStartDictation: () => calls.push("dictation"),
+    sendOpenAssistantPanel: () => calls.push("assistant"),
+    startManualMeeting: async () => calls.push("meeting"),
+  };
+
+  const [listen, assistant, meeting, separator] = trayManager.buildContextMenuTemplate();
+
+  assert.deepEqual(
+    [listen.label, assistant.label, meeting.label, separator.type],
+    [
+      "app.commandMenu.startListening",
+      "app.commandMenu.askAssistant",
+      "app.commandMenu.startMeetingRecording",
+      "separator",
+    ]
+  );
+
+  listen.click();
+  assistant.click();
+  meeting.click();
+  assert.deepEqual(calls, ["dictation", "assistant", "meeting"]);
+});

--- a/test/helpers/trayQuickActions.test.js
+++ b/test/helpers/trayQuickActions.test.js
@@ -18,7 +18,7 @@ function createTrayManager(calls, { dictating = false } = {}) {
   trayManager.windowManager = {
     isDictationPanelVisible: () => false,
     isDictating: () => dictating,
-    sendStartDictation: () => calls.push("start-dictation"),
+    sendStartListening: () => calls.push("start-listening"),
     sendStopDictation: () => calls.push("stop-dictation"),
     sendOpenAssistantPanel: () => calls.push("assistant"),
     sendStartMeeting: () => calls.push("meeting"),
@@ -44,9 +44,9 @@ test("the tray menu leads with the dictation pill's quick actions", () => {
   listen.click();
   assistant.click();
   meeting.click();
-  // Both go to the renderer, which owns the policy and recording state the pill
-  // menu gates these items on.
-  assert.deepEqual(calls, ["start-dictation", "assistant", "meeting"]);
+  // All three go through the window manager's tray entries, which either ask the
+  // renderer or explain a refusal rather than swallowing the click.
+  assert.deepEqual(calls, ["start-listening", "assistant", "meeting"]);
 });
 
 test("the tray's listen item stops the recording it reflects", () => {

--- a/test/helpers/trayQuickActions.test.js
+++ b/test/helpers/trayQuickActions.test.js
@@ -13,17 +13,23 @@ Module._load = function loadTrayWithStubs(request, parent, isMain) {
 const TrayManager = require("../../src/helpers/tray");
 Module._load = originalLoad;
 
-test("the tray menu leads with the dictation pill's quick actions", () => {
-  const calls = [];
+function createTrayManager(calls, { dictating = false } = {}) {
   const trayManager = new TrayManager();
   trayManager.windowManager = {
     isDictationPanelVisible: () => false,
-    sendStartDictation: () => calls.push("dictation"),
+    isDictating: () => dictating,
+    sendStartDictation: () => calls.push("start-dictation"),
+    sendStopDictation: () => calls.push("stop-dictation"),
     sendOpenAssistantPanel: () => calls.push("assistant"),
-    startManualMeeting: async () => calls.push("meeting"),
+    sendStartMeeting: () => calls.push("meeting"),
   };
+  return trayManager;
+}
 
-  const [listen, assistant, meeting, separator] = trayManager.buildContextMenuTemplate();
+test("the tray menu leads with the dictation pill's quick actions", () => {
+  const calls = [];
+  const [listen, assistant, meeting, separator] =
+    createTrayManager(calls).buildContextMenuTemplate();
 
   assert.deepEqual(
     [listen.label, assistant.label, meeting.label, separator.type],
@@ -38,5 +44,16 @@ test("the tray menu leads with the dictation pill's quick actions", () => {
   listen.click();
   assistant.click();
   meeting.click();
-  assert.deepEqual(calls, ["dictation", "assistant", "meeting"]);
+  // Both go to the renderer, which owns the policy and recording state the pill
+  // menu gates these items on.
+  assert.deepEqual(calls, ["start-dictation", "assistant", "meeting"]);
+});
+
+test("the tray's listen item stops the recording it reflects", () => {
+  const calls = [];
+  const [listen] = createTrayManager(calls, { dictating: true }).buildContextMenuTemplate();
+
+  assert.equal(listen.label, "app.commandMenu.stopListening");
+  listen.click();
+  assert.deepEqual(calls, ["stop-dictation"]);
 });

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -763,3 +763,45 @@ test("a detection card whose load fails releases that detection", async () => {
   await assert.rejects(showPromise, /load failed/);
   assert.deepEqual(closedDetections, ["audio:sustained-audio"]);
 });
+
+test("manual meeting starts fail closed like the meeting hotkey", async () => {
+  let starts = 0;
+  const engine = { startManualMeeting: async () => (starts += 1) };
+
+  const onboarding = new WindowManager();
+  onboarding.meetingDetectionEngine = engine;
+  await onboarding.startManualMeeting();
+  assert.equal(starts, 0);
+
+  const manager = createNormalWindowManager();
+  manager.meetingDetectionEngine = engine;
+  manager.hotkeyManager.isInListeningMode = () => true;
+  await manager.startManualMeeting();
+  assert.equal(starts, 0);
+
+  manager.hotkeyManager.isInListeningMode = () => false;
+  await manager.startManualMeeting();
+  assert.equal(starts, 1);
+});
+
+test("the tray's Ask Assistant focuses the pill before asking for the panel", () => {
+  const fakeMainWindow = (events) => ({
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => true,
+    focus: () => events.push("focus"),
+    webContents: { send: (channel) => events.push(channel) },
+  });
+
+  const onboardingEvents = [];
+  const onboarding = new WindowManager();
+  onboarding.mainWindow = fakeMainWindow(onboardingEvents);
+  onboarding.sendOpenAssistantPanel();
+  assert.deepEqual(onboardingEvents, []);
+
+  const events = [];
+  const manager = createNormalWindowManager();
+  manager.mainWindow = fakeMainWindow(events);
+  manager.sendOpenAssistantPanel();
+  assert.deepEqual(events, ["focus", "open-assistant-panel"]);
+});

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -86,7 +86,14 @@ Module._load = function loadWindowManagerWithStubs(request, parent, isMain) {
       dialog: {},
     };
   }
-  if (request === "./debugLogger") return { warn: () => undefined };
+  if (request === "./debugLogger") {
+    return {
+      info: () => undefined,
+      warn: () => undefined,
+      debug: () => undefined,
+      error: () => undefined,
+    };
+  }
   if (request === "./hotkeyManager") return FakeHotkeyManager;
   if (request === "./dragManager") return FakeDragManager;
   if (request === "./menuManager") return {};
@@ -819,4 +826,45 @@ test("the tray's quick actions ask the renderer without showing or focusing the 
   capturing.sendStartMeeting();
   capturing.sendOpenAssistantPanel();
   assert.deepEqual(capturingEvents, []);
+});
+
+// The tray shows its listen item whatever the state, so the gates only this
+// process can see have to answer rather than go quiet.
+test("the tray's listen item explains a refusal the renderer cannot see", () => {
+  const events = [];
+  const manager = createNormalWindowManager();
+  manager.mainWindow = {
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => true,
+    focus: () => events.push("focus"),
+    showInactive: () => events.push("show"),
+    webContents: { send: (channel, payload) => events.push([channel, payload?.messageKey]) },
+  };
+
+  // A panel owning the pill blocks dictation input; the click must say so.
+  // Stubbed because the real gate also re-kicks the companion pill's load.
+  manager._shouldBlockDictationInput = () => true;
+  manager.sendStartListening();
+  assert.deepEqual(events, [["tray-action-refused", "app.commandMenu.busyRecording"]]);
+
+  // A transcription still settling refuses the same way.
+  events.length = 0;
+  manager._shouldBlockDictationInput = () => false;
+  manager._dictationLifecycleState = "processing";
+  manager.sendStartListening();
+  assert.deepEqual(events, [["tray-action-refused", "app.commandMenu.busyRecording"]]);
+  manager._dictationLifecycleState = "idle";
+
+  // Idle again, it hands off to the ordinary dictation start, which carries the
+  // target capture and panel choreography its own tests cover.
+  events.length = 0;
+  manager._assistantPanelOpen = false;
+  let starts = 0;
+  manager.sendStartDictation = () => {
+    starts += 1;
+  };
+  manager.sendStartListening();
+  assert.equal(starts, 1);
+  assert.deepEqual(events, [], "an accepted click refuses nothing");
 });

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -811,11 +811,12 @@ test("the tray's quick actions ask the renderer without showing or focusing the 
   manager.sendStartMeeting();
   assert.deepEqual(events, ["open-assistant-panel", "start-meeting"]);
 
-  // Capturing a hotkey swallows the meeting request, like the hotkey paths.
+  // Capturing a hotkey swallows both, like every other input path.
   const capturingEvents = [];
   const capturing = createNormalWindowManager();
   capturing.mainWindow = fakeMainWindow(capturingEvents);
   capturing.hotkeyManager.isInListeningMode = () => true;
   capturing.sendStartMeeting();
+  capturing.sendOpenAssistantPanel();
   assert.deepEqual(capturingEvents, []);
 });

--- a/test/helpers/windowManagerMeetingNotification.test.js
+++ b/test/helpers/windowManagerMeetingNotification.test.js
@@ -784,12 +784,16 @@ test("manual meeting starts fail closed like the meeting hotkey", async () => {
   assert.equal(starts, 1);
 });
 
-test("the tray's Ask Assistant focuses the pill before asking for the panel", () => {
+// The renderer owns the policy and recording state these tray items are gated on,
+// so nothing may be shown, focused, or created before it accepts.
+test("the tray's quick actions ask the renderer without showing or focusing the pill", () => {
   const fakeMainWindow = (events) => ({
     isDestroyed: () => false,
     isMinimized: () => false,
     isVisible: () => true,
     focus: () => events.push("focus"),
+    show: () => events.push("show"),
+    showInactive: () => events.push("show"),
     webContents: { send: (channel) => events.push(channel) },
   });
 
@@ -797,11 +801,21 @@ test("the tray's Ask Assistant focuses the pill before asking for the panel", ()
   const onboarding = new WindowManager();
   onboarding.mainWindow = fakeMainWindow(onboardingEvents);
   onboarding.sendOpenAssistantPanel();
+  onboarding.sendStartMeeting();
   assert.deepEqual(onboardingEvents, []);
 
   const events = [];
   const manager = createNormalWindowManager();
   manager.mainWindow = fakeMainWindow(events);
   manager.sendOpenAssistantPanel();
-  assert.deepEqual(events, ["focus", "open-assistant-panel"]);
+  manager.sendStartMeeting();
+  assert.deepEqual(events, ["open-assistant-panel", "start-meeting"]);
+
+  // Capturing a hotkey swallows the meeting request, like the hotkey paths.
+  const capturingEvents = [];
+  const capturing = createNormalWindowManager();
+  capturing.mainWindow = fakeMainWindow(capturingEvents);
+  capturing.hotkeyManager.isInListeningMode = () => true;
+  capturing.sendStartMeeting();
+  assert.deepEqual(capturingEvents, []);
 });

--- a/test/helpers/windowsPasteTarget.test.js
+++ b/test/helpers/windowsPasteTarget.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  isRestorablePasteTarget,
+  parseWindowHandle,
+} = require("../../src/helpers/windowsPasteTarget");
+
+const OWN_EXE = "OpenWhispr.exe";
+
+function handleBuffer(hex, bytes = 8) {
+  const buffer = Buffer.alloc(bytes);
+  if (bytes >= 8) buffer.writeBigUInt64LE(BigInt(`0x${hex}`));
+  else buffer.writeUInt32LE(Number(`0x${hex}`));
+  return buffer;
+}
+
+test("another app's window is restored, as it was before the tray could start dictation", () => {
+  const restorable = isRestorablePasteTarget({
+    target: { id: "00001A2B", exeName: "notepad.exe" },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [],
+  });
+
+  assert.equal(restorable, true);
+});
+
+test("our own window stays a target, so dictating into a note still pastes there", () => {
+  const restorable = isRestorablePasteTarget({
+    target: { id: "00001A2B", exeName: "openwhispr.exe" },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [handleBuffer("0000BEEF"), handleBuffer("00001A2B")],
+  });
+
+  assert.equal(restorable, true);
+});
+
+// The tray menu's owner window: ours, but not one of our windows.
+test("our own non-window surface is dropped rather than force-activated", () => {
+  const restorable = isRestorablePasteTarget({
+    target: { id: "00001A2B", exeName: "OpenWhispr.exe" },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [handleBuffer("0000BEEF")],
+  });
+
+  assert.equal(restorable, false);
+});
+
+test("a 32-bit window handle compares by value, not by buffer width", () => {
+  const restorable = isRestorablePasteTarget({
+    target: { id: "0x1A2B", exeName: OWN_EXE },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [handleBuffer("00001A2B", 4)],
+  });
+
+  assert.equal(restorable, true);
+});
+
+test("an unreadable window identity keeps the old behaviour", () => {
+  const noExeName = isRestorablePasteTarget({
+    target: { id: "00001A2B", exeName: null },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [],
+  });
+  assert.equal(noExeName, true, "a missing exe name reads as another app's window");
+
+  const unparsableOwn = isRestorablePasteTarget({
+    target: { id: "not-a-handle", exeName: OWN_EXE },
+    ownExeName: OWN_EXE,
+    ownWindowHandles: [handleBuffer("00001A2B")],
+  });
+  assert.equal(unparsableOwn, false, "ours but unidentifiable: don't force the foreground");
+
+  assert.equal(isRestorablePasteTarget({ target: null, ownExeName: OWN_EXE }), false);
+});
+
+test("handles parse as hex with or without the 0x the helper may print", () => {
+  assert.equal(parseWindowHandle("00001A2B"), 0x1a2bn);
+  assert.equal(parseWindowHandle("0x00001A2B"), 0x1a2bn);
+  assert.equal(parseWindowHandle("nope"), null);
+});

--- a/test/hooks/canCreateTeamSpace.test.js
+++ b/test/hooks/canCreateTeamSpace.test.js
@@ -1,0 +1,74 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const React = require("react");
+const { createRoot } = require("react-dom/client");
+const {
+  createRendererServer,
+  installBrowserGlobals,
+  installHookDom,
+} = require("../lib/rendererTestHarness");
+
+// canManageWorkspace stays real: the rule under test is which roles it lets through.
+test("team space creation is offered to workspace managers and to users with none yet", async (t) => {
+  let root = null;
+  t.after(async () => {
+    if (root) await React.act(async () => root.unmount());
+  });
+
+  installBrowserGlobals(t);
+  const container = installHookDom(t);
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-can-create-team-space-",
+    mockModules: {
+      "/useAuth": "export const useAuth = () => ({ isSignedIn: globalThis.__state.isSignedIn });",
+      "/useTeamSpacesCapability": `
+        export const useTeamSpacesCapability = (isSignedIn) =>
+          isSignedIn && globalThis.__state.teamSpacesAvailable;
+      `,
+      "/useWorkspace": `
+        export const useWorkspace = () => ({
+          workspaces: globalThis.__state.workspaces,
+          loaded: globalThis.__state.loaded,
+        });
+      `,
+    },
+  });
+  const { useCanCreateTeamSpace } = await vite.ssrLoadModule("/hooks/useCanCreateTeamSpace.ts");
+
+  let latest = null;
+  function Harness() {
+    latest = useCanCreateTeamSpace();
+    return null;
+  }
+
+  root = createRoot(container);
+  t.after(() => {
+    delete globalThis.__state;
+  });
+  const canCreate = async (state) => {
+    globalThis.__state = { isSignedIn: true, teamSpacesAvailable: true, loaded: true, ...state };
+    await React.act(async () => {
+      root.render(React.createElement(Harness, { key: JSON.stringify(state) }));
+      await Promise.resolve();
+    });
+    return latest;
+  };
+
+  assert.equal(await canCreate({ isSignedIn: false, workspaces: [] }), false);
+  assert.equal(await canCreate({ teamSpacesAvailable: false, workspaces: [] }), false);
+  assert.equal(await canCreate({ loaded: false, workspaces: [] }), false);
+  // No workspace yet: the dialog walks the user through creating one.
+  assert.equal(await canCreate({ workspaces: [] }), true);
+  assert.equal(await canCreate({ workspaces: [{ id: "w1", role: "member" }] }), false);
+  assert.equal(await canCreate({ workspaces: [{ id: "w1", role: "admin" }] }), true);
+  assert.equal(
+    await canCreate({
+      workspaces: [
+        { id: "w1", role: "member" },
+        { id: "w2", role: "owner" },
+      ],
+    }),
+    true
+  );
+});


### PR DESCRIPTION
## Summary

- **Settings — org-managed notice.** The "managed by your organization" banner sat inset (`mx-4` inside the content padding), 40px down, with no gap before the section. It now renders through a `notice` slot on the settings shell: the shared `InfoBox` at the full content width, starting just below the floating close button in both regular and compact layouts, with the sections' own `mb-6` rhythm before the first section, and a shield icon.
- **Settings — focused close button.** Radix focuses the first tabbable element when a dialog opens; in the settings shell that is the X, which sits before the sidebar, and its ring used `focus:`, so every open showed a focused X. The dialog now takes the initial focus itself (focus trap and Esc unchanged; the first Tab reaches the X), and the X's ring only shows for keyboard focus. Scoped to `SidebarModal` (Settings is its only consumer); the shared `DialogContent` is untouched.
- **Notes — "Enhanced" is now "AI Summary".** Matches the "Generate AI Summary" action that produces it, in all locales.
- **Quick actions — pill and tray.** The dictation pill's right-click menu gains *Start meeting recording* (idle only, and only when policy allows meeting transcription). The tray menu leads with the pill's quick actions: *Start listening* / *Stop listening*, *Ask assistant*, *Start meeting recording*.
  - **Two of the three need nothing from the renderer.** *Start listening* goes straight to the same dictation start every other input path uses, and *Start meeting recording* calls `windowManager.startManualMeeting()` — the one gated entry for manual meetings, exactly as the meeting hotkey has always called it. The recording those open is policy-gated where it actually begins, in the control panel, so routing them through the dictation renderer bought nothing.
  - **Only *Ask assistant* asks the renderer**, because only the renderer can open the assistant panel and only it knows the policy and panel state the pill's menu gates the item on. `trayActionPolicy.js` is a pure seam deciding what it does with the request: run, or refuse with the reason. A refusal surfaces the pill first, so the message is visible even when the pill was hidden.
  - **A policy that never loaded is not an org restriction.** Policy fails closed while it is loading or after a failed fetch, so an offline user was being told their organization had blocked something it never blocked. The resolver takes `policyResolved` and says the settings have not loaded yet instead; a real restriction still names itself (`common.policyAgentRestricted`).
  - `startManualMeeting()` returns early when a recording is live and brings that note forward instead of opening an empty one over it. The engine's recording session carries the note id, which is the only signal that actually means "recording" (`_meetingModeActive` can stick, and the stored meeting note id goes stale after a streaming stop).
  - The tray's listen item is a real toggle, rebuilt when dictation starts or stops.
- **Windows — no paste into our own window.** A dictation started from the tray captures our own menu-owner window as the paste target, and the fast-paste helper force-activates that handle before Ctrl+V, which would pull the foreground onto OpenWhispr, drop the keystroke, and then restore the previous clipboard over the dictated text. `windowsPasteTarget.js` is a pure, unit-tested seam (the repo's `dockPolicy` / `meetingMicGate` pattern, for logic no non-Windows machine can exercise) that drops a target which is ours but is not one of our `BrowserWindow`s. Real windows — the control panel's note editor — stay valid targets, so dictating into a note still pastes there.
- **Notes topbar — New note split button.** `+ New note | ▾`, with the chevron offering *Note*, *Assistant chat*, and *Team space*.
  - **Placement follows the platform.** On Windows and Linux it sits just right of the search bar, with the window controls still at the far end. macOS has no window controls in this bar, so the button takes the far right.
  - **Matched to the search bar beside it**, which previously shared none of its styling: the same translucent fill that lifts on hover, under the same hairline, with the same keyboard focus ring. The search bar gains the border it lacked. Those overrides are scoped to this instance, so the note editor's Share control — which shares the same split-button definition — keeps the pill it already had.
  - The main segment is the notes page's existing New note: it creates a note in the current space or folder and starts recording. *Assistant chat* opens a new chat in the Chat tab, and is hidden when policy turns the assistant off (the Chat tab is hidden then too). *Team space* opens the existing team-space dialog, for users who can create one.
  - The chat and team-space items keep the focus they hand to what they open; a new note and a dismissed menu return focus to the chevron, as Radix does by default.
  - The topbar exposes an actions slot that `PersonalNotesView` portals into, so the handlers and the notes-onboarding state stay in the view; the button is absent during notes onboarding and in the side-panel layout.
  - The trailing grid column no longer shrinks below its content, so the button and the window controls are never clipped; the search yields at narrow widths.
  - The "can create a team space" rule moves from `SpacesTree` into `useCanCreateTeamSpace`, and the Share control's split-pill classes move to `ui/splitButton`, so both call sites share one definition.

## A note on scope

An earlier revision of this branch mirrored the renderer's gating into the main process for all three tray entries: a `start-meeting` push channel, a `tray-action-refused` channel, a renderer-readiness handshake, and the meeting hotkey rerouted through the renderer for symmetry. That last change was the source of two regressions — the hotkey went silent whenever the dictation window was not mounted, which a signed-in launch does while policy resolves.

It was also unnecessary: the meeting recording is already policy-gated at the control panel's recording mount, so the round trip bought a slightly earlier refusal message rather than any enforcement. All of it has been removed (net −284 lines). The meeting hotkey is byte-for-byte what it was before this branch, and the only surviving renderer round trip is the one that genuinely needs it.

## Test plan

- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run i18n:check`
- [x] Full suite green, with no `ERR_DLOPEN_FAILED` (those failures on some machines are a broken local `better-sqlite3`, not this PR)
- [x] Tests added: the Windows paste-target seam; the tray action policy (org restriction, busy pill, and an unresolved policy not blaming the org); the tray menu's three entries and where each one goes; the manual-meeting guard during a live recording, with and without a note; the assistant request taking no focus and refusing under hotkey capture; the pill menu's meeting item; `NewNoteMenu`'s items (including the assistant hidden by policy); `useCanCreateTeamSpace`
- [x] `useTrayQuickActions` is mounted for real in its test (not SSR-rendered), so the wiring — not just the pure resolver — is covered: a swapped or forgotten input fails loudly
- [x] macOS dev build driven over CDP: Settings opened with ⌘, and by click keeps focus on the dialog with no ring on the X; org notice full width in regular and compact layouts; pill menu shows *Start meeting recording* and fits its window; *AI Summary* toggle on a summarized note; New note and its menu in the topbar; the button is absent in the side-panel layout and on other pages
- [x] Placement on both platforms: macOS — New note flush to the far right (12px gap to the window edge); Windows 11 VM — the button sits right of the search at x 881–1014 with the window controls after it at 1073–1177
- [x] New note and the search bar measured in the running app: identical fill, border and radius
- [ ] Tray *Ask assistant* under an org policy that blocks the assistant: the refusal explains itself and no panel opens
- [ ] Tray *Start meeting recording* while a meeting is already recording brings the live note forward
- [ ] Windows: dictation started from the tray pastes into the app you were using (or leaves the text recoverable)
- [ ] *Team space* with a signed-in account that can manage a workspace

https://claude.ai/code/session_013hZY5WHN4aNYZA2fAowZrj
