### PR TITLE
fix(dictation): cut the Windows mic cold start on the first hotkey press

### DIFF
--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -559,13 +559,7 @@ class AudioManager {
 
     // Invalidate the pinned mic device when the OS adds/removes/suspends inputs.
     // Otherwise wake-after-idle keeps requesting a stale deviceId that yields silence.
-    this._onDeviceChange = () => {
-      this.cachedMicDeviceId = null;
-      this._micWarmedAt = 0;
-      this.rejectedMicDeviceId = null;
-      this.cancelPreparedMicCapture();
-      this.micStreamHold.drop();
-    };
+    this._onDeviceChange = () => this._handleDeviceChange();
     navigator.mediaDevices?.addEventListener?.("devicechange", this._onDeviceChange);
     this.recordingStartTime = null;
     this.reasoningAvailabilityCache = { value: false, expiresAt: 0 };
@@ -583,6 +577,7 @@ class AudioManager {
     this.streamingTextDebounce = null;
     this.cachedMicDeviceId = null;
     this.rejectedMicDeviceId = null;
+    this._refreshSystemDefaultOnNextResolve = false;
     this.persistentAudioContext = null;
     this.workletModuleLoaded = false;
     this.workletBlobUrl = null;
@@ -980,6 +975,8 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   async getAudioConstraints(forceDefaultMic = false, refreshSystemDefault = false) {
     const settings = getSettings();
+    const refreshDefault = refreshSystemDefault || this._refreshSystemDefaultOnNextResolve === true;
+    this._refreshSystemDefaultOnNextResolve = false;
 
     // All browser audio processing disabled to avoid OS-level side-effects.
     // AGC off: Chromium's AGC on Windows mutates the system mic volume via WASAPI (#476).
@@ -994,7 +991,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
     if (
       !forceDefaultMic &&
-      !refreshSystemDefault &&
+      !refreshDefault &&
       this.cachedMicDeviceId &&
       this.cachedMicDeviceId !== this.rejectedMicDeviceId
     ) {
@@ -1007,7 +1004,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       const resolution = await resolvePreferredMicrophone({
         settings,
         forceSystemDefault: forceDefaultMic,
-        refreshSystemDefault: forceDefaultMic || refreshSystemDefault,
+        refreshSystemDefault: forceDefaultMic || refreshDefault,
       });
       const deviceId = resolution.device?.deviceId;
 
@@ -1104,6 +1101,19 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
 
   cancelPreparedMicCapture() {
     this.preparedMicCapture.cancel();
+  }
+
+  _handleDeviceChange() {
+    this.cachedMicDeviceId = null;
+    this._micWarmedAt = 0;
+    this.rejectedMicDeviceId = null;
+    // Dropping the pin is not enough. The main process caches the OS default's
+    // *name* for 30s, so a resolution in that window would match the name the
+    // device had before the change and re-pin the old microphone — which then
+    // survives until the next device change, if one ever comes.
+    this._refreshSystemDefaultOnNextResolve = true;
+    this.cancelPreparedMicCapture();
+    this.micStreamHold.drop();
   }
 
   // Tells the main process whether this renderer is holding the mic open outside

--- a/src/helpers/microphoneSelection.js
+++ b/src/helpers/microphoneSelection.js
@@ -3,6 +3,14 @@ import { resolveMicDeviceSelection } from "./micDeviceSelection";
 
 export const MICROPHONE_SELECTION_MODES = ["system", "built-in", "specific"];
 
+// Chromium publishes the OS default input twice on Windows — as "default" and as
+// the "communications" role alias — both carrying the real device's own label.
+// They are aliases, not candidates: matching against them makes every Windows mic
+// tie with itself, so the unique-match branches below bail to the "default" id,
+// which isCacheableMicrophoneResolution rejects. The resolution is then re-run on
+// every mic open, and with it the slow Windows system-default lookup.
+const CHROMIUM_ALIAS_DEVICE_IDS = new Set(["default", "communications"]);
+
 export function getMicrophoneSelectionMode(settings = {}) {
   if (MICROPHONE_SELECTION_MODES.includes(settings.microphoneSelectionMode)) {
     return settings.microphoneSelectionMode;
@@ -30,7 +38,7 @@ function comparableLabel(label) {
 export function resolveSystemDefaultMicDevice(devices, systemDefault) {
   const inputs = devices.filter((device) => device.kind === "audioinput");
   const chromiumDefault = inputs.find((device) => device.deviceId === "default") || null;
-  const physicalInputs = inputs.filter((device) => device.deviceId !== "default");
+  const physicalInputs = inputs.filter((device) => !CHROMIUM_ALIAS_DEVICE_IDS.has(device.deviceId));
   const nativeName = systemDefault?.name?.trim();
 
   if (nativeName) {

--- a/src/helpers/systemDefaultMicrophone.js
+++ b/src/helpers/systemDefaultMicrophone.js
@@ -163,6 +163,8 @@ function createSystemDefaultMicrophoneResolver({
 } = {}) {
   let cache = null;
   let cachedAt = 0;
+  let pending = null;
+  let generation = 0;
 
   const resolveDarwin = async () => {
     const helper = resolveBinary("macos-mic-listener", "audio");
@@ -200,8 +202,18 @@ function createSystemDefaultMicrophoneResolver({
     return parsePactlSources(sources, defaultSourceName);
   };
 
-  return async ({ refresh = false } = {}) => {
-    if (!refresh && cache && now() - cachedAt < CACHE_TTL_MS) return cache;
+  const lookup = async () => {
+    const issued = ++generation;
+    // A lookup overtaken by a newer one still answers its own caller, but must
+    // not put its older answer back in the cache — that is precisely the
+    // staleness the newer (refresh) lookup was issued to escape.
+    const commit = (value) => {
+      if (issued === generation) {
+        cache = value;
+        cachedAt = now();
+      }
+      return value;
+    };
 
     try {
       let result = null;
@@ -209,20 +221,37 @@ function createSystemDefaultMicrophoneResolver({
       else if (platform === "win32") result = await resolveWindows();
       else if (platform === "linux") result = await resolveLinux();
 
-      cache = result
-        ? { ...result, platform, source: "system" }
-        : { name: "", platform, source: "unavailable" };
-      cachedAt = now();
-      return cache;
+      return commit(
+        result
+          ? { ...result, platform, source: "system" }
+          : { name: "", platform, source: "unavailable" }
+      );
     } catch (error) {
       debugLogger.debug(
         "Failed to resolve the system default microphone",
         { platform, error: error.message },
         "audio"
       );
-      cache = { name: "", platform, source: "unavailable" };
-      cachedAt = now();
-      return cache;
+      return commit({ name: "", platform, source: "unavailable" });
+    }
+  };
+
+  return async ({ refresh = false } = {}) => {
+    if (!refresh) {
+      if (cache && now() - cachedAt < CACHE_TTL_MS) return cache;
+      // The cache is only written once a lookup settles, so without this a burst
+      // of callers each start their own — and on Windows each one is a separate
+      // PowerShell process compiling the C# helper from source. A refresh never
+      // joins: its caller asked precisely because the in-flight answer is stale.
+      if (pending) return pending;
+    }
+
+    const inFlight = lookup();
+    pending = inFlight;
+    try {
+      return await inFlight;
+    } finally {
+      if (pending === inFlight) pending = null;
     }
   };
 }

--- a/src/hooks/useAudioRecording.js
+++ b/src/hooks/useAudioRecording.js
@@ -316,6 +316,12 @@ export const useAudioRecording = (toast, options = {}) => {
   useEffect(() => {
     audioManagerRef.current = new AudioManager();
 
+    // Resolve and pin the input device now rather than on the first hotkey press.
+    // On Windows that resolution shells out to PowerShell, and prepareMicCapture
+    // waits on it before opening the mic — so leaving it to the first press puts
+    // seconds between the hotkey and the recording the user can see.
+    void audioManagerRef.current.cacheMicrophoneDeviceId?.();
+
     // Reset stale main-process state after a renderer reload or crash recovery.
     reportLifecycle("idle");
 

--- a/test/helpers/audioManagerMicRefreshAfterDeviceChange.test.js
+++ b/test/helpers/audioManagerMicRefreshAfterDeviceChange.test.js
@@ -1,0 +1,73 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { loadAudioManager } = require("./harness/audioManager");
+
+// Records the options each resolution is called with, so a test can assert
+// whether the expensive system-default lookup was asked to bypass its cache.
+// `setCacheable(false)` keeps the resolution unpinnable, which is how a test
+// gets two consecutive resolutions instead of one plus a cache hit.
+const MICROPHONE_SELECTION_MOCK = `
+export const resolveCalls = [];
+let cacheable = true;
+export function setCacheable(next) {
+  cacheable = next;
+}
+export function resolvePreferredMicrophone(options) {
+  resolveCalls.push(options);
+  return Promise.resolve({
+    mode: "system",
+    status: "native-exact",
+    device: { deviceId: "mic-1", label: "Desk Microphone" },
+  });
+}
+export function isCacheableMicrophoneResolution(resolution) {
+  return cacheable && Boolean(resolution?.device?.deviceId);
+}
+`;
+
+async function setupManager(t) {
+  const loaded = await loadAudioManager(t, {
+    cachePrefix: "openwhispr-audio-manager-mic-refresh-",
+    settingsKey: "__micRefreshAfterDeviceChangeSettings",
+    settings: {},
+    mockModules: { "/microphoneSelection": MICROPHONE_SELECTION_MOCK },
+  });
+  const selection = await loaded.vite.ssrLoadModule("/helpers/microphoneSelection");
+  const manager = loaded.createManager({
+    cachedMicDeviceId: null,
+    rejectedMicDeviceId: null,
+    micStreamHold: { drop() {} },
+    preparedMicCapture: { cancel() {} },
+  });
+  return { manager, selection };
+}
+
+const refreshFlags = (selection) => selection.resolveCalls.map((call) => call.refreshSystemDefault);
+
+test("a device change makes the next microphone resolution bypass the system-default cache", async (t) => {
+  const { manager, selection } = await setupManager(t);
+
+  manager._handleDeviceChange();
+  await manager.getAudioConstraints();
+
+  assert.deepEqual(refreshFlags(selection), [true]);
+});
+
+test("a resolution with no device change reuses the system-default cache", async (t) => {
+  const { manager, selection } = await setupManager(t);
+
+  await manager.getAudioConstraints();
+
+  assert.deepEqual(refreshFlags(selection), [false]);
+});
+
+test("only the first resolution after a device change bypasses the cache", async (t) => {
+  const { manager, selection } = await setupManager(t);
+  selection.setCacheable(false);
+
+  manager._handleDeviceChange();
+  await manager.getAudioConstraints();
+  await manager.getAudioConstraints();
+
+  assert.deepEqual(refreshFlags(selection), [true, false]);
+});

--- a/test/helpers/microphoneSelection.test.js
+++ b/test/helpers/microphoneSelection.test.js
@@ -63,3 +63,22 @@ test("legacy microphone preferences retain their behavior", async () => {
   );
   assert.equal(getMicrophoneSelectionMode({ preferBuiltInMic: false }), "system");
 });
+
+test("system mode ignores Chromium's Windows 'communications' alias when matching the native default", async () => {
+  const { isCacheableMicrophoneResolution, resolveMicrophoneSelection } =
+    await import("../../src/helpers/microphoneSelection.js");
+  const expected = mic("9f2c1e5a7b3d", "Microphone (Realtek(R) Audio)");
+  const result = resolveMicrophoneSelection(
+    [
+      mic("default", "Default - Microphone (Realtek(R) Audio)"),
+      mic("communications", "Communications - Microphone (Realtek(R) Audio)"),
+      expected,
+    ],
+    { microphoneSelectionMode: "system" },
+    { name: "Microphone (Realtek(R) Audio)" }
+  );
+
+  assert.equal(result.device, expected);
+  assert.equal(result.status, "native-exact");
+  assert.equal(isCacheableMicrophoneResolution(result), true);
+});

--- a/test/helpers/systemDefaultMicrophone.test.js
+++ b/test/helpers/systemDefaultMicrophone.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const helper = require("../../src/helpers/systemDefaultMicrophone");
+const { deferred } = require("./harness/deferred");
 
 test("parses a WirePlumber default source", () => {
   assert.deepEqual(
@@ -42,4 +43,64 @@ test("resolver caches a successful platform result briefly", async () => {
   assert.equal((await resolve()).name, "Desk Microphone");
   assert.equal((await resolve()).name, "Desk Microphone");
   assert.equal(calls, 1);
+});
+
+// Each lookup answers with the next name and stays pending until settle(index),
+// so a test can choose which of two concurrent lookups finishes first.
+function gatedResolver(names) {
+  const gates = names.map(() => deferred());
+  let calls = 0;
+  const resolve = helper.createSystemDefaultMicrophoneResolver({
+    platform: "linux",
+    now: () => 100,
+    run: async () => {
+      const index = calls;
+      calls += 1;
+      await gates[index].promise;
+      return `node.description = "${names[index]}"`;
+    },
+  });
+  return { resolve, settle: (index) => gates[index].resolve(), calls: () => calls };
+}
+
+test("resolver shares one in-flight lookup between concurrent callers", async () => {
+  const { resolve, settle, calls } = gatedResolver(["Desk Microphone", "Desk Microphone"]);
+
+  const first = resolve();
+  const second = resolve();
+
+  assert.equal(calls(), 1);
+  settle(0);
+  assert.deepEqual(
+    (await Promise.all([first, second])).map((result) => result.name),
+    ["Desk Microphone", "Desk Microphone"]
+  );
+});
+
+test("a refresh never joins a lookup that started before it", async () => {
+  const { resolve, settle, calls } = gatedResolver(["Old Microphone", "New Microphone"]);
+
+  const stale = resolve();
+  const fresh = resolve({ refresh: true });
+
+  assert.equal(calls(), 2);
+  settle(1);
+  assert.equal((await fresh).name, "New Microphone");
+  settle(0);
+  await stale;
+});
+
+test("a lookup overtaken by a fresher one does not write its result to the cache", async () => {
+  const { resolve, settle, calls } = gatedResolver(["Old Microphone", "New Microphone"]);
+
+  const stale = resolve();
+  const fresh = resolve({ refresh: true });
+  assert.equal(calls(), 2);
+
+  settle(1);
+  await fresh;
+  settle(0);
+  await stale;
+
+  assert.equal((await resolve()).name, "New Microphone");
 });

--- a/test/helpers/useAudioRecordingMicPrecache.test.js
+++ b/test/helpers/useAudioRecordingMicPrecache.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const React = require("react");
+const { createRoot } = require("react-dom/client");
+const {
+  createRendererServer,
+  installBrowserGlobals,
+  installHookDom,
+} = require("../lib/rendererTestHarness");
+
+// Counts cacheMicrophoneDeviceId() calls and reports a non-streaming setup, so
+// the assertion below cannot be satisfied by the streaming warm-up path that
+// already calls it.
+const FAKE_AUDIO_MANAGER_SOURCE = `
+export const micPrecacheCalls = [];
+export default class FakeAudioManager {
+  getState() {
+    return {};
+  }
+  setCallbacks() {}
+  shouldUseStreaming() {
+    return false;
+  }
+  cacheMicrophoneDeviceId() {
+    micPrecacheCalls.push(Date.now());
+  }
+  cancelPreparedMicCapture() {}
+  cleanup() {}
+}
+`;
+
+test("the mount effect pre-caches the microphone device id when streaming is off", async (t) => {
+  let root = null;
+  t.after(async () => {
+    if (root) await React.act(async () => root.unmount());
+  });
+
+  const noopDispose = () => () => {};
+  installBrowserGlobals(t, {
+    window: {
+      electronAPI: {
+        onToggleDictation: noopDispose,
+        onToggleVoiceAgent: noopDispose,
+        onToggleTranslation: noopDispose,
+        onStartDictation: noopDispose,
+        onPrepareDictation: noopDispose,
+        onCancelDictationPreparation: noopDispose,
+        onStopDictation: noopDispose,
+        dictationLifecycleStateChanged: () => {},
+      },
+    },
+  });
+  const container = installHookDom(t);
+
+  const vite = await createRendererServer(t, {
+    cachePrefix: "openwhispr-audio-recording-mic-precache-",
+    mockModules: {
+      "/helpers/audioManager": FAKE_AUDIO_MANAGER_SOURCE,
+    },
+  });
+  const { useAudioRecording } = await vite.ssrLoadModule("/hooks/useAudioRecording.js");
+  const { micPrecacheCalls } = await vite.ssrLoadModule("/helpers/audioManager");
+
+  function Harness() {
+    useAudioRecording(() => {}, { onDemoEvent: () => {} });
+    return null;
+  }
+
+  root = createRoot(container);
+  await React.act(async () => {
+    root.render(React.createElement(Harness));
+  });
+
+  assert.equal(micPrecacheCalls.length, 1);
+});


### PR DESCRIPTION
Windows users report 1–2s between pressing the dictation hotkey and the recording actually starting. Regression introduced in v1.9.0 (#1670), still present on v1.10.0.

## Root cause

`getAudioConstraints()` has a `cachedMicDeviceId` fast path that is unreachable on Windows. `resolveSystemDefaultMicDevice()` filtered `physicalInputs` by `deviceId !== "default"`, which leaves in Chromium's Windows-only `communications` role alias — it carries the same label as the real device, so `exactMatches`/`containedMatches` always saw 2 candidates, required exactly 1, and fell through to the uncacheable Chromium `default` id.

With nothing cached, every mic open re-ran `enumerateDevices()` plus `getSystemDefaultMicrophone()`, which shells out to `powershell.exe` with `Add-Type -TypeDefinition <C# source>` (runtime C# compilation, 3s timeout, only a 30s cache). `prepareMicCapture` waits on that before `getUserMedia`, and `startRecording()`'s `take()` waits on the whole thing — so `isRecording`, the visible start of the recording, sits behind it.

macOS/Linux have no `communications` device, so they resolved `native-exact`, cached, and never felt this.

## Changes

1. `microphoneSelection.js` — exclude both Chromium aliases (`default`, `communications`) from `physicalInputs`, so Windows resolves `native-exact` and the result is cacheable.
2. `useAudioRecording.js` — pre-resolve the device in the mount effect. `cacheMicrophoneDeviceId()` already existed but was only reachable from `warmupStreamingConnection()`, i.e. never for local/non-streaming users, so without this the first press of every session still paid the full cost.

## Tests

Both written test-first and watched fail. Every existing case in `microphoneSelection.test.js` used a macOS-shaped device list, which is why this was never caught.

- Windows device topology now resolves `native-exact` / cacheable (was `chromium-default-unmatched` / not cacheable).
- New `useAudioRecordingMicPrecache.test.js` pins that the mount effect pre-caches with streaming off.

## Not covered

A user whose OS default name matches 0 or 2+ enumerated labels (two identical USB mics) still resolves to the uncacheable Chromium default and re-runs the lookup every press past the 30s TTL. Closing that means not awaiting a cold lookup on the hot path, or replacing `Add-Type` with a prebuilt native helper.

Separately: `"Recording start timing"` starts its clock inside `startRecording()`, after every wait above — so Windows logs look clean even when the user waited seconds. Worth fixing before asking reporters for logs.