### PR TITLE
fix(transcription): proxy batch dictation through main process to avoid renderer CORS

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -599,6 +599,16 @@ contextBridge.exposeInMainWorld("electronAPI", {
   proxyXaiTranscription: (data) => ipcRenderer.invoke("proxy-xai-transcription", data),
   proxyMistralTranscription: (data) => ipcRenderer.invoke("proxy-mistral-transcription", data),
   proxyGeminiTranscription: (data) => ipcRenderer.invoke("proxy-gemini-transcription", data),
+  proxyBatchDictation: (endpoint, headers, formDataFieldsArray, audioBuffer, mimeType, fileName) =>
+    ipcRenderer.invoke(
+      "proxy-batch-dictation",
+      endpoint,
+      headers,
+      formDataFieldsArray,
+      audioBuffer,
+      mimeType,
+      fileName
+    ),
 
   // Corti API
   getCortiClientId: () => ipcRenderer.invoke("get-corti-client-id"),

--- a/src/helpers/audioManager.js
+++ b/src/helpers/audioManager.js
@@ -3548,6 +3548,7 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       if (language) {
         formData.append("language", language);
       }
+      formData.append("response_format", "json");
 
       const endpoint = this.getTranscriptionEndpoint(route);
 
@@ -3628,54 +3629,99 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         "transcription"
       );
 
-      requestController = new AbortController();
-      this._activeTranscriptionAbortController = requestController;
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers,
-        body: formData,
-        signal: requestController.signal,
-      });
+      let responseOk,
+        responseStatus,
+        responseStatusText,
+        responseContentType,
+        rawText,
+        responseStream;
 
-      const responseContentType = response.headers.get("content-type") || "";
+      if (!shouldStream && window.electronAPI?.proxyBatchDictation) {
+        const formDataFieldsArray = [];
+        if (model) formDataFieldsArray.push(["model", model]);
+        if (language && language !== "auto") formDataFieldsArray.push(["language", language]);
+        formDataFieldsArray.push(["response_format", "json"]);
+        if (dictionaryPrompt) formDataFieldsArray.push(["prompt", dictionaryPrompt]);
+        if (usesKeywords) {
+          for (const keyword of dictionaryKeywords(dictionary)) {
+            formDataFieldsArray.push(["keywords[]", keyword]);
+          }
+        }
+
+        requestController = new AbortController();
+        this._activeTranscriptionAbortController = requestController;
+
+        const proxyResult = await window.electronAPI.proxyBatchDictation(
+          endpoint,
+          headers,
+          formDataFieldsArray,
+          await optimizedAudio.arrayBuffer(),
+          mimeType,
+          `audio.${extension}`
+        );
+
+        responseOk = proxyResult.ok;
+        responseStatus = proxyResult.status;
+        responseStatusText = proxyResult.statusText;
+        responseContentType = proxyResult.contentType;
+        rawText = proxyResult.text;
+      } else {
+        requestController = new AbortController();
+        this._activeTranscriptionAbortController = requestController;
+        const response = await fetch(endpoint, {
+          method: "POST",
+          headers,
+          body: formData,
+          signal: requestController.signal,
+        });
+
+        responseOk = response.ok;
+        responseStatus = response.status;
+        responseStatusText = response.statusText;
+        responseContentType = response.headers.get("content-type") || "";
+        if (!responseOk || !shouldStream || !responseContentType.includes("text/event-stream")) {
+          rawText = await response.text();
+        } else {
+          responseStream = response;
+        }
+      }
 
       logger.debug(
         "Transcription API response received",
         {
-          status: response.status,
-          statusText: response.statusText,
+          status: responseStatus,
+          statusText: responseStatusText,
           contentType: responseContentType,
-          ok: response.ok,
+          ok: responseOk,
         },
         "transcription"
       );
 
-      if (!response.ok) {
-        const errorText = await response.text();
+      if (!responseOk) {
         logger.error(
           "Transcription API error response",
           {
-            status: response.status,
-            errorText,
+            status: responseStatus,
+            errorText: rawText,
           },
           "transcription"
         );
-        const err = new Error(`API Error: ${response.status} ${errorText}`);
-        if (response.status === 401) err.code = "INVALID_KEY";
-        else if (response.status === 429) {
+        const err = new Error(`API Error: ${responseStatus} ${rawText}`);
+        if (responseStatus === 401) err.code = "INVALID_KEY";
+        else if (responseStatus === 429) {
           // The user's own provider rate-limited the request — not an OpenWhispr plan limit
           err.code = "PROVIDER_RATE_LIMITED";
           err.messageKey = "hooks.audioRecording.errorDescriptions.providerRateLimited";
-        } else if (response.status >= 500) err.code = "SERVER_ERROR";
+        } else if (responseStatus >= 500) err.code = "SERVER_ERROR";
         throw err;
       }
 
       let result;
       const contentType = responseContentType;
 
-      if (shouldStream && contentType.includes("text/event-stream")) {
+      if (shouldStream && contentType.includes("text/event-stream") && responseStream) {
         logger.debug("Processing streaming response", { contentType }, "transcription");
-        const streamedText = await this.readTranscriptionStream(response);
+        const streamedText = await this.readTranscriptionStream(responseStream);
         result = { text: streamedText };
         logger.debug(
           "Streaming response parsed",
@@ -3686,7 +3732,6 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
           "transcription"
         );
       } else {
-        const rawText = await response.text();
         logger.debug(
           "Raw API response body",
           {
@@ -3699,15 +3744,20 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
         try {
           result = JSON.parse(rawText);
         } catch (parseError) {
-          logger.error(
-            "Failed to parse JSON response",
-            {
-              parseError: parseError.message,
-              rawText: rawText.substring(0, 500),
-            },
-            "transcription"
-          );
-          throw new Error(`Failed to parse API response: ${parseError.message}`);
+          const trimmed = rawText.trim();
+          if (trimmed.length > 0 && !trimmed.startsWith("{") && !trimmed.startsWith("<")) {
+            result = { text: trimmed };
+          } else {
+            logger.error(
+              "Failed to parse JSON response",
+              {
+                parseError: parseError.message,
+                rawText: rawText.substring(0, 500),
+              },
+              "transcription"
+            );
+            throw new Error(`Failed to parse API response: ${parseError.message}`);
+          }
         }
 
         logger.debug(
@@ -3783,6 +3833,9 @@ registerProcessor("pcm-streaming-processor", PCMStreamingProcessor);
       }
       if (error.message === "No audio detected") {
         throw error;
+      }
+      if (error.message === "Failed to fetch") {
+        error.message = "Failed to fetch. Check your endpoint URL and network connection.";
       }
 
       const isOpenAIMode = !getSettings().useLocalWhisper;

--- a/src/helpers/ipcHandlers.js
+++ b/src/helpers/ipcHandlers.js
@@ -6264,6 +6264,28 @@ class IPCHandlers {
       }
     });
 
+    ipcMain.handle(
+      "proxy-batch-dictation",
+      async (event, endpoint, headers, formDataFieldsArray, audioBuffer, mimeType, fileName) => {
+        const formData = new FormData();
+        for (const [key, value] of formDataFieldsArray || []) {
+          formData.append(key, value);
+        }
+        formData.append("file", new Blob([audioBuffer], { type: mimeType }), fileName);
+
+        const response = await proxyFetch(endpoint, { method: "POST", headers, body: formData });
+        const responseText = await response.text();
+
+        return {
+          ok: response.ok,
+          status: response.status,
+          statusText: response.statusText,
+          contentType: response.headers.get("content-type") || "",
+          text: responseText,
+        };
+      }
+    );
+
     ipcMain.handle("retry-transcription", async (event, id, settings) => {
       const buffer = this.audioStorageManager.getAudioBuffer(id);
       if (!buffer) return { success: false, error: "Audio file not found" };


### PR DESCRIPTION
## Summary

Dictation against self-hosted and local OpenAI-compatible endpoints (such as LocalAI) consistently failed in the renderer with `Failed to fetch`.

### Root Cause
When dictation runs in the renderer window via `window.fetch`, Chromium enforces strict CORS preflight (`OPTIONS`) requirements because custom request headers (such as `Authorization: Bearer <key>`) are present. Even if the local server sets `Access-Control-Allow-Origin: *`, many local engines fail to explicitly respond with `Access-Control-Allow-Headers: Authorization` on the preflight check. Consequently, Chromium blocks the response and throws `TypeError: Failed to fetch`, leaving OpenWhispr unable to receive the transcript even when the model finishes processing on the server.

Furthermore, several self-hosted servers default to returning plain text unless `response_format: json` is explicitly specified, causing subsequent JSON parsing errors.

## Changes

1. **Main-Process Batch Proxy (`proxyBatchDictation`):**
   - Added `proxy-batch-dictation` IPC handler in `src/helpers/ipcHandlers.js` using `proxyFetch` (`net.fetch`).
   - Exposed `proxyBatchDictation` in `preload.js` through `contextBridge`.
   - Updated `audioManager.js` to route non-streaming STT requests through `proxyBatchDictation`, completely avoiding Chromium renderer CORS/preflight restrictions while maintaining existing fallback to native `fetch`.

2. **Standardized `response_format` Parameter:**
   - Explicitly added `formData.append("response_format", "json")` to match OpenAI's STT contract across compatible local backends.

3. **Graceful Plaintext Fallback:**
   - In `audioManager.js`, if a server ignores the requested JSON format and returns raw text directly, it now falls back to `{ text: trimmed }` rather than crashing on `JSON.parse`.

## Verification

- Tested against a LocalAI instance (`http://localhost:8080/v1`) running Whisper STT. Audio was captured, routed through `proxyBatchDictation`, and transcribed text returned seamlessly to OpenWhispr without CORS errors.
- Prettier: `npx prettier --check preload.js src/helpers/audioManager.js src/helpers/ipcHandlers.js` clean.
- ESLint: `npm run lint` passed with 0 errors.

---
*Note: Gemini AI was used for the entire process—including root cause analysis of the issue, drafting and implementing the changes, and creating this pull request.*
